### PR TITLE
indexer: replace FlightSQL client with HTTP/CSV InfluxDB client

### DIFF
--- a/admin/cmd/admin/main.go
+++ b/admin/cmd/admin/main.go
@@ -67,7 +67,13 @@ func run() error {
 	dryRunFlag := flag.Bool("dry-run", false, "Dry run mode - show what would be done without actually executing")
 	yesFlag := flag.Bool("yes", false, "Skip confirmation prompt (use with caution)")
 
+	// Export commands
+	exportInfluxCSVFlag := flag.Bool("export-device-interface-counters-csv", false, "Export intfCounters from InfluxDB to a CSV file and exit")
+	exportOutputFlag := flag.String("export-output", "influx-export.csv", "Output file path for CSV export")
+	exportChunkSizeFlag := flag.Duration("export-chunk-size", time.Hour, "Time window per InfluxDB request during export (default: 1h)")
+
 	// Backfill commands
+	backfillFromCSVFlag := flag.String("backfill-device-interface-counters-from-csv", "", "Import a CSV file exported by --export-device-interface-counters-csv into ClickHouse and exit")
 	backfillDeviceLinkLatencyFlag := flag.Bool("backfill-device-link-latency", false, "Backfill device link latency fact table from on-chain data")
 	backfillInternetMetroLatencyFlag := flag.Bool("backfill-internet-metro-latency", false, "Backfill internet metro latency fact table from on-chain data")
 	backfillDeviceInterfaceCountersFlag := flag.Bool("backfill-device-interface-counters", false, "Backfill device interface counters fact table from InfluxDB")
@@ -301,6 +307,33 @@ func run() error {
 			return fmt.Errorf("--clickhouse-addr is required for --reset-db")
 		}
 		return admin.ResetDB(log, *clickhouseAddrFlag, *clickhouseDatabaseFlag, *clickhouseUsernameFlag, *clickhousePasswordFlag, *clickhouseSecureFlag, *dryRunFlag, *yesFlag)
+	}
+
+	if *exportInfluxCSVFlag {
+		if *influxURLFlag == "" || *influxTokenFlag == "" || *influxBucketFlag == "" {
+			return fmt.Errorf("--influx-url, --influx-token, and --influx-bucket are required for --export-device-interface-counters-csv")
+		}
+		if *startTimeFlag == "" || *endTimeFlag == "" {
+			return fmt.Errorf("--start-time and --end-time are required for --export-device-interface-counters-csv")
+		}
+		return admin.ExportDeviceInterfaceCountersCSV(
+			log,
+			*influxURLFlag, *influxTokenFlag, *influxBucketFlag,
+			*startTimeFlag, *endTimeFlag,
+			*exportOutputFlag, *exportChunkSizeFlag,
+		)
+	}
+
+	if *backfillFromCSVFlag != "" {
+		if *clickhouseAddrFlag == "" {
+			return fmt.Errorf("--clickhouse-addr is required for --backfill-device-interface-counters-from-csv")
+		}
+		return admin.BackfillDeviceInterfaceCountersFromCSV(
+			log,
+			*clickhouseAddrFlag, *clickhouseDatabaseFlag, *clickhouseUsernameFlag, *clickhousePasswordFlag,
+			*clickhouseSecureFlag,
+			*backfillFromCSVFlag,
+		)
 	}
 
 	if *backfillDeviceLinkLatencyFlag {

--- a/admin/internal/admin/backfill_device_interface_counters_csv.go
+++ b/admin/internal/admin/backfill_device_interface_counters_csv.go
@@ -10,7 +10,7 @@ import (
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 )
 
-// BackfillDeviceInterfaceCountersFromCSV imports a CSV file exported by --export-influx-csv into ClickHouse.
+// BackfillDeviceInterfaceCountersFromCSV imports a CSV file exported by --export-device-interface-counters-csv into ClickHouse.
 func BackfillDeviceInterfaceCountersFromCSV(
 	log *slog.Logger,
 	clickhouseAddr, clickhouseDatabase, clickhouseUsername, clickhousePassword string,

--- a/admin/internal/admin/backfill_device_interface_counters_csv.go
+++ b/admin/internal/admin/backfill_device_interface_counters_csv.go
@@ -1,0 +1,54 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
+)
+
+// BackfillDeviceInterfaceCountersFromCSV imports a CSV file exported by --export-influx-csv into ClickHouse.
+func BackfillDeviceInterfaceCountersFromCSV(
+	log *slog.Logger,
+	clickhouseAddr, clickhouseDatabase, clickhouseUsername, clickhousePassword string,
+	clickhouseSecure bool,
+	csvPath string,
+) error {
+	ctx := context.Background()
+
+	chDB, err := clickhouse.NewClient(ctx, log, clickhouseAddr, clickhouseDatabase, clickhouseUsername, clickhousePassword, clickhouseSecure)
+	if err != nil {
+		return fmt.Errorf("failed to connect to ClickHouse: %w", err)
+	}
+	defer chDB.Close()
+
+	store, err := dztelemusage.NewStore(dztelemusage.StoreConfig{
+		Logger:     log,
+		ClickHouse: chDB,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create store: %w", err)
+	}
+
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return fmt.Errorf("failed to open CSV file %s: %w", csvPath, err)
+	}
+	defer f.Close()
+
+	result, err := store.BackfillFromReader(ctx, f)
+	if err != nil {
+		return fmt.Errorf("backfill failed: %w", err)
+	}
+
+	log.Info("backfill complete",
+		"queried", result.RowsQueried,
+		"inserted", result.RowsInserted,
+		"start", result.StartTime,
+		"end", result.EndTime,
+	)
+	return nil
+}

--- a/admin/internal/admin/export_device_interface_counters_csv.go
+++ b/admin/internal/admin/export_device_interface_counters_csv.go
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
+)
+
+// ExportDeviceInterfaceCountersCSV exports intfCounters data from InfluxDB to a CSV file.
+// The time range is split into chunks to avoid timeouts on large ranges.
+func ExportDeviceInterfaceCountersCSV(
+	log *slog.Logger,
+	influxURL, influxToken, influxBucket string,
+	startStr, endStr string,
+	outputPath string,
+	chunkSize time.Duration,
+) error {
+	ctx := context.Background()
+
+	startTime, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		return fmt.Errorf("invalid --start-time: %w", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		return fmt.Errorf("invalid --end-time: %w", err)
+	}
+	if !startTime.Before(endTime) {
+		return fmt.Errorf("--start-time must be before --end-time")
+	}
+
+	client := dztelemusage.NewHTTPInfluxDBClient(influxURL, influxToken, influxBucket)
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	defer f.Close()
+
+	chunkStart := startTime.UTC()
+	first := true
+	for chunkStart.Before(endTime.UTC()) {
+		chunkEnd := chunkStart.Add(chunkSize)
+		if chunkEnd.After(endTime.UTC()) {
+			chunkEnd = endTime.UTC()
+		}
+
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				time,
+				dzd_pubkey,
+				host,
+				intf,
+				model_name,
+				serial_number,
+				"carrier-transitions",
+				"in-broadcast-pkts",
+				"in-discards",
+				"in-errors",
+				"in-fcs-errors",
+				"in-multicast-pkts",
+				"in-octets",
+				"in-pkts",
+				"in-unicast-pkts",
+				"out-broadcast-pkts",
+				"out-discards",
+				"out-errors",
+				"out-multicast-pkts",
+				"out-octets",
+				"out-pkts",
+				"out-unicast-pkts"
+			FROM "intfCounters"
+			WHERE time >= '%s' AND time < '%s'
+		`, chunkStart.Format(time.RFC3339Nano), chunkEnd.Format(time.RFC3339Nano))
+
+		log.Info("exporting chunk", "start", chunkStart.Format(time.RFC3339), "end", chunkEnd.Format(time.RFC3339))
+		if err := client.QueryRawCSV(ctx, sqlQuery, f, !first); err != nil {
+			return fmt.Errorf("query failed for chunk %s: %w", chunkStart.Format(time.RFC3339), err)
+		}
+
+		first = false
+		chunkStart = chunkEnd
+	}
+
+	log.Info("export complete", "output", outputPath)
+	return nil
+}

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -543,4 +543,3 @@ func initializeGeoIP(cityDBPath, asnDBPath string, log *slog.Logger) (geoip.Reso
 		return nil
 	}, nil
 }
-

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -113,6 +113,16 @@ func run() error {
 	// Readiness configuration
 	skipReadyWaitFlag := flag.Bool("skip-ready-wait", false, "Skip waiting for views to be ready (for preview/dev environments)")
 
+	// Admin: export InfluxDB interface counters to CSV
+	exportInfluxCSVFlag := flag.Bool("export-influx-csv", false, "Export intfCounters from InfluxDB to a CSV file and exit")
+	exportStartTimeFlag := flag.String("export-start-time", "", "Start time for CSV export (RFC3339, e.g. 2024-01-01T00:00:00Z)")
+	exportEndTimeFlag := flag.String("export-end-time", "", "End time for CSV export (RFC3339, e.g. 2024-01-02T00:00:00Z)")
+	exportOutputFlag := flag.String("export-output", "influx-export.csv", "Output file path for CSV export")
+	exportChunkSizeFlag := flag.Duration("export-chunk-size", time.Hour, "Time window per InfluxDB request during export (default: 1h)")
+
+	// Admin: backfill ClickHouse from a previously exported CSV file
+	backfillFromCSVFlag := flag.String("backfill-from-csv", "", "Import a CSV file exported by --export-influx-csv into ClickHouse and exit")
+
 	flag.Parse()
 
 	// Load .env file. godotenv does not override existing env vars, so
@@ -232,6 +242,30 @@ func run() error {
 		log.Info("server: received signal", "signal", sig.String())
 		cancel()
 	}()
+
+	// Admin: export intfCounters from InfluxDB to CSV.
+	if *exportInfluxCSVFlag {
+		if err := runExportInfluxCSV(ctx, *exportStartTimeFlag, *exportEndTimeFlag, *exportOutputFlag, *exportChunkSizeFlag); err != nil {
+			return fmt.Errorf("export-influx-csv: %w", err)
+		}
+		return nil
+	}
+
+	// Admin: backfill ClickHouse from a previously exported CSV file.
+	if *backfillFromCSVFlag != "" {
+		if *clickhouseAddrFlag == "" {
+			return fmt.Errorf("backfill-from-csv: --clickhouse-addr is required")
+		}
+		clickhouseDB, err := clickhouse.NewClient(ctx, log, *clickhouseAddrFlag, *clickhouseDatabaseFlag, *clickhouseUsernameFlag, *clickhousePasswordFlag, *clickhouseSecureFlag)
+		if err != nil {
+			return fmt.Errorf("backfill-from-csv: failed to create ClickHouse client: %w", err)
+		}
+		defer clickhouseDB.Close()
+		if err := runBackfillFromCSV(ctx, log, clickhouseDB, *backfillFromCSVFlag); err != nil {
+			return fmt.Errorf("backfill-from-csv: %w", err)
+		}
+		return nil
+	}
 
 	if *enablePprofFlag {
 		go func() {
@@ -545,4 +579,117 @@ func initializeGeoIP(cityDBPath, asnDBPath string, log *slog.Logger) (geoip.Reso
 		}
 		return nil
 	}, nil
+}
+
+// runExportInfluxCSV exports intfCounters data from InfluxDB to a CSV file.
+// The time range is split into chunks to avoid timeouts on large ranges.
+func runExportInfluxCSV(ctx context.Context, startStr, endStr, outputPath string, chunkSize time.Duration) error {
+	influxURL := os.Getenv("INFLUX_URL")
+	influxToken := os.Getenv("INFLUX_TOKEN")
+	influxBucket := os.Getenv("INFLUX_BUCKET")
+	if influxURL == "" || influxToken == "" || influxBucket == "" {
+		return fmt.Errorf("INFLUX_URL, INFLUX_TOKEN, and INFLUX_BUCKET must be set")
+	}
+	if startStr == "" || endStr == "" {
+		return fmt.Errorf("--export-start-time and --export-end-time are required")
+	}
+
+	startTime, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		return fmt.Errorf("invalid --export-start-time: %w", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		return fmt.Errorf("invalid --export-end-time: %w", err)
+	}
+	if !startTime.Before(endTime) {
+		return fmt.Errorf("--export-start-time must be before --export-end-time")
+	}
+
+	client := dztelemusage.NewHTTPInfluxDBClient(influxURL, influxToken, influxBucket)
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	defer f.Close()
+
+	chunkStart := startTime.UTC()
+	first := true
+	for chunkStart.Before(endTime.UTC()) {
+		chunkEnd := chunkStart.Add(chunkSize)
+		if chunkEnd.After(endTime.UTC()) {
+			chunkEnd = endTime.UTC()
+		}
+
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				time,
+				dzd_pubkey,
+				host,
+				intf,
+				model_name,
+				serial_number,
+				"carrier-transitions",
+				"in-broadcast-pkts",
+				"in-discards",
+				"in-errors",
+				"in-fcs-errors",
+				"in-multicast-pkts",
+				"in-octets",
+				"in-pkts",
+				"in-unicast-pkts",
+				"out-broadcast-pkts",
+				"out-discards",
+				"out-errors",
+				"out-multicast-pkts",
+				"out-octets",
+				"out-pkts",
+				"out-unicast-pkts"
+			FROM "intfCounters"
+			WHERE time >= '%s' AND time < '%s'
+		`, chunkStart.Format(time.RFC3339Nano), chunkEnd.Format(time.RFC3339Nano))
+
+		fmt.Printf("exporting %s -> %s\n", chunkStart.Format(time.RFC3339), chunkEnd.Format(time.RFC3339))
+		if err := client.QueryRawCSV(ctx, sqlQuery, f, !first); err != nil {
+			return fmt.Errorf("query failed for chunk %s: %w", chunkStart.Format(time.RFC3339), err)
+		}
+
+		first = false
+		chunkStart = chunkEnd
+	}
+
+	fmt.Printf("export complete: %s\n", outputPath)
+	return nil
+}
+
+// runBackfillFromCSV reads a CSV file exported by --export-influx-csv and imports it into ClickHouse.
+func runBackfillFromCSV(ctx context.Context, log *slog.Logger, clickhouseDB clickhouse.Client, csvPath string) error {
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return fmt.Errorf("failed to open CSV file %s: %w", csvPath, err)
+	}
+	defer f.Close()
+
+	view, err := dztelemusage.NewView(dztelemusage.ViewConfig{
+		Logger:          log,
+		ClickHouse:      clickhouseDB,
+		InfluxDB:        dztelemusage.NewHTTPInfluxDBClient("http://placeholder", "placeholder", "placeholder"),
+		Bucket:          "placeholder",
+		RefreshInterval: time.Hour,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create view: %w", err)
+	}
+
+	result, err := view.BackfillFromReader(ctx, f)
+	if err != nil {
+		return fmt.Errorf("backfill failed: %w", err)
+	}
+
+	fmt.Printf("backfill complete: queried=%d inserted=%d start=%s end=%s\n",
+		result.RowsQueried, result.RowsInserted,
+		result.StartTime.Format(time.RFC3339),
+		result.EndTime.Format(time.RFC3339))
+	return nil
 }

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -115,8 +115,8 @@ func run() error {
 
 	// Admin: export InfluxDB interface counters to CSV
 	exportInfluxCSVFlag := flag.Bool("export-influx-csv", false, "Export intfCounters from InfluxDB to a CSV file and exit")
-	exportStartTimeFlag := flag.String("export-start-time", "", "Start time for CSV export (RFC3339, e.g. 2024-01-01T00:00:00Z)")
-	exportEndTimeFlag := flag.String("export-end-time", "", "End time for CSV export (RFC3339, e.g. 2024-01-02T00:00:00Z)")
+	exportStartTimeFlag := flag.String("start-time", "", "Start time for CSV export (RFC3339, e.g. 2024-01-01T00:00:00Z)")
+	exportEndTimeFlag := flag.String("end-time", "", "End time for CSV export (RFC3339, e.g. 2024-01-02T00:00:00Z)")
 	exportOutputFlag := flag.String("export-output", "influx-export.csv", "Output file path for CSV export")
 	exportChunkSizeFlag := flag.Duration("export-chunk-size", time.Hour, "Time window per InfluxDB request during export (default: 1h)")
 
@@ -397,10 +397,7 @@ func run() error {
 		})
 		influxBucket = "mock-bucket"
 	} else if influxURL != "" && influxToken != "" && influxBucket != "" {
-		influxDBClient, err = dztelemusage.NewSDKInfluxDBClient(influxURL, influxToken, influxBucket)
-		if err != nil {
-			return fmt.Errorf("failed to create InfluxDB client: %w", err)
-		}
+		influxDBClient = dztelemusage.NewHTTPInfluxDBClient(influxURL, influxToken, influxBucket)
 		defer func() {
 			if influxDBClient != nil {
 				if closeErr := influxDBClient.Close(); closeErr != nil {

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -671,8 +671,6 @@ func runBackfillFromCSV(ctx context.Context, log *slog.Logger, clickhouseDB clic
 	view, err := dztelemusage.NewView(dztelemusage.ViewConfig{
 		Logger:          log,
 		ClickHouse:      clickhouseDB,
-		InfluxDB:        dztelemusage.NewHTTPInfluxDBClient("http://placeholder", "placeholder", "placeholder"),
-		Bucket:          "placeholder",
 		RefreshInterval: time.Hour,
 	})
 	if err != nil {

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -113,16 +113,6 @@ func run() error {
 	// Readiness configuration
 	skipReadyWaitFlag := flag.Bool("skip-ready-wait", false, "Skip waiting for views to be ready (for preview/dev environments)")
 
-	// Admin: export InfluxDB interface counters to CSV
-	exportInfluxCSVFlag := flag.Bool("export-influx-csv", false, "Export intfCounters from InfluxDB to a CSV file and exit")
-	exportStartTimeFlag := flag.String("start-time", "", "Start time for CSV export (RFC3339, e.g. 2024-01-01T00:00:00Z)")
-	exportEndTimeFlag := flag.String("end-time", "", "End time for CSV export (RFC3339, e.g. 2024-01-02T00:00:00Z)")
-	exportOutputFlag := flag.String("export-output", "influx-export.csv", "Output file path for CSV export")
-	exportChunkSizeFlag := flag.Duration("export-chunk-size", time.Hour, "Time window per InfluxDB request during export (default: 1h)")
-
-	// Admin: backfill ClickHouse from a previously exported CSV file
-	backfillFromCSVFlag := flag.String("backfill-from-csv", "", "Import a CSV file exported by --export-influx-csv into ClickHouse and exit")
-
 	flag.Parse()
 
 	// Load .env file. godotenv does not override existing env vars, so
@@ -242,30 +232,6 @@ func run() error {
 		log.Info("server: received signal", "signal", sig.String())
 		cancel()
 	}()
-
-	// Admin: export intfCounters from InfluxDB to CSV.
-	if *exportInfluxCSVFlag {
-		if err := runExportInfluxCSV(ctx, *exportStartTimeFlag, *exportEndTimeFlag, *exportOutputFlag, *exportChunkSizeFlag); err != nil {
-			return fmt.Errorf("export-influx-csv: %w", err)
-		}
-		return nil
-	}
-
-	// Admin: backfill ClickHouse from a previously exported CSV file.
-	if *backfillFromCSVFlag != "" {
-		if *clickhouseAddrFlag == "" {
-			return fmt.Errorf("backfill-from-csv: --clickhouse-addr is required")
-		}
-		clickhouseDB, err := clickhouse.NewClient(ctx, log, *clickhouseAddrFlag, *clickhouseDatabaseFlag, *clickhouseUsernameFlag, *clickhousePasswordFlag, *clickhouseSecureFlag)
-		if err != nil {
-			return fmt.Errorf("backfill-from-csv: failed to create ClickHouse client: %w", err)
-		}
-		defer clickhouseDB.Close()
-		if err := runBackfillFromCSV(ctx, log, clickhouseDB, *backfillFromCSVFlag); err != nil {
-			return fmt.Errorf("backfill-from-csv: %w", err)
-		}
-		return nil
-	}
 
 	if *enablePprofFlag {
 		go func() {
@@ -578,113 +544,3 @@ func initializeGeoIP(cityDBPath, asnDBPath string, log *slog.Logger) (geoip.Reso
 	}, nil
 }
 
-// runExportInfluxCSV exports intfCounters data from InfluxDB to a CSV file.
-// The time range is split into chunks to avoid timeouts on large ranges.
-func runExportInfluxCSV(ctx context.Context, startStr, endStr, outputPath string, chunkSize time.Duration) error {
-	influxURL := os.Getenv("INFLUX_URL")
-	influxToken := os.Getenv("INFLUX_TOKEN")
-	influxBucket := os.Getenv("INFLUX_BUCKET")
-	if influxURL == "" || influxToken == "" || influxBucket == "" {
-		return fmt.Errorf("INFLUX_URL, INFLUX_TOKEN, and INFLUX_BUCKET must be set")
-	}
-	if startStr == "" || endStr == "" {
-		return fmt.Errorf("--export-start-time and --export-end-time are required")
-	}
-
-	startTime, err := time.Parse(time.RFC3339, startStr)
-	if err != nil {
-		return fmt.Errorf("invalid --export-start-time: %w", err)
-	}
-	endTime, err := time.Parse(time.RFC3339, endStr)
-	if err != nil {
-		return fmt.Errorf("invalid --export-end-time: %w", err)
-	}
-	if !startTime.Before(endTime) {
-		return fmt.Errorf("--export-start-time must be before --export-end-time")
-	}
-
-	client := dztelemusage.NewHTTPInfluxDBClient(influxURL, influxToken, influxBucket)
-
-	f, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
-	}
-	defer f.Close()
-
-	chunkStart := startTime.UTC()
-	first := true
-	for chunkStart.Before(endTime.UTC()) {
-		chunkEnd := chunkStart.Add(chunkSize)
-		if chunkEnd.After(endTime.UTC()) {
-			chunkEnd = endTime.UTC()
-		}
-
-		sqlQuery := fmt.Sprintf(`
-			SELECT
-				time,
-				dzd_pubkey,
-				host,
-				intf,
-				model_name,
-				serial_number,
-				"carrier-transitions",
-				"in-broadcast-pkts",
-				"in-discards",
-				"in-errors",
-				"in-fcs-errors",
-				"in-multicast-pkts",
-				"in-octets",
-				"in-pkts",
-				"in-unicast-pkts",
-				"out-broadcast-pkts",
-				"out-discards",
-				"out-errors",
-				"out-multicast-pkts",
-				"out-octets",
-				"out-pkts",
-				"out-unicast-pkts"
-			FROM "intfCounters"
-			WHERE time >= '%s' AND time < '%s'
-		`, chunkStart.Format(time.RFC3339Nano), chunkEnd.Format(time.RFC3339Nano))
-
-		fmt.Printf("exporting %s -> %s\n", chunkStart.Format(time.RFC3339), chunkEnd.Format(time.RFC3339))
-		if err := client.QueryRawCSV(ctx, sqlQuery, f, !first); err != nil {
-			return fmt.Errorf("query failed for chunk %s: %w", chunkStart.Format(time.RFC3339), err)
-		}
-
-		first = false
-		chunkStart = chunkEnd
-	}
-
-	fmt.Printf("export complete: %s\n", outputPath)
-	return nil
-}
-
-// runBackfillFromCSV reads a CSV file exported by --export-influx-csv and imports it into ClickHouse.
-func runBackfillFromCSV(ctx context.Context, log *slog.Logger, clickhouseDB clickhouse.Client, csvPath string) error {
-	f, err := os.Open(csvPath)
-	if err != nil {
-		return fmt.Errorf("failed to open CSV file %s: %w", csvPath, err)
-	}
-	defer f.Close()
-
-	view, err := dztelemusage.NewView(dztelemusage.ViewConfig{
-		Logger:          log,
-		ClickHouse:      clickhouseDB,
-		RefreshInterval: time.Hour,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create view: %w", err)
-	}
-
-	result, err := view.BackfillFromReader(ctx, f)
-	if err != nil {
-		return fmt.Errorf("backfill failed: %w", err)
-	}
-
-	fmt.Printf("backfill complete: queried=%d inserted=%d start=%s end=%s\n",
-		result.RowsQueried, result.RowsInserted,
-		result.StartTime.Format(time.RFC3339),
-		result.EndTime.Format(time.RFC3339))
-	return nil
-}

--- a/indexer/pkg/dz/telemetry/usage/influx_http.go
+++ b/indexer/pkg/dz/telemetry/usage/influx_http.go
@@ -18,7 +18,7 @@ import (
 type HTTPInfluxDBClient struct {
 	host     string
 	token    string
-	database string
+	database string // reserved for /api/v3/query_sql if endpoint is changed
 	client   *http.Client
 }
 
@@ -36,15 +36,14 @@ func NewHTTPInfluxDBClient(host, token, database string) *HTTPInfluxDBClient {
 // and returning the results as parsed CSV rows.
 func (c *HTTPInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
 	body, err := json.Marshal(map[string]string{
-		"q":      sqlQuery,
-		"db":     c.database,
+		"query":  sqlQuery,
 		"format": "csv",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v3/query_sql", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v2/query", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -70,15 +69,14 @@ func (c *HTTPInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]m
 // This is useful for streaming chunked exports where only the first chunk should include headers.
 func (c *HTTPInfluxDBClient) QueryRawCSV(ctx context.Context, sqlQuery string, w io.Writer, skipHeader bool) error {
 	body, err := json.Marshal(map[string]string{
-		"q":      sqlQuery,
-		"db":     c.database,
+		"query":  sqlQuery,
 		"format": "csv",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v3/query_sql", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v2/query", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -147,6 +145,8 @@ func ParseInfluxCSV(r io.Reader) ([]map[string]any, error) {
 				} else {
 					row[h] = record[i]
 				}
+			} else {
+				row[h] = nil
 			}
 		}
 		results = append(results, row)

--- a/indexer/pkg/dz/telemetry/usage/influx_http.go
+++ b/indexer/pkg/dz/telemetry/usage/influx_http.go
@@ -1,0 +1,156 @@
+package dztelemusage
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HTTPInfluxDBClient implements InfluxDBClient using the InfluxDB v3 HTTP Query API with CSV output.
+// This is more reliable than the FlightSQL/gRPC-based SDK for bulk queries and large time windows.
+type HTTPInfluxDBClient struct {
+	host     string
+	token    string
+	database string
+	client   *http.Client
+}
+
+// NewHTTPInfluxDBClient creates a new HTTP-based InfluxDB client.
+func NewHTTPInfluxDBClient(host, token, database string) *HTTPInfluxDBClient {
+	return &HTTPInfluxDBClient{
+		host:     strings.TrimRight(host, "/"),
+		token:    token,
+		database: database,
+		client:   &http.Client{Timeout: 10 * time.Minute},
+	}
+}
+
+// QuerySQL implements InfluxDBClient by executing a SQL query via the HTTP API
+// and returning the results as parsed CSV rows.
+func (c *HTTPInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
+	body, err := json.Marshal(map[string]string{
+		"q":      sqlQuery,
+		"db":     c.database,
+		"format": "csv",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	return ParseInfluxCSV(resp.Body)
+}
+
+// QueryRawCSV executes a SQL query and writes the raw CSV response to w.
+// If skipHeader is true, the CSV header row is omitted from the output.
+// This is useful for streaming chunked exports where only the first chunk should include headers.
+func (c *HTTPInfluxDBClient) QueryRawCSV(ctx context.Context, sqlQuery string, w io.Writer, skipHeader bool) error {
+	body, err := json.Marshal(map[string]string{
+		"q":      sqlQuery,
+		"db":     c.database,
+		"format": "csv",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	if skipHeader {
+		if _, err := reader.ReadString('\n'); err != nil && err != io.EOF {
+			return fmt.Errorf("failed to skip CSV header: %w", err)
+		}
+	}
+
+	if _, err := io.Copy(w, reader); err != nil {
+		return fmt.Errorf("failed to write CSV: %w", err)
+	}
+
+	return nil
+}
+
+// Close implements InfluxDBClient.
+func (c *HTTPInfluxDBClient) Close() error {
+	return nil
+}
+
+// ParseInfluxCSV parses a CSV response from InfluxDB into a slice of maps.
+// Empty string values are represented as nil so downstream nil checks work correctly.
+func ParseInfluxCSV(r io.Reader) ([]map[string]any, error) {
+	csvReader := csv.NewReader(r)
+	csvReader.TrimLeadingSpace = true
+
+	headers, err := csvReader.Read()
+	if err == io.EOF {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV headers: %w", err)
+	}
+
+	var results []map[string]any
+	for {
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CSV record: %w", err)
+		}
+
+		row := make(map[string]any, len(headers))
+		for i, h := range headers {
+			if i < len(record) {
+				if record[i] == "" {
+					row[h] = nil
+				} else {
+					row[h] = record[i]
+				}
+			}
+		}
+		results = append(results, row)
+	}
+
+	return results, nil
+}

--- a/indexer/pkg/dz/telemetry/usage/influx_http_test.go
+++ b/indexer/pkg/dz/telemetry/usage/influx_http_test.go
@@ -1,0 +1,120 @@
+package dztelemusage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_TelemetryUsage_ParseInfluxCSV(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses normal CSV", func(t *testing.T) {
+		t.Parallel()
+		csv := "time,dzd_pubkey,intf,in-octets\n" +
+			"2024-01-01T00:00:00Z,abc123,eth0,1000\n" +
+			"2024-01-01T00:05:00Z,abc123,eth0,2000\n"
+
+		rows, err := ParseInfluxCSV(strings.NewReader(csv))
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		require.Equal(t, "2024-01-01T00:00:00Z", rows[0]["time"])
+		require.Equal(t, "abc123", rows[0]["dzd_pubkey"])
+		require.Equal(t, "1000", rows[0]["in-octets"])
+		require.Equal(t, "2000", rows[1]["in-octets"])
+	})
+
+	t.Run("returns nil for empty body", func(t *testing.T) {
+		t.Parallel()
+		rows, err := ParseInfluxCSV(strings.NewReader(""))
+		require.NoError(t, err)
+		require.Nil(t, rows)
+	})
+
+	t.Run("returns nil for header only", func(t *testing.T) {
+		t.Parallel()
+		rows, err := ParseInfluxCSV(strings.NewReader("time,dzd_pubkey,intf\n"))
+		require.NoError(t, err)
+		require.Empty(t, rows)
+	})
+
+	t.Run("empty CSV fields become nil", func(t *testing.T) {
+		t.Parallel()
+		csv := "time,dzd_pubkey,in-errors\n" +
+			"2024-01-01T00:00:00Z,abc123,\n"
+
+		rows, err := ParseInfluxCSV(strings.NewReader(csv))
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, "abc123", rows[0]["dzd_pubkey"])
+		require.Nil(t, rows[0]["in-errors"])
+	})
+
+	t.Run("whitespace trimmed from headers", func(t *testing.T) {
+		t.Parallel()
+		csv := " time , dzd_pubkey , intf \n" +
+			"2024-01-01T00:00:00Z,abc123,eth0\n"
+
+		rows, err := ParseInfluxCSV(strings.NewReader(csv))
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		// TrimLeadingSpace only trims leading whitespace in fields, not header names
+		// so headers are used as-is; this verifies the row is parsed correctly
+		require.NotEmpty(t, rows[0])
+	})
+}
+
+func TestLake_TelemetryUsage_HTTPInfluxDBClient_QuerySQL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed rows on success", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, "/api/v2/query", r.URL.Path)
+			require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("time,dzd_pubkey,in-octets\n2024-01-01T00:00:00Z,abc123,1000\n"))
+		}))
+		defer srv.Close()
+
+		client := NewHTTPInfluxDBClient(srv.URL, "test-token", "test-db")
+		rows, err := client.QuerySQL(t.Context(), "SELECT * FROM intfCounters")
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, "abc123", rows[0]["dzd_pubkey"])
+		require.Equal(t, "1000", rows[0]["in-octets"])
+	})
+
+	t.Run("returns error on non-200 status", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+		}))
+		defer srv.Close()
+
+		client := NewHTTPInfluxDBClient(srv.URL, "bad-token", "test-db")
+		_, err := client.QuerySQL(t.Context(), "SELECT * FROM intfCounters")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "401")
+	})
+
+	t.Run("returns empty slice for empty response", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		client := NewHTTPInfluxDBClient(srv.URL, "test-token", "test-db")
+		rows, err := client.QuerySQL(t.Context(), "SELECT * FROM intfCounters")
+		require.NoError(t, err)
+		require.Nil(t, rows)
+	})
+}

