### PR TITLE
agent: add multicast group context and eval tests

### DIFF
--- a/agent/evals/helpers_test.go
+++ b/agent/evals/helpers_test.go
@@ -724,6 +724,20 @@ func seedUsers(t *testing.T, ctx context.Context, conn clickhouse.Connection, us
 	require.NoError(t, err)
 }
 
+func seedMulticastGroups(t *testing.T, ctx context.Context, conn clickhouse.Connection, groups []serviceability.MulticastGroup, snapshotTS time.Time, opID uuid.UUID) {
+	log := testLogger(t)
+	mgDS, err := serviceability.NewMulticastGroupDataset(log)
+	require.NoError(t, err)
+	var mgSchema serviceability.MulticastGroupSchema
+	err = mgDS.WriteBatch(ctx, conn, len(groups), func(i int) ([]any, error) {
+		return mgSchema.ToRow(groups[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		SnapshotTS: snapshotTS,
+		OpID:       opID,
+	})
+	require.NoError(t, err)
+}
+
 // Test helper types for Solana entities (used by test files)
 type testGossipNode struct {
 	Pubkey      string

--- a/agent/evals/multicast_group_members_test.go
+++ b/agent/evals/multicast_group_members_test.go
@@ -1,0 +1,195 @@
+//go:build evals
+
+package evals_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+	serviceability "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_Agent_Evals_Anthropic_MulticastGroupMembers(t *testing.T) {
+	t.Parallel()
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping eval test")
+	}
+
+	runTest_MulticastGroupMembers(t, newAnthropicLLMClient)
+}
+
+func runTest_MulticastGroupMembers(t *testing.T, llmFactory LLMClientFactory) {
+	ctx := context.Background()
+
+	debugLevel, debug := getDebugLevel()
+
+	clientInfo := testClientInfo(t)
+
+	conn, err := clientInfo.Client.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	seedMulticastGroupMembersData(t, ctx, conn)
+
+	validateMulticastGroupMembersQuery(t, ctx, conn)
+
+	if testing.Short() {
+		t.Log("Skipping workflow execution in short mode")
+		return
+	}
+
+	p := setupWorkflow(t, ctx, clientInfo, llmFactory, debug, debugLevel)
+
+	question := "which validators are publishers in multicast group solana-shreds and what metros are they in?"
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Query: '%s' ===\n", question)
+		} else {
+			t.Logf("=== Starting workflow query: '%s' ===\n", question)
+		}
+	}
+	result, err := p.Run(ctx, question)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Answer)
+
+	response := result.Answer
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Response ===\n%s\n", response)
+		} else {
+			t.Logf("\n=== Final Workflow Response ===\n%s\n", response)
+		}
+	} else {
+		t.Logf("Workflow response:\n%s", response)
+	}
+
+	expectations := []Expectation{
+		{
+			Description:   "Three publishers identified",
+			ExpectedValue: "3 publishers found: owner1/node1, owner2/node2, owner3/node3",
+			Rationale:     "There are 3 users who publish to solana-shreds, each with a matching gossip node and vote account",
+		},
+		{
+			Description:   "NYC metro has 2 publishers",
+			ExpectedValue: "New York (nyc) has 2 publishers",
+			Rationale:     "user1 and user2 are publishers on device1 in NYC metro",
+		},
+		{
+			Description:   "London metro has 1 publisher",
+			ExpectedValue: "London (lon) has 1 publisher",
+			Rationale:     "user3 is a publisher on device2 in London metro",
+		},
+	}
+	isCorrect, err := evaluateResponse(t, ctx, question, response, expectations...)
+	require.NoError(t, err, "Evaluation must be available")
+	require.True(t, isCorrect, "Evaluation indicates the response does not correctly identify multicast group publishers")
+}
+
+// seedMulticastGroupMembersData seeds data for multicast group members test.
+// Scenario:
+// - 2 metros: NYC, London
+// - 2 devices: one per metro
+// - 1 multicast group: solana-shreds
+// - 5 multicast users:
+//   - user1: publisher only (NYC)
+//   - user2: publisher+subscriber (NYC)
+//   - user3: publisher only (LON)
+//   - user4: subscriber only (LON) — should NOT appear
+//   - user5: subscriber only (NYC) — should NOT appear
+// - 3 gossip nodes matching publisher client_ips
+// - 3 vote accounts for those nodes
+func seedMulticastGroupMembersData(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	now := testTime()
+	opID := uuid.New()
+
+	metros := []serviceability.Metro{
+		{PK: "metro1", Code: "nyc", Name: "New York"},
+		{PK: "metro2", Code: "lon", Name: "London"},
+	}
+	seedMetros(t, ctx, conn, metros, now, now)
+
+	devices := []serviceability.Device{
+		{PK: "device1", Code: "nyc-dzd1", Status: "activated", MetroPK: "metro1", DeviceType: "DZD"},
+		{PK: "device2", Code: "lon-dzd1", Status: "activated", MetroPK: "metro2", DeviceType: "DZD"},
+	}
+	seedDevices(t, ctx, conn, devices, now, now)
+
+	group1PK := "group1"
+	multicastGroups := []serviceability.MulticastGroup{
+		{PK: group1PK, OwnerPubkey: "group-owner1", Code: "solana-shreds", MulticastIP: net.ParseIP("239.1.1.1"), MaxBandwidth: 1000000000, Status: "activated", PublisherCount: 3, SubscriberCount: 3},
+	}
+	seedMulticastGroups(t, ctx, conn, multicastGroups, now, opID)
+
+	users := []serviceability.User{
+		// Publishers (should appear in results)
+		{PK: "user1", OwnerPubkey: "owner1", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.1"), ClientIP: net.ParseIP("203.0.113.1"), Kind: "multicast", TunnelID: 101, Publishers: []string{group1PK}, Subscribers: []string{}},
+		{PK: "user2", OwnerPubkey: "owner2", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.2"), ClientIP: net.ParseIP("203.0.113.2"), Kind: "multicast", TunnelID: 102, Publishers: []string{group1PK}, Subscribers: []string{group1PK}},
+		{PK: "user3", OwnerPubkey: "owner3", Status: "activated", DevicePK: "device2", DZIP: net.ParseIP("10.2.1.1"), ClientIP: net.ParseIP("198.51.100.1"), Kind: "multicast", TunnelID: 201, Publishers: []string{group1PK}, Subscribers: []string{}},
+		// Subscribers only (should NOT appear)
+		{PK: "user4", OwnerPubkey: "owner4", Status: "activated", DevicePK: "device2", DZIP: net.ParseIP("10.2.1.2"), ClientIP: net.ParseIP("198.51.100.2"), Kind: "multicast", TunnelID: 202, Publishers: []string{}, Subscribers: []string{group1PK}},
+		{PK: "user5", OwnerPubkey: "owner5", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.3"), ClientIP: net.ParseIP("203.0.113.3"), Kind: "multicast", TunnelID: 103, Publishers: []string{}, Subscribers: []string{group1PK}},
+	}
+	seedUsers(t, ctx, conn, users, now, now, opID)
+
+	gossipNodes := []*testGossipNode{
+		{Pubkey: "node1", GossipIP: net.ParseIP("203.0.113.1"), GossipPort: 8001, TPUQUICIP: net.ParseIP("203.0.113.1"), TPUQUICPort: 8003, Version: "1.18.0", Epoch: 500},
+		{Pubkey: "node2", GossipIP: net.ParseIP("203.0.113.2"), GossipPort: 8001, TPUQUICIP: net.ParseIP("203.0.113.2"), TPUQUICPort: 8003, Version: "1.18.0", Epoch: 500},
+		{Pubkey: "node3", GossipIP: net.ParseIP("198.51.100.1"), GossipPort: 8001, TPUQUICIP: net.ParseIP("198.51.100.1"), TPUQUICPort: 8003, Version: "1.18.0", Epoch: 500},
+	}
+	seedGossipNodes(t, ctx, conn, gossipNodes, now, now, opID)
+
+	voteAccounts := []testVoteAccount{
+		{VotePubkey: "vote1", NodePubkey: "node1", EpochVoteAccount: true, Epoch: 500, ActivatedStake: 1000000000000, Commission: 5},
+		{VotePubkey: "vote2", NodePubkey: "node2", EpochVoteAccount: true, Epoch: 500, ActivatedStake: 800000000000, Commission: 5},
+		{VotePubkey: "vote3", NodePubkey: "node3", EpochVoteAccount: true, Epoch: 500, ActivatedStake: 1200000000000, Commission: 10},
+	}
+	seedVoteAccounts(t, ctx, conn, voteAccounts, now, now, opID)
+}
+
+func validateMulticastGroupMembersQuery(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	// Verify publishers for solana-shreds group with metro info
+	query := `
+SELECT
+    u.owner_pubkey,
+    gn.pubkey AS node_pubkey,
+    va.vote_pubkey,
+    m.code AS metro_code
+FROM dz_users_current u
+JOIN dz_devices_current d ON u.device_pk = d.pk
+JOIN dz_metros_current m ON d.metro_pk = m.pk
+JOIN solana_gossip_nodes_current gn ON u.client_ip = gn.gossip_ip
+JOIN solana_vote_accounts_current va ON gn.pubkey = va.node_pubkey
+WHERE u.status = 'activated'
+  AND u.kind = 'multicast'
+  AND has(JSONExtract(u.publishers, 'Array(String)'), 'group1')
+ORDER BY u.owner_pubkey
+`
+	result, err := dataset.Query(ctx, conn, query, nil)
+	require.NoError(t, err, "Failed to execute multicast group members query")
+	require.Equal(t, 3, result.Count, "Should have exactly 3 publishers")
+
+	// Verify specific publishers and their metros
+	nycCount := 0
+	lonCount := 0
+	for _, row := range result.Rows {
+		metro := row["metro_code"].(string)
+		switch metro {
+		case "nyc":
+			nycCount++
+		case "lon":
+			lonCount++
+		}
+	}
+	require.Equal(t, 2, nycCount, "NYC should have 2 publishers")
+	require.Equal(t, 1, lonCount, "London should have 1 publisher")
+
+	t.Logf("Database validation passed: 3 publishers (nyc=2, lon=1)")
+}

--- a/agent/evals/multicast_group_summary_test.go
+++ b/agent/evals/multicast_group_summary_test.go
@@ -1,0 +1,186 @@
+//go:build evals
+
+package evals_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+	serviceability "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_Agent_Evals_Anthropic_MulticastGroupSummary(t *testing.T) {
+	t.Parallel()
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping eval test")
+	}
+
+	runTest_MulticastGroupSummary(t, newAnthropicLLMClient)
+}
+
+func runTest_MulticastGroupSummary(t *testing.T, llmFactory LLMClientFactory) {
+	ctx := context.Background()
+
+	debugLevel, debug := getDebugLevel()
+
+	clientInfo := testClientInfo(t)
+
+	conn, err := clientInfo.Client.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	seedMulticastGroupSummaryData(t, ctx, conn)
+
+	validateMulticastGroupSummaryQuery(t, ctx, conn)
+
+	if testing.Short() {
+		t.Log("Skipping workflow execution in short mode")
+		return
+	}
+
+	p := setupWorkflow(t, ctx, clientInfo, llmFactory, debug, debugLevel)
+
+	question := "how many publishers and subscribers are in each multicast group?"
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Query: '%s' ===\n", question)
+		} else {
+			t.Logf("=== Starting workflow query: '%s' ===\n", question)
+		}
+	}
+	result, err := p.Run(ctx, question)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Answer)
+
+	response := result.Answer
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Response ===\n%s\n", response)
+		} else {
+			t.Logf("\n=== Final Workflow Response ===\n%s\n", response)
+		}
+	} else {
+		t.Logf("Workflow response:\n%s", response)
+	}
+
+	expectations := []Expectation{
+		{
+			Description:   "Both multicast groups listed",
+			ExpectedValue: "solana-shreds and validator-gossip both appear in the response",
+			Rationale:     "There are 2 multicast groups seeded",
+		},
+		{
+			Description:   "solana-shreds publisher and subscriber counts",
+			ExpectedValue: "solana-shreds has 2 publishers and 2 subscribers",
+			Rationale:     "user1 publishes to shreds, user2 publishes to both; user3 subscribes to both, user4 subscribes to shreds only",
+		},
+		{
+			Description:   "validator-gossip publisher and subscriber counts",
+			ExpectedValue: "validator-gossip has 1 publisher and 2 subscribers",
+			Rationale:     "user2 publishes to both; user1 subscribes to gossip, user3 subscribes to both",
+		},
+	}
+	isCorrect, err := evaluateResponse(t, ctx, question, response, expectations...)
+	require.NoError(t, err, "Evaluation must be available")
+	require.True(t, isCorrect, "Evaluation indicates the response does not correctly summarize multicast group membership")
+}
+
+// seedMulticastGroupSummaryData seeds data for multicast group summary test.
+// Scenario:
+// - 1 metro, 1 device
+// - 2 multicast groups: solana-shreds and validator-gossip
+// - 4 multicast users with varied membership:
+//   - user1: publishes to shreds, subscribes to gossip
+//   - user2: publishes to both
+//   - user3: subscribes to both
+//   - user4: subscribes to shreds only
+//
+// Expected counts:
+//   - solana-shreds: 2 publishers (user1, user2), 2 subscribers (user3, user4)
+//   - validator-gossip: 1 publisher (user2), 2 subscribers (user1, user3)
+func seedMulticastGroupSummaryData(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	now := testTime()
+	opID := uuid.New()
+
+	metros := []serviceability.Metro{
+		{PK: "metro1", Code: "nyc", Name: "New York"},
+	}
+	seedMetros(t, ctx, conn, metros, now, now)
+
+	devices := []serviceability.Device{
+		{PK: "device1", Code: "nyc-dzd1", Status: "activated", MetroPK: "metro1", DeviceType: "DZD"},
+	}
+	seedDevices(t, ctx, conn, devices, now, now)
+
+	shredsPK := "group-shreds"
+	gossipPK := "group-gossip"
+	multicastGroups := []serviceability.MulticastGroup{
+		{PK: shredsPK, OwnerPubkey: "group-owner1", Code: "solana-shreds", MulticastIP: net.ParseIP("239.1.1.1"), MaxBandwidth: 1000000000, Status: "activated", PublisherCount: 2, SubscriberCount: 2},
+		{PK: gossipPK, OwnerPubkey: "group-owner2", Code: "validator-gossip", MulticastIP: net.ParseIP("239.1.1.2"), MaxBandwidth: 500000000, Status: "activated", PublisherCount: 1, SubscriberCount: 2},
+	}
+	seedMulticastGroups(t, ctx, conn, multicastGroups, now, opID)
+
+	users := []serviceability.User{
+		// user1: publishes to shreds, subscribes to gossip
+		{PK: "user1", OwnerPubkey: "owner1", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.1"), ClientIP: net.ParseIP("203.0.113.1"), Kind: "multicast", TunnelID: 101, Publishers: []string{shredsPK}, Subscribers: []string{gossipPK}},
+		// user2: publishes to both
+		{PK: "user2", OwnerPubkey: "owner2", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.2"), ClientIP: net.ParseIP("203.0.113.2"), Kind: "multicast", TunnelID: 102, Publishers: []string{shredsPK, gossipPK}, Subscribers: []string{}},
+		// user3: subscribes to both
+		{PK: "user3", OwnerPubkey: "owner3", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.3"), ClientIP: net.ParseIP("203.0.113.3"), Kind: "multicast", TunnelID: 103, Publishers: []string{}, Subscribers: []string{shredsPK, gossipPK}},
+		// user4: subscribes to shreds only
+		{PK: "user4", OwnerPubkey: "owner4", Status: "activated", DevicePK: "device1", DZIP: net.ParseIP("10.1.1.4"), ClientIP: net.ParseIP("203.0.113.4"), Kind: "multicast", TunnelID: 104, Publishers: []string{}, Subscribers: []string{shredsPK}},
+	}
+	seedUsers(t, ctx, conn, users, now, now, opID)
+}
+
+func validateMulticastGroupSummaryQuery(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	query := `
+SELECT
+    g.code AS group_code,
+    countIf(mode = 'P') AS pub_count,
+    countIf(mode = 'S') AS sub_count
+FROM (
+    SELECT
+        arrayJoin(JSONExtract(u.publishers, 'Array(String)')) AS group_pk,
+        'P' AS mode
+    FROM dz_users_current u
+    WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.publishers) > 0
+    UNION ALL
+    SELECT
+        arrayJoin(JSONExtract(u.subscribers, 'Array(String)')) AS group_pk,
+        'S' AS mode
+    FROM dz_users_current u
+    WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.subscribers) > 0
+) AS memberships
+JOIN dz_multicast_groups_current g ON memberships.group_pk = g.pk
+GROUP BY g.code
+ORDER BY g.code
+`
+	result, err := dataset.Query(ctx, conn, query, nil)
+	require.NoError(t, err, "Failed to execute multicast group summary query")
+	require.Equal(t, 2, result.Count, "Should have exactly 2 groups")
+
+	for _, row := range result.Rows {
+		code := row["group_code"].(string)
+		pubCount := row["pub_count"].(uint64)
+		subCount := row["sub_count"].(uint64)
+		switch code {
+		case "solana-shreds":
+			require.Equal(t, uint64(2), pubCount, "solana-shreds should have 2 publishers")
+			require.Equal(t, uint64(2), subCount, "solana-shreds should have 2 subscribers")
+		case "validator-gossip":
+			require.Equal(t, uint64(1), pubCount, "validator-gossip should have 1 publisher")
+			require.Equal(t, uint64(2), subCount, "validator-gossip should have 2 subscribers")
+		}
+	}
+
+	t.Logf("Database validation passed: solana-shreds (2 pub, 2 sub), validator-gossip (1 pub, 2 sub)")
+}

--- a/agent/pkg/workflow/prompts/SQL_CONTEXT.md
+++ b/agent/pkg/workflow/prompts/SQL_CONTEXT.md
@@ -470,6 +470,51 @@ GROUP BY u.owner_pubkey, u.dz_ip
 ORDER BY total_bytes DESC
 ```
 
+### Multicast Groups & Members
+The `dz_multicast_groups_current` table stores multicast group metadata:
+- Columns: `pk`, `code`, `multicast_ip`, `max_bandwidth`, `status`, `publisher_count`, `subscriber_count`
+
+**Publisher/subscriber membership** is stored as JSON arrays on `dz_users_current`:
+- `publishers` column: `["group_pk1","group_pk2"]` — groups this user publishes to
+- `subscribers` column: `["group_pk1","group_pk2"]` — groups this user subscribes to
+- Multicast users have `kind = 'multicast'`
+
+**Key ClickHouse JSON patterns:**
+```sql
+-- Check if user is a publisher for a specific group
+has(JSONExtract(u.publishers, 'Array(String)'), 'group_pk_value')
+
+-- Expand JSON array to rows (one row per group membership)
+arrayJoin(JSONExtract(u.publishers, 'Array(String)')) AS group_pk
+
+-- Check non-empty array
+JSONLength(u.publishers) > 0
+```
+
+**Canonical pub/sub counting query** — get publisher and subscriber counts per group:
+```sql
+SELECT group_pk, countIf(mode = 'P' OR mode = 'P+S') AS pub_count, countIf(mode = 'S' OR mode = 'P+S') AS sub_count
+FROM (
+    SELECT arrayJoin(JSONExtract(u.publishers, 'Array(String)')) AS group_pk, 'P' AS mode FROM dz_users_current u WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.publishers) > 0
+    UNION ALL
+    SELECT arrayJoin(JSONExtract(u.subscribers, 'Array(String)')) AS group_pk, 'S' AS mode FROM dz_users_current u WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.subscribers) > 0
+)
+GROUP BY group_pk
+```
+
+**Multicast user → validator enrichment:** Join via `client_ip = gossip_ip` (same as unicast users):
+```sql
+SELECT u.owner_pubkey, u.client_ip, gn.pubkey AS node_pubkey, va.vote_pubkey, d.code AS device_code, m.code AS metro_code
+FROM dz_users_current u
+JOIN dz_devices_current d ON u.device_pk = d.pk
+JOIN dz_metros_current m ON d.metro_pk = m.pk
+JOIN solana_gossip_nodes_current gn ON u.client_ip = gn.gossip_ip
+JOIN solana_vote_accounts_current va ON gn.pubkey = va.node_pubkey
+WHERE u.status = 'activated' AND u.kind = 'multicast' AND has(JSONExtract(u.publishers, 'Array(String)'), 'group_pk_value')
+```
+
+**Traffic gotcha:** On tunnel interfaces, use `in_octets_delta`/`out_octets_delta` for bandwidth. Do NOT use `in_multicast_pkts_delta`/`out_multicast_pkts_delta` — these counters are unreliable on tunnel interfaces.
+
 ### History Tables (CRITICAL)
 **ALWAYS check the schema for exact table and column names.** Do NOT guess.
 


### PR DESCRIPTION
## Summary of Changes

- Add multicast groups & members section to `SQL_CONTEXT.md` covering `dz_multicast_groups_current`, publisher/subscriber JSON arrays on `dz_users_current`, ClickHouse JSON patterns (`has()`, `arrayJoin()`, `JSONLength()`), canonical pub/sub counting query, validator enrichment joins, and tunnel traffic gotcha
- Add `seedMulticastGroups` helper to eval test helpers
- Add `MulticastGroupMembers` eval test validating publisher identification with metro breakdown (3 publishers across NYC and London)
- Add `MulticastGroupSummary` eval test validating per-group publisher/subscriber counting across two groups with varied membership

## Testing Verification

- Both eval tests pass in short mode (`go test -tags evals -short -run 'MulticastGroupMembers|MulticastGroupSummary'`)
- Both eval tests pass in full mode with Anthropic API (`run-evals.sh -f 'MulticastGroupMembers'` and `run-evals.sh -f 'MulticastGroupSummary'`), no SQL errors