### PR TITLE
incidents: show inline loading skeleton instead of full page replacement

### DIFF
--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -28,24 +28,16 @@ function Skeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
 }
 
-function IncidentsPageSkeleton() {
+function IncidentsContentSkeleton() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-6xl mx-auto px-4 sm:px-8 py-8">
-        <div className="mb-6">
-          <Skeleton className="h-8 w-48" />
-        </div>
-        <div className="mb-6">
-          <Skeleton className="h-10 w-full max-w-lg" />
-        </div>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-20" />
-          ))}
-        </div>
-        <Skeleton className="h-[400px] rounded-lg" />
+    <>
+      <div className="grid grid-cols-3 sm:grid-cols-5 gap-3 mb-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-[72px]" />
+        ))}
       </div>
-    </div>
+      <Skeleton className="h-[400px] rounded-lg" />
+    </>
   )
 }
 
@@ -453,33 +445,6 @@ export function IncidentsPage() {
     return `${base}?${params.toString()}`
   }, [scope, range, threshold, errorsThreshold, discardsThreshold, carrierThreshold, minDuration, coalesceGap, filterParam, showLinkInterfaces])
 
-  if (isLoading) {
-    return <IncidentsPageSkeleton />
-  }
-
-  if (error) {
-    return (
-      <div className="flex-1 overflow-auto">
-        <div className="max-w-6xl mx-auto px-4 sm:px-8 py-8">
-          <PageHeader icon={ShieldAlert} title="Incidents" />
-          <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
-            <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">Unable to load incidents</h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              {(error as Error).message || 'Something went wrong. The API server may be unavailable.'}
-            </p>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 text-sm border border-border rounded-md hover:bg-muted transition-colors"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="flex-1 overflow-auto">
       <div className="max-w-6xl mx-auto px-4 sm:px-8 py-8">
@@ -650,6 +615,21 @@ export function IncidentsPage() {
 
         {/* Link interfaces toggle is rendered inline with "Show detecting" in the Active view header */}
 
+        {isLoading ? <IncidentsContentSkeleton /> : error ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
+            <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">Unable to load incidents</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              {(error as Error).message || 'Something went wrong. The API server may be unavailable.'}
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 text-sm border border-border rounded-md hover:bg-muted transition-colors"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (<>
         {/* Type stat cards — clickable multi-select filters */}
         <div className={`grid gap-3 mb-6 ${scope === 'links' ? 'grid-cols-3 sm:grid-cols-5' : 'grid-cols-2 sm:grid-cols-4'}`}>
           {([
@@ -859,6 +839,7 @@ export function IncidentsPage() {
             })()}
           </>
         )}
+        </>)}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary of Changes

- Always render page chrome (header, scope toggle, time range selector, filters, settings) during loading instead of replacing the entire page with a skeleton
- Show skeleton loaders only for data-dependent content (stat cards and tables)
- Move error state inline so controls remain accessible when the API fails

## Testing Verification

- Verified the build passes with `bun run build`
- Visually confirmed page chrome stays stable while data loads