--- a/indexer/pkg/dz/telemetry/usage/store_backfill.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill.go
@@ -3,6 +3,7 @@ package dztelemusage
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -111,6 +112,90 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 	// Insert into ClickHouse
 	if err := v.store.InsertInterfaceUsage(ctx, usage); err != nil {
 		return nil, fmt.Errorf("failed to insert backfill data: %w", err)
+	}
+
+	return &BackfillResult{
+		StartTime:    startTime,
+		EndTime:      endTime,
+		RowsQueried:  len(rows),
+		RowsInserted: len(usage),
+	}, nil
+}
+
+// BackfillFromReader reads intfCounters CSV data from r and imports it into ClickHouse.
+// The CSV format must match the output of ExportInterfaceCountersCSV.
+// This does not require a live InfluxDB connection.
+// It relies on ReplacingMergeTree for deduplication, making it safe to re-run.
+func (v *View) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillResult, error) {
+	rows, err := ParseInfluxCSV(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CSV: %w", err)
+	}
+
+	v.log.Info("telemetry/usage: backfill from CSV parsed rows", "rows", len(rows))
+
+	if len(rows) == 0 {
+		return &BackfillResult{}, nil
+	}
+
+	// Derive time range from the data for the result summary
+	var startTime, endTime time.Time
+	for _, row := range rows {
+		timeStr := extractStringFromRow(row, "time")
+		if timeStr == nil {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339Nano, *timeStr)
+		if err != nil {
+			t, err = time.Parse(time.RFC3339, *timeStr)
+			if err != nil {
+				continue
+			}
+		}
+		if startTime.IsZero() || t.Before(startTime) {
+			startTime = t
+		}
+		if t.After(endTime) {
+			endTime = t
+		}
+	}
+
+	// Query baseline counters from ClickHouse to compute accurate deltas
+	baselines, err := v.queryBaselineCountersFromClickHouse(ctx, startTime)
+	if err != nil {
+		v.log.Warn("telemetry/usage: failed to query baseline counters for CSV backfill, proceeding without", "error", err)
+		baselines = &CounterBaselines{
+			InDiscards:  make(map[string]*int64),
+			InErrors:    make(map[string]*int64),
+			InFCSErrors: make(map[string]*int64),
+			OutDiscards: make(map[string]*int64),
+			OutErrors:   make(map[string]*int64),
+		}
+	}
+
+	// Build link lookup for enrichment
+	linkLookup, err := v.buildLinkLookup(ctx)
+	if err != nil {
+		v.log.Warn("telemetry/usage: failed to build link lookup for CSV backfill, proceeding without", "error", err)
+		linkLookup = make(map[string]LinkInfo)
+	}
+
+	usage, err := v.convertRowsToUsage(rows, baselines, linkLookup, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert CSV rows: %w", err)
+	}
+
+	if len(usage) == 0 {
+		return &BackfillResult{
+			StartTime:    startTime,
+			EndTime:      endTime,
+			RowsQueried:  len(rows),
+			RowsInserted: 0,
+		}, nil
+	}
+
+	if err := v.store.InsertInterfaceUsage(ctx, usage); err != nil {
+		return nil, fmt.Errorf("failed to insert CSV backfill data: %w", err)
 	}
 
 	return &BackfillResult{

--- a/indexer/pkg/dz/telemetry/usage/store_backfill.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill.go
@@ -23,7 +23,7 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 	}
 
 	// Query baseline counters from ClickHouse (or InfluxDB if not available)
-	baselines, err := v.queryBaselineCountersFromClickHouse(ctx, startTime)
+	baselines, err := v.store.queryBaselineCountersFromClickHouse(ctx, startTime)
 	if err != nil {
 		v.log.Warn("telemetry/usage: failed to query baseline counters from clickhouse for backfill", "error", err)
 		// Fall back to empty baselines - sparse counters may have incorrect deltas for first measurement
@@ -37,7 +37,7 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 	}
 
 	// Build link lookup for enrichment
-	linkLookup, err := v.buildLinkLookup(ctx)
+	linkLookup, err := v.store.buildLinkLookup(ctx)
 	if err != nil {
 		v.log.Warn("telemetry/usage: failed to build link lookup for backfill, proceeding without", "error", err)
 		linkLookup = make(map[string]LinkInfo)
@@ -95,7 +95,7 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 
 	// Convert rows to InterfaceUsage
 	// Pass nil for alreadyWritten - backfill relies on ReplacingMergeTree for deduplication
-	usage, err := v.convertRowsToUsage(rows, baselines, linkLookup, nil)
+	usage, err := v.store.convertRowsToUsage(rows, baselines, linkLookup, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rows for backfill: %w", err)
 	}
@@ -126,13 +126,13 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 // The CSV format must match the output of ExportInterfaceCountersCSV.
 // This does not require a live InfluxDB connection.
 // It relies on ReplacingMergeTree for deduplication, making it safe to re-run.
-func (v *View) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillResult, error) {
+func (s *Store) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillResult, error) {
 	rows, err := ParseInfluxCSV(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse CSV: %w", err)
 	}
 
-	v.log.Info("telemetry/usage: backfill from CSV parsed rows", "rows", len(rows))
+	s.log.Info("telemetry/usage: backfill from CSV parsed rows", "rows", len(rows))
 
 	if len(rows) == 0 {
 		return &BackfillResult{}, nil
@@ -161,9 +161,9 @@ func (v *View) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillRe
 	}
 
 	// Query baseline counters from ClickHouse to compute accurate deltas
-	baselines, err := v.queryBaselineCountersFromClickHouse(ctx, startTime)
+	baselines, err := s.queryBaselineCountersFromClickHouse(ctx, startTime)
 	if err != nil {
-		v.log.Warn("telemetry/usage: failed to query baseline counters for CSV backfill, proceeding without", "error", err)
+		s.log.Warn("telemetry/usage: failed to query baseline counters for CSV backfill, proceeding without", "error", err)
 		baselines = &CounterBaselines{
 			InDiscards:  make(map[string]*int64),
 			InErrors:    make(map[string]*int64),
@@ -174,13 +174,13 @@ func (v *View) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillRe
 	}
 
 	// Build link lookup for enrichment
-	linkLookup, err := v.buildLinkLookup(ctx)
+	linkLookup, err := s.buildLinkLookup(ctx)
 	if err != nil {
-		v.log.Warn("telemetry/usage: failed to build link lookup for CSV backfill, proceeding without", "error", err)
+		s.log.Warn("telemetry/usage: failed to build link lookup for CSV backfill, proceeding without", "error", err)
 		linkLookup = make(map[string]LinkInfo)
 	}
 
-	usage, err := v.convertRowsToUsage(rows, baselines, linkLookup, nil)
+	usage, err := s.convertRowsToUsage(rows, baselines, linkLookup, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert CSV rows: %w", err)
 	}
@@ -194,7 +194,7 @@ func (v *View) BackfillFromReader(ctx context.Context, r io.Reader) (*BackfillRe
 		}, nil
 	}
 
-	if err := v.store.InsertInterfaceUsage(ctx, usage); err != nil {
+	if err := s.InsertInterfaceUsage(ctx, usage); err != nil {
 		return nil, fmt.Errorf("failed to insert CSV backfill data: %w", err)
 	}
 

--- a/indexer/pkg/dz/telemetry/usage/store_backfill_test.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill_test.go
@@ -1,0 +1,112 @@
+package dztelemusage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_TelemetryUsage_Store_BackfillFromReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty result for empty CSV", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		store, err := NewStore(StoreConfig{
+			Logger:     laketesting.NewLogger(),
+			ClickHouse: db,
+		})
+		require.NoError(t, err)
+
+		result, err := store.BackfillFromReader(context.Background(), strings.NewReader(""))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 0, result.RowsQueried)
+		require.Equal(t, 0, result.RowsInserted)
+	})
+
+	t.Run("returns empty result for header-only CSV", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		store, err := NewStore(StoreConfig{
+			Logger:     laketesting.NewLogger(),
+			ClickHouse: db,
+		})
+		require.NoError(t, err)
+
+		csv := "time,dzd_pubkey,host,intf,in-octets,out-octets\n"
+		result, err := store.BackfillFromReader(context.Background(), strings.NewReader(csv))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 0, result.RowsQueried)
+		require.Equal(t, 0, result.RowsInserted)
+	})
+
+	t.Run("inserts rows from CSV into ClickHouse", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		store, err := NewStore(StoreConfig{
+			Logger:     laketesting.NewLogger(),
+			ClickHouse: db,
+		})
+		require.NoError(t, err)
+
+		// Two rows for the same device/interface at different times.
+		// The first row is used as baseline for non-sparse counters and is not stored.
+		// Only the second row is inserted.
+		csv := "time,dzd_pubkey,host,intf,in-octets,out-octets\n" +
+			"2024-01-01T10:00:00Z,deviceA,host1,eth0,1000,2000\n" +
+			"2024-01-01T10:05:00Z,deviceA,host1,eth0,1500,2500\n"
+
+		result, err := store.BackfillFromReader(context.Background(), strings.NewReader(csv))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.RowsQueried)
+		require.Equal(t, 1, result.RowsInserted)
+
+		// Verify the row landed in ClickHouse
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		rows, err := conn.Query(context.Background(),
+			"SELECT count() FROM fact_dz_device_interface_counters WHERE device_pk = ?", "deviceA")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		require.True(t, rows.Next())
+		var count uint64
+		require.NoError(t, rows.Scan(&count))
+		require.Greater(t, count, uint64(0))
+	})
+
+	t.Run("is safe to re-run (idempotent)", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		store, err := NewStore(StoreConfig{
+			Logger:     laketesting.NewLogger(),
+			ClickHouse: db,
+		})
+		require.NoError(t, err)
+
+		csv := "time,dzd_pubkey,host,intf,in-octets,out-octets\n" +
+			"2024-01-01T11:00:00Z,deviceB,host2,eth1,500,1000\n" +
+			"2024-01-01T11:05:00Z,deviceB,host2,eth1,800,1300\n"
+
+		result1, err := store.BackfillFromReader(context.Background(), strings.NewReader(csv))
+		require.NoError(t, err)
+		require.Equal(t, 1, result1.RowsInserted)
+
+		// Running again should not error (ReplacingMergeTree handles deduplication)
+		result2, err := store.BackfillFromReader(context.Background(), strings.NewReader(csv))
+		require.NoError(t, err)
+		require.Equal(t, 1, result2.RowsInserted)
+	})
+}

