### PR TITLE
agent: fix hop count reporting in cypher context

### DIFF
--- a/agent/evals/multi_hop_latency_test.go
+++ b/agent/evals/multi_hop_latency_test.go
@@ -126,6 +126,11 @@ func runTest_MultiHopLatency(t *testing.T, llmFactory LLMClientFactory) {
 			ExpectedValue: "Does NOT mention NYC-LON, SIN-HKG, or other distractor link latencies as the answer",
 			Rationale:     "Distractor links have telemetry but are not on the TYO-AMS path",
 		},
+		{
+			Description:   "Response correctly reports the hop count as 2 hops",
+			ExpectedValue: "Says '2 hops' or '2 links' for the TYO-FRA-AMS path. Must NOT say '4 hops'.",
+			Rationale:     "The path traverses 2 links (TYO-FRA and FRA-AMS) which is 2 hops, not 4. length(path) returns 4 edges but that equals 2 hops.",
+		},
 	}
 	isCorrect, err := evaluateResponse(t, ctx, question, response, expectations...)
 	require.NoError(t, err)

--- a/agent/evals/network_paths_test.go
+++ b/agent/evals/network_paths_test.go
@@ -397,6 +397,11 @@ func runTest_MetroToMetroShortestPath(t *testing.T, llmFactory LLMClientFactory)
 			ExpectedValue: "Describes one clear path, not a mix of segments from different paths",
 			Rationale:     "Query asked for 'shortest path' (singular), should return the one shortest",
 		},
+		{
+			Description:   "Response correctly reports the hop count as 1 hop for the direct link",
+			ExpectedValue: "Says '1 hop' or 'direct link' or 'single hop'. Must NOT say '2 hops' for the direct NYC-LON path.",
+			Rationale:     "A direct link between two devices is 1 hop (1 link traversal), not 2. length(path) returns 2 edges but that equals 1 hop.",
+		},
 	}
 	isCorrect, err := evaluateResponse(t, ctx, question, response, expectations...)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary of Changes
- Add hop count definition to CYPHER_CONTEXT.md clarifying that 1 hop = 1 link = 2 CONNECTS edges, and that `length(path) / 2` gives the true hop count
- Fix all example Cypher queries that incorrectly aliased `length(path)` as hops (was causing the agent to report direct links as "2 hops" instead of "1 hop")
- Add hop count accuracy expectations to NetworkPaths and MultiHopLatency evals

## Testing Verification
- NetworkPaths eval passes, now verifying direct NYC-LON link is reported as 1 hop
- MultiHopLatency eval passes, now verifying TYO-FRA-AMS path is reported as 2 hops