### PR TITLE
agent: use claude-haiku-4-5 latest alias instead of pinned model

### DIFF
--- a/agent/evals/cypher_generation_test.go
+++ b/agent/evals/cypher_generation_test.go
@@ -48,7 +48,7 @@ func runTest_CypherGenerationLiteral(t *testing.T) {
 
 	// Create LLM client
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaude3_5Haiku20241022,
+		anthropic.ModelClaudeHaiku4_5,
 		1024,
 		"cypher-gen-eval",
 	)
@@ -191,7 +191,7 @@ func runTest_CypherGenerationPreserveQuery(t *testing.T) {
 
 	// Create LLM client
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaude3_5Haiku20241022,
+		anthropic.ModelClaudeHaiku4_5,
 		1024,
 		"cypher-gen-eval",
 	)
@@ -402,7 +402,7 @@ func TestLake_Agent_Evals_Anthropic_CypherExecutionIntegration(t *testing.T) {
 
 	// Create LLM client
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaude3_5Haiku20241022,
+		anthropic.ModelClaudeHaiku4_5,
 		1024,
 		"cypher-exec-eval",
 	)

--- a/agent/evals/helpers_test.go
+++ b/agent/evals/helpers_test.go
@@ -175,7 +175,7 @@ Respond with only "YES" or "NO" followed by a brief explanation.`, currentDate, 
 
 	// Use Anthropic Haiku for evaluation - fast and reliable
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaudeHaiku4_5_20251001,
+		anthropic.ModelClaudeHaiku4_5,
 		1024, // Short response needed for YES/NO + explanation
 		"eval",
 	)
@@ -329,7 +329,7 @@ func newAnthropicLLMClient(t *testing.T) workflow.LLMClient {
 	require.NotEmpty(t, apiKey, "ANTHROPIC_API_KEY must be set for Anthropic tests")
 
 	return workflow.NewAnthropicLLMClient(
-		anthropic.ModelClaudeHaiku4_5_20251001, // Use Haiku for faster/cheaper eval tests
+		anthropic.ModelClaudeHaiku4_5, // Use Haiku for faster/cheaper eval tests
 		4096,
 	)
 }

--- a/agent/evals/sql_generation_literal_test.go
+++ b/agent/evals/sql_generation_literal_test.go
@@ -48,7 +48,7 @@ func runTest_SQLGenerationLiteral(t *testing.T) {
 
 	// Create LLM client - use Haiku like the real endpoint
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaude3_5Haiku20241022,
+		anthropic.ModelClaudeHaiku4_5,
 		1024,
 		"sql-gen-eval",
 	)
@@ -137,7 +137,7 @@ func runTest_SQLGenerationPreserveQuery(t *testing.T) {
 
 	// Create LLM client
 	llmClient := workflow.NewAnthropicLLMClientWithName(
-		anthropic.ModelClaude3_5Haiku20241022,
+		anthropic.ModelClaudeHaiku4_5,
 		1024,
 		"sql-gen-eval",
 	)

--- a/api/handlers/auto_generate.go
+++ b/api/handlers/auto_generate.go
@@ -112,7 +112,7 @@ Respond with ONLY one word: either "sql" or "cypher"`
 
 	start := time.Now()
 	msg, err := client.Messages.New(ctx, anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaude3_5Haiku20241022,
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 10,
 		System: []anthropic.TextBlockParam{
 			{Type: "text", Text: systemPrompt},

--- a/api/handlers/chat.go
+++ b/api/handlers/chat.go
@@ -143,7 +143,7 @@ func Chat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create workflow components
-	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaude3_5Haiku20241022, 4096)
+	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaudeHaiku4_5, 4096)
 	querier := NewDBQuerier()
 	schemaFetcher := NewDBSchemaFetcher()
 
@@ -533,7 +533,7 @@ func Complete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a simple LLM client
-	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaude3_5Haiku20241022, 256)
+	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaudeHaiku4_5, 256)
 
 	// Simple completion with minimal system prompt
 	response, err := llm.Complete(r.Context(), "You are a helpful assistant. Respond concisely.", req.Message)

