### PR TITLE
incidents: use coarser bucket intervals for longer time ranges

### DIFF
--- a/api/handlers/detection.go
+++ b/api/handlers/detection.go
@@ -368,7 +368,7 @@ type linkMetadata struct {
 
 // pairPacketLossEventsCompleted finds completed packet loss events within the time window
 // Links with ongoing events are excluded (they're handled separately)
-func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]linkMetadata, threshold float64, excludeLinks map[string]bool) []DetectedEvent {
+func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]linkMetadata, threshold float64, excludeLinks map[string]bool, bucketInterval time.Duration) []DetectedEvent {
 	var events []DetectedEvent
 	eventIDCounter := 1000 // Start high to avoid collision with ongoing IDs
 
@@ -451,7 +451,7 @@ func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]lin
 			} else if !aboveThreshold && wasAbove && activeEvent != nil {
 				if consecutiveBuckets >= 2 {
 					prevBucket := linkBuckets[i-1]
-					endedAt := prevBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+					endedAt := prevBucket.Bucket.Add(bucketInterval).UTC().Format(time.RFC3339)
 					activeEvent.EndedAt = &endedAt
 					activeEvent.IsOngoing = false
 					peak := peakLoss
@@ -459,7 +459,7 @@ func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]lin
 					activeEvent.Severity = packetLossSeverity(peakLoss)
 
 					startTime, _ := time.Parse(time.RFC3339, activeEvent.StartedAt)
-					endTime := prevBucket.Bucket.Add(5 * time.Minute)
+					endTime := prevBucket.Bucket.Add(bucketInterval)
 					durationSecs := int64(endTime.Sub(startTime).Seconds())
 					activeEvent.DurationSeconds = &durationSecs
 
@@ -483,18 +483,18 @@ func pairPacketLossEventsCompleted(buckets []lossBucket, linkMeta map[string]lin
 			activeEvent.PeakLossPct = &peak
 			activeEvent.Severity = packetLossSeverity(peakLoss)
 
-			// If the last bucket is recent (within 15 minutes of now), the event
+			// If the last bucket is recent (within 3 bucket intervals of now), the event
 			// is likely still ongoing but wasn't caught by the current detection
-			// (e.g., the most recent 5-min bucket doesn't have enough samples yet).
-			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+			// (e.g., the most recent bucket doesn't have enough samples yet).
+			if time.Since(lastBucket.Bucket) <= 3*bucketInterval {
 				activeEvent.IsOngoing = true
 			} else {
-				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				endedAt := lastBucket.Bucket.Add(bucketInterval).UTC().Format(time.RFC3339)
 				activeEvent.EndedAt = &endedAt
 				activeEvent.IsOngoing = false
 
 				startTime, _ := time.Parse(time.RFC3339, activeEvent.StartedAt)
-				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				endTime := lastBucket.Bucket.Add(bucketInterval)
 				durationSecs := int64(endTime.Sub(startTime).Seconds())
 				activeEvent.DurationSeconds = &durationSecs
 			}

--- a/api/handlers/detection_test.go
+++ b/api/handlers/detection_test.go
@@ -248,7 +248,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-1", Bucket: bucket(5 * time.Minute), LossPct: 50.0},
 			{LinkPK: "pk-1", Bucket: bucket(10 * time.Minute), LossPct: 0.0},
 		}
-		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil)
+		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil, 5*time.Minute)
 		assert.Empty(t, got)
 	})
 
@@ -259,7 +259,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-1", Bucket: bucket(10 * time.Minute), LossPct: 25.0},
 			{LinkPK: "pk-1", Bucket: bucket(15 * time.Minute), LossPct: 0.0},
 		}
-		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil)
+		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil, 5*time.Minute)
 		assert.Len(t, got, 1)
 		assert.Equal(t, "packet_loss", got[0].EventType)
 		assert.Equal(t, "LINK-1", got[0].LinkCode)
@@ -275,7 +275,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-1", Bucket: bucket(10 * time.Minute), LossPct: 8.0},
 			{LinkPK: "pk-1", Bucket: bucket(15 * time.Minute), LossPct: 0.0},
 		}
-		got := pairPacketLossEventsCompleted(buckets, meta, 1.0, nil)
+		got := pairPacketLossEventsCompleted(buckets, meta, 1.0, nil, 5*time.Minute)
 		assert.Len(t, got, 1)
 		assert.Equal(t, "degraded", got[0].Severity)
 	})
