### PR TITLE
web, api: fix chat response intermittently disappearing after streaming

### DIFF
--- a/web/src/hooks/use-chat.ts
+++ b/web/src/hooks/use-chat.ts
@@ -423,7 +423,6 @@ export function useChatStream(sessionId: string | undefined) {
               if (!converted.name && converted.messages.length <= 3) {
                 generateChatSessionTitle(converted.messages).then(result => {
                   if (result.title) {
-                    queryClient.invalidateQueries({ queryKey: chatKeys.detail(sessionId) })
                     queryClient.invalidateQueries({ queryKey: chatKeys.list() })
                   }
                 }).catch(() => {})


### PR DESCRIPTION
## Summary of Changes

- Fix race condition where the `done` SSE event was broadcast before session data was persisted to the database, causing the client's immediate `getSession` fetch to return stale data and overwrite the cache with missing response content
- Move `CompleteWorkflowRun` and `updateSessionContent` DB writes before broadcasting the `done` event in the workflow manager
- Remove unnecessary detail query invalidation after title generation that could trigger the same cache overwrite for new sessions

## Testing Verification

- Ask several questions in new and existing chat sessions, verify response always renders after streaming completes
- Verify sidebar title still updates for new sessions