### PR TITLE
web: fix timeline filter dropdowns clipped by overflow-hidden

### DIFF
--- a/web/src/components/timeline-filters.tsx
+++ b/web/src/components/timeline-filters.tsx
@@ -441,8 +441,8 @@ export function TimelineFilters({
         {/* Collapsible advanced filters */}
         <div
           className={cn(
-            'overflow-hidden transition-[max-height,opacity] duration-200',
-            advancedOpen ? 'max-h-[200px] opacity-100 mt-2' : 'max-h-0 opacity-0'
+            'transition-[max-height,opacity] duration-200',
+            advancedOpen ? 'max-h-[200px] opacity-100 mt-2 overflow-visible' : 'max-h-0 opacity-0 overflow-hidden'
           )}
         >
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-border bg-muted/20 p-3">


### PR DESCRIPTION
## Summary of Changes

- Fix advanced filter dropdowns being clipped on the timeline page by only applying `overflow-hidden` during the collapse animation, switching to `overflow-visible` when the filter bar is open

## Testing Verification

- Verified filter dropdowns render fully when opened on the timeline page