### PR TITLE
web: fix down links not appearing in status page link history

### DIFF
--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -688,8 +688,8 @@ export function LinkStatusTimelines({
     if (linksWithHealth) {
       const health = linksWithHealth.get(link.code)
       if (health) {
-        // Map no_data to unhealthy for filter matching (no_data is a status, not a filter option)
-        const filterHealth = health === 'no_data' ? 'unhealthy' : health
+        // Map no_data and down to unhealthy for filter matching (not separate filter options)
+        const filterHealth = (health === 'no_data' || health === 'down') ? 'unhealthy' : health
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return healthFilters.includes(filterHealth as any)
       }


### PR DESCRIPTION
## Summary of Changes

- Fix links with `is_down=true` (e.g. 100% packet loss) being filtered out of the link history timeline
- Map `down` health status to `unhealthy` in `linkMatchesHealthFilters`, consistent with how `status-page.tsx` handles it in all other places

## Testing Verification

- Verified `tyo001-dz002:sin001-dz002` (currently 100% loss, `is_down=true`) was being excluded due to `down` not matching any health filter option