### PR TITLE
web: default to all publishers enabled for multicast overlay

### DIFF
--- a/web/src/components/topology/useMulticastState.ts
+++ b/web/src/components/topology/useMulticastState.ts
@@ -184,14 +184,12 @@ export function useMulticastState({ enabled, isDark }: UseMulticastStateOptions)
       return
     }
 
-    // Default: enable only first publisher + all subscribers
+    // Default: enable all publishers + all subscribers
     const pubs = new Set<string>()
     const subs = new Set<string>()
-    let firstPubAdded = false
     detail.members.forEach(m => {
-      if ((m.mode === 'P' || m.mode === 'P+S') && !firstPubAdded) {
+      if (m.mode === 'P' || m.mode === 'P+S') {
         pubs.add(m.user_pk)
-        firstPubAdded = true
       }
       if (m.mode === 'S' || m.mode === 'P+S') {
         subs.add(m.user_pk)


### PR DESCRIPTION
## Summary of Changes
- Default to enabling all publishers (instead of just the first) when selecting a multicast group, now that server-side segment aggregation makes this performant

## Testing Verification
- Manual: select a multicast group, verify all publishers are enabled by default
- `bun run build` passes