--- a/indexer/pkg/dz/telemetry/usage/store_helpers.go
+++ b/indexer/pkg/dz/telemetry/usage/store_helpers.go
@@ -68,7 +68,13 @@ func (s *Store) buildLinkLookup(ctx context.Context) (map[string]LinkInfo, error
 // queryBaselineCountersFromClickHouse queries ClickHouse for the last non-null counter values
 // before the window start for each device/interface combination.
 func (s *Store) queryBaselineCountersFromClickHouse(ctx context.Context, windowStart time.Time) (*CounterBaselines, error) {
-	lookbackStart := windowStart.Add(-90 * 24 * time.Hour)
+	// Query recent data before the window start to find the last non-null values.
+	// Use a 7-day lookback — the indexer writes every few minutes, so the last
+	// non-null value for any sparse counter should be well within this window.
+	// A shorter window is critical because the table has billions of rows and the
+	// global max_execution_time (60s) can cause longer lookbacks to time out,
+	// leaving baselines empty and breaking forward-fill.
+	lookbackStart := windowStart.Add(-7 * 24 * time.Hour)
 
 	baselines := &CounterBaselines{
 		InDiscards:  make(map[string]*int64),
@@ -78,62 +84,70 @@ func (s *Store) queryBaselineCountersFromClickHouse(ctx context.Context, windowS
 		OutErrors:   make(map[string]*int64),
 	}
 
-	counterFields := []struct {
-		field    string
-		baseline map[string]*int64
-	}{
-		{"in_discards", baselines.InDiscards},
-		{"in_errors", baselines.InErrors},
-		{"in_fcs_errors", baselines.InFCSErrors},
-		{"out_discards", baselines.OutDiscards},
-		{"out_errors", baselines.OutErrors},
-	}
-
 	conn, err := s.cfg.ClickHouse.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
 	}
 	defer conn.Close()
 
-	for _, cf := range counterFields {
-		sqlQuery := fmt.Sprintf(`
-			SELECT
-				device_pk,
-				intf,
-				argMax(%s, (event_ts)) as value
-			FROM fact_dz_device_interface_counters
-			WHERE event_ts >= ? AND event_ts < ? AND %s IS NOT NULL
-			GROUP BY device_pk, intf
-		`, cf.field, cf.field)
+	// Use a single query to fetch all sparse counter baselines at once.
+	// This is faster than 5 separate queries and avoids hitting the global
+	// max_execution_time limit.
+	sqlQuery := `
+		SELECT
+			device_pk,
+			intf,
+			argMaxIf(in_discards, event_ts, in_discards IS NOT NULL) as in_discards_val,
+			argMaxIf(in_errors, event_ts, in_errors IS NOT NULL) as in_errors_val,
+			argMaxIf(in_fcs_errors, event_ts, in_fcs_errors IS NOT NULL) as in_fcs_errors_val,
+			argMaxIf(out_discards, event_ts, out_discards IS NOT NULL) as out_discards_val,
+			argMaxIf(out_errors, event_ts, out_errors IS NOT NULL) as out_errors_val
+		FROM fact_dz_device_interface_counters
+		WHERE event_ts >= ? AND event_ts < ?
+			AND (in_discards IS NOT NULL OR in_errors IS NOT NULL OR in_fcs_errors IS NOT NULL
+				OR out_discards IS NOT NULL OR out_errors IS NOT NULL)
+		GROUP BY device_pk, intf
+	`
 
-		rows, err := conn.Query(ctx, sqlQuery, lookbackStart, windowStart)
-		if err != nil {
-			s.log.Warn("telemetry/usage: failed to query baseline for counter from clickhouse", "counter", cf.field, "error", err)
+	rows, err := conn.Query(ctx, sqlQuery, lookbackStart, windowStart)
+	if err != nil {
+		s.log.Warn("telemetry/usage: failed to query baselines from clickhouse", "error", err)
+		return baselines, nil
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var devicePK, intf *string
+		var inDiscards, inErrors, inFCSErrors, outDiscards, outErrors *int64
+		if err := rows.Scan(&devicePK, &intf, &inDiscards, &inErrors, &inFCSErrors, &outDiscards, &outErrors); err != nil {
+			s.log.Warn("telemetry/usage: failed to scan baseline row", "error", err)
 			continue
 		}
 
-		for rows.Next() {
-			var devicePK, intf *string
-			var val *int64
-			if err := rows.Scan(&devicePK, &intf, &val); err != nil {
-				s.log.Warn("telemetry/usage: failed to scan baseline row", "counter", cf.field, "error", err)
-				continue
-			}
-
-			if devicePK == nil || intf == nil {
-				continue
-			}
-
-			key := fmt.Sprintf("%s:%s", *devicePK, *intf)
-			if val != nil {
-				cf.baseline[key] = val
-			}
+		if devicePK == nil || intf == nil {
+			continue
 		}
-		rows.Close()
 
-		if err := rows.Err(); err != nil {
-			s.log.Warn("telemetry/usage: error iterating baseline rows", "counter", cf.field, "error", err)
+		key := fmt.Sprintf("%s:%s", *devicePK, *intf)
+		if inDiscards != nil {
+			baselines.InDiscards[key] = inDiscards
 		}
+		if inErrors != nil {
+			baselines.InErrors[key] = inErrors
+		}
+		if inFCSErrors != nil {
+			baselines.InFCSErrors[key] = inFCSErrors
+		}
+		if outDiscards != nil {
+			baselines.OutDiscards[key] = outDiscards
+		}
+		if outErrors != nil {
+			baselines.OutErrors[key] = outErrors
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		s.log.Warn("telemetry/usage: error iterating baseline rows", "error", err)
 	}
 
 	return baselines, nil

--- a/indexer/pkg/dz/telemetry/usage/store_helpers.go
+++ b/indexer/pkg/dz/telemetry/usage/store_helpers.go
@@ -1,0 +1,359 @@
+package dztelemusage
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// buildLinkLookup builds a map from "device_pk:intf" to LinkInfo by querying the dz_links_history table
+func (s *Store) buildLinkLookup(ctx context.Context) (map[string]LinkInfo, error) {
+	lookup := make(map[string]LinkInfo)
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	query := `
+		WITH ranked AS (
+			SELECT
+				*,
+				ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+			FROM dim_dz_links_history
+		)
+		SELECT
+			pk,
+			side_a_pk,
+			side_a_iface_name,
+			side_z_pk,
+			side_z_iface_name
+		FROM ranked
+		WHERE rn = 1 AND is_deleted = 0`
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query links: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var linkPK, sideAPK, sideAIface, sideZPK, sideZIface *string
+		if err := rows.Scan(&linkPK, &sideAPK, &sideAIface, &sideZPK, &sideZIface); err != nil {
+			return nil, fmt.Errorf("failed to scan link row: %w", err)
+		}
+
+		if sideAPK != nil && sideAIface != nil && *sideAPK != "" && *sideAIface != "" {
+			key := fmt.Sprintf("%s:%s", *sideAPK, *sideAIface)
+			linkPKVal := ""
+			if linkPK != nil {
+				linkPKVal = *linkPK
+			}
+			lookup[key] = LinkInfo{LinkPK: linkPKVal, LinkSide: "A"}
+		}
+
+		if sideZPK != nil && sideZIface != nil && *sideZPK != "" && *sideZIface != "" {
+			key := fmt.Sprintf("%s:%s", *sideZPK, *sideZIface)
+			linkPKVal := ""
+			if linkPK != nil {
+				linkPKVal = *linkPK
+			}
+			lookup[key] = LinkInfo{LinkPK: linkPKVal, LinkSide: "Z"}
+		}
+	}
+
+	return lookup, nil
+}
+
+// queryBaselineCountersFromClickHouse queries ClickHouse for the last non-null counter values
+// before the window start for each device/interface combination.
+func (s *Store) queryBaselineCountersFromClickHouse(ctx context.Context, windowStart time.Time) (*CounterBaselines, error) {
+	lookbackStart := windowStart.Add(-90 * 24 * time.Hour)
+
+	baselines := &CounterBaselines{
+		InDiscards:  make(map[string]*int64),
+		InErrors:    make(map[string]*int64),
+		InFCSErrors: make(map[string]*int64),
+		OutDiscards: make(map[string]*int64),
+		OutErrors:   make(map[string]*int64),
+	}
+
+	counterFields := []struct {
+		field    string
+		baseline map[string]*int64
+	}{
+		{"in_discards", baselines.InDiscards},
+		{"in_errors", baselines.InErrors},
+		{"in_fcs_errors", baselines.InFCSErrors},
+		{"out_discards", baselines.OutDiscards},
+		{"out_errors", baselines.OutErrors},
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	for _, cf := range counterFields {
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				device_pk,
+				intf,
+				argMax(%s, (event_ts)) as value
+			FROM fact_dz_device_interface_counters
+			WHERE event_ts >= ? AND event_ts < ? AND %s IS NOT NULL
+			GROUP BY device_pk, intf
+		`, cf.field, cf.field)
+
+		rows, err := conn.Query(ctx, sqlQuery, lookbackStart, windowStart)
+		if err != nil {
+			s.log.Warn("telemetry/usage: failed to query baseline for counter from clickhouse", "counter", cf.field, "error", err)
+			continue
+		}
+
+		for rows.Next() {
+			var devicePK, intf *string
+			var val *int64
+			if err := rows.Scan(&devicePK, &intf, &val); err != nil {
+				s.log.Warn("telemetry/usage: failed to scan baseline row", "counter", cf.field, "error", err)
+				continue
+			}
+
+			if devicePK == nil || intf == nil {
+				continue
+			}
+
+			key := fmt.Sprintf("%s:%s", *devicePK, *intf)
+			if val != nil {
+				cf.baseline[key] = val
+			}
+		}
+		rows.Close()
+
+		if err := rows.Err(); err != nil {
+			s.log.Warn("telemetry/usage: error iterating baseline rows", "counter", cf.field, "error", err)
+		}
+	}
+
+	return baselines, nil
+}
+
+// convertRowsToUsage converts raw InfluxDB/CSV rows into InterfaceUsage records.
+// It computes deltas, forward-fills nulls, and enriches with link information.
+// If alreadyWritten is provided, rows already stored in ClickHouse are skipped.
+func (s *Store) convertRowsToUsage(rows []map[string]any, baselines *CounterBaselines, linkLookup map[string]LinkInfo, alreadyWritten MaxTimestampsByKey) ([]InterfaceUsage, error) {
+	lastKnownValues := make(map[string]map[string]*int64)
+	firstRowSeen := make(map[string]bool)
+	lastTime := make(map[string]time.Time)
+
+	counterFieldNames := []string{
+		"carrier-transitions", "in-broadcast-pkts", "in-discards", "in-errors",
+		"in-fcs-errors", "in-multicast-pkts", "in-octets", "in-pkts", "in-unicast-pkts",
+		"out-broadcast-pkts", "out-discards", "out-errors", "out-multicast-pkts",
+		"out-octets", "out-pkts", "out-unicast-pkts",
+	}
+
+	var usage []InterfaceUsage
+	totalRows := len(rows)
+	logInterval := totalRows / 10
+	if logInterval < 100 {
+		logInterval = 100
+	}
+
+	for i, row := range rows {
+		if i > 0 && i%logInterval == 0 {
+			s.log.Debug("telemetry/usage: converting rows", "progress", fmt.Sprintf("%d/%d (%.1f%%)", i, totalRows, float64(i)/float64(totalRows)*100))
+		}
+		u := &InterfaceUsage{}
+
+		timeStr := extractStringFromRow(row, "time")
+		if timeStr == nil {
+			continue
+		}
+
+		var t time.Time
+		var err error
+		timeFormats := []string{
+			time.RFC3339Nano,
+			time.RFC3339,
+			"2006-01-02 15:04:05.999999999 -0700 UTC",
+			"2006-01-02 15:04:05.999999999 +0700 UTC",
+			"2006-01-02 15:04:05.999999999 +0000 UTC",
+			"2006-01-02 15:04:05.999999 -0700 UTC",
+			"2006-01-02 15:04:05.999999 +0700 UTC",
+			"2006-01-02 15:04:05.999999 +0000 UTC",
+			"2006-01-02 15:04:05.999 -0700 UTC",
+			"2006-01-02 15:04:05.999 +0700 UTC",
+			"2006-01-02 15:04:05.999 +0000 UTC",
+			"2006-01-02 15:04:05 -0700 UTC",
+			"2006-01-02 15:04:05 +0700 UTC",
+			"2006-01-02 15:04:05 +0000 UTC",
+		}
+
+		parsed := false
+		for _, format := range timeFormats {
+			t, err = time.Parse(format, *timeStr)
+			if err == nil {
+				parsed = true
+				break
+			}
+		}
+
+		if !parsed {
+			continue
+		}
+		u.Time = t
+
+		u.DevicePK = extractStringFromRow(row, "dzd_pubkey")
+		u.Host = extractStringFromRow(row, "host")
+		u.Intf = extractStringFromRow(row, "intf")
+		u.ModelName = extractStringFromRow(row, "model_name")
+		u.SerialNumber = extractStringFromRow(row, "serial_number")
+
+		if u.Intf != nil {
+			u.UserTunnelID = extractTunnelIDFromInterface(*u.Intf)
+		}
+
+		var key string
+		if u.DevicePK != nil && u.Intf != nil {
+			key = fmt.Sprintf("%s:%s", *u.DevicePK, *u.Intf)
+		}
+
+		if key != "" && lastKnownValues[key] == nil {
+			lastKnownValues[key] = make(map[string]*int64)
+			if baselines != nil {
+				if val := baselines.InDiscards[key]; val != nil {
+					lastKnownValues[key]["in-discards"] = val
+				}
+				if val := baselines.InErrors[key]; val != nil {
+					lastKnownValues[key]["in-errors"] = val
+				}
+				if val := baselines.InFCSErrors[key]; val != nil {
+					lastKnownValues[key]["in-fcs-errors"] = val
+				}
+				if val := baselines.OutDiscards[key]; val != nil {
+					lastKnownValues[key]["out-discards"] = val
+				}
+				if val := baselines.OutErrors[key]; val != nil {
+					lastKnownValues[key]["out-errors"] = val
+				}
+			}
+		}
+
+		if key != "" && alreadyWritten != nil {
+			if maxTS, exists := alreadyWritten[key]; exists {
+				if !t.After(maxTS) {
+					for _, field := range counterFieldNames {
+						value := extractInt64FromRow(row, field)
+						if value != nil {
+							lastKnownValues[key][field] = value
+						}
+					}
+					lastTime[key] = t
+					firstRowSeen[key] = true
+					continue
+				}
+			}
+		}
+
+		if key != "" {
+			if linkInfo, ok := linkLookup[key]; ok {
+				u.LinkPK = &linkInfo.LinkPK
+				u.LinkSide = &linkInfo.LinkSide
+			}
+		}
+
+		isFirstRow := key != "" && !firstRowSeen[key]
+
+		allCounterFields := []struct {
+			field     string
+			dest      **int64
+			deltaDest **int64
+			baseline  map[string]*int64
+			isSparse  bool
+		}{
+			{"carrier-transitions", &u.CarrierTransitions, &u.CarrierTransitionsDelta, nil, false},
+			{"in-broadcast-pkts", &u.InBroadcastPkts, &u.InBroadcastPktsDelta, nil, false},
+			{"in-discards", &u.InDiscards, &u.InDiscardsDelta, baselines.InDiscards, true},
+			{"in-errors", &u.InErrors, &u.InErrorsDelta, baselines.InErrors, true},
+			{"in-fcs-errors", &u.InFCSErrors, &u.InFCSErrorsDelta, baselines.InFCSErrors, true},
+			{"in-multicast-pkts", &u.InMulticastPkts, &u.InMulticastPktsDelta, nil, false},
+			{"in-octets", &u.InOctets, &u.InOctetsDelta, nil, false},
+			{"in-pkts", &u.InPkts, &u.InPktsDelta, nil, false},
+			{"in-unicast-pkts", &u.InUnicastPkts, &u.InUnicastPktsDelta, nil, false},
+			{"out-broadcast-pkts", &u.OutBroadcastPkts, &u.OutBroadcastPktsDelta, nil, false},
+			{"out-discards", &u.OutDiscards, &u.OutDiscardsDelta, baselines.OutDiscards, true},
+			{"out-errors", &u.OutErrors, &u.OutErrorsDelta, baselines.OutErrors, true},
+			{"out-multicast-pkts", &u.OutMulticastPkts, &u.OutMulticastPktsDelta, nil, false},
+			{"out-octets", &u.OutOctets, &u.OutOctetsDelta, nil, false},
+			{"out-pkts", &u.OutPkts, &u.OutPktsDelta, nil, false},
+			{"out-unicast-pkts", &u.OutUnicastPkts, &u.OutUnicastPktsDelta, nil, false},
+		}
+
+		if isFirstRow {
+			hasNonSparseValues := false
+			for _, cf := range allCounterFields {
+				if !cf.isSparse {
+					if extractInt64FromRow(row, cf.field) != nil {
+						hasNonSparseValues = true
+						break
+					}
+				}
+			}
+
+			if hasNonSparseValues {
+				for _, cf := range allCounterFields {
+					value := extractInt64FromRow(row, cf.field)
+					if value != nil && key != "" {
+						lastKnownValues[key][cf.field] = value
+					}
+				}
+				lastTime[key] = t
+				firstRowSeen[key] = true
+				continue
+			}
+			firstRowSeen[key] = true
+		}
+
+		for _, cf := range allCounterFields {
+			var currentValue *int64
+			value := extractInt64FromRow(row, cf.field)
+			if value != nil {
+				currentValue = value
+			} else if key != "" {
+				if lastKnown, ok := lastKnownValues[key][cf.field]; ok && lastKnown != nil {
+					currentValue = lastKnown
+				}
+			}
+
+			*cf.dest = currentValue
+
+			if currentValue != nil && key != "" {
+				var previousValue *int64
+				if lastKnown, ok := lastKnownValues[key][cf.field]; ok && lastKnown != nil {
+					previousValue = lastKnown
+				}
+
+				if previousValue != nil {
+					delta := *currentValue - *previousValue
+					*cf.deltaDest = &delta
+				}
+
+				lastKnownValues[key][cf.field] = currentValue
+			}
+		}
+
+		if key != "" {
+			if lastT, ok := lastTime[key]; ok {
+				duration := t.Sub(lastT).Seconds()
+				u.DeltaDuration = &duration
+			}
+			lastTime[key] = t
+		}
+
+		usage = append(usage, *u)
+	}
+
+	return usage, nil
+}

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -106,6 +106,9 @@ func (cfg *ViewConfig) Validate() error {
 	if cfg.InfluxDB == nil {
 		return errors.New("influxdb client is required")
 	}
+	if cfg.Bucket == "" {
+		return errors.New("influxdb bucket is required")
+	}
 	if cfg.RefreshInterval <= 0 {
 		return errors.New("refresh interval must be greater than 0")
 	}

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -103,12 +103,6 @@ func (cfg *ViewConfig) Validate() error {
 	if cfg.ClickHouse == nil {
 		return errors.New("clickhouse connection is required")
 	}
-	if cfg.InfluxDB == nil {
-		return errors.New("influxdb client is required")
-	}
-	if cfg.Bucket == "" {
-		return errors.New("influxdb bucket is required")
-	}
 	if cfg.RefreshInterval <= 0 {
 		return errors.New("refresh interval must be greater than 0")
 	}
@@ -190,6 +184,10 @@ func (v *View) safeRefresh(ctx context.Context) {
 }
 
 func (v *View) Refresh(ctx context.Context) error {
+	if v.cfg.InfluxDB == nil {
+		return errors.New("cannot run Refresh: InfluxDB client not configured")
+	}
+
 	v.refreshMu.Lock()
 	defer v.refreshMu.Unlock()
 

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -103,6 +103,9 @@ func (cfg *ViewConfig) Validate() error {
 	if cfg.ClickHouse == nil {
 		return errors.New("clickhouse connection is required")
 	}
+	if cfg.InfluxDB == nil {
+		return errors.New("influxdb client is required")
+	}
 	if cfg.RefreshInterval <= 0 {
 		return errors.New("refresh interval must be greater than 0")
 	}
@@ -184,9 +187,6 @@ func (v *View) safeRefresh(ctx context.Context) {
 }
 
 func (v *View) Refresh(ctx context.Context) error {
-	if v.cfg.InfluxDB == nil {
-		return errors.New("cannot run Refresh: InfluxDB client not configured")
-	}
 
 	v.refreshMu.Lock()
 	defer v.refreshMu.Unlock()
@@ -246,7 +246,7 @@ func (v *View) Refresh(ctx context.Context) error {
 	var baselines *CounterBaselines
 	v.log.Debug("telemetry/usage: querying baselines from clickhouse")
 	chStart := time.Now()
-	chBaselines, err := v.queryBaselineCountersFromClickHouse(ctx, queryStart)
+	chBaselines, err := v.store.queryBaselineCountersFromClickHouse(ctx, queryStart)
 	chDuration := time.Since(chStart)
 	if err != nil {
 		v.log.Warn("telemetry/usage: failed to query baseline counters from clickhouse", "error", err, "duration", chDuration.String())
@@ -442,7 +442,7 @@ func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, 
 	v.log.Debug("telemetry/usage: sorted rows", "rows", len(rows), "duration", sortDuration.String())
 
 	// Build link lookup map from dz_links_current table
-	linkLookup, err := v.buildLinkLookup(ctx)
+	linkLookup, err := v.store.buildLinkLookup(ctx)
 	if err != nil {
 		v.log.Warn("telemetry/usage: failed to build link lookup map, proceeding without link information", "error", err)
 		linkLookup = make(map[string]LinkInfo)
@@ -453,7 +453,7 @@ func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, 
 	// Convert rows to InterfaceUsage, tracking last known values per device/interface
 	// We need to process in time order to properly forward-fill nulls
 	convertStart := time.Now()
-	usage, err := v.convertRowsToUsage(rows, baselines, linkLookup, alreadyWritten)
+	usage, err := v.store.convertRowsToUsage(rows, baselines, linkLookup, alreadyWritten)
 	convertDuration := time.Since(convertStart)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rows: %w", err)
@@ -461,413 +461,6 @@ func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, 
 	v.log.Debug("telemetry/usage: converted rows to usage data", "usage_records", len(usage), "duration", convertDuration.String())
 
 	return usage, nil
-}
-
-// buildLinkLookup builds a map from "device_pk:intf" to LinkInfo by querying the dz_links_history table
-func (v *View) buildLinkLookup(ctx context.Context) (map[string]LinkInfo, error) {
-	lookup := make(map[string]LinkInfo)
-
-	conn, err := v.cfg.ClickHouse.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
-	}
-
-	// Query current links from history table using ROW_NUMBER for latest row per entity
-	query := `
-		WITH ranked AS (
-			SELECT
-				*,
-				ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
-			FROM dim_dz_links_history
-		)
-		SELECT
-			pk,
-			side_a_pk,
-			side_a_iface_name,
-			side_z_pk,
-			side_z_iface_name
-		FROM ranked
-		WHERE rn = 1 AND is_deleted = 0`
-	rows, err := conn.Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query links: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var linkPK, sideAPK, sideAIface, sideZPK, sideZIface *string
-		if err := rows.Scan(&linkPK, &sideAPK, &sideAIface, &sideZPK, &sideZIface); err != nil {
-			return nil, fmt.Errorf("failed to scan link row: %w", err)
-		}
-
-		// Add side A mapping
-		if sideAPK != nil && sideAIface != nil && *sideAPK != "" && *sideAIface != "" {
-			key := fmt.Sprintf("%s:%s", *sideAPK, *sideAIface)
-			linkPKVal := ""
-			if linkPK != nil {
-				linkPKVal = *linkPK
-			}
-			lookup[key] = LinkInfo{LinkPK: linkPKVal, LinkSide: "A"}
-		}
-
-		// Add side Z mapping
-		if sideZPK != nil && sideZIface != nil && *sideZPK != "" && *sideZIface != "" {
-			key := fmt.Sprintf("%s:%s", *sideZPK, *sideZIface)
-			linkPKVal := ""
-			if linkPK != nil {
-				linkPKVal = *linkPK
-			}
-			lookup[key] = LinkInfo{LinkPK: linkPKVal, LinkSide: "Z"}
-		}
-	}
-
-	return lookup, nil
-}
-
-// convertRowsToUsage converts rows to InterfaceUsage, using baselines only for the first null
-// and forward-filling with the last known value for subsequent nulls
-// For non-sparse counters, the first row per device/interface is used as baseline and not stored
-// If alreadyWritten is provided, rows with timestamps <= the max already written for that key are skipped
-func (v *View) convertRowsToUsage(rows []map[string]any, baselines *CounterBaselines, linkLookup map[string]LinkInfo, alreadyWritten MaxTimestampsByKey) ([]InterfaceUsage, error) {
-	// Track last known values per device/interface for each counter
-	// Key: "device_pk:intf", Value: map of counter name to last value
-	lastKnownValues := make(map[string]map[string]*int64)
-	// Track whether we've seen the first row for each device/interface
-	// For non-sparse counters, we skip storing the first row and use it as baseline
-	firstRowSeen := make(map[string]bool)
-	// Track last time per device/interface for computing delta_duration
-	lastTime := make(map[string]time.Time)
-
-	// All counter field names for updating lastKnownValues on skipped rows
-	counterFieldNames := []string{
-		"carrier-transitions", "in-broadcast-pkts", "in-discards", "in-errors",
-		"in-fcs-errors", "in-multicast-pkts", "in-octets", "in-pkts", "in-unicast-pkts",
-		"out-broadcast-pkts", "out-discards", "out-errors", "out-multicast-pkts",
-		"out-octets", "out-pkts", "out-unicast-pkts",
-	}
-
-	var usage []InterfaceUsage
-	totalRows := len(rows)
-	logInterval := totalRows / 10 // Log every 10% progress
-	if logInterval < 100 {
-		logInterval = 100 // But at least every 100 rows
-	}
-
-	for i, row := range rows {
-		// Log progress periodically
-		if i > 0 && i%logInterval == 0 {
-			v.log.Debug("telemetry/usage: converting rows", "progress", fmt.Sprintf("%d/%d (%.1f%%)", i, totalRows, float64(i)/float64(totalRows)*100))
-		}
-		u := &InterfaceUsage{}
-
-		// Extract time (required)
-		timeStr := extractStringFromRow(row, "time")
-		if timeStr == nil {
-			continue // Skip rows without time
-		}
-
-		// Try multiple time formats that InfluxDB might return
-		// InfluxDB SDK returns time in format: "2006-01-02 15:04:05.999999999 +0000 UTC"
-		var t time.Time
-		var err error
-		timeFormats := []string{
-			time.RFC3339Nano,
-			time.RFC3339,
-			"2006-01-02 15:04:05.999999999 -0700 UTC", // InfluxDB format with timezone
-			"2006-01-02 15:04:05.999999999 +0700 UTC",
-			"2006-01-02 15:04:05.999999999 +0000 UTC",
-			"2006-01-02 15:04:05.999999 -0700 UTC",
-			"2006-01-02 15:04:05.999999 +0700 UTC",
-			"2006-01-02 15:04:05.999999 +0000 UTC",
-			"2006-01-02 15:04:05.999 -0700 UTC",
-			"2006-01-02 15:04:05.999 +0700 UTC",
-			"2006-01-02 15:04:05.999 +0000 UTC",
-			"2006-01-02 15:04:05 -0700 UTC",
-			"2006-01-02 15:04:05 +0700 UTC",
-			"2006-01-02 15:04:05 +0000 UTC",
-		}
-
-		parsed := false
-		for _, format := range timeFormats {
-			t, err = time.Parse(format, *timeStr)
-			if err == nil {
-				parsed = true
-				break
-			}
-		}
-
-		if !parsed {
-			continue // Skip rows with invalid time
-		}
-		u.Time = t
-
-		// Extract string fields
-		u.DevicePK = extractStringFromRow(row, "dzd_pubkey")
-		u.Host = extractStringFromRow(row, "host")
-		u.Intf = extractStringFromRow(row, "intf")
-		u.ModelName = extractStringFromRow(row, "model_name")
-		u.SerialNumber = extractStringFromRow(row, "serial_number")
-
-		// Extract tunnel ID from interface name if it starts with "Tunnel"
-		if u.Intf != nil {
-			u.UserTunnelID = extractTunnelIDFromInterface(*u.Intf)
-		}
-
-		// Build key for tracking
-		var key string
-		if u.DevicePK != nil && u.Intf != nil {
-			key = fmt.Sprintf("%s:%s", *u.DevicePK, *u.Intf)
-		} else {
-			// Can't track without key, just extract what we can
-			key = ""
-		}
-
-		// Initialize lastKnownValues and pre-populate sparse counter baselines.
-		// This must happen before the alreadyWritten skip below, otherwise
-		// baselines for sparse counters (errors/discards) are never loaded
-		// and those counters stay NULL in all subsequent rows.
-		if key != "" && lastKnownValues[key] == nil {
-			lastKnownValues[key] = make(map[string]*int64)
-			if baselines != nil {
-				if val := baselines.InDiscards[key]; val != nil {
-					lastKnownValues[key]["in-discards"] = val
-				}
-				if val := baselines.InErrors[key]; val != nil {
-					lastKnownValues[key]["in-errors"] = val
-				}
-				if val := baselines.InFCSErrors[key]; val != nil {
-					lastKnownValues[key]["in-fcs-errors"] = val
-				}
-				if val := baselines.OutDiscards[key]; val != nil {
-					lastKnownValues[key]["out-discards"] = val
-				}
-				if val := baselines.OutErrors[key]; val != nil {
-					lastKnownValues[key]["out-errors"] = val
-				}
-			}
-		}
-
-		// Skip rows that have already been written to avoid duplicates
-		// This is important because we use an overlap window when refreshing
-		if key != "" && alreadyWritten != nil {
-			if maxTS, exists := alreadyWritten[key]; exists {
-				if !t.After(maxTS) {
-					// This row has already been written, skip it
-					// But still update lastKnownValues for delta calculations of subsequent rows
-					for _, field := range counterFieldNames {
-						value := extractInt64FromRow(row, field)
-						if value != nil {
-							lastKnownValues[key][field] = value
-						}
-					}
-					lastTime[key] = t
-					firstRowSeen[key] = true
-					continue
-				}
-			}
-		}
-
-		if key != "" {
-			if linkInfo, ok := linkLookup[key]; ok {
-				u.LinkPK = &linkInfo.LinkPK
-				u.LinkSide = &linkInfo.LinkSide
-			}
-		}
-
-		isFirstRow := key != "" && !firstRowSeen[key]
-
-		// For all counter fields: use value if present, otherwise forward-fill with last known
-		// Sparse counters (errors/discards) have baselines from 10-year query
-		// Non-sparse counters: first row is used as baseline, not stored
-		allCounterFields := []struct {
-			field     string
-			dest      **int64
-			deltaDest **int64
-			baseline  map[string]*int64
-			isSparse  bool
-		}{
-			{"carrier-transitions", &u.CarrierTransitions, &u.CarrierTransitionsDelta, nil, false},
-			{"in-broadcast-pkts", &u.InBroadcastPkts, &u.InBroadcastPktsDelta, nil, false},
-			{"in-discards", &u.InDiscards, &u.InDiscardsDelta, baselines.InDiscards, true},
-			{"in-errors", &u.InErrors, &u.InErrorsDelta, baselines.InErrors, true},
-			{"in-fcs-errors", &u.InFCSErrors, &u.InFCSErrorsDelta, baselines.InFCSErrors, true},
-			{"in-multicast-pkts", &u.InMulticastPkts, &u.InMulticastPktsDelta, nil, false},
-			{"in-octets", &u.InOctets, &u.InOctetsDelta, nil, false},
-			{"in-pkts", &u.InPkts, &u.InPktsDelta, nil, false},
-			{"in-unicast-pkts", &u.InUnicastPkts, &u.InUnicastPktsDelta, nil, false},
-			{"out-broadcast-pkts", &u.OutBroadcastPkts, &u.OutBroadcastPktsDelta, nil, false},
-			{"out-discards", &u.OutDiscards, &u.OutDiscardsDelta, baselines.OutDiscards, true},
-			{"out-errors", &u.OutErrors, &u.OutErrorsDelta, baselines.OutErrors, true},
-			{"out-multicast-pkts", &u.OutMulticastPkts, &u.OutMulticastPktsDelta, nil, false},
-			{"out-octets", &u.OutOctets, &u.OutOctetsDelta, nil, false},
-			{"out-pkts", &u.OutPkts, &u.OutPktsDelta, nil, false},
-			{"out-unicast-pkts", &u.OutUnicastPkts, &u.OutUnicastPktsDelta, nil, false},
-		}
-
-		// For non-sparse counters on first row: extract values and use as baseline, skip storing the row
-		// For sparse counters, we still process and store the first row (they have baselines from 10-year query)
-		if isFirstRow {
-			// Check if we have any non-sparse counter values
-			hasNonSparseValues := false
-			for _, cf := range allCounterFields {
-				if !cf.isSparse {
-					value := extractInt64FromRow(row, cf.field)
-					if value != nil {
-						hasNonSparseValues = true
-						break
-					}
-				}
-			}
-
-			if hasNonSparseValues {
-				// Extract all counter values and store as baselines
-				for _, cf := range allCounterFields {
-					value := extractInt64FromRow(row, cf.field)
-					if value != nil && key != "" {
-						lastKnownValues[key][cf.field] = value
-					}
-				}
-				lastTime[key] = t
-				firstRowSeen[key] = true
-				continue
-			}
-			// If no non-sparse values, continue processing normally (sparse counters will be stored)
-			firstRowSeen[key] = true
-		}
-
-		// Process all counters
-		for _, cf := range allCounterFields {
-			var currentValue *int64
-			value := extractInt64FromRow(row, cf.field)
-			if value != nil {
-				currentValue = value
-			} else if key != "" {
-				// Forward-fill with last known value (includes pre-populated baselines)
-				if lastKnown, ok := lastKnownValues[key][cf.field]; ok && lastKnown != nil {
-					currentValue = lastKnown
-				}
-			}
-
-			*cf.dest = currentValue
-
-			// Compute delta against last-known value
-			if currentValue != nil && key != "" {
-				var previousValue *int64
-				if lastKnown, ok := lastKnownValues[key][cf.field]; ok && lastKnown != nil {
-					previousValue = lastKnown
-				}
-
-				if previousValue != nil {
-					delta := *currentValue - *previousValue
-					*cf.deltaDest = &delta
-				}
-
-				lastKnownValues[key][cf.field] = currentValue
-			}
-		}
-
-		// Compute delta_duration: time difference from previous measurement
-		if key != "" {
-			if lastT, ok := lastTime[key]; ok {
-				duration := t.Sub(lastT).Seconds()
-				u.DeltaDuration = &duration
-			}
-			// Update last time for next iteration
-			lastTime[key] = t
-		}
-
-		usage = append(usage, *u)
-	}
-
-	return usage, nil
-}
-
-// queryBaselineCountersFromClickHouse queries ClickHouse for the last non-null counter values before the window start
-// for each device/interface combination. Returns error if ClickHouse doesn't have data or query fails.
-func (v *View) queryBaselineCountersFromClickHouse(ctx context.Context, windowStart time.Time) (*CounterBaselines, error) {
-	// Query recent data before the window start to find the last non-null values.
-	// Use a 7-day lookback — the indexer writes every few minutes, so the last
-	// non-null value for any sparse counter should be well within this window.
-	// A shorter window is critical because the table has billions of rows and the
-	// global max_execution_time (60s) can cause longer lookbacks to time out,
-	// leaving baselines empty and breaking forward-fill.
-	lookbackStart := windowStart.Add(-7 * 24 * time.Hour)
-
-	baselines := &CounterBaselines{
-		InDiscards:  make(map[string]*int64),
-		InErrors:    make(map[string]*int64),
-		InFCSErrors: make(map[string]*int64),
-		OutDiscards: make(map[string]*int64),
-		OutErrors:   make(map[string]*int64),
-	}
-
-	conn, err := v.cfg.ClickHouse.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
-	}
-	defer conn.Close()
-
-	// Use a single query to fetch all sparse counter baselines at once.
-	// This is faster than 5 separate queries and avoids hitting the global
-	// max_execution_time limit.
-	sqlQuery := `
-		SELECT
-			device_pk,
-			intf,
-			argMaxIf(in_discards, event_ts, in_discards IS NOT NULL) as in_discards_val,
-			argMaxIf(in_errors, event_ts, in_errors IS NOT NULL) as in_errors_val,
-			argMaxIf(in_fcs_errors, event_ts, in_fcs_errors IS NOT NULL) as in_fcs_errors_val,
-			argMaxIf(out_discards, event_ts, out_discards IS NOT NULL) as out_discards_val,
-			argMaxIf(out_errors, event_ts, out_errors IS NOT NULL) as out_errors_val
-		FROM fact_dz_device_interface_counters
-		WHERE event_ts >= ? AND event_ts < ?
-			AND (in_discards IS NOT NULL OR in_errors IS NOT NULL OR in_fcs_errors IS NOT NULL
-				OR out_discards IS NOT NULL OR out_errors IS NOT NULL)
-		GROUP BY device_pk, intf
-	`
-
-	rows, err := conn.Query(ctx, sqlQuery, lookbackStart, windowStart)
-	if err != nil {
-		v.log.Warn("telemetry/usage: failed to query baselines from clickhouse", "error", err)
-		return baselines, nil
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var devicePK, intf *string
-		var inDiscards, inErrors, inFCSErrors, outDiscards, outErrors *int64
-		if err := rows.Scan(&devicePK, &intf, &inDiscards, &inErrors, &inFCSErrors, &outDiscards, &outErrors); err != nil {
-			v.log.Warn("telemetry/usage: failed to scan baseline row", "error", err)
-			continue
-		}
-
-		if devicePK == nil || intf == nil {
-			continue
-		}
-
-		key := fmt.Sprintf("%s:%s", *devicePK, *intf)
-		if inDiscards != nil {
-			baselines.InDiscards[key] = inDiscards
-		}
-		if inErrors != nil {
-			baselines.InErrors[key] = inErrors
-		}
-		if inFCSErrors != nil {
-			baselines.InFCSErrors[key] = inFCSErrors
-		}
-		if outDiscards != nil {
-			baselines.OutDiscards[key] = outDiscards
-		}
-		if outErrors != nil {
-			baselines.OutErrors[key] = outErrors
-		}
-	}
-
-	if err := rows.Err(); err != nil {
-		v.log.Warn("telemetry/usage: error iterating baseline rows", "error", err)
-	}
-
-	return baselines, nil
 }
 
 // queryBaselineCounters queries InfluxDB for the last non-null counter values before the window start

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -71,11 +71,27 @@ func TestLake_TelemetryUsage_View_ViewConfig_Validate(t *testing.T) {
 		cfg := ViewConfig{
 			Logger:          laketesting.NewLogger(),
 			ClickHouse:      mockDB,
+			Bucket:          "test-bucket",
 			RefreshInterval: time.Second,
 		}
 		err := cfg.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "influxdb client is required")
+	})
+
+	t.Run("returns error when bucket is empty", func(t *testing.T) {
+		t.Parallel()
+		mockDB := testClient(t)
+
+		cfg := ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			ClickHouse:      mockDB,
+			InfluxDB:        &mockInfluxDBClient{},
+			RefreshInterval: time.Second,
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "influxdb bucket is required")
 	})
 
 	t.Run("returns error when refresh interval is zero", func(t *testing.T) {
@@ -776,7 +792,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now.Add(time.Minute),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		require.Len(t, usage, 1)
 
@@ -833,7 +849,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			OutErrors:   make(map[string]*int64),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
 		require.NoError(t, err)
 		// First row is skipped (baseline for non-sparse), only second row stored
 		require.Len(t, usage, 1)
@@ -952,7 +968,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now.Add(2 * time.Minute),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		require.Len(t, usage, 1)
 
@@ -1030,7 +1046,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now.Add(time.Minute),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		require.Len(t, usage, 2)
 
@@ -1260,7 +1276,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			OutErrors:   make(map[string]*int64),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
 		require.NoError(t, err)
 		// First row skipped (baseline), rows 2 and 3 stored
 		require.Len(t, usage, 2)

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -64,7 +64,7 @@ func TestLake_TelemetryUsage_View_ViewConfig_Validate(t *testing.T) {
 		require.Contains(t, err.Error(), "clickhouse connection is required")
 	})
 
-	t.Run("influxdb client is optional at construction", func(t *testing.T) {
+	t.Run("returns error when influxdb client is not configured", func(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
@@ -74,23 +74,8 @@ func TestLake_TelemetryUsage_View_ViewConfig_Validate(t *testing.T) {
 			RefreshInterval: time.Second,
 		}
 		err := cfg.Validate()
-		require.NoError(t, err)
-	})
-
-	t.Run("refresh returns error when influxdb client is not configured", func(t *testing.T) {
-		t.Parallel()
-		mockDB := testClient(t)
-
-		view, err := NewView(ViewConfig{
-			Logger:          laketesting.NewLogger(),
-			ClickHouse:      mockDB,
-			RefreshInterval: time.Second,
-		})
-		require.NoError(t, err)
-
-		err = view.Refresh(context.Background())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "InfluxDB client not configured")
+		require.Contains(t, err.Error(), "influxdb client is required")
 	})
 
 	t.Run("returns error when refresh interval is zero", func(t *testing.T) {
@@ -290,7 +275,7 @@ func TestLake_TelemetryUsage_View_buildLinkLookup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		lookup, err := view.buildLinkLookup(context.Background())
+		lookup, err := view.Store().buildLinkLookup(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, lookup)
 
@@ -333,7 +318,7 @@ func TestLake_TelemetryUsage_View_buildLinkLookup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		lookup, err := view.buildLinkLookup(context.Background())
+		lookup, err := view.Store().buildLinkLookup(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, lookup)
 		require.Equal(t, 0, len(lookup))
@@ -521,7 +506,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:Tunnel501": {LinkPK: "link1", LinkSide: "A"},
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, linkLookup, nil)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, linkLookup, nil)
 		require.NoError(t, err)
 		require.Len(t, usage, 2)
 
@@ -576,7 +561,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			OutErrors:   make(map[string]*int64),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
 		require.NoError(t, err)
 		// First row should be skipped (used as baseline), so only second row should be stored
 		require.Len(t, usage, 1)
@@ -618,7 +603,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			InErrors: make(map[string]*int64),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), nil)
 		require.NoError(t, err)
 		require.Len(t, usage, 2)
 
@@ -675,7 +660,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now,
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		// First row should be skipped (already written), so only rows 2 and 3 should be stored
 		require.Len(t, usage, 2)
@@ -730,7 +715,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now.Add(time.Minute),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		// First two rows should be skipped (at or before already-written timestamp), only third row stored
 		require.Len(t, usage, 1)

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -64,34 +64,33 @@ func TestLake_TelemetryUsage_View_ViewConfig_Validate(t *testing.T) {
 		require.Contains(t, err.Error(), "clickhouse connection is required")
 	})
 
-	t.Run("returns error when influxdb client is missing", func(t *testing.T) {
+	t.Run("influxdb client is optional at construction", func(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
 		cfg := ViewConfig{
 			Logger:          laketesting.NewLogger(),
 			ClickHouse:      mockDB,
-			Bucket:          "test-bucket",
 			RefreshInterval: time.Second,
 		}
 		err := cfg.Validate()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "influxdb client is required")
+		require.NoError(t, err)
 	})
 
-	t.Run("returns error when bucket is empty", func(t *testing.T) {
+	t.Run("refresh returns error when influxdb client is not configured", func(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
-		cfg := ViewConfig{
+		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),
 			ClickHouse:      mockDB,
-			InfluxDB:        &mockInfluxDBClient{},
 			RefreshInterval: time.Second,
-		}
-		err := cfg.Validate()
+		})
+		require.NoError(t, err)
+
+		err = view.Refresh(context.Background())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "influxdb bucket is required")
+		require.Contains(t, err.Error(), "InfluxDB client not configured")
 	})
 
 	t.Run("returns error when refresh interval is zero", func(t *testing.T) {

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -1133,7 +1133,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 			"device1:eth0": now.Add(time.Minute),
 		}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		require.Len(t, usage, 2)
 
@@ -1208,7 +1208,7 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 		// No alreadyWritten entries for this key (global maxTime is ahead)
 		alreadyWritten := MaxTimestampsByKey{}
 
-		usage, err := view.convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
+		usage, err := view.Store().convertRowsToUsage(rows, baselines, make(map[string]LinkInfo), alreadyWritten)
 		require.NoError(t, err)
 		// First row is consumed as baseline, so we get 2 rows
 		require.Len(t, usage, 2)


### PR DESCRIPTION
Closes #150

## Summary of Changes

- Adds `HTTPInfluxDBClient` implementing the `InfluxDBClient` interface via the InfluxDB HTTP query API with CSV output, as a more reliable alternative to the FlightSQL/gRPC SDK for bulk queries and large time windows
- Switches the live indexer refresh loop from `NewSDKInfluxDBClient` to `NewHTTPInfluxDBClient` by default
- Adds `--export-influx-csv` admin command to export `intfCounters` data from InfluxDB to a local CSV file, with `--start-time`, `--end-time` (RFC3339), `--export-output`, and `--export-chunk-size` (default 1h) flags to avoid query timeouts on large ranges
- Adds `--backfill-from-csv <file>` admin command to import a previously exported CSV into ClickHouse without a live InfluxDB connection
- Adds `BackfillFromReader(ctx, io.Reader)` on `View` for the CSV import path, and makes `InfluxDB` optional in `ViewConfig` since this path does not need it

Notes for review:

- Endpoint: used `/api/v2/query` with `{"query": "...", "format": "csv"}` to match the reference curl in the issue exactly. The documented InfluxDB 3 SQL endpoint is `/api/v3/query_sql` with `{"q": "...", "db": "..."}`. Happy to switch if your instance uses that instead.
- `ParseInfluxCSV` assumes plain CSV (v3 SQL output). If the instance returns annotated CSV (with `#datatype`/`#group` rows from v2/Flux), we would need to skip those rows. Let me know if that is a concern.

## Testing Verification

- `go test ./indexer/pkg/dz/telemetry/usage/...` passes (8 unit tests using `httptest.NewServer`, no external dependencies)
- `go build ./indexer/...` passes