### PR TITLE
api: return 404 for well-known paths instead of SPA fallback

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -156,6 +156,15 @@ func spaHandler(staticDir, assetBucketURL string) http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Never serve SPA fallback for .well-known paths — they must 404
+		// if not explicitly handled. Returning 200 + HTML for OAuth
+		// discovery paths (e.g. /.well-known/oauth-protected-resource)
+		// causes MCP clients to think auth is misconfigured.
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			http.NotFound(w, r)
+			return
+		}
+
 		path := filepath.Join(staticDir, strings.TrimPrefix(r.URL.Path, "/"))
 
 		// Check if file exists locally


### PR DESCRIPTION
## Summary of Changes

- Return 404 for `/.well-known/*` paths instead of serving the SPA's `index.html`
- Fixes Claude Desktop MCP connector failing to connect because `/.well-known/oauth-protected-resource` returned `200 + text/html`, which MCP clients interpret as broken OAuth metadata rather than no auth required

## Testing Verification

- Verified `/.well-known/oauth-protected-resource` returns 404 instead of SPA HTML
- Verified SPA routing still works for all other paths