### PR TITLE
api: make shredder database configurable via CLICKHOUSE_SHREDDER_DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ CLICKHOUSE_PASSWORD=
 # Each points to a separate ClickHouse database on the same server.
 # CLICKHOUSE_DATABASE_DEVNET=lake_devnet
 # CLICKHOUSE_DATABASE_TESTNET=lake_testnet
+# Shredder database name (default: shredder). Set to shredder_qa for QA environment.
+# CLICKHOUSE_SHREDDER_DB=shredder
 
 # -----------------------------------------------------------------------------
 # PostgreSQL (required)

--- a/README.md
+++ b/README.md
@@ -162,10 +162,12 @@ For testing the UI with real production data without running the full indexer, y
    ```
 
 This creates local proxy tables using ClickHouse `remoteSecure()` that transparently forward reads to the remote instance:
-- `all` mode discovers all tables in the remote `lake` database and creates local proxies, plus creates proxies for external service tables (e.g., `shredder.publisher_shred_stats`)
+- `all` mode discovers all tables in the remote `lake` database and creates local proxies, plus creates proxies for external service tables (e.g., `shredder.publisher_shred_stats`, `shredder_qa.publisher_shred_stats`)
 - `external` mode only creates the external service proxies (used in k8s staging/PR preview environments)
 
 The API and web UI work as normal — they query local ClickHouse which forwards to remote. No code changes needed.
+
+Set `CLICKHOUSE_SHREDDER_DB` to control which shredder database the publisher check queries use (default: `shredder`). For example, set `CLICKHOUSE_SHREDDER_DB=shredder_qa` to use the QA environment.
 
 To add proxies for additional external tables, add entries to `externalRemoteTables` in `admin/internal/admin/setup_remote_tables.go`.
 

--- a/admin/internal/admin/setup_remote_tables.go
+++ b/admin/internal/admin/setup_remote_tables.go
@@ -18,6 +18,7 @@ var externalRemoteTables = []struct {
 	RemoteTable string
 }{
 	{"shredder", "publisher_shred_stats"},
+	{"shredder_qa", "publisher_shred_stats"},
 }
 
 // SetupRemoteTables creates remoteSecure() proxy tables in local ClickHouse

--- a/api/.env.example
+++ b/api/.env.example
@@ -12,6 +12,8 @@ CLICKHOUSE_PASSWORD=
 # Each points to a separate ClickHouse database on the same server.
 # CLICKHOUSE_DATABASE_DEVNET=lake_devnet
 # CLICKHOUSE_DATABASE_TESTNET=lake_testnet
+# Shredder database name (default: shredder). Set to shredder_qa for QA environment.
+# CLICKHOUSE_SHREDDER_DB=shredder
 
 # PostgreSQL configuration (for session persistence)
 POSTGRES_HOST=localhost

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -15,6 +15,9 @@ import (
 // DB is the global ClickHouse connection pool (mainnet-beta)
 var DB driver.Conn
 
+// ShredderDB is the ClickHouse database name for shredder tables (default: "shredder").
+var ShredderDB = "shredder"
+
 // EnvDBs maps environment names to their ClickHouse connection pools.
 // The mainnet-beta entry always points to DB.
 var EnvDBs map[string]driver.Conn
@@ -87,6 +90,10 @@ func Load() error {
 
 	cfg.Password = os.Getenv("CLICKHOUSE_PASSWORD")
 
+	if db := os.Getenv("CLICKHOUSE_SHREDDER_DB"); db != "" {
+		ShredderDB = db
+	}
+
 	// Build env -> database mapping
 	EnvDatabases = map[string]string{
 		"mainnet-beta": cfg.Database,
@@ -100,7 +107,7 @@ func Load() error {
 
 	secure := os.Getenv("CLICKHOUSE_SECURE") == "true"
 
-	log.Printf("Connecting to ClickHouse: addr=%s, database=%s, username=%s, secure=%v", cfg.Addr, cfg.Database, cfg.Username, secure)
+	log.Printf("Connecting to ClickHouse: addr=%s, database=%s, username=%s, secure=%v, shredder_db=%s", cfg.Addr, cfg.Database, cfg.Username, secure, ShredderDB)
 
 	// Create connection pool
 	opts := &clickhouse.Options{

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"golang.org/x/mod/semver"
 
+	"github.com/malbeclabs/lake/api/config"
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
@@ -97,9 +99,10 @@ func GetPublisherCheck(w http.ResponseWriter, r *http.Request) {
 
 	// Build query: start from all bebop publishers (dz_users_current),
 	// LEFT JOIN shred stats and validator info.
-	query := `
+	shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", config.ShredderDB)
+	query := fmt.Sprintf(`
 		WITH current_epoch AS (
-			SELECT max(epoch) AS epoch FROM shredder.publisher_shred_stats
+			SELECT max(epoch) AS epoch FROM %s
 		),
 		stats AS (
 			SELECT
@@ -110,7 +113,7 @@ func GetPublisherCheck(w http.ResponseWriter, r *http.Request) {
 				countIf(is_scheduled_leader = false) AS retransmit_slots,
 				sum(unique_shreds) AS total_unique_shreds,
 				countIf(needs_repair = true) AS slots_needing_repair
-			FROM shredder.publisher_shred_stats
+			FROM %s
 			WHERE epoch >= (SELECT epoch FROM current_epoch) - ? + 1
 			GROUP BY dz_user_pubkey
 		)
@@ -140,7 +143,7 @@ func GetPublisherCheck(w http.ResponseWriter, r *http.Request) {
 		LEFT JOIN validatorsapp_validators_current va ON v.vote_pubkey = va.vote_account
 		WHERE u.status = 'activated'
 			AND has(JSONExtract(u.publishers, 'Array(String)'), ?)
-	`
+	`, shredStatsTable, shredStatsTable)
 
 	// Query args: epochsParam for stats CTE, then bebopPK for has() filter
 	args := []any{epochsParam, bebopPK}

--- a/api/handlers/publisher_check_test.go
+++ b/api/handlers/publisher_check_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,15 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// createPublisherShredStatsTable creates the shredder.publisher_shred_stats table
-// (normally created by shredder migrations, not lake migrations).
+// createPublisherShredStatsTable creates the publisher_shred_stats table
+// in the configured shredder database (normally created by shredder migrations, not lake migrations).
 func createPublisherShredStatsTable(t *testing.T) {
 	t.Helper()
 	ctx := t.Context()
-	err := config.DB.Exec(ctx, `CREATE DATABASE IF NOT EXISTS shredder`)
+	err := config.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", config.ShredderDB))
 	require.NoError(t, err)
-	err = config.DB.Exec(ctx, `
-		CREATE TABLE IF NOT EXISTS shredder.publisher_shred_stats (
+	err = config.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.publisher_shred_stats (
 			event_ts DateTime64(3),
 			ingested_at DateTime64(3),
 			host String,
@@ -47,7 +48,7 @@ func createPublisherShredStatsTable(t *testing.T) {
 		) ENGINE = ReplacingMergeTree(ingested_at)
 		PARTITION BY toYYYYMM(event_ts)
 		ORDER BY (host, slot, publisher_ip)
-	`)
+	`, "`"+config.ShredderDB+"`"))
 	require.NoError(t, err)
 }
 
