### PR TITLE
indexer: add laconic and velia contributor mappings

### DIFF
--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -29,11 +29,13 @@ var (
 		"cherry":   "Cherry Servers",
 		"cdrw":     "Cumberland/DRW",
 		"glxy":     "Galaxy",
+		"laconic":  "Laconic",
 		"latitude": "Latitude",
 		"rox":      "RockawayX",
 		"s3v":      "S3V",
 		"stakefac": "Staking Facilities",
 		"tsw":      "Terraswitch",
+		"velia":    "Velia",
 	}
 )
 


### PR DESCRIPTION
## Summary of Changes

- Add Laconic and Velia to the contributor name mappings in the serviceability view

## Testing Verification

- Verified in dev