### PR TITLE
incidents: fix ongoing incidents incorrectly showing as resolved

### DIFF
--- a/api/handlers/detection.go
+++ b/api/handlers/detection.go
@@ -481,17 +481,25 @@ func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]lin
 		// Handle event that was active at end of time window
 		if activeEvent != nil && len(linkBuckets) > 0 && consecutiveBuckets >= 2 {
 			lastBucket := linkBuckets[len(linkBuckets)-1]
-			endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
-			activeEvent.EndedAt = &endedAt
-			activeEvent.IsOngoing = false
 			peak := peakLoss
 			activeEvent.PeakLossPct = &peak
 			activeEvent.Severity = packetLossSeverity(peakLoss)
 
-			startTime, _ := time.Parse(time.RFC3339, activeEvent.StartedAt)
-			endTime := lastBucket.Bucket.Add(5 * time.Minute)
-			durationSecs := int64(endTime.Sub(startTime).Seconds())
-			activeEvent.DurationSeconds = &durationSecs
+			// If the last bucket is recent (within 15 minutes of now), the event
+			// is likely still ongoing but wasn't caught by the current detection
+			// (e.g., the most recent 5-min bucket doesn't have enough samples yet).
+			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+				activeEvent.IsOngoing = true
+			} else {
+				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				activeEvent.EndedAt = &endedAt
+				activeEvent.IsOngoing = false
+
+				startTime, _ := time.Parse(time.RFC3339, activeEvent.StartedAt)
+				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				durationSecs := int64(endTime.Sub(startTime).Seconds())
+				activeEvent.DurationSeconds = &durationSecs
+			}
 
 			events = append(events, *activeEvent)
 		}

--- a/api/handlers/device_incidents.go
+++ b/api/handlers/device_incidents.go
@@ -474,16 +474,23 @@ func pairDeviceCounterIncidentsCompleted(buckets []deviceCounterBucket, deviceMe
 		// Handle incident active at end of window
 		if activeIncident != nil && consecutiveBuckets >= dp.minBuckets() {
 			lastBucket := deviceBuckets[len(deviceBuckets)-1]
-			endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
-			activeIncident.EndedAt = &endedAt
 			peak := peakValue
 			activeIncident.PeakCount = &peak
 			activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
-			startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-			endTime := lastBucket.Bucket.Add(5 * time.Minute)
-			durationSecs := int64(endTime.Sub(startTime).Seconds())
-			activeIncident.DurationSeconds = &durationSecs
+			// If the last bucket is recent (within 15 minutes of now), the incident
+			// is likely still ongoing but wasn't caught by the current detection.
+			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+				activeIncident.IsOngoing = true
+			} else {
+				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				activeIncident.EndedAt = &endedAt
+
+				startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
+				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				durationSecs := int64(endTime.Sub(startTime).Seconds())
+				activeIncident.DurationSeconds = &durationSecs
+			}
 
 			incidents = append(incidents, *activeIncident)
 		}

--- a/api/handlers/incidents.go
+++ b/api/handlers/incidents.go
@@ -762,16 +762,23 @@ func pairCounterIncidentsCompleted(buckets []counterBucket, linkMeta map[string]
 		// Handle incident active at end of window
 		if activeIncident != nil && consecutiveBuckets >= dp.minBuckets() {
 			lastBucket := linkBuckets[len(linkBuckets)-1]
-			endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
-			activeIncident.EndedAt = &endedAt
 			peak := peakValue
 			activeIncident.PeakCount = &peak
 			activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
-			startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-			endTime := lastBucket.Bucket.Add(5 * time.Minute)
-			durationSecs := int64(endTime.Sub(startTime).Seconds())
-			activeIncident.DurationSeconds = &durationSecs
+			// If the last bucket is recent (within 15 minutes of now), the incident
+			// is likely still ongoing but wasn't caught by the current detection.
+			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+				activeIncident.IsOngoing = true
+			} else {
+				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				activeIncident.EndedAt = &endedAt
+
+				startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
+				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				durationSecs := int64(endTime.Sub(startTime).Seconds())
+				activeIncident.DurationSeconds = &durationSecs
+			}
 
 			incidents = append(incidents, *activeIncident)
 		}


### PR DESCRIPTION
## Summary of Changes

- Fix ongoing incidents being marked as "Resolved" when the current detection window has insufficient samples in the newest 5-minute bucket
- When the historical pairing finds an incident active at the end of the data window and the last bucket is within 15 minutes of now, mark it as ongoing instead of resolved
- Applied the same fix to packet loss, counter metric (errors/discards/carrier), and device incident detection

## Testing Verification

- Verified the link `dz-mrs-01:dz-mad-01` was showing as "Resolved" despite active 100% packet loss visible in the chart
- The fix acts as a safety net: if the strict sample-count requirements in the current detection cause it to miss an active incident, the historical pairing now correctly marks it as ongoing