### PR TITLE
web: show in/out independently for interface errors and discards

### DIFF
--- a/web/src/components/topology/InterfaceCharts.tsx
+++ b/web/src/components/topology/InterfaceCharts.tsx
@@ -106,8 +106,6 @@ function HealthLegendTable({
     })
   }, [interfaces, data, bidirectional, directionActivity])
 
-  if (activeInterfaces.length === 0) return null
-
   // Build legend rows: for bidirectional, one row per active direction per interface
   const legendRows = useMemo(() => {
     if (!bidirectional) {
@@ -131,6 +129,8 @@ function HealthLegendTable({
     }
     return rows
   }, [activeInterfaces, bidirectional, directionActivity, interfaceLabels])
+
+  if (activeInterfaces.length === 0) return null
 
   return (
     <div className="flex flex-col text-xs px-2 pt-1 pb-2">


### PR DESCRIPTION
## Summary of Changes
* Interface errors and discards charts now filter in/out directions independently: only show a direction's line if that direction has non-zero data across the time range
* Legend displays a dash for inactive directions instead of a misleading zero count
* Addresses #162

## Testing Verification
* TypeScript build passes (tsc -b)
* Visual behavior: if an interface has only out_errors, only the dashed (out) line appears; if only in_errors, only the solid (in) line appears; both appear when both have data
