### PR TITLE
api: add MCP GET discovery endpoint for connector validation

### DIFF
--- a/api/handlers/mcp.go
+++ b/api/handlers/mcp.go
@@ -28,9 +28,23 @@ func InitMCP() http.Handler {
 		return mcpHandler
 	}
 
-	mcpHandler = mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+	streamableHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return createMCPServer(r)
 	}, nil)
+
+	// Wrap the handler to support GET requests for discovery/health checks.
+	// Some MCP clients probe with GET before connecting, but Streamable HTTP
+	// only accepts GET for SSE with an active session.
+	mcpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.Header.Get("Mcp-Session-Id") == "" {
+			// Discovery/health check - return server info
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"doublezero","version":"1.0.0","protocol":"mcp","transport":"streamable-http"}`))
+			return
+		}
+		streamableHandler.ServeHTTP(w, r)
+	})
 
 	return mcpHandler
 }

--- a/api/handlers/mcp_test.go
+++ b/api/handlers/mcp_test.go
@@ -50,6 +50,28 @@ func parseSSEResponse(body string) (map[string]any, error) {
 	return response, nil
 }
 
+func TestMCPHandler_Discovery(t *testing.T) {
+	handler := handlers.InitMCP()
+	require.NotNil(t, handler)
+
+	// GET request without session ID should return server info (for discovery/health checks)
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var response map[string]any
+	err := json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "doublezero", response["name"])
+	assert.Equal(t, "1.0.0", response["version"])
+	assert.Equal(t, "mcp", response["protocol"])
+	assert.Equal(t, "streamable-http", response["transport"])
+}
+
 func TestMCPHandler_Initialize(t *testing.T) {
 	handler := handlers.InitMCP()
 	require.NotNil(t, handler)


### PR DESCRIPTION
## Summary of Changes

- Add wrapper around MCP Streamable HTTP handler to respond to GET requests without a session ID
- Returns server info JSON for discovery/health checks, enabling MCP clients that probe with GET before connecting

## Testing Verification

- Added `TestMCPHandler_Discovery` test for the new GET endpoint behavior
- All existing MCP handler tests pass