### PR TITLE
status: show links as down when is_down flag is set

### DIFF
--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -576,6 +576,9 @@ function LinkRow({ link, linksWithIssues, criticalityMap, bucketMinutes = 60, da
             </div>
             {issueReasons.length > 0 && (
               <div className="flex flex-wrap gap-1 mt-1">
+                {issueReasons.includes('down') && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded font-medium" style={{ backgroundColor: 'rgba(17, 24, 39, 0.15)', color: '#111827' }}>Down</span>
+                )}
                 {issueReasons.includes('packet_loss') && (
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-medium" style={{ backgroundColor: 'rgba(168, 85, 247, 0.15)', color: '#9333ea' }}>Loss</span>
                 )}

--- a/web/src/components/status-timeline.tsx
+++ b/web/src/components/status-timeline.tsx
@@ -32,18 +32,20 @@ function formatTimeRange(isoString: string, bucketMinutes: number = 60): string 
   return `${formatDate(isoString)} ${startTime} — ${endTime}`
 }
 
-const statusColors = {
+const statusColors: Record<string, string> = {
   healthy: 'bg-green-500',
   degraded: 'bg-amber-500',
   unhealthy: 'bg-red-500',
+  down: 'bg-gray-900 dark:bg-gray-950',
   no_data: 'bg-transparent border border-gray-200 dark:border-gray-700',
   disabled: 'bg-gray-500 dark:bg-gray-700',
 }
 
-const statusLabels = {
+const statusLabels: Record<string, string> = {
   healthy: 'Healthy',
   degraded: 'Degraded',
   unhealthy: 'Unhealthy',
+  down: 'Down',
   no_data: 'No Data',
   disabled: 'Disabled',
 }
@@ -71,7 +73,7 @@ function hasInterfaceIssues(hour: LinkHourStatus): boolean {
   )
 }
 
-function getEffectiveStatus(hour: LinkHourStatus, committedRttUs?: number): 'healthy' | 'degraded' | 'unhealthy' | 'no_data' | 'disabled' {
+function getEffectiveStatus(hour: LinkHourStatus, committedRttUs?: number): string {
   // Keep original status if not healthy
   if (hour.status !== 'healthy') {
     return hour.status
@@ -181,9 +183,10 @@ export function StatusTimeline({ hours, committedRttUs, bucketMinutes = 60, time
                     effectiveStatus === 'healthy' ? 'text-green-600 dark:text-green-400' :
                     effectiveStatus === 'degraded' ? 'text-amber-600 dark:text-amber-400' :
                     effectiveStatus === 'unhealthy' ? 'text-red-600 dark:text-red-400' :
+                    effectiveStatus === 'down' ? 'text-gray-900 dark:text-gray-300' :
                     'text-muted-foreground'
                   }`}>
-                    {statusLabels[effectiveStatus]}
+                    {statusLabels[effectiveStatus] || effectiveStatus}
                   </div>
                   {/* Reasons */}
                   {(() => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1362,8 +1362,9 @@ export interface LinkHistory {
   side_z_device: string
   bandwidth_bps: number
   committed_rtt_us: number
+  is_down?: boolean
   hours: LinkHourStatus[]
-  issue_reasons: string[] // "packet_loss", "high_latency", "drained", "no_data", "interface_errors", "discards", "carrier_transitions"
+  issue_reasons: string[] // "packet_loss", "high_latency", "drained", "no_data", "interface_errors", "discards", "carrier_transitions", "down"
 }
 
 export interface LinkHistoryResponse {


### PR DESCRIPTION
## Summary of Changes
- Query `is_down` from `dz_links_health_current` in the link history endpoint and expose it on `LinkHistory` responses
- Links with 100% recent packet loss now classify as "down" (highest priority) instead of "unhealthy" on the status page
- Add "Down" badge, issue filter, progress bar segment, and timeline color (dark gray/black) to the frontend

## Testing Verification
- Confirmed down link (tyo001-dz002:sin001-dz002) shows correctly on the status page overview

Closes #81