### PR TITLE
dev: add remote ClickHouse Cloud table setup for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ CLICKHOUSE_ADDR_TCP=localhost:9100
 CLICKHOUSE_DATABASE=default
 CLICKHOUSE_USERNAME=default
 CLICKHOUSE_PASSWORD=
+# Remote ClickHouse Cloud (for local dev to pull shredder data).
+# Set both to enable the remote table in dev-setup.
+CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST=
+CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD=
 # Multi-environment: set these to enable devnet/testnet env switching in the UI.
 # Each points to a separate ClickHouse database on the same server.
 # CLICKHOUSE_DATABASE_DEVNET=lake_devnet

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -30,7 +30,12 @@ else
 fi
 echo ""
 
-# Step 3: Download and extract GeoIP databases
+# Step 3: Set up remote ClickHouse Cloud tables
+echo "=== Setting up remote ClickHouse Cloud tables ==="
+"$SCRIPT_DIR/setup-remote-tables.sh" || true
+echo ""
+
+# Step 4: Download and extract GeoIP databases
 echo "=== Setting up GeoIP databases ==="
 GEOIP_DIR="$ROOT_DIR/.tmp/geoip"
 mkdir -p "$GEOIP_DIR"
@@ -54,7 +59,7 @@ echo "  GEOIP_CITY_DB_PATH=$GEOIP_DIR/GeoLite2-City.mmdb"
 echo "  GEOIP_ASN_DB_PATH=$GEOIP_DIR/GeoLite2-ASN.mmdb"
 echo ""
 
-# Step 4: Check for bun
+# Step 5: Check for bun
 echo "=== Checking dependencies ==="
 if ! command -v bun &> /dev/null; then
     echo "bun is not installed. Install it with:"
@@ -72,7 +77,7 @@ else
 fi
 echo ""
 
-# Step 5: Print next steps
+# Step 6: Print next steps
 echo "=== Setup complete! ==="
 echo ""
 echo "Next steps:"

--- a/scripts/setup-remote-tables.sh
+++ b/scripts/setup-remote-tables.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# Set up remoteSecure tables in local ClickHouse pointing to ClickHouse Cloud.
+# Reads CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST and CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD from .env.
+#
+# Usage:
+#   ./scripts/setup-remote-tables.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$ROOT_DIR"
+
+if [[ -f .env ]]; then
+    CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST=$(grep -E '^CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST=' .env | cut -d= -f2- || true)
+    CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD=$(grep -E '^CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD=' .env | cut -d= -f2- || true)
+fi
+
+if [[ -z "${CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST:-}" ]] || [[ -z "${CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD:-}" ]]; then
+    echo "CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST or CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD not set in .env, skipping"
+    echo "Set both to enable querying shredder data from ClickHouse Cloud"
+    exit 0
+fi
+
+# Wait for local ClickHouse to be ready
+echo "Waiting for local ClickHouse..."
+for i in {1..30}; do
+    if curl -sf http://localhost:8123/ping > /dev/null 2>&1; then
+        break
+    fi
+    if [[ $i -eq 30 ]]; then
+        echo "ClickHouse not ready after 30s, skipping"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Add remote tables here: "local_table_name remote_db.remote_table_name"
+REMOTE_TABLES=(
+    "dz_publisher_shred_stats shredder.publisher_shred_stats"
+)
+
+failed=0
+for entry in "${REMOTE_TABLES[@]}"; do
+    local_name="${entry%% *}"
+    remote_path="${entry#* }"
+    if curl -sf http://localhost:8123/ -d "
+        CREATE TABLE IF NOT EXISTS ${local_name}
+        AS remoteSecure(
+            '${CLICKHOUSE_CLOUD_REMOTE_TABLE_HOST}',
+            '${remote_path}',
+            'lake_dev_reader',
+            '${CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD}'
+        )
+    "; then
+        echo "${local_name}: ok"
+    else
+        echo "${local_name}: FAILED"
+        ((failed++))
+    fi
+done
+
+if [[ $failed -gt 0 ]]; then
+    echo "${failed} remote table(s) failed to create"
+    exit 1
+fi


### PR DESCRIPTION
## Summary of Changes
- Add `setup-remote-tables.sh` script that creates `remoteSecure` tables in local ClickHouse pointing to ClickHouse Cloud for shredder data
- Integrate into `dev-setup.sh` as a new step, also runnable standalone
- Add `CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD` env var to `.env.example`
- Skips gracefully if password not set or ClickHouse not running; idempotent via `CREATE TABLE IF NOT EXISTS`

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +66 / -0    |  +66 |
| Scaffolding  |     1 | +8 / -3     |  +5  |
| Config/build |     1 | +3 / -0     |  +3  |

New standalone script with minor wiring into existing dev setup.

<details>
<summary>Key files (click to expand)</summary>

- `scripts/setup-remote-tables.sh` — new script that reads password from .env, waits for local ClickHouse, and creates remoteSecure tables in a loop
- `scripts/dev-setup.sh` — calls setup-remote-tables.sh as step 3, renumbers subsequent steps
- `.env.example` — adds CLICKHOUSE_CLOUD_REMOTE_TABLE_PASSWORD variable

</details>

## Testing Verification
- Ran `setup-remote-tables.sh` standalone against local ClickHouse with password set; table created successfully
- Verified idempotency by re-running; table skipped without error
- Verified graceful skip when password is not set