@@ -163,8 +164,8 @@ func insertPublisherCheckTestData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Shred stats: only dzuser1 and dzuser2 are publishing (dzuser3 is NOT)
-	err = config.DB.Exec(ctx, `
-		INSERT INTO shredder.publisher_shred_stats
+	err = config.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.publisher_shred_stats`, "`"+config.ShredderDB+"`")+`
 			(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
 			 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,

--- a/scripts/setup-remote-tables.sh
+++ b/scripts/setup-remote-tables.sh
@@ -30,6 +30,7 @@ REMOTE_LAKE_DB="lake"
 # External tables from other services (format: "remote_db.remote_table:local_table_name")
 EXTERNAL_TABLES=(
   "shredder.publisher_shred_stats:publisher_shred_stats"
+  "shredder_qa.publisher_shred_stats:publisher_shred_stats"
 )
 
 # ─── Load environment ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary of Changes

- Add `CLICKHOUSE_SHREDDER_DB` env var to configure which shredder database the publisher check queries use (defaults to `shredder`)
- Add `shredder_qa.publisher_shred_stats` to the remote tables registry so both `shredder` and `shredder_qa` get proxied
- Log the configured shredder database on API startup

## Testing Verification

- Verified the API builds successfully
- Publisher check queries use the configured database name instead of hardcoded `shredder`
- Tests updated to use `config.ShredderDB` instead of hardcoded values