### PR TITLE
agent: fix multi-hop latency and metro path query reliability

### DIFF
--- a/agent/pkg/workflow/v3/prompts/SYSTEM.md
+++ b/agent/pkg/workflow/v3/prompts/SYSTEM.md
@@ -78,13 +78,17 @@ Examples: "What's the path from NYC to LON?", "What devices are reachable from T
 **CRITICAL - Path keywords ALWAYS mean Cypher:**
 If the question contains "path", "route", "shortest", "traverse", "hops", "reachable", or "connectivity" → use `execute_cypher`, NOT SQL. This applies even when metros are mentioned. The SQL `dz_vs_internet_latency_comparison` view is for latency metrics, NOT for finding paths.
 
+**CRITICAL - Latency between metros ALWAYS starts with Cypher:**
+When asked about latency between two metros (e.g., "what's the latency between NYC and Tokyo?"), ALWAYS use Cypher first to find the path and sum the link RTTs. SQL only has latency data for **directly-connected** metro pairs, so it will fail for multi-hop routes. Cypher handles both cases correctly.
+
 - "shortest path from NYC to Singapore" → **Cypher** (path finding)
-- "latency between NYC and Singapore" → **SQL** (metrics)
+- "latency between NYC and Singapore" → **Cypher** (find path, sum link RTTs)
 - "route from Tokyo to London" → **Cypher** (path finding)
-- "compare DZ vs internet for NYC-LON" → **SQL** (metrics comparison)
+- "compare DZ vs internet for NYC-LON" → **SQL** (metrics comparison for known direct link)
 
 **Decision matrix:**
 - **Listing, metrics, status → SQL** (show devices, link health, validator stats)
+- **Latency between metros → Cypher** (find path, sum committed RTT from links)
 - **Paths, reachability, impact → Cypher** (route finding, connectivity analysis)
 
 ### Combining Both Tools


### PR DESCRIPTION
## Summary of Changes
- Fix "latency between metros" questions to use Cypher instead of SQL (SQL only has directly-connected pairs, causing failures for multi-hop routes)
- Add explicit "Find Shortest Path Between Metros (by hop count)" pattern to CYPHER_CONTEXT.md with CRITICAL note about ORDER BY/LIMIT requirement
- Clarify that metro-to-metro Cypher queries MUST use ORDER BY/LIMIT since metros have multiple devices
- Strengthen multi-hop latency eval to require Cypher within first 2 queries (catches agent fumbling with SQL first)

## Testing Verification
- `MultiHopLatency` eval: was flaky (2/3 pass) on main, now passes consistently (3/3)
- `MetroToMetroShortestPath` eval: was flaky (2/3 pass) on main, now passes consistently (3/3)