### PR TITLE
api: fix clickhouse connection pool exhaustion from cache refreshes

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -111,7 +111,7 @@ func Load() error {
 			Password: cfg.Password,
 		},
 		DialTimeout:     5 * time.Second,
-		MaxOpenConns:    30,
+		MaxOpenConns:    50,
 		MaxIdleConns:    10,
 		ConnMaxLifetime: 10 * time.Minute,
 	}

--- a/api/handlers/status_cache.go
+++ b/api/handlers/status_cache.go
@@ -14,7 +14,7 @@ const cacheStopTimeout = 5 * time.Second
 
 // maxConcurrentRefreshes limits how many cache refreshes can run simultaneously.
 // With a limit of 2, worst case is status (10 queries) + timeline (10 queries)
-// = 20 connections, leaving 10 of the 30-connection pool for API/agent requests.
+// = 20 connections, leaving 30 of the 50-connection pool for API/agent requests.
 const maxConcurrentRefreshes = 2
 
 // refreshCheckInterval is how often the refresh loop checks for due refreshes.
@@ -161,6 +161,9 @@ func (c *StatusCache) refreshLoop() {
 			for i, entry := range entries {
 				if now.Sub(lastRefresh[i]) < entry.interval {
 					continue
+				}
+				if c.ctx.Err() != nil {
+					break
 				}
 				i, entry := i, entry
 				g.Go(func() error {


### PR DESCRIPTION
## Summary of Changes
- Replace 7 independent cache refresh goroutines with a single coordinated loop that limits concurrent refreshes to 2 via errgroup, preventing all refreshers from hitting ClickHouse simultaneously when their ticker intervals align (30s/60s/120s share common multiples)
- Priority-order refreshes so status and timeline (which gate readyz) run before lower-priority caches
- Increase ClickHouse connection pool from 30 to 50 to provide headroom for API/agent requests during cache refreshes

## Testing Verification
- Existing cache tests pass (TestStatusCache_RefreshStatusKeepsStaleData, TestStatusCache_RefreshTimelineKeepsStaleData, TestStatusCache_RefreshOutagesKeepsStaleData)