--- a/api/handlers/cypher_generate.go
+++ b/api/handlers/cypher_generate.go
@@ -320,7 +320,7 @@ func generateCypherWithAnthropic(schema, prompt string, history []HistoryMessage
 
 	start := time.Now()
 	msg, err := client.Messages.New(context.Background(), anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaude3_5Haiku20241022,
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 1024,
 		System: []anthropic.TextBlockParam{
 			{Type: "text", Text: systemPrompt},
@@ -355,7 +355,7 @@ func streamCypherWithAnthropic(schema, prompt string, history []HistoryMessage, 
 
 	start := time.Now()
 	stream := client.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaude3_5Haiku20241022,
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 1024,
 		System: []anthropic.TextBlockParam{
 			{Type: "text", Text: systemPrompt},

--- a/api/handlers/generate.go
+++ b/api/handlers/generate.go
@@ -269,7 +269,7 @@ func streamWithAnthropic(ctx context.Context, schema, prompt string, history []H
 	systemPrompt := buildSystemPrompt(schema)
 
 	// Start Sentry span for AI monitoring
-	model := anthropic.ModelClaude3_5Haiku20241022
+	model := anthropic.ModelClaudeHaiku4_5
 	span := sentry.StartSpan(ctx, "gen_ai.chat", sentry.WithDescription(fmt.Sprintf("chat %s (stream)", model)))
 	span.SetData("gen_ai.operation.name", "chat")
 	span.SetData("gen_ai.request.model", string(model))
@@ -371,7 +371,7 @@ func generateWithAnthropic(ctx context.Context, schema, prompt string, history [
 	client := anthropic.NewClient()
 
 	// Start Sentry span for AI monitoring
-	model := anthropic.ModelClaude3_5Haiku20241022
+	model := anthropic.ModelClaudeHaiku4_5
 	span := sentry.StartSpan(ctx, "gen_ai.chat", sentry.WithDescription(fmt.Sprintf("chat %s", model)))
 	span.SetData("gen_ai.operation.name", "chat")
 	span.SetData("gen_ai.request.model", string(model))

--- a/api/handlers/visualize.go
+++ b/api/handlers/visualize.go
@@ -60,7 +60,7 @@ func RecommendVisualization(w http.ResponseWriter, r *http.Request) {
 	client := anthropic.NewClient()
 	start := time.Now()
 	message, err := client.Messages.New(r.Context(), anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaude3_5Haiku20241022,
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 1024,
 		Messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),

--- a/api/handlers/workflow_manager.go
+++ b/api/handlers/workflow_manager.go
@@ -458,7 +458,7 @@ func (m *WorkflowManager) runWorkflow(
 	}
 
 	// Create workflow components
-	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaude3_5Haiku20241022, 4096)
+	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaudeHaiku4_5, 4096)
 	querier := NewDBQuerier()
 	schemaFetcher := NewDBSchemaFetcher()
 
@@ -882,7 +882,7 @@ func (m *WorkflowManager) resumeWorkflow(
 	}
 
 	// Create workflow components
-	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaude3_5Haiku20241022, 4096)
+	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaudeHaiku4_5, 4096)
 	querier := NewDBQuerier()
 	schemaFetcher := NewDBSchemaFetcher()
 

--- a/slack/bot/workflow_runner.go
+++ b/slack/bot/workflow_runner.go
@@ -69,7 +69,7 @@ func (r *WorkflowRunner) ChatStream(
 	}
 
 	// Create workflow components
-	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaude3_5Haiku20241022, 4096)
+	llm := workflow.NewAnthropicLLMClient(anthropic.ModelClaudeHaiku4_5, 4096)
 	querier := handlers.NewDBQuerier()
 	schemaFetcher := handlers.NewDBSchemaFetcher()
 


### PR DESCRIPTION
## Summary of Changes
- Replace deprecated `claude-3-5-haiku-20241022` with the `claude-haiku-4-5` latest alias across all API handlers, Slack bot, and eval tests
- Prevents future deprecation breakage by using the auto-updating alias instead of a date-pinned model ID

## Testing Verification
- Verified the API server builds successfully
- Confirmed chat works after restarting the API with the new model alias