### PR TITLE
admin: fix backfill-sparse-counters memory usage

### DIFF
--- a/admin/internal/admin/backfill_sparse_counters.go
+++ b/admin/internal/admin/backfill_sparse_counters.go
@@ -224,11 +224,11 @@ func streamSparseChunk(
 		r.deltas = make(map[string]*int64)
 
 		var (
-			inDiscards, inErrors, inFCSErrors       *int64
-			outDiscards, outErrors                   *int64
-			inDiscardsDelta, inErrorsDelta           *int64
-			inFCSErrorsDelta, outDiscardsDelta       *int64
-			outErrorsDelta                           *int64
+			inDiscards, inErrors, inFCSErrors  *int64
+			outDiscards, outErrors             *int64
+			inDiscardsDelta, inErrorsDelta     *int64
+			inFCSErrorsDelta, outDiscardsDelta *int64
+			outErrorsDelta                     *int64
 		)
 
 		err := rows.Scan(


### PR DESCRIPTION
## Summary of Changes

- Stream rows from ClickHouse via `rows.Next()` instead of loading entire chunks into a `[]counterRow` slice
- Flush corrections to ClickHouse every 10K rows to bound memory
- Reduce default chunk interval from 24h to 1h

## Testing Verification

- Verified the command builds and runs with `--dry-run`