### PR TITLE
web: standardize topology overlay panel styling

### DIFF
--- a/web/src/components/topology/overlays/ContributorsOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/ContributorsOverlayPanel.tsx
@@ -1,4 +1,5 @@
-import { Building2 } from 'lucide-react'
+import { Building2, X } from 'lucide-react'
+import { useTopology } from '../TopologyContext'
 
 interface ContributorInfo {
   code: string
@@ -24,6 +25,8 @@ export function ContributorsOverlayPanel({
   totalLinkCount,
   isLoading,
 }: ContributorsOverlayPanelProps) {
+  const { overlays, toggleOverlay } = useTopology()
+
   // Sort contributors by device count descending
   const sortedContributors = Array.from(contributorInfoMap.entries())
     .map(([pk, info]) => ({
@@ -37,9 +40,21 @@ export function ContributorsOverlayPanel({
 
   return (
     <div className="p-3 text-xs">
-      <div className="flex items-center gap-1.5 mb-2">
-        <Building2 className="h-3.5 w-3.5 text-purple-500" />
-        <span className="font-medium">Contributors</span>
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium flex items-center gap-1.5">
+          <Building2 className="h-3.5 w-3.5 text-purple-500" />
+          Contributors
+        </span>
+        <button
+          onClick={() => {
+            if (overlays.contributorDevices) toggleOverlay('contributorDevices')
+            if (overlays.contributorLinks) toggleOverlay('contributorLinks')
+          }}
+          className="p-1 hover:bg-[var(--muted)] rounded"
+          title="Close"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
 
       {isLoading && (

--- a/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
@@ -1,3 +1,6 @@
+import { Monitor, X } from 'lucide-react'
+import { useTopology } from '../TopologyContext'
+
 // Device type colors (must match topology-graph.tsx and topology-map.tsx)
 // Avoid green/red (status colors) and blue/purple (link colors)
 const DEVICE_TYPE_COLORS: Record<string, { light: string; dark: string }> = {
@@ -15,16 +18,25 @@ interface DeviceTypeOverlayPanelProps {
 }
 
 export function DeviceTypeOverlayPanel({ isDark, deviceCounts }: DeviceTypeOverlayPanelProps) {
+  const { toggleOverlay } = useTopology()
+
   return (
-    <div className="p-4 space-y-4">
-      <div>
-        <h3 className="text-sm font-medium mb-2">Device Types</h3>
-        <p className="text-xs text-muted-foreground mb-3">
-          Devices are colored by their network role type.
-        </p>
+    <div className="p-3 text-xs">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium flex items-center gap-1.5">
+          <Monitor className="h-3.5 w-3.5 text-blue-500" />
+          Device Types
+        </span>
+        <button
+          onClick={() => toggleOverlay('deviceType')}
+          className="p-1 hover:bg-[var(--muted)] rounded"
+          title="Close"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         {DEVICE_TYPES.map((type) => {
           const colors = DEVICE_TYPE_COLORS[type] || DEVICE_TYPE_COLORS.default
           const count = deviceCounts?.[type] ?? 0
@@ -37,10 +49,10 @@ export function DeviceTypeOverlayPanel({ isDark, deviceCounts }: DeviceTypeOverl
                     backgroundColor: isDark ? colors.dark : colors.light,
                   }}
                 />
-                <span className="text-sm capitalize">{type}</span>
+                <span className="capitalize">{type}</span>
               </div>
               {deviceCounts && (
-                <span className="text-xs text-muted-foreground">{count}</span>
+                <span className="text-muted-foreground">{count}</span>
               )}
             </div>
           )

--- a/web/src/components/topology/overlays/LinkTypeOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/LinkTypeOverlayPanel.tsx
@@ -1,3 +1,6 @@
+import { Cable, X } from 'lucide-react'
+import { useTopology } from '../TopologyContext'
+
 // Link type colors (distinct from device type colors: yellow, orange, cyan)
 // Avoid green/red as those indicate status
 // eslint-disable-next-line react-refresh/only-export-components
@@ -14,21 +17,30 @@ interface LinkTypeOverlayPanelProps {
 }
 
 export function LinkTypeOverlayPanel({ isDark, linkCounts }: LinkTypeOverlayPanelProps) {
+  const { toggleOverlay } = useTopology()
+
   // Get all link types from counts, or use defaults
   const linkTypes = linkCounts
     ? Object.keys(linkCounts).filter(type => type !== 'Inter-Metro').sort()
     : ['WAN', 'DZX']
 
   return (
-    <div className="p-4 space-y-4">
-      <div>
-        <h3 className="text-sm font-medium mb-2">Link Types</h3>
-        <p className="text-xs text-muted-foreground mb-3">
-          Links are colored by their connection type.
-        </p>
+    <div className="p-3 text-xs">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium flex items-center gap-1.5">
+          <Cable className="h-3.5 w-3.5 text-blue-500" />
+          Link Types
+        </span>
+        <button
+          onClick={() => toggleOverlay('linkType')}
+          className="p-1 hover:bg-[var(--muted)] rounded"
+          title="Close"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         {linkTypes.map((type) => {
           const colors = LINK_TYPE_COLORS[type] || LINK_TYPE_COLORS.default
           const count = linkCounts?.[type] ?? 0
@@ -41,16 +53,15 @@ export function LinkTypeOverlayPanel({ isDark, linkCounts }: LinkTypeOverlayPane
                     backgroundColor: isDark ? colors.dark : colors.light,
                   }}
                 />
-                <span className="text-sm">{type}</span>
+                <span>{type}</span>
               </div>
               {linkCounts && (
-                <span className="text-xs text-muted-foreground">{count}</span>
+                <span className="text-muted-foreground">{count}</span>
               )}
             </div>
           )
         })}
       </div>
-
     </div>
   )
 }

--- a/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
@@ -263,9 +263,9 @@ export function MulticastTreesOverlayPanel({
   return (
     <div className="p-3 text-xs">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <span className="font-medium flex items-center gap-1.5 text-sm">
-          <Radio className="h-4 w-4 text-purple-500" />
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium flex items-center gap-1.5">
+          <Radio className="h-3.5 w-3.5 text-purple-500" />
           Multicast
         </span>
         <button
@@ -273,7 +273,7 @@ export function MulticastTreesOverlayPanel({
           className="p-1 hover:bg-[var(--muted)] rounded"
           title="Close"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-3 w-3" />
         </button>
       </div>
 

--- a/web/src/components/topology/overlays/ValidatorsOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/ValidatorsOverlayPanel.tsx
@@ -1,4 +1,5 @@
-import { Users } from 'lucide-react'
+import { Users, X } from 'lucide-react'
+import { useTopology } from '../TopologyContext'
 import type { TopologyValidator } from '@/lib/api'
 
 interface ValidatorsOverlayPanelProps {
@@ -10,6 +11,8 @@ export function ValidatorsOverlayPanel({
   validators,
   isLoading,
 }: ValidatorsOverlayPanelProps) {
+  const { toggleOverlay } = useTopology()
+
   // Calculate totals
   const totalValidators = validators.length
   const totalStakeSol = validators.reduce((sum, v) => sum + (v.stake_sol ?? 0), 0)
@@ -36,9 +39,18 @@ export function ValidatorsOverlayPanel({
 
   return (
     <div className="p-3 text-xs">
-      <div className="flex items-center gap-1.5 mb-2">
-        <Users className="h-3.5 w-3.5 text-purple-500" />
-        <span className="font-medium">Validators</span>
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium flex items-center gap-1.5">
+          <Users className="h-3.5 w-3.5 text-purple-500" />
+          Validators
+        </span>
+        <button
+          onClick={() => toggleOverlay('validators')}
+          className="p-1 hover:bg-[var(--muted)] rounded"
+          title="Close"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
 
       {isLoading && (


### PR DESCRIPTION
## Summary of Changes

- Standardize all topology overlay panels to consistent Pattern B structure (`p-3 text-xs` wrapper, icon + title + X close button header row)
- Add close buttons to DeviceType, LinkType, Contributors, and Validators overlay panels
- Normalize Multicast overlay header icon and close button sizing to match other panels
- Remove descriptive paragraphs from DeviceType and LinkType panels in favor of compact legend-style layout

## Testing Verification

- Verified `bun run build` passes with no TypeScript errors
- Visual inspection of all modified overlay panels: DeviceType, LinkType, Contributors, Validators, Multicast
- Confirmed X close buttons dismiss their respective overlays