@@ -288,7 +288,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-1", Bucket: bucket(15 * time.Minute), LossPct: 0.0},
 		}
 		excluded := map[string]bool{"LINK-1": true}
-		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, excluded)
+		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, excluded, 5*time.Minute)
 		assert.Empty(t, got)
 	})
 
@@ -297,7 +297,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-unknown", Bucket: bucket(0), LossPct: 50.0},
 			{LinkPK: "pk-unknown", Bucket: bucket(5 * time.Minute), LossPct: 50.0},
 		}
-		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil)
+		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil, 5*time.Minute)
 		assert.Empty(t, got)
 	})
 
@@ -307,7 +307,7 @@ func TestPairPacketLossEventsCompleted(t *testing.T) {
 			{LinkPK: "pk-1", Bucket: bucket(5 * time.Minute), LossPct: 20.0},
 			{LinkPK: "pk-1", Bucket: bucket(10 * time.Minute), LossPct: 30.0},
 		}
-		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil)
+		got := pairPacketLossEventsCompleted(buckets, meta, 10.0, nil, 5*time.Minute)
 		assert.Len(t, got, 1)
 		assert.Equal(t, 30.0, *got[0].PeakLossPct)
 	})

--- a/api/handlers/device_incidents.go
+++ b/api/handlers/device_incidents.go
@@ -166,7 +166,7 @@ func fetchDeviceCounterIncidents(ctx context.Context, conn driver.Conn, duration
 	query := fmt.Sprintf(`
 		SELECT
 			ic.device_pk,
-			toStartOfInterval(ic.event_ts, INTERVAL 5 MINUTE) as bucket,
+			toStartOfInterval(ic.event_ts, INTERVAL %s) as bucket,
 			%s as metric_value
 		FROM fact_dz_device_interface_counters ic
 		WHERE ic.event_ts >= now() - INTERVAL $1 SECOND
@@ -174,7 +174,7 @@ func fetchDeviceCounterIncidents(ctx context.Context, conn driver.Conn, duration
 		  %s
 		GROUP BY ic.device_pk, bucket
 		ORDER BY ic.device_pk, bucket
-	`, metricExpr, linkFilter)
+	`, sqlBucketInterval(dp.bucketSize()), metricExpr, linkFilter)
 
 	lookbackSecs := int64((duration + 24*time.Hour).Seconds())
 	rows, err := conn.Query(ctx, query, lookbackSecs, devicePKs)
@@ -447,14 +447,14 @@ func pairDeviceCounterIncidentsCompleted(buckets []deviceCounterBucket, deviceMe
 			} else if !aboveThreshold && prevAbove && activeIncident != nil {
 				if consecutiveBuckets >= dp.minBuckets() {
 					prevBucket := deviceBuckets[i-1]
-					endedAt := prevBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+					endedAt := prevBucket.Bucket.Add(dp.bucketSize()).UTC().Format(time.RFC3339)
 					activeIncident.EndedAt = &endedAt
 					peak := peakValue
 					activeIncident.PeakCount = &peak
 					activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
 					startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-					endTime := prevBucket.Bucket.Add(5 * time.Minute)
+					endTime := prevBucket.Bucket.Add(dp.bucketSize())
 					durationSecs := int64(endTime.Sub(startTime).Seconds())
 					activeIncident.DurationSeconds = &durationSecs
 
@@ -478,16 +478,16 @@ func pairDeviceCounterIncidentsCompleted(buckets []deviceCounterBucket, deviceMe
 			activeIncident.PeakCount = &peak
 			activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
-			// If the last bucket is recent (within 15 minutes of now), the incident
+			// If the last bucket is recent (within 3 bucket intervals of now), the incident
 			// is likely still ongoing but wasn't caught by the current detection.
-			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+			if time.Since(lastBucket.Bucket) <= 3*dp.bucketSize() {
 				activeIncident.IsOngoing = true
 			} else {
-				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				endedAt := lastBucket.Bucket.Add(dp.bucketSize()).UTC().Format(time.RFC3339)
 				activeIncident.EndedAt = &endedAt
 
 				startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				endTime := lastBucket.Bucket.Add(dp.bucketSize())
 				durationSecs := int64(endTime.Sub(startTime).Seconds())
 				activeIncident.DurationSeconds = &durationSecs
 			}
@@ -1064,8 +1064,9 @@ func GetDeviceIncidents(w http.ResponseWriter, r *http.Request) {
 		coalesceGapMin = 0
 	}
 	detectParams := incidentDetectionParams{
-		MinDuration: time.Duration(minDurationMin) * time.Minute,
-		CoalesceGap: time.Duration(coalesceGapMin) * time.Minute,
+		MinDuration:    time.Duration(minDurationMin) * time.Minute,
+		CoalesceGap:    time.Duration(coalesceGapMin) * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	incidentType := r.URL.Query().Get("type")
@@ -1275,8 +1276,9 @@ func GetDeviceIncidentsCSV(w http.ResponseWriter, r *http.Request) {
 		coalesceGapMin = 0
 	}
 	detectParams := incidentDetectionParams{
-		MinDuration: time.Duration(minDurationMin) * time.Minute,
-		CoalesceGap: time.Duration(coalesceGapMin) * time.Minute,
+		MinDuration:    time.Duration(minDurationMin) * time.Minute,
+		CoalesceGap:    time.Duration(coalesceGapMin) * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	incidentType := r.URL.Query().Get("type")
@@ -1439,8 +1441,9 @@ func fetchDefaultDeviceIncidentsData(ctx context.Context) *DeviceIncidentsRespon
 	var filters []IncidentFilter
 
 	detectParams := incidentDetectionParams{
-		MinDuration: 30 * time.Minute,
-		CoalesceGap: 180 * time.Minute,
+		MinDuration:    30 * time.Minute,
+		CoalesceGap:    180 * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	deviceMeta, err := fetchDeviceMetadata(ctx, envDB(ctx), filters)

--- a/api/handlers/incidents.go
+++ b/api/handlers/incidents.go
@@ -88,22 +88,47 @@ type linkMetadataWithStatus struct {
 
 // incidentDetectionParams holds configurable detection parameters
 type incidentDetectionParams struct {
-	MinDuration time.Duration // minimum consecutive duration above threshold (default 30m)
-	CoalesceGap time.Duration // gap between incidents to merge (default 180m/3h)
+	MinDuration    time.Duration // minimum consecutive duration above threshold (default 30m)
+	CoalesceGap    time.Duration // gap between incidents to merge (default 180m/3h)
+	BucketInterval time.Duration // aggregation bucket size (default 5m, larger for longer ranges)
 }
 
-const bucketInterval = 5 * time.Minute
+const defaultBucketInterval = 5 * time.Minute
 
-// minBuckets returns the minimum number of consecutive 5-min buckets for the configured duration
+// bucketIntervalForDuration returns a coarser bucket interval for longer time ranges
+// to reduce the amount of data scanned in ClickHouse.
+func bucketIntervalForDuration(d time.Duration) time.Duration {
+	switch {
+	case d > 3*24*time.Hour: // 7d, 30d
+		return 15 * time.Minute
+	default: // 3h, 6h, 12h, 24h, 3d
+		return defaultBucketInterval
+	}
+}
+
+// sqlBucketInterval returns the SQL INTERVAL string for a bucket interval duration.
+func sqlBucketInterval(d time.Duration) string {
+	return fmt.Sprintf("%d MINUTE", int(d.Minutes()))
+}
+
+// bucketSize returns the configured bucket interval, defaulting to 5 minutes.
+func (p incidentDetectionParams) bucketSize() time.Duration {
+	if p.BucketInterval == 0 {
+		return defaultBucketInterval
+	}
+	return p.BucketInterval
+}
+
+// minBuckets returns the minimum number of consecutive buckets for the configured duration
 func (p incidentDetectionParams) minBuckets() int {
-	n := int(p.MinDuration / bucketInterval)
+	n := int(p.MinDuration / p.bucketSize())
 	if n < 1 {
 		return 1
 	}
 	return n
 }
 
-// counterBucket represents a 5-minute aggregation of counter metrics
+// counterBucket represents a bucketed aggregation of counter metrics
 type counterBucket struct {
 	LinkPK string
 	Bucket time.Time
@@ -215,11 +240,11 @@ func fetchPacketLossIncidents(ctx context.Context, conn driver.Conn, duration ti
 		return convertEventsToIncidents(currentEvents, linkMeta), nil
 	}
 
-	query := `
+	query := fmt.Sprintf(`
 		WITH buckets AS (
 			SELECT
 				lat.link_pk,
-				toStartOfInterval(lat.event_ts, INTERVAL 5 MINUTE) as bucket,
+				toStartOfInterval(lat.event_ts, INTERVAL %s) as bucket,
 				countIf(lat.loss = true OR lat.rtt_us = 0) * 100.0 / count(*) as loss_pct,
 				count(*) as sample_count
 			FROM fact_dz_device_link_latency lat
@@ -231,7 +256,7 @@ func fetchPacketLossIncidents(ctx context.Context, conn driver.Conn, duration ti
 		SELECT b.link_pk, b.bucket, b.loss_pct, b.sample_count
 		FROM buckets b
 		ORDER BY b.link_pk, b.bucket
-	`
+	`, sqlBucketInterval(dp.bucketSize()))
 
 	// Add 1 day of lookback padding so incidents starting before the time range boundary get their true start time
 	lookbackSecs := int64((duration + 24*time.Hour).Seconds())
@@ -250,7 +275,7 @@ func fetchPacketLossIncidents(ctx context.Context, conn driver.Conn, duration ti
 		buckets = append(buckets, lb)
 	}
 
-	completedEvents := pairPacketLossEventsCompleted(buckets, plainMeta, threshold, ongoingLinks)
+	completedEvents := pairPacketLossEventsCompleted(buckets, plainMeta, threshold, ongoingLinks, dp.bucketSize())
 	allEvents := append(currentEvents, completedEvents...)
 	allEvents = coalescePacketLossEvents(allEvents, dp.CoalesceGap)
 
@@ -445,14 +470,14 @@ func fetchCounterIncidents(ctx context.Context, conn driver.Conn, duration time.
 	query := fmt.Sprintf(`
 		SELECT
 			ic.link_pk,
-			toStartOfInterval(ic.event_ts, INTERVAL 5 MINUTE) as bucket,
+			toStartOfInterval(ic.event_ts, INTERVAL %s) as bucket,
 			%s as metric_value
 		FROM fact_dz_device_interface_counters ic
 		WHERE ic.event_ts >= now() - INTERVAL $1 SECOND
 		  AND ic.link_pk IN ($2)
 		GROUP BY ic.link_pk, bucket
 		ORDER BY ic.link_pk, bucket
-	`, metricExpr)
+	`, sqlBucketInterval(dp.bucketSize()), metricExpr)
 
 	// Add 1 day of lookback padding so incidents starting before the time range boundary get their true start time
 	lookbackSecs := int64((duration + 24*time.Hour).Seconds())
@@ -735,14 +760,14 @@ func pairCounterIncidentsCompleted(buckets []counterBucket, linkMeta map[string]
 			} else if !aboveThreshold && prevAbove && activeIncident != nil {
 				if consecutiveBuckets >= dp.minBuckets() {
 					prevBucket := linkBuckets[i-1]
-					endedAt := prevBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+					endedAt := prevBucket.Bucket.Add(dp.bucketSize()).UTC().Format(time.RFC3339)
 					activeIncident.EndedAt = &endedAt
 					peak := peakValue
 					activeIncident.PeakCount = &peak
 					activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
 					startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-					endTime := prevBucket.Bucket.Add(5 * time.Minute)
+					endTime := prevBucket.Bucket.Add(dp.bucketSize())
 					durationSecs := int64(endTime.Sub(startTime).Seconds())
 					activeIncident.DurationSeconds = &durationSecs
 
@@ -766,16 +791,16 @@ func pairCounterIncidentsCompleted(buckets []counterBucket, linkMeta map[string]
 			activeIncident.PeakCount = &peak
 			activeIncident.Severity = incidentSeverity(incidentType, 0, peakValue)
 
-			// If the last bucket is recent (within 15 minutes of now), the incident
+			// If the last bucket is recent (within 3 bucket intervals of now), the incident
 			// is likely still ongoing but wasn't caught by the current detection.
-			if time.Since(lastBucket.Bucket) <= 15*time.Minute {
+			if time.Since(lastBucket.Bucket) <= 3*dp.bucketSize() {
 				activeIncident.IsOngoing = true
 			} else {
-				endedAt := lastBucket.Bucket.Add(5 * time.Minute).UTC().Format(time.RFC3339)
+				endedAt := lastBucket.Bucket.Add(dp.bucketSize()).UTC().Format(time.RFC3339)
 				activeIncident.EndedAt = &endedAt
 
 				startTime, _ := time.Parse(time.RFC3339, activeIncident.StartedAt)
-				endTime := lastBucket.Bucket.Add(5 * time.Minute)
+				endTime := lastBucket.Bucket.Add(dp.bucketSize())
 				durationSecs := int64(endTime.Sub(startTime).Seconds())
 				activeIncident.DurationSeconds = &durationSecs
 			}
@@ -972,8 +997,9 @@ func GetLinkIncidents(w http.ResponseWriter, r *http.Request) {
 		coalesceGapMin = 0
 	}
 	detectParams := incidentDetectionParams{
-		MinDuration: time.Duration(minDurationMin) * time.Minute,
-		CoalesceGap: time.Duration(coalesceGapMin) * time.Minute,
+		MinDuration:    time.Duration(minDurationMin) * time.Minute,
+		CoalesceGap:    time.Duration(coalesceGapMin) * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	incidentType := r.URL.Query().Get("type")
@@ -1202,8 +1228,9 @@ func GetLinkIncidentsCSV(w http.ResponseWriter, r *http.Request) {
 		coalesceGapMin = 0
 	}
 	detectParams := incidentDetectionParams{
-		MinDuration: time.Duration(minDurationMin) * time.Minute,
-		CoalesceGap: time.Duration(coalesceGapMin) * time.Minute,
+		MinDuration:    time.Duration(minDurationMin) * time.Minute,
+		CoalesceGap:    time.Duration(coalesceGapMin) * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	incidentType := r.URL.Query().Get("type")
@@ -1511,8 +1538,9 @@ func fetchDefaultIncidentsData(ctx context.Context) *LinkIncidentsResponse {
 	var filters []IncidentFilter
 
 	detectParams := incidentDetectionParams{
-		MinDuration: 30 * time.Minute,
-		CoalesceGap: 180 * time.Minute,
+		MinDuration:    30 * time.Minute,
+		CoalesceGap:    180 * time.Minute,
+		BucketInterval: bucketIntervalForDuration(duration),
 	}
 
 	linkMeta, err := fetchLinkMetadataWithStatus(ctx, envDB(ctx), filters)


### PR DESCRIPTION
## Summary of Changes
- Use 15-minute aggregation buckets instead of 5-minute for incident queries with time ranges >3d (7d, 30d), reducing ClickHouse scan volume by ~3x
- Keep 5-minute buckets for short ranges (≤3d), current/ongoing detection, and no-data gap detection to preserve accuracy where it matters
- Add `BucketInterval` to detection params with `bucketSize()` fallback so all existing behavior is preserved when unset

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +77 / -46   | +31  |
| Tests        |     1 | +6 / -6     |   0  |

Mostly core logic changes with test updates to match the new function signature.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/incidents.go`](https://github.com/malbeclabs/lake/pull/194/files#diff-f586e36ddeb6cfea74834f8a531219639e56ac48177fadbadc15face72fb4f87) — add `bucketIntervalForDuration()`, `sqlBucketInterval()`, `bucketSize()` helpers; update SQL queries and pairing logic to use dynamic interval
- [`api/handlers/device_incidents.go`](https://github.com/malbeclabs/lake/pull/194/files#diff-25108a0faedbc6d3c82882a39dbd80c72cbbb161207afd50d259a954c3af28e4) — same SQL and pairing updates for device counter incidents
- [`api/handlers/detection.go`](https://github.com/malbeclabs/lake/pull/194/files#diff-094b37f27b7d2f29d2ba6a8dc633ffa0507fd1467c95b0af0e40d24e0220be62) — add `bucketInterval` param to `pairPacketLossEventsCompleted`, update end time and recency calculations

</details>

## Testing Verification
- All incident-related unit tests pass (MinBuckets, PairPacketLossEvents, PairCounterIncidents, PairDeviceCounterIncidents, Coalesce, IsDefaultIncidents)
- `go vet ./api/...` clean