### PR TITLE
api: fix trailing chart drop by excluding incomplete time buckets

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -1275,7 +1275,8 @@ func fetchLinkHistoryData(ctx context.Context, timeRange string, requestedBucket
 	// Loss is computed as the max of 5-minute sub-bucket loss percentages within each
 	// display bucket, matching Grafana's [5m] window for sharper spike visibility.
 	lossBucketInterval := fmt.Sprintf("toStartOfInterval(f.event_ts, INTERVAL %d MINUTE, 'UTC')", min(bucketMinutes, 5))
-	timeFilterExpr := fmt.Sprintf("f.event_ts > now() - INTERVAL %d HOUR", totalHours)
+	// Exclude the current incomplete bucket so chart lines don't drop to zero.
+	timeFilterExpr := fmt.Sprintf("f.event_ts > now() - INTERVAL %d HOUR AND f.event_ts < toStartOfInterval(now(), INTERVAL %d MINUTE, 'UTC')", totalHours, bucketMinutes)
 	historyQuery := `
 		WITH loss_sub AS (
 			SELECT
@@ -1416,12 +1417,13 @@ func fetchLinkHistoryData(ctx context.Context, timeRange string, requestedBucket
 			toUInt64(SUM(greatest(0, carrier_transitions_delta))) as carrier_transitions
 		FROM fact_dz_device_interface_counters
 		WHERE event_ts > now() - INTERVAL ? HOUR
+		  AND event_ts < toStartOfInterval(now(), INTERVAL ? MINUTE, 'UTC')
 		  AND link_pk != ''
 		GROUP BY link_pk, link_side, bucket
 		ORDER BY link_pk, link_side, bucket
 	`
 
-	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, totalHours)
+	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, totalHours, bucketMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("link interface query error: %w", err)
 	}
@@ -1718,7 +1720,7 @@ func fetchLinkHistoryData(ctx context.Context, timeRange string, requestedBucket
 		}
 
 		var hourStatuses []LinkHourStatus
