### PR TITLE
web: fix multiple filters not being applied

### DIFF
--- a/web/src/components/validators-page.tsx
+++ b/web/src/components/validators-page.tsx
@@ -108,25 +108,77 @@ export function ValidatorsPage() {
   const searchParam = searchParams.get('search') || ''
   const searchFilters = parseSearchFilters(searchParam)
 
-  // Combine committed filters with live filter for API
-  // Use first committed filter OR live filter
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
-  const activeFilter = activeFilterRaw ? parseFilter(activeFilterRaw) : null
+  // Combine committed filters with live filter
+  // Live filter is combined with committed filters (all must match)
+  const allFilters = liveFilter
+    ? [...searchFilters, liveFilter]
+    : searchFilters
+
+  // Use first filter for server-side filtering, apply rest client-side
+  const serverFilterRaw = allFilters[0] || ''
+  const serverFilter = serverFilterRaw ? parseFilter(serverFilterRaw) : null
+  const clientFilters = allFilters.slice(1)
 
   const { data: response, isLoading, isFetching, error } = useQuery({
-    queryKey: ['validators', offset, sortField, sortDirection, activeFilterRaw],
+    queryKey: ['validators', offset, sortField, sortDirection, serverFilterRaw],
     queryFn: () => fetchValidators(
       PAGE_SIZE,
       offset,
       sortField,
       sortDirection,
-      activeFilter?.field,
-      activeFilter?.value
+      serverFilter?.field,
+      serverFilter?.value
     ),
     refetchInterval: 60000,
     placeholderData: keepPreviousData,
   })
-  const validators = response?.items ?? []
+
+  // Helper to check if a validator matches a single filter (for client-side filtering)
+  const matchesSingleFilter = (validator: NonNullable<typeof response>['items'][number], filterRaw: string): boolean => {
+    const filter = parseFilter(filterRaw)
+    const field = filter.field
+    const needle = filter.value.trim().toLowerCase()
+    if (!needle) return true
+
+    // Text matching for various fields
+    switch (field) {
+      case 'vote':
+        return validator.vote_pubkey.toLowerCase().includes(needle)
+      case 'node':
+        return validator.node_pubkey.toLowerCase().includes(needle)
+      case 'city':
+        return (validator.city || '').toLowerCase().includes(needle)
+      case 'country':
+        return (validator.country || '').toLowerCase().includes(needle)
+      case 'device':
+        return (validator.device_code || '').toLowerCase().includes(needle)
+      case 'version':
+        return (validator.version || '').toLowerCase().includes(needle)
+      case 'dz': {
+        const isDZ = validator.on_dz
+        return needle === 'yes' ? isDZ : needle === 'no' ? !isDZ : true
+      }
+      case 'all': {
+        // Search across multiple text fields
+        const textFields = [
+          validator.vote_pubkey,
+          validator.node_pubkey,
+          validator.city || '',
+          validator.country || '',
+          validator.device_code || '',
+          validator.version || '',
+        ]
+        return textFields.some(v => v.toLowerCase().includes(needle))
+      }
+      default:
+        return true
+    }
+  }
+
+  // Apply client-side filters to server results
+  const validators = (response?.items ?? []).filter(v =>
+    clientFilters.every(f => matchesSingleFilter(v, f))
+  )
   const onDZCount = response?.on_dz_count ?? 0
 
   const removeFilter = useCallback((filterToRemove: string) => {
@@ -176,7 +228,7 @@ export function ValidatorsPage() {
   // Reset to first page when filter changes
   useEffect(() => {
     setOffset(0)
-  }, [activeFilterRaw])
+  }, [allFilters])
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary of Changes

- Fix bug where only the first filter was applied when multiple filters were added via the UI
- All filters now combine with AND logic - items must match all filters to be shown
- Client-side filtered pages (devices, links) apply all filters in the filtering memo
- Server-side filtered pages (validators, gossip-nodes) send first filter to API and apply additional filters client-side

Fixes #76

## Testing Verification

- Manually test by applying multiple filters (e.g., `type:WAN` then `contributor:TSW`) on devices/links pages and confirming both filters are applied