### PR TITLE
incidents: use coalesce gap for ongoing counter detection window

### DIFF
--- a/api/handlers/device_incidents.go
+++ b/api/handlers/device_incidents.go
@@ -209,6 +209,7 @@ func fetchCurrentHighCounterDevices(ctx context.Context, conn driver.Conn, thres
 		return nil, nil
 	}
 
+	lookbackSecs := int64(dp.CoalesceGap.Seconds())
 	query := fmt.Sprintf(`
 		WITH recent_buckets AS (
 			SELECT
@@ -216,8 +217,8 @@ func fetchCurrentHighCounterDevices(ctx context.Context, conn driver.Conn, thres
 				toStartOfInterval(ic.event_ts, INTERVAL 5 MINUTE) as bucket,
 				%s as metric_value
 			FROM fact_dz_device_interface_counters ic
-			WHERE ic.event_ts >= now() - INTERVAL 15 MINUTE
-			  AND ic.device_pk IN ($1)
+			WHERE ic.event_ts >= now() - INTERVAL $1 SECOND
+			  AND ic.device_pk IN ($2)
 			  %s
 			GROUP BY ic.device_pk, bucket
 		),
@@ -235,7 +236,7 @@ func fetchCurrentHighCounterDevices(ctx context.Context, conn driver.Conn, thres
 		ORDER BY device_pk, rn
 	`, metricExpr, linkFilter)
 
-	rows, err := conn.Query(ctx, query, devicePKs)
+	rows, err := conn.Query(ctx, query, lookbackSecs, devicePKs)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}

--- a/api/handlers/incidents.go
+++ b/api/handlers/incidents.go
@@ -489,6 +489,7 @@ func fetchCurrentHighCounterLinks(ctx context.Context, conn driver.Conn, thresho
 		return nil, nil
 	}
 
+	lookbackSecs := int64(dp.CoalesceGap.Seconds())
 	query := fmt.Sprintf(`
 		WITH recent_buckets AS (
 			SELECT
@@ -496,8 +497,8 @@ func fetchCurrentHighCounterLinks(ctx context.Context, conn driver.Conn, thresho
 				toStartOfInterval(ic.event_ts, INTERVAL 5 MINUTE) as bucket,
 				%s as metric_value
 			FROM fact_dz_device_interface_counters ic
-			WHERE ic.event_ts >= now() - INTERVAL 15 MINUTE
-			  AND ic.link_pk IN ($1)
+			WHERE ic.event_ts >= now() - INTERVAL $1 SECOND
+			  AND ic.link_pk IN ($2)
 			GROUP BY ic.link_pk, bucket
 		),
 		ranked AS (
@@ -514,7 +515,7 @@ func fetchCurrentHighCounterLinks(ctx context.Context, conn driver.Conn, thresho
 		ORDER BY link_pk, rn
 	`, metricExpr)
 
-	rows, err := conn.Query(ctx, query, linkPKs)
+	rows, err := conn.Query(ctx, query, lookbackSecs, linkPKs)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}


### PR DESCRIPTION
## Summary of Changes
- Fix counter incidents (errors, discards, carrier) falsely resolving due to a hardcoded 15-minute ongoing detection window that was inconsistent with the 12-hour coalesce gap
- The ongoing detection query now uses the coalesce gap as its lookback window, so an incident stays ongoing as long as recent above-threshold data exists within the coalesce period

## Testing Verification
- Verified API builds cleanly
- The bug was observed in production: a carrier transition incident on dgt-dzd-ams-ams1 showed "Resolved" despite the chart showing non-zero carrier transitions just 16 minutes prior — falling outside the 15-minute window by 1 minute