### PR TITLE
indexer: sub-batch device link latency fact table ClickHouse writes

### DIFF
--- a/indexer/pkg/clickhouse/dataset/fact.go
+++ b/indexer/pkg/clickhouse/dataset/fact.go
@@ -19,6 +19,10 @@ type FactDataset struct {
 	payloadCols   []string
 	uniqueKeyCols []string
 	cols          []string
+
+	// WriteBatchSize overrides the default sub-batch size for WriteBatch.
+	// If zero, defaults to 50,000 rows.
+	WriteBatchSize int
 }
 
 func NewFactDataset(log *slog.Logger, schema FactSchema) (*FactDataset, error) {

--- a/indexer/pkg/clickhouse/dataset/fact_write.go
+++ b/indexer/pkg/clickhouse/dataset/fact_write.go
@@ -7,9 +7,12 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 )
 
+const defaultWriteBatchSize = 50_000
+
 // WriteBatch writes a batch of fact table data to ClickHouse using PrepareBatch.
 // The writeRowFn should return data in the order specified by the Columns configuration.
 // Note: ingested_at should be included in writeRowFn output if required by the table schema.
+// Large batches are automatically split into sub-batches of defaultWriteBatchSize rows.
 func (f *FactDataset) WriteBatch(
 	ctx context.Context,
 	conn clickhouse.Connection,
@@ -20,42 +23,61 @@ func (f *FactDataset) WriteBatch(
 		return nil
 	}
 
-	f.log.Debug("writing fact batch", "table", f.schema.Name(), "count", count)
-
-	// Build batch insert
-	batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", f.TableName()))
-	if err != nil {
-		return fmt.Errorf("failed to prepare batch: %w", err)
+	batchSize := defaultWriteBatchSize
+	if f.WriteBatchSize > 0 {
+		batchSize = f.WriteBatchSize
 	}
-	defer batch.Close() // Always release the connection back to the pool
 
-	for i := range count {
+	f.log.Debug("writing fact batch", "table", f.schema.Name(), "count", count, "batchSize", batchSize)
+
+	insertSQL := fmt.Sprintf("INSERT INTO %s", f.TableName())
+	expectedColCount := len(f.cols)
+
+	for start := 0; start < count; start += batchSize {
+		end := min(start+batchSize, count)
+
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled during batch insert: %w", ctx.Err())
 		default:
 		}
 
-		// Get row data from callback
-		row, err := writeRowFn(i)
+		batch, err := conn.PrepareBatch(ctx, insertSQL)
 		if err != nil {
-			return fmt.Errorf("failed to get row data %d: %w", i, err)
+			return fmt.Errorf("failed to prepare batch: %w", err)
 		}
 
-		expectedColCount := len(f.cols)
-		if len(row) != expectedColCount {
-			return fmt.Errorf("row %d has %d columns, expected exactly %d", i, len(row), expectedColCount)
+		for i := start; i < end; i++ {
+			select {
+			case <-ctx.Done():
+				batch.Close()
+				return fmt.Errorf("context cancelled during batch insert: %w", ctx.Err())
+			default:
+			}
+
+			row, err := writeRowFn(i)
+			if err != nil {
+				batch.Close()
+				return fmt.Errorf("failed to get row data %d: %w", i, err)
+			}
+
+			if len(row) != expectedColCount {
+				batch.Close()
+				return fmt.Errorf("row %d has %d columns, expected exactly %d", i, len(row), expectedColCount)
+			}
+
+			if err := batch.Append(row...); err != nil {
+				batch.Close()
+				return fmt.Errorf("failed to append row %d: %w", i, err)
+			}
 		}
 
-		if err := batch.Append(row...); err != nil {
-			return fmt.Errorf("failed to append row %d: %w", i, err)
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("failed to send batch: %w", err)
 		}
+
+		f.log.Debug("wrote fact sub-batch", "table", f.schema.Name(), "start", start, "end", end, "total", count)
 	}
 
-	if err := batch.Send(); err != nil {
-		return fmt.Errorf("failed to send batch: %w", err)
-	}
-
-	f.log.Debug("wrote fact batch", "table", f.schema.Name(), "count", count)
 	return nil
 }


### PR DESCRIPTION
  ## Summary of Changes
  - `FactDataset.WriteBatch` now splits large inserts into sub-batches of 50,000 rows (configurable via `WriteBatchSize`), each with its own `PrepareBatch`/`Send` cycle
  - Reduces peak memory usage during latency backfill, where an entire epoch of device link and internet metro latency samples was previously buffered as a single ClickHouse batch
  - Adds per-sub-batch debug logging for progress visibility

  ## Testing Verification
  - `make build && make lint && make test` all pass
  - Existing `WriteBatch` unit tests cover the unchanged interface; sub-batching is transparent to callers