### PR TITLE
web: highlight specific row when navigating from status summary

### DIFF
--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -545,7 +545,7 @@ function LinkRow({ link, linksWithIssues, criticalityMap, bucketMinutes = 60, da
   const hasExpandableContent = showInterfaceChart || showPacketLossChart
 
   return (
-    <div className="border-b border-border last:border-b-0">
+    <div id={`link-row-${link.code}`} className="border-b border-border last:border-b-0">
       <div
         className={`px-4 py-3 transition-colors ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30' : ''}`}
         onClick={hasExpandableContent ? () => setExpanded(!expanded) : undefined}

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -193,7 +193,7 @@ function IssueDetails({
   nonActivatedLinks: NonActivatedLink[]
   deviceIssues: InterfaceIssue[]
   nonActivatedDevices: NonActivatedDevice[]
-  onIssueClick: () => void
+  onIssueClick: (linkCode: string) => void
   onNonActivatedClick: () => void
   onDeviceIssueClick: (devicePk: string) => void
 }) {
@@ -246,7 +246,7 @@ function IssueDetails({
               {sectionIssues.map((issue, idx) => (
                 <button
                   key={idx}
-                  onClick={onIssueClick}
+                  onClick={() => onIssueClick(issue.code)}
                   className="flex items-center justify-between w-full py-2 px-3 rounded-md bg-muted/50 hover:bg-muted transition-colors text-left"
                 >
                   <div className="flex items-center gap-3">
@@ -431,35 +431,53 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
     return () => clearInterval(interval)
   }, [])
 
-  const scrollToLinkHistory = () => {
+  const flashHighlight = (el: Element) => {
+    el.classList.remove('scroll-highlight')
+    // Force reflow so re-adding the class restarts the animation
+    void (el as HTMLElement).offsetWidth
+    el.classList.add('scroll-highlight')
+  }
+
+  const scrollAndHighlight = (id: string, block: ScrollLogicalPosition = 'start') => {
+    const el = document.getElementById(id)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block })
+      flashHighlight(el)
+    }
+    return el
+  }
+
+  const scrollToLinkHistory = (linkCode: string) => {
+    const scrollToLink = () => {
+      const el = scrollAndHighlight(`link-row-${linkCode}`, 'center')
+      if (!el) {
+        scrollAndHighlight('link-status-history')
+      }
+    }
     // If not on links tab, navigate there first
     if (!location.pathname.includes('/status/links')) {
       navigate('/status/links')
       // Wait for navigation then scroll
-      setTimeout(() => {
-        document.getElementById('link-status-history')?.scrollIntoView({ behavior: 'smooth' })
-      }, 100)
+      setTimeout(scrollToLink, 100)
     } else {
-      document.getElementById('link-status-history')?.scrollIntoView({ behavior: 'smooth' })
+      scrollToLink()
     }
   }
   const scrollToDisabledLinks = () => {
     if (!location.pathname.includes('/status/links')) {
       navigate('/status/links')
       setTimeout(() => {
-        document.getElementById('disabled-links')?.scrollIntoView({ behavior: 'smooth' })
+        scrollAndHighlight('disabled-links')
       }, 100)
     } else {
-      document.getElementById('disabled-links')?.scrollIntoView({ behavior: 'smooth' })
+      scrollAndHighlight('disabled-links')
     }
   }
   const scrollToDeviceHistory = (devicePk: string) => {
     const scrollToDevice = () => {
-      const deviceRow = document.getElementById(`device-row-${devicePk}`)
-      if (deviceRow) {
-        deviceRow.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      } else {
-        document.getElementById('device-status-history')?.scrollIntoView({ behavior: 'smooth' })
+      const el = scrollAndHighlight(`device-row-${devicePk}`, 'center')
+      if (!el) {
+        scrollAndHighlight('device-status-history')
       }
     }
     if (!location.pathname.includes('/status/devices')) {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -367,3 +367,19 @@ table {
 .animate-slide-in {
   animation: slideIn 0.4s ease-out;
 }
+
+/* Scroll-to highlight flash */
+@keyframes scrollHighlight {
+  0% {
+    background-color: oklch(from var(--muted-foreground) l c h / 12%);
+    box-shadow: inset 0 0 0 2px oklch(from var(--muted-foreground) l c h / 60%);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px transparent;
+  }
+}
+
+.scroll-highlight {
+  animation: scrollHighlight 3.5s ease-out;
+}


### PR DESCRIPTION
## Summary of Changes
- Clicking a link or device issue in the status summary card now scrolls to and highlights the specific row in the timeline section, instead of just scrolling to the section container
- Added a subtle CSS flash animation (border + background fade) so the target row is visually obvious after scrolling

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     3 | +49 / -15   |  +34 |

34 net lines of UI logic and CSS for scroll-to-highlight behavior.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/status-page.tsx` — added `scrollAndHighlight` helper, updated scroll functions to target specific rows by link code / device PK
- `web/src/index.css` — added `scrollHighlight` keyframe animation (border + background fade over 3.5s)
- `web/src/components/link-status-timelines.tsx` — added `id` attribute to each link row for scroll targeting

</details>

## Testing Verification
- Manually tested on local dev environment: clicking link issues in the status summary scrolls to and highlights the correct row
- Verified highlight works when navigating across tabs (e.g., from devices tab to links tab)
- Verified repeated clicks on the same item restart the animation