### PR TITLE
slack: fix silent error handling in OAuth and disconnect flows

### DIFF
--- a/web/src/components/settings-page.tsx
+++ b/web/src/components/settings-page.tsx
@@ -42,7 +42,9 @@ export function SettingsPage() {
     if (slackParam === 'installed') {
       setSlackMessage({ type: 'success', text: 'Slack workspace connected successfully.' })
       // Refresh installations list
-      getSlackInstallations().then(setInstallations).catch(() => {})
+      getSlackInstallations().then(setInstallations).catch(() => {
+        setSlackMessage({ type: 'warning', text: 'Slack workspace connected, but failed to refresh installations. Try reloading the page.' })
+      })
       window.history.replaceState({}, '', window.location.pathname)
     } else if (slackParam === 'confirm_takeover') {
       const team = params.get('team') || 'this workspace'
@@ -78,7 +80,9 @@ export function SettingsPage() {
     try {
       await confirmSlackInstallation(pendingId)
       setSlackMessage({ type: 'success', text: 'Slack workspace connected successfully.' })
-      getSlackInstallations().then(setInstallations).catch(() => {})
+      getSlackInstallations().then(setInstallations).catch(() => {
+        setSlackMessage({ type: 'warning', text: 'Workspace connected, but failed to refresh installations. Try reloading the page.' })
+      })
     } catch {
       setSlackMessage({ type: 'error', text: 'Failed to confirm installation. The request may have expired.' })
     } finally {


### PR DESCRIPTION
Follow-up to address post-close review comments on #17.

## Summary of Changes
- Surface warning messages to users when refreshing the Slack installations list fails after a successful OAuth install or takeover confirmation
- Return an error from `DeactivateSlackInstallation` when the target team_id does not exist
- Fail the disconnect request with a 502 when the Slack API uninstall call fails, instead of silently continuing with local deactivation

## Testing Verification
- Verified Go API builds cleanly
- Verified TypeScript type-checks pass