### PR TITLE
api: fix publisher check slot counts doubled by multiple shredder hosts

### DIFF
--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -105,17 +105,28 @@ func GetPublisherCheck(w http.ResponseWriter, r *http.Request) {
 		WITH current_epoch AS (
 			SELECT max(epoch) AS epoch FROM %s
 		),
+		per_slot AS (
+			SELECT
+				dz_user_pubkey,
+				slot,
+				max(activated_stake) AS activated_stake,
+				max(is_scheduled_leader) AS is_scheduled_leader,
+				max(unique_shreds) AS unique_shreds,
+				max(needs_repair) AS needs_repair
+			FROM %s
+			WHERE epoch >= (SELECT epoch FROM current_epoch) - ? + 1
+			GROUP BY dz_user_pubkey, slot
+		),
 		stats AS (
 			SELECT
 				dz_user_pubkey,
 				max(activated_stake) AS activated_stake,
-				count(*) AS total_slots,
+				count() AS total_slots,
 				countIf(is_scheduled_leader = true) AS leader_slots,
 				countIf(is_scheduled_leader = false) AS retransmit_slots,
 				sum(unique_shreds) AS total_unique_shreds,
 				countIf(needs_repair = true) AS slots_needing_repair
-			FROM %s
-			WHERE epoch >= (SELECT epoch FROM current_epoch) - ? + 1
+			FROM per_slot
 			GROUP BY dz_user_pubkey
 		)
 		SELECT

--- a/api/handlers/publisher_check_test.go
+++ b/api/handlers/publisher_check_test.go
@@ -340,6 +340,53 @@ func TestGetPublisherCheck_EpochsParam(t *testing.T) {
 	assert.Len(t, resp.Publishers, 3)
 }
 
+// TestGetPublisherCheck_MultiHost verifies that slot counts are not inflated
+// when multiple shredder hosts report stats for the same (publisher, slot) pair.
+// The publisher_shred_stats table is keyed by (host, slot, publisher_ip), so each
+// shredder instance writes its own row per slot. The query must deduplicate by slot.
+func TestGetPublisherCheck_MultiHost(t *testing.T) {
+	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
+	insertPublisherCheckTestData(t)
+
+	// Insert duplicate rows from a second shredder host for dzuser1's slots.
+	ctx := t.Context()
+	err := config.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.publisher_shred_stats`, "`"+config.ShredderDB+"`")+`
+			(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
+			 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
+			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
+			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+		VALUES
+			(now(), now(), 'shredder-2', '10.0.0.1', '203.0.113.1', 'nodepub1',
+			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
+			 800, 1001, 100, 64, 32, 32, 31, false, 0, 0, true),
+			(now(), now(), 'shredder-2', '10.0.0.1', '203.0.113.1', 'nodepub1',
+			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
+			 800, 1002, 100, 64, 32, 32, 31, true, 0, 0, false),
+			(now(), now(), 'shredder-2', '10.0.0.2', '203.0.113.2', 'nodepub2',
+			 'votepub2', 10000000000, 'dzuser2', 'nyc1', 'NYC',
+			 800, 1001, 50, 32, 16, 16, 15, false, 0, 0, false)
+	`)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/publisher-check?q=dzuser1", nil)
+	rr := httptest.NewRecorder()
+	handlers.GetPublisherCheck(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp handlers.PublisherCheckResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp.Publishers, 1)
+
+	pub := resp.Publishers[0]
+	// With 2 shredder hosts, each slot has 2 rows. Slot counts must NOT be doubled.
+	assert.Equal(t, uint64(1), pub.LeaderSlots, "leader_slots should count distinct slots, not rows")
+	assert.Equal(t, uint64(2), pub.TotalSlots, "total_slots should count distinct slots, not rows")
+	assert.Equal(t, uint64(128), pub.TotalUniqueShreds, "unique_shreds should use max per slot, not sum across hosts")
+}
+
 func TestGetPublisherCheck_FilterByDZID(t *testing.T) {
 	apitesting.SetupTestClickHouseWithMigrations(t, testChDB)
 	insertPublisherCheckTestData(t)


### PR DESCRIPTION
## Summary of Changes
- Fix publisher check slot counts being inflated when multiple shredder hosts report stats for the same slots
- Add `per_slot` CTE that deduplicates `publisher_shred_stats` to one row per `(dz_user_pubkey, slot)` before aggregating, using `max()` for `is_scheduled_leader`, `unique_shreds`, and `needs_repair`
- Add multi-host regression test that inserts data from two shredder hosts and verifies counts are not doubled

## Testing Verification
- All existing publisher check integration tests pass
- New `TestGetPublisherCheck_MultiHost` test reproduces the bug scenario (2 shredder hosts) and verifies correct counts