-		for i := bucketCount - 1; i >= 0; i-- {
+		for i := bucketCount - 1; i >= 1; i-- {
 			bucketStart := now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
 			key := bucketStart.UTC().Format(time.RFC3339)
 
@@ -2124,11 +2126,12 @@ func fetchDeviceHistoryData(ctx context.Context, timeRange string, requestedBuck
 			toUInt64(SUM(greatest(0, carrier_transitions_delta))) as carrier_transitions
 		FROM fact_dz_device_interface_counters
 		WHERE event_ts > now() - INTERVAL ? HOUR
+		  AND event_ts < toStartOfInterval(now(), INTERVAL ? MINUTE, 'UTC')
 		GROUP BY device_pk, bucket
 		ORDER BY device_pk, bucket
 	`
 
-	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, totalHours)
+	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, totalHours, bucketMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("device interface query error: %w", err)
 	}
@@ -2267,7 +2270,7 @@ func fetchDeviceHistoryData(ctx context.Context, timeRange string, requestedBuck
 		}
 
 		var hourStatuses []DeviceHourStatus
-		for i := bucketCount - 1; i >= 0; i-- {
+		for i := bucketCount - 1; i >= 1; i-- {
 			bucketStart := now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
 			key := bucketStart.UTC().Format(time.RFC3339)
 
@@ -2569,7 +2572,8 @@ func fetchDeviceInterfaceHistoryData(ctx context.Context, devicePK string, timeR
 	// Build interval expression for ClickHouse
 	bucketInterval := fmt.Sprintf("toStartOfInterval(event_ts, INTERVAL %d MINUTE, 'UTC')", bucketMinutes)
 
-	// Query interface stats per bucket for this device
+	// Query interface stats per bucket for this device.
+	// Exclude the current incomplete bucket so chart lines don't drop to zero.
 	query := `
 		SELECT
 			c.intf as interface_name,
@@ -2587,11 +2591,12 @@ func fetchDeviceInterfaceHistoryData(ctx context.Context, devicePK string, timeR
 		LEFT JOIN dz_links_current l ON c.link_pk = l.pk
 		WHERE c.device_pk = ?
 		  AND c.event_ts > now() - INTERVAL ? HOUR
+		  AND c.event_ts < toStartOfInterval(now(), INTERVAL ? MINUTE)
 		GROUP BY c.intf, l.pk, l.code, l.link_type, c.link_side, bucket
 		ORDER BY c.intf, bucket
 	`
 
-	rows, err := envDB(ctx).Query(ctx, query, devicePK, totalHours)
+	rows, err := envDB(ctx).Query(ctx, query, devicePK, totalHours, bucketMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("interface history query error: %w", err)
 	}
@@ -2656,7 +2661,7 @@ func fetchDeviceInterfaceHistoryData(ctx context.Context, devicePK string, timeR
 		}
 
 		var hourStatuses []InterfaceHourStatus
-		for i := bucketCount - 1; i >= 0; i-- {
+		for i := bucketCount - 1; i >= 1; i-- {
 			bucketStart := now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
 			key := bucketStart.UTC().Format(time.RFC3339)
 
@@ -2819,7 +2824,8 @@ func fetchSingleLinkHistoryData(ctx context.Context, linkPK string, timeRange st
 	// Loss is computed as the max of 5-minute sub-bucket loss percentages within each
 	// display bucket, matching Grafana's [5m] window for sharper spike visibility.
 	singleLossBucket := fmt.Sprintf("toStartOfInterval(event_ts, INTERVAL %d MINUTE, 'UTC')", min(bucketMinutes, 5))
-	singleTimeFilter := fmt.Sprintf("event_ts > now() - INTERVAL %d HOUR", totalHours)
+	// Exclude the current incomplete bucket so chart lines don't drop to zero.
+	singleTimeFilter := fmt.Sprintf("event_ts > now() - INTERVAL %d HOUR AND event_ts < toStartOfInterval(now(), INTERVAL %d MINUTE, 'UTC')", totalHours, bucketMinutes)
 	latencyQuery := `
 		WITH loss_sub AS (
 			SELECT
@@ -2901,10 +2907,11 @@ func fetchSingleLinkHistoryData(ctx context.Context, linkPK string, timeRange st
 			sum(delta_duration) as duration
 		FROM fact_dz_device_interface_counters
 		WHERE link_pk = ? AND event_ts > now() - INTERVAL ? HOUR
+		  AND event_ts < toStartOfInterval(now(), INTERVAL ? MINUTE, 'UTC')
 		GROUP BY bucket, side
 		ORDER BY bucket, side
 	`
-	ifaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, sideAPK, linkPK, totalHours)
+	ifaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, sideAPK, linkPK, totalHours, bucketMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("interface query error: %w", err)
 	}
@@ -2945,9 +2952,10 @@ func fetchSingleLinkHistoryData(ctx context.Context, linkPK string, timeRange st
 		}
 	}
 
-	// Build hour statuses
+	// Build hour statuses. Start from i=1 to skip the current incomplete bucket
+	// (whose data is already excluded from the SQL queries).
 	var hourStatuses []LinkHourStatus
-	for i := bucketCount - 1; i >= 0; i-- {
+	for i := bucketCount - 1; i >= 1; i-- {
 		bucketStart := now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
 		key := bucketStart.UTC().Format(time.RFC3339)
 
@@ -3161,11 +3169,12 @@ func fetchSingleDeviceHistoryData(ctx context.Context, devicePK string, timeRang
 			toUInt64(SUM(greatest(0, carrier_transitions_delta))) as carrier_transitions
 		FROM fact_dz_device_interface_counters
 		WHERE device_pk = ? AND event_ts > now() - INTERVAL ? HOUR
+		  AND event_ts < toStartOfInterval(now(), INTERVAL ? MINUTE, 'UTC')
 		GROUP BY bucket
 		ORDER BY bucket
 	`
 
-	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, devicePK, totalHours)
+	interfaceRows, err := envDB(ctx).Query(ctx, interfaceQuery, devicePK, totalHours, bucketMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("device interface query error: %w", err)
 	}
@@ -3246,9 +3255,9 @@ func fetchSingleDeviceHistoryData(ctx context.Context, devicePK string, timeRang
 		}
 	}
 
-	// Build bucket status array
+	// Build bucket status array. Start from i=1 to skip the current incomplete bucket.
 	var hourStatuses []DeviceHourStatus
-	for i := bucketCount - 1; i >= 0; i-- {
+	for i := bucketCount - 1; i >= 1; i-- {
 		bucketStart := now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
 		key := bucketStart.UTC().Format(time.RFC3339)
 

--- a/api/handlers/topology.go
+++ b/api/handlers/topology.go
@@ -447,6 +447,7 @@ func GetTopologyTraffic(w http.ResponseWriter, r *http.Request) {
 	var timeFilter string
 	var bucketSeconds int
 	var timeFormat string
+	isPresetRange := false
 
 	if fromParam != "" && toParam != "" {
 		fromTime, err := time.Parse("2006-01-02-15:04:05", fromParam)
@@ -468,6 +469,7 @@ func GetTopologyTraffic(w http.ResponseWriter, r *http.Request) {
 			fromTime.UTC().Format("2006-01-02 15:04:05"),
 			toTime.UTC().Format("2006-01-02 15:04:05"))
 	} else {
+		isPresetRange = true
 		var intervalMinutes int
 		switch rangeParam {
 		case "15m":
@@ -501,6 +503,12 @@ func GetTopologyTraffic(w http.ResponseWriter, r *http.Request) {
 			bucketSeconds = override
 			timeFormat = timeFormatForBucket(bucketSeconds)
 		}
+	}
+
+	// Exclude the current incomplete bucket for preset ranges so the chart
+	// line doesn't drop to zero at the trailing edge.
+	if isPresetRange {
+		timeFilter += fmt.Sprintf(" AND event_ts < toStartOfInterval(now(), INTERVAL %d SECOND)", bucketSeconds)
 	}
 
 	bucketExpr := fmt.Sprintf("toStartOfInterval(event_ts, INTERVAL %d SECOND)", bucketSeconds)
@@ -790,7 +798,8 @@ func GetLinkLatencyHistory(w http.ResponseWriter, r *http.Request) {
 		}
 		bucketSeconds = calculateBucketSize(time.Duration(intervalMinutes) * time.Minute)
 		timeFormat = timeFormatForBucket(bucketSeconds)
-		timeFilter = fmt.Sprintf("f.event_ts > now() - INTERVAL %d MINUTE", intervalMinutes)
+		// Exclude the current incomplete bucket so the chart line doesn't drop to zero.
+		timeFilter = fmt.Sprintf("f.event_ts > now() - INTERVAL %d MINUTE AND f.event_ts < toStartOfInterval(now(), INTERVAL %d SECOND)", intervalMinutes, bucketSeconds)
 	}
 
 	start := time.Now()
@@ -1298,8 +1307,9 @@ func GetLatencyHistory(w http.ResponseWriter, r *http.Request) {
 		LEFT JOIN dz_data dz ON tb.bucket = dz.bucket
 		LEFT JOIN inet_data inet ON tb.bucket = inet.bucket
 		WHERE tb.bucket >= now() - INTERVAL %d HOUR
+		  AND tb.bucket < toStartOfInterval(now(), INTERVAL %d MINUTE)
 		ORDER BY tb.bucket ASC
-	`, intervalHours, bucketMinutes, bucketMinutes, 48, bucketMinutes, bucketMinutes, intervalHours)
+	`, intervalHours, bucketMinutes, bucketMinutes, 48, bucketMinutes, bucketMinutes, intervalHours, bucketMinutes)
 
 	rows, err := envDB(ctx).Query(ctx, query, metro1, metro2)
 	duration := time.Since(start)


### PR DESCRIPTION
## Summary of Changes
- Exclude the current incomplete time bucket from all time series SQL queries so aggregated values (averages, rates, sums) don't appear artificially low at the trailing edge
- Skip generating the trailing empty bucket slot in response assembly loops, preventing chart lines from dropping to zero at the end of the time range
- Applies to all chart endpoints: traffic, latency, packet loss, interface issues, and metro latency history

## Testing Verification
- Manually verified on link and device detail pages that chart lines no longer drop to zero at the trailing edge
- Verified the fix works across multiple time range presets (24h, 7d)
- Confirmed the status timeline expanded charts (packet loss, interface issues) also no longer show the trailing drop