### PR TITLE
ci: add short mode agent evals to go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: ./scripts/run-evals.sh --short --show-failures
+      - run: go test -short -tags evals -v ./agent/evals/...


### PR DESCRIPTION
## Summary of Changes

- Add `evals-short` job to the Go CI workflow that runs agent evals in short mode (code validation only, no API calls)

## Testing Verification

- Ran evals locally in short mode, all 39 tests passed