### PR TITLE
web: graceful fallback when WebGL/GPU is unavailable

### DIFF
--- a/web/src/components/topology-page.tsx
+++ b/web/src/components/topology-page.tsx
@@ -1,15 +1,73 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, lazy, Suspense, Component, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { fetchTopology } from '@/lib/api'
 import { TopologyMap } from '@/components/topology-map'
 import { TopologyGraph } from '@/components/topology-graph'
-import { TopologyGlobe } from '@/components/topology-globe'
 import { TopologyProvider } from '@/components/topology'
-import { Globe } from 'lucide-react'
+import { Globe, MonitorX } from 'lucide-react'
+
+// Lazy-load the globe to avoid importing three.js/WebGL modules when GPU is unavailable
+const TopologyGlobe = lazy(() => import('@/components/topology-globe').then(m => ({ default: m.TopologyGlobe })))
 
 // Only show loading indicator after this delay to avoid flash on fast loads
 const LOADING_DELAY_MS = 300
+
+function isWebGLAvailable(): boolean {
+  try {
+    const canvas = document.createElement('canvas')
+    return !!(canvas.getContext('webgl2') || canvas.getContext('webgl'))
+  } catch {
+    return false
+  }
+}
+
+function GlobeUnsupported() {
+  return (
+    <div className="absolute inset-0 z-0 flex items-center justify-center bg-background">
+      <div className="flex flex-col items-center gap-3 max-w-md text-center px-4">
+        <MonitorX className="h-10 w-10 text-muted-foreground" />
+        <div className="text-sm font-medium text-foreground">3D Globe Unavailable</div>
+        <div className="text-sm text-muted-foreground">
+          Your browser does not support WebGL, which is required for the 3D globe view.
+          Try enabling hardware acceleration in your browser settings, or use the{' '}
+          <a href="/topology/map" className="underline text-foreground hover:text-foreground/80">map view</a> instead.
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface GlobeErrorBoundaryState {
+  hasError: boolean
+}
+
+class GlobeErrorBoundary extends Component<{ children: ReactNode }, GlobeErrorBoundaryState> {
+  state: GlobeErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): GlobeErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="absolute inset-0 z-0 flex items-center justify-center bg-background">
+          <div className="flex flex-col items-center gap-3 max-w-md text-center px-4">
+            <MonitorX className="h-10 w-10 text-muted-foreground" />
+            <div className="text-sm font-medium text-foreground">3D Globe Unavailable</div>
+            <div className="text-sm text-muted-foreground">
+              Something went wrong loading the 3D globe. Your browser or device may not support the required graphics features.
+              Try the{' '}
+              <a href="/topology/map" className="underline text-foreground hover:text-foreground/80">map view</a> instead.
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
 
 type ViewMode = 'map' | 'graph' | 'globe'
 
@@ -99,12 +157,20 @@ export function TopologyPage({ view }: TopologyPageProps) {
         )}
 
         {view === 'globe' && data && (
-          <TopologyGlobe
-            metros={data.metros}
-            devices={data.devices}
-            links={data.links}
-            validators={data.validators}
-          />
+          isWebGLAvailable() ? (
+            <GlobeErrorBoundary>
+              <Suspense fallback={<TopologyLoading />}>
+                <TopologyGlobe
+                  metros={data.metros}
+                  devices={data.devices}
+                  links={data.links}
+                  validators={data.validators}
+                />
+              </Suspense>
+            </GlobeErrorBoundary>
+          ) : (
+            <GlobeUnsupported />
+          )
         )}
       </div>
     </TopologyProvider>


### PR DESCRIPTION
## Summary of Changes
- Show a friendly message on the globe page when WebGL is not supported instead of crashing the app
- Wrap the globe component in an error boundary to catch runtime GPU failures
- Fallback message links to the map view as an alternative

<img width="1280" height="720" alt="globe-fallback" src="https://github.com/user-attachments/assets/40ee371b-b7ae-448f-ac6f-270efeb67137" />

## Testing Verification
- Temporarily forced `isWebGLAvailable()` to return `false` and confirmed the fallback message renders on `/topology/globe`