### PR TITLE
api: fix clickhouse connection pool exhaustion

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -113,7 +113,7 @@ func Load() error {
 		DialTimeout:     5 * time.Second,
 		MaxOpenConns:    30,
 		MaxIdleConns:    10,
-		ConnMaxLifetime: time.Hour,
+		ConnMaxLifetime: 10 * time.Minute,
 	}
 
 	// Enable TLS for ClickHouse Cloud (port 9440)
@@ -155,7 +155,7 @@ func Load() error {
 			DialTimeout:     5 * time.Second,
 			MaxOpenConns:    10,
 			MaxIdleConns:    5,
-			ConnMaxLifetime: time.Hour,
+			ConnMaxLifetime: 10 * time.Minute,
 		}
 		if secure {
 			envOpts.TLS = &tls.Config{}

--- a/api/handlers/stats.go
+++ b/api/handlers/stats.go
@@ -64,6 +64,7 @@ func GetStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
 
 	// Count validators on DZ (Solana validators connected via dz_users)
 	g.Go(func() error {

--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -247,6 +247,9 @@ func fetchStatusData(ctx context.Context) *StatusResponse {
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
+	// Limit concurrent ClickHouse queries to avoid exhausting the connection pool
+	// during cache refreshes (this function launches ~22 parallel queries).
+	g.SetLimit(10)
 
 	// Check database connectivity
 	g.Go(func() error {

--- a/api/handlers/timeline.go
+++ b/api/handlers/timeline.go
@@ -571,6 +571,7 @@ func GetTimeline(w http.ResponseWriter, r *http.Request) {
 	params := parseTimelineParams(r)
 
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
 	var (
 		deviceEvents      []TimelineEvent
 		linkEvents        []TimelineEvent
@@ -3548,6 +3549,7 @@ func fetchDefaultTimelineData(ctx context.Context) *TimelineResponse {
 	offset := 0
 
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
 	var (
 		deviceEvents        []TimelineEvent
 		linkEvents          []TimelineEvent


### PR DESCRIPTION
## Summary of Changes
- Cap errgroup concurrency to 10 in status, timeline, and stats handlers to prevent 10-22 simultaneous queries from saturating the connection pool during cache refreshes
- Cache schema fetcher results with a 60-second TTL to eliminate 2 redundant ClickHouse queries per agent request
- Add 5-minute timeout to background workflow contexts to prevent indefinite connection holds from stuck LLM calls
- Reduce ConnMaxLifetime from 1 hour to 10 minutes to recycle stale connections faster

## Testing Verification
- Audited all ClickHouse Query/QueryRow call sites across handlers to confirm rows.Close() patterns are correct
- Reviewed connection pool lifecycle to identify exhaustion vectors under concurrent load