### PR TITLE
web: fix latency showing 0ms on 100% packet loss

### DIFF
--- a/web/src/components/topology-graph.tsx
+++ b/web/src/components/topology-graph.tsx
@@ -3742,7 +3742,7 @@ export function TopologyGraph({
                 {hoveredEdge.contributorCode && (
                   <div>Contributor: <span className="text-foreground">{hoveredEdge.contributorCode}</span></div>
                 )}
-                <div>Latency: <span className="text-foreground">{hoveredEdge.latencyMs || (hoveredEdge.metric ? `${(hoveredEdge.metric / 1000).toFixed(2)}ms` : 'N/A')}</span></div>
+                <div>Latency: <span className="text-foreground">{hoveredEdge.latencyMs || 'N/A'}</span></div>
                 <div>Bandwidth: <span className="text-foreground">{hoveredEdge.bandwidth || 'N/A'}</span></div>
               </div>
             </div>

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -2990,7 +2990,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
                   </>
                 ) : (
                   <>
-                    <div>Latency: <span className="text-foreground">{hoveredLink.sampleCount > 0 ? `${(hoveredLink.latencyUs / 1000).toFixed(2)} ms` : 'N/A'}</span></div>
+                    <div>Latency: <span className="text-foreground">{hoveredLink.latencyUs > 0 ? `${(hoveredLink.latencyUs / 1000).toFixed(2)} ms` : 'N/A'}</span></div>
                     <div>Bandwidth: <span className="text-foreground">{formatBandwidth(hoveredLink.bandwidthBps)}</span></div>
                   </>
                 )}


### PR DESCRIPTION
## Summary of Changes

- Fix link hover popover in graph view incorrectly using ISIS routing metric as latency fallback
- Fix link hover popover in map view showing "0.00 ms" when samples exist but all packets are lost
- Both views now display "N/A" when no valid latency data is available

## Testing Verification

- Verified link popovers display correctly in graph and map views