### PR TITLE
web: fix version check always showing update available

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -77,6 +77,8 @@ jobs:
           cd web
           bun install --frozen-lockfile
           bun run build
+        env:
+          BUILD_COMMIT: ${{ steps.v.outputs.short_sha }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,8 +6,12 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 function getGitCommit(): string {
+  // In CI, use the commit SHA passed via env var to match the API's build commit
+  if (process.env.BUILD_COMMIT) {
+    return process.env.BUILD_COMMIT
+  }
   try {
-    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim()
+    return execSync('git rev-parse --short=8 HEAD', { encoding: 'utf-8' }).trim()
   } catch {
     return 'unknown'
   }


### PR DESCRIPTION
## Summary of Changes
- Pass the computed short SHA to the Vite build via `BUILD_COMMIT` env var in the release workflow so the bundle commit matches the API's commit
- Validate both bundle and server commits are valid short SHAs before comparing, suppressing false notifications from bogus values like synthetic merge SHAs
- Expose `__DZ_BUILD_COMMIT__` on `globalThis` for debugging version mismatches in the browser console
- Use `git rev-parse --short=8` as local fallback to match the 8-char format used by the API

## Testing Verification
- Verified `__DZ_BUILD_COMMIT__` is accessible from the browser console and matches https://pr-29.data.malbeclabs.com/api/version
- Confirmed invalid SHAs (e.g. 40-char synthetic merge commits, `unknown`, `none`) are rejected by the validation and do not trigger the notification