### PR TITLE
build: add npm ecosystem and dependency groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,54 @@ updates:
     - "**/*"
     schedule:
       interval: "weekly"
+    groups:
+      aws:
+        patterns:
+        - "github.com/aws/*"
+      testcontainers:
+        patterns:
+        - "github.com/testcontainers/*"
+      chi:
+        patterns:
+        - "github.com/go-chi/*"
+      prometheus:
+        patterns:
+        - "github.com/prometheus/*"
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      react:
+        patterns:
+        - "react"
+        - "react-dom"
+        - "@types/react"
+        - "@types/react-dom"
+      solana:
+        patterns:
+        - "@solana/*"
+      tailwind:
+        patterns:
+        - "tailwindcss"
+        - "@tailwindcss/*"
+        - "tailwind-merge"
+      tanstack:
+        patterns:
+        - "@tanstack/*"
+      testing:
+        patterns:
+        - "vitest"
+        - "@testing-library/*"
+        - "jsdom"
+      linting:
+        patterns:
+        - "eslint"
+        - "eslint-plugin-*"
+        - "@eslint/*"
+        - "typescript-eslint"
+      vite:
+        patterns:
+        - "vite"
+        - "@vitejs/*"


### PR DESCRIPTION
## Summary of Changes

- Add npm ecosystem for `web/` frontend dependencies
- Add dependency groups for Go (aws, testcontainers, chi, prometheus)
- Add dependency groups for npm (react, solana, tailwind, tanstack, testing, linting, vite)

## Testing Verification

- Dependabot config syntax validated by schema