### PR TITLE
slack: strengthen unordered list preference in agent prompt

### DIFF
--- a/agent/pkg/workflow/prompts/SLACK.md
+++ b/agent/pkg/workflow/prompts/SLACK.md
@@ -7,7 +7,6 @@ Follow these Slack-specific formatting rules:
 ### Tables
 
 - You may use markdown tables when appropriate for presenting structured data.
-- Tables will be automatically converted to ASCII format for Slack rendering.
 - Keep tables concise - use only essential columns and rows.
 - For very large datasets, summarize key findings rather than showing all data.
 


### PR DESCRIPTION
## Summary of Changes
- Change Slack agent prompt from soft "avoid numbered lists" to hard "NEVER use numbered lists" directive to improve compliance — markdown-to-Slack conversion doesn't reliably render numbered lists, sometimes producing `1. 1. 1. 1.` instead of incrementing
- Remove implementation detail about ASCII table conversion from prompt to avoid confusing the model

## Testing Verification
- Slack-specific prompt-only changes; verified with dev Slack app installation