### PR TITLE
api: scope fact table queries by time range

### DIFF
--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -131,9 +131,11 @@ func GetValidators(w http.ResponseWriter, r *http.Request) {
 					ELSE 0
 				END as skip_rate
 			FROM fact_solana_block_production
-			WHERE (leader_identity_pubkey, event_ts) IN (
+			WHERE event_ts >= now() - INTERVAL 1 DAY
+				AND (leader_identity_pubkey, event_ts) IN (
 				SELECT leader_identity_pubkey, max(event_ts)
 				FROM fact_solana_block_production
+				WHERE event_ts >= now() - INTERVAL 1 DAY
 				GROUP BY leader_identity_pubkey
 			)
 		),
@@ -367,9 +369,11 @@ func GetValidator(w http.ResponseWriter, r *http.Request) {
 					ELSE 0
 				END as skip_rate
 			FROM fact_solana_block_production
-			WHERE (leader_identity_pubkey, event_ts) IN (
+			WHERE event_ts >= now() - INTERVAL 1 DAY
+				AND (leader_identity_pubkey, event_ts) IN (
 				SELECT leader_identity_pubkey, max(event_ts)
 				FROM fact_solana_block_production
+				WHERE event_ts >= now() - INTERVAL 1 DAY
 				GROUP BY leader_identity_pubkey
 			)
 		)

--- a/api/handlers/validators_test.go
+++ b/api/handlers/validators_test.go
@@ -1,0 +1,133 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/malbeclabs/lake/api/config"
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedValidatorData inserts minimal dimension and fact data for validator queries.
+// Uses _history tables (SCD2 pattern) since the schema comes from migrations.
+func seedValidatorData(t *testing.T) {
+	ctx := t.Context()
+
+	// Vote account
+	require.NoError(t, config.DB.Exec(ctx, `INSERT INTO dim_solana_vote_accounts_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 vote_pubkey, epoch, node_pubkey, activated_stake_lamports, epoch_vote_account, commission_percentage)
+		VALUES
+		('vote1', now(), now(), generateUUIDv4(), 0, 1,
+		 'vote1', 100, 'node1', 1000000000000, 'true', 5)`))
+
+	// Gossip node
+	require.NoError(t, config.DB.Exec(ctx, `INSERT INTO dim_solana_gossip_nodes_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pubkey, epoch, gossip_ip, gossip_port, tpuquic_ip, tpuquic_port, version)
+		VALUES
+		('node1', now(), now(), generateUUIDv4(), 0, 1,
+		 'node1', 100, '1.2.3.4', 8001, '', 0, '2.0.0')`))
+
+	// Block production fact with recent data
+	require.NoError(t, config.DB.Exec(ctx, `INSERT INTO fact_solana_block_production
+		(epoch, event_ts, ingested_at, leader_identity_pubkey, leader_slots_assigned_cum, blocks_produced_cum)
+		VALUES
+		(100, now() - INTERVAL 30 MINUTE, now(), 'node1', 100, 95)`))
+
+	// GeoIP record
+	require.NoError(t, config.DB.Exec(ctx, `INSERT INTO dim_geoip_records_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 ip, asn, asn_org, city, region, country, latitude, longitude)
+		VALUES
+		('1.2.3.4', now(), now(), generateUUIDv4(), 0, 1,
+		 '1.2.3.4', 12345, 'TestASN', 'Berlin', 'BE', 'DE', 52.52, 13.405)`))
+}
+
+func TestGetValidators(t *testing.T) {
+	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
+	seedValidatorData(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/validators", nil)
+	rr := httptest.NewRecorder()
+
+	handlers.GetValidators(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp handlers.ValidatorListResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Items, 1)
+
+	v := resp.Items[0]
+	assert.Equal(t, "vote1", v.VotePubkey)
+	assert.Equal(t, "node1", v.NodePubkey)
+	assert.Equal(t, "2.0.0", v.Version)
+	assert.Equal(t, "Berlin", v.City)
+	assert.Equal(t, "DE", v.Country)
+	assert.Equal(t, 5.0, v.SkipRate, "skip rate should be 5%% (5 skipped out of 100)")
+}
+
+func TestGetValidators_Empty(t *testing.T) {
+	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/validators", nil)
+	rr := httptest.NewRecorder()
+
+	handlers.GetValidators(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp handlers.ValidatorListResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Items)
+}
+
+func TestGetValidator(t *testing.T) {
+	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
+	seedValidatorData(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/validators/vote1", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("vote_pubkey", "vote1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+
+	handlers.GetValidator(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp handlers.ValidatorDetail
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "vote1", resp.VotePubkey)
+	assert.Equal(t, "node1", resp.NodePubkey)
+	assert.Equal(t, "2.0.0", resp.Version)
+	assert.Equal(t, "Berlin", resp.City)
+	assert.Equal(t, "DE", resp.Country)
+	assert.Equal(t, 5.0, resp.SkipRate, "skip rate should be 5%% (5 skipped out of 100)")
+}
+
+func TestGetValidator_NotFound(t *testing.T) {
+	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/validators/nonexistent", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("vote_pubkey", "nonexistent")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+
+	handlers.GetValidator(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/web/src/components/traffic-dashboard/dashboard-filters.tsx
+++ b/web/src/components/traffic-dashboard/dashboard-filters.tsx
@@ -124,6 +124,7 @@ const autocompleteConfig: Record<string, { entity: string; field: string; minCha
 
 function DashboardSearch() {
   const {
+    timeRange,
     metroFilter, setMetroFilter,
     deviceFilter, setDeviceFilter,
     linkTypeFilter, setLinkTypeFilter,
@@ -136,6 +137,7 @@ function DashboardSearch() {
   // results are scoped to the active dashboard filters.
   const scopeFilters = useMemo(() => {
     const f: Record<string, string> = {}
+    if (timeRange && timeRange !== 'custom') f.time_range = timeRange
     if (metroFilter.length > 0) f.metro = metroFilter.join(',')
     if (deviceFilter.length > 0) f.device = deviceFilter.join(',')
     if (linkTypeFilter.length > 0) f.link_type = linkTypeFilter.join(',')
@@ -143,7 +145,7 @@ function DashboardSearch() {
     if (intfFilter.length > 0) f.intf = intfFilter.join(',')
     if (userKindFilter.length > 0) f.user_kind = userKindFilter.join(',')
     return Object.keys(f).length > 0 ? f : undefined
-  }, [metroFilter, deviceFilter, linkTypeFilter, contributorFilter, intfFilter, userKindFilter])
+  }, [timeRange, metroFilter, deviceFilter, linkTypeFilter, contributorFilter, intfFilter, userKindFilter])
 
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')


### PR DESCRIPTION
## Summary of Changes
- Field-values endpoint accepts `time_range` param and uses it to bound `fact_*` table queries (defaults to 1 day when not provided), fixing production timeouts on the 83M-row interface counters table
- Bound `fact_solana_block_production` queries in both `GetValidators` and `GetValidator` with a 1-day window
- Dashboard frontend passes the selected time range to field-values API calls for autocomplete

## Testing Verification
- Added `TestFieldValues_WithTimeRange` covering default, 1h, 7d, and scoped+time_range variants
- Added `TestGetValidators`, `TestGetValidators_Empty`, `TestGetValidator`, and `TestGetValidator_NotFound` exercising the full validator query including bounded skip_rates CTE
- All tests use `SetupTestClickHouseWithMigrations` with real schema migrations