### PR TITLE
web: add FCS errors as a separate filter and metric

### DIFF
--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -155,6 +155,12 @@ function DeviceStatusTimeline({ hours, bucketMinutes = 60, timeRange = '24h' }: 
                           </span>
                         </div>
                       )}
+                      {hour.in_fcs_errors > 0 && (
+                        <div className="flex justify-between gap-4">
+                          <span>FCS Errors:</span>
+                          <span className="font-mono">{hour.in_fcs_errors.toLocaleString()}</span>
+                        </div>
+                      )}
                       {(hour.in_discards > 0 || hour.out_discards > 0) && (
                         <div className="flex justify-between gap-4">
                           <span>Discards:</span>
@@ -184,6 +190,7 @@ function DeviceStatusTimeline({ hours, bucketMinutes = 60, timeRange = '24h' }: 
                         </div>
                       )}
                       {hour.in_errors === 0 && hour.out_errors === 0 &&
+                       hour.in_fcs_errors === 0 &&
                        hour.in_discards === 0 && hour.out_discards === 0 &&
                        hour.carrier_transitions === 0 && hour.max_users === 0 && (
                         <div className="text-xs">No issues detected</div>
@@ -248,10 +255,11 @@ const INTERFACE_COLORS = [
   '#6366f1', // indigo-500
 ]
 
-type MetricType = 'errors' | 'discards' | 'carrier'
+type MetricType = 'errors' | 'fcs_errors' | 'discards' | 'carrier'
 
 const METRIC_CONFIG: Record<MetricType, { label: string; color: string }> = {
   errors: { label: 'Errors', color: '#d946ef' },
+  fcs_errors: { label: 'FCS Errors', color: '#ea580c' },
   discards: { label: 'Discards', color: '#f43f5e' },
   carrier: { label: 'Carrier Transitions', color: '#f97316' },
 }
@@ -336,7 +344,7 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
   const { resolvedTheme } = useTheme()
   const isDarkMode = resolvedTheme === 'dark'
   const [enabledInterfaces, setEnabledInterfaces] = useState<Set<string>>(new Set())
-  const [enabledMetrics, setEnabledMetrics] = useState<Set<MetricType>>(new Set(['errors', 'discards', 'carrier']))
+  const [enabledMetrics, setEnabledMetrics] = useState<Set<MetricType>>(new Set(['errors', 'fcs_errors', 'discards', 'carrier']))
   const [initialized, setInitialized] = useState(false)
 
   const { data, isLoading, error } = useQuery({
@@ -349,7 +357,7 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
   const interfacesWithIssues = useMemo(() => {
     if (!data?.interfaces) return []
     return data.interfaces.filter(intf =>
-      intf.hours.some(h => h.in_errors > 0 || h.out_errors > 0 || h.in_discards > 0 || h.out_discards > 0 || h.carrier_transitions > 0)
+      intf.hours.some(h => h.in_errors > 0 || h.out_errors > 0 || h.in_fcs_errors > 0 || h.in_discards > 0 || h.out_discards > 0 || h.carrier_transitions > 0)
     )
   }, [data?.interfaces])
 
@@ -367,6 +375,7 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
     for (const intf of interfacesWithIssues) {
       for (const h of intf.hours) {
         if (h.in_errors > 0 || h.out_errors > 0) metrics.add('errors')
+        if (h.in_fcs_errors > 0) metrics.add('fcs_errors')
         if (h.in_discards > 0 || h.out_discards > 0) metrics.add('discards')
         if (h.carrier_transitions > 0) metrics.add('carrier')
       }
@@ -468,6 +477,7 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
       if (h) {
         point[`${intf.interface_name}_errors_in`] = h.in_errors || 0
         point[`${intf.interface_name}_errors_out`] = h.out_errors ? -h.out_errors : 0
+        point[`${intf.interface_name}_fcs_errors`] = h.in_fcs_errors || 0
         point[`${intf.interface_name}_discards_in`] = h.in_discards || 0
         point[`${intf.interface_name}_discards_out`] = h.out_discards ? -h.out_discards : 0
         point[`${intf.interface_name}_carrier`] = h.carrier_transitions || 0
@@ -485,18 +495,20 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
     if (!data) return null
 
     // Group by interface
-    const interfaceData: Record<string, { errorsIn: number; errorsOut: number; discardsIn: number; discardsOut: number; carrier: number; color: string }> = {}
+    const interfaceData: Record<string, { errorsIn: number; errorsOut: number; fcsErrors: number; discardsIn: number; discardsOut: number; carrier: number; color: string }> = {}
     for (const intf of interfacesWithIssues) {
       if (!enabledInterfaces.has(intf.interface_name)) continue
       const errorsIn = data[`${intf.interface_name}_errors_in`] || 0
       const errorsOut = Math.abs(data[`${intf.interface_name}_errors_out`] || 0)
+      const fcsErrors = data[`${intf.interface_name}_fcs_errors`] || 0
       const discardsIn = data[`${intf.interface_name}_discards_in`] || 0
       const discardsOut = Math.abs(data[`${intf.interface_name}_discards_out`] || 0)
       const carrier = data[`${intf.interface_name}_carrier`] || 0
-      if (errorsIn > 0 || errorsOut > 0 || discardsIn > 0 || discardsOut > 0 || carrier > 0) {
+      if (errorsIn > 0 || errorsOut > 0 || fcsErrors > 0 || discardsIn > 0 || discardsOut > 0 || carrier > 0) {
         interfaceData[intf.interface_name] = {
           errorsIn,
           errorsOut,
+          fcsErrors,
           discardsIn,
           discardsOut,
           carrier,
@@ -525,6 +537,9 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
                 <div className="pl-3.5 text-xs text-muted-foreground space-y-0.5">
                   {enabledMetrics.has('errors') && (values.errorsIn > 0 || values.errorsOut > 0) && (
                     <div>Errors: {values.errorsIn.toLocaleString()} in / {values.errorsOut.toLocaleString()} out</div>
+                  )}
+                  {enabledMetrics.has('fcs_errors') && values.fcsErrors > 0 && (
+                    <div>FCS Errors: {values.fcsErrors.toLocaleString()}</div>
                   )}
                   {enabledMetrics.has('discards') && (values.discardsIn > 0 || values.discardsOut > 0) && (
                     <div>Discards: {values.discardsIn.toLocaleString()} in / {values.discardsOut.toLocaleString()} out</div>
@@ -557,6 +572,9 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
       lines.push({ dataKey: `${intf.interface_name}_errors_in`, color, strokeDasharray: undefined })
       lines.push({ dataKey: `${intf.interface_name}_errors_out`, color, strokeDasharray: undefined })
     }
+    if (enabledMetrics.has('fcs_errors') && availableMetrics.has('fcs_errors')) {
+      lines.push({ dataKey: `${intf.interface_name}_fcs_errors`, color, strokeDasharray: '8 3' })
+    }
     if (enabledMetrics.has('discards') && availableMetrics.has('discards')) {
       lines.push({ dataKey: `${intf.interface_name}_discards_in`, color, strokeDasharray: '5 5' })
       lines.push({ dataKey: `${intf.interface_name}_discards_out`, color, strokeDasharray: '5 5' })
@@ -574,11 +592,11 @@ function InterfaceIssueChart({ devicePk, timeRange, buckets, controlsWidth = 'w-
         <div className="space-y-1.5">
           <span className="text-xs text-muted-foreground">Metrics</span>
           <div className="flex flex-col gap-1">
-            {(['errors', 'discards', 'carrier'] as MetricType[]).map(metric => {
+            {(['errors', 'fcs_errors', 'discards', 'carrier'] as MetricType[]).map(metric => {
               if (!availableMetrics.has(metric)) return null
               const config = METRIC_CONFIG[metric]
               const isEnabled = enabledMetrics.has(metric)
-              const dashArray = metric === 'errors' ? undefined : metric === 'discards' ? '5 5' : '2 2'
+              const dashArray = metric === 'errors' ? undefined : metric === 'fcs_errors' ? '8 3' : metric === 'discards' ? '5 5' : '2 2'
               return (
                 <button
                   key={metric}
@@ -804,7 +822,7 @@ function DeviceRow({ device, devicesWithIssues, bucketMinutes, dataTimeRange, bu
 export function DeviceStatusTimelines({
   timeRange = '24h',
   onTimeRangeChange,
-  issueFilters = ['interface_errors', 'discards', 'carrier_transitions', 'drained'],
+  issueFilters = ['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained'],
   healthFilters = ['healthy', 'degraded', 'unhealthy', 'disabled'],
   devicesWithIssues,
   devicesWithHealth,
@@ -867,7 +885,7 @@ export function DeviceStatusTimelines({
       const hasIssues = issueReasons.length > 0
 
       const matchesIssue = hasIssues
-        ? issueReasons.some(reason => issueTypesSelected.includes(reason === 'fcs_errors' ? 'interface_errors' : reason))
+        ? issueReasons.some(reason => issueTypesSelected.includes(reason))
         : noIssuesSelected
 
       const matchesHealth = deviceMatchesHealthFilters(device)

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -158,10 +158,11 @@ function hasPacketLoss(hours: LinkHourStatus[]): boolean {
   return hours.some(h => h.avg_loss_pct > 0)
 }
 
-type MetricType = 'errors' | 'discards' | 'carrier'
+type MetricType = 'errors' | 'fcs_errors' | 'discards' | 'carrier'
 
 const METRIC_CONFIG: Record<MetricType, { label: string; dashArray?: string }> = {
   errors: { label: 'Errors', dashArray: undefined },
+  fcs_errors: { label: 'FCS Errors', dashArray: '8 3' },
   discards: { label: 'Discards', dashArray: '5 5' },
   carrier: { label: 'Carrier Transitions', dashArray: '2 2' },
 }
@@ -181,7 +182,7 @@ interface LinkInterfaceChartProps {
 function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: LinkInterfaceChartProps) {
   const { resolvedTheme } = useTheme()
   const isDarkMode = resolvedTheme === 'dark'
-  const [enabledMetrics, setEnabledMetrics] = useState<Set<MetricType>>(new Set(['errors', 'discards', 'carrier']))
+  const [enabledMetrics, setEnabledMetrics] = useState<Set<MetricType>>(new Set(['errors', 'fcs_errors', 'discards', 'carrier']))
   const [enabledSides, setEnabledSides] = useState<Set<'A' | 'Z'>>(new Set(['A', 'Z']))
 
   // Determine which metrics have data
@@ -191,6 +192,9 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
       if ((h.side_a_in_errors ?? 0) > 0 || (h.side_a_out_errors ?? 0) > 0 ||
           (h.side_z_in_errors ?? 0) > 0 || (h.side_z_out_errors ?? 0) > 0) {
         metrics.add('errors')
+      }
+      if ((h.side_a_in_fcs_errors ?? 0) > 0 || (h.side_z_in_fcs_errors ?? 0) > 0) {
+        metrics.add('fcs_errors')
       }
       if ((h.side_a_in_discards ?? 0) > 0 || (h.side_a_out_discards ?? 0) > 0 ||
           (h.side_z_in_discards ?? 0) > 0 || (h.side_z_out_discards ?? 0) > 0) {
@@ -208,11 +212,13 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
     const sides: Set<'A' | 'Z'> = new Set()
     for (const h of hours) {
       if ((h.side_a_in_errors ?? 0) > 0 || (h.side_a_out_errors ?? 0) > 0 ||
+          (h.side_a_in_fcs_errors ?? 0) > 0 ||
           (h.side_a_in_discards ?? 0) > 0 || (h.side_a_out_discards ?? 0) > 0 ||
           (h.side_a_carrier_transitions ?? 0) > 0) {
         sides.add('A')
       }
       if ((h.side_z_in_errors ?? 0) > 0 || (h.side_z_out_errors ?? 0) > 0 ||
+          (h.side_z_in_fcs_errors ?? 0) > 0 ||
           (h.side_z_in_discards ?? 0) > 0 || (h.side_z_out_discards ?? 0) > 0 ||
           (h.side_z_carrier_transitions ?? 0) > 0) {
         sides.add('Z')
@@ -248,12 +254,14 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
       // Side A
       A_errors_in: h.side_a_in_errors ?? 0,
       A_errors_out: -(h.side_a_out_errors ?? 0),
+      A_fcs_errors: h.side_a_in_fcs_errors ?? 0,
       A_discards_in: h.side_a_in_discards ?? 0,
       A_discards_out: -(h.side_a_out_discards ?? 0),
       A_carrier: h.side_a_carrier_transitions ?? 0,
       // Side Z
       Z_errors_in: h.side_z_in_errors ?? 0,
       Z_errors_out: -(h.side_z_out_errors ?? 0),
+      Z_fcs_errors: h.side_z_in_fcs_errors ?? 0,
       Z_discards_in: h.side_z_in_discards ?? 0,
       Z_discards_out: -(h.side_z_out_discards ?? 0),
       Z_carrier: h.side_z_carrier_transitions ?? 0,
@@ -280,10 +288,12 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
             if (!enabledSides.has(side)) return null
             const errorsIn = data[`${side}_errors_in`] || 0
             const errorsOut = Math.abs(data[`${side}_errors_out`] || 0)
+            const fcsErrors = data[`${side}_fcs_errors`] || 0
             const discardsIn = data[`${side}_discards_in`] || 0
             const discardsOut = Math.abs(data[`${side}_discards_out`] || 0)
             const carrier = data[`${side}_carrier`] || 0
             const hasData = (enabledMetrics.has('errors') && (errorsIn > 0 || errorsOut > 0)) ||
+                           (enabledMetrics.has('fcs_errors') && fcsErrors > 0) ||
                            (enabledMetrics.has('discards') && (discardsIn > 0 || discardsOut > 0)) ||
                            (enabledMetrics.has('carrier') && carrier > 0)
             if (!hasData) return null
@@ -296,6 +306,9 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
                 <div className="pl-3.5 text-xs text-muted-foreground space-y-0.5">
                   {enabledMetrics.has('errors') && (errorsIn > 0 || errorsOut > 0) && (
                     <div>Errors: {errorsIn.toLocaleString()} in / {errorsOut.toLocaleString()} out</div>
+                  )}
+                  {enabledMetrics.has('fcs_errors') && fcsErrors > 0 && (
+                    <div>FCS Errors: {fcsErrors.toLocaleString()}</div>
                   )}
                   {enabledMetrics.has('discards') && (discardsIn > 0 || discardsOut > 0) && (
                     <div>Discards: {discardsIn.toLocaleString()} in / {discardsOut.toLocaleString()} out</div>
@@ -324,6 +337,9 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
       lines.push({ dataKey: `${side}_errors_in`, color })
       lines.push({ dataKey: `${side}_errors_out`, color })
     }
+    if (enabledMetrics.has('fcs_errors') && availableMetrics.has('fcs_errors')) {
+      lines.push({ dataKey: `${side}_fcs_errors`, color, strokeDasharray: '8 3' })
+    }
     if (enabledMetrics.has('discards') && availableMetrics.has('discards')) {
       lines.push({ dataKey: `${side}_discards_in`, color, strokeDasharray: '5 5' })
       lines.push({ dataKey: `${side}_discards_out`, color, strokeDasharray: '5 5' })
@@ -340,7 +356,7 @@ function LinkInterfaceChart({ hours, bucketMinutes, controlsWidth = 'w-32' }: Li
         <div className="space-y-1.5">
           <span className="text-xs text-muted-foreground">Metrics</span>
           <div className="flex flex-wrap gap-1">
-            {(['errors', 'discards', 'carrier'] as MetricType[]).map(metric => {
+            {(['errors', 'fcs_errors', 'discards', 'carrier'] as MetricType[]).map(metric => {
               if (!availableMetrics.has(metric)) return null
               const config = METRIC_CONFIG[metric]
               const isEnabled = enabledMetrics.has(metric)
@@ -660,7 +676,7 @@ function LinkRow({ link, linksWithIssues, criticalityMap, bucketMinutes = 60, da
 export function LinkStatusTimelines({
   timeRange = '24h',
   onTimeRangeChange,
-  issueFilters = ['packet_loss', 'high_latency', 'high_utilization', 'interface_errors', 'discards', 'carrier_transitions'],
+  issueFilters = ['packet_loss', 'high_latency', 'high_utilization', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions'],
   healthFilters = ['healthy', 'degraded', 'unhealthy'],
   showDrained = false,
   onShowDrainedChange,
@@ -742,7 +758,7 @@ export function LinkStatusTimelines({
       }
 
       const matchesIssue = hasIssues
-        ? issueReasons.some(reason => issueTypesSelected.includes(reason === 'fcs_errors' ? 'interface_errors' : reason))
+        ? issueReasons.some(reason => issueTypesSelected.includes(reason))
         : noIssuesSelected
 
       // Must match at least one health filter

--- a/web/src/components/single-device-status-row.tsx
+++ b/web/src/components/single-device-status-row.tsx
@@ -42,8 +42,10 @@ function deviceHourToLinkHour(hour: DeviceHourStatus) {
     samples: 0,
     side_a_in_errors: hour.in_errors,
     side_a_out_errors: hour.out_errors,
+    side_a_in_fcs_errors: hour.in_fcs_errors,
     side_z_in_errors: 0,
     side_z_out_errors: 0,
+    side_z_in_fcs_errors: 0,
     side_a_in_discards: hour.in_discards,
     side_a_out_discards: hour.out_discards,
     side_z_in_discards: 0,
@@ -79,11 +81,13 @@ export function SingleDeviceStatusRow({ devicePk, timeRange = '24h' }: SingleDev
   // Extract issue reasons from hours data
   const issueReasons: string[] = []
   const hasAnyErrors = data.hours.some(h => h.in_errors > 0 || h.out_errors > 0)
+  const hasAnyFcsErrors = data.hours.some(h => h.in_fcs_errors > 0)
   const hasAnyDiscards = data.hours.some(h => h.in_discards > 0 || h.out_discards > 0)
   const hasAnyCarrier = data.hours.some(h => h.carrier_transitions > 0)
   const hasAnyDrained = data.issue_reasons?.includes('drained') ?? false
 
   if (hasAnyErrors) issueReasons.push('interface_errors')
+  if (hasAnyFcsErrors) issueReasons.push('fcs_errors')
   if (hasAnyDiscards) issueReasons.push('discards')
   if (hasAnyCarrier) issueReasons.push('carrier_transitions')
   if (hasAnyDrained) issueReasons.push('drained')
@@ -98,6 +102,9 @@ export function SingleDeviceStatusRow({ devicePk, timeRange = '24h' }: SingleDev
         <div className="flex flex-wrap gap-1.5">
           {issueReasons.includes('interface_errors') && (
             <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#dc2626' }}>Errors</span>
+          )}
+          {issueReasons.includes('fcs_errors') && (
+            <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(249, 115, 22, 0.15)', color: '#ea580c' }}>FCS Errors</span>
           )}
           {issueReasons.includes('discards') && (
             <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(20, 184, 166, 0.15)', color: '#0d9488' }}>Discards</span>

--- a/web/src/components/single-link-status-row.tsx
+++ b/web/src/components/single-link-status-row.tsx
@@ -66,12 +66,14 @@ export function SingleLinkStatusRow({ linkPk, timeRange = '24h' }: SingleLinkSta
     return latencyOveragePct >= 20 // LATENCY_WARNING_PCT from backend
   })
   const hasAnyErrors = data.hours.some(h => (h.side_a_in_errors ?? 0) > 0 || (h.side_a_out_errors ?? 0) > 0 || (h.side_z_in_errors ?? 0) > 0 || (h.side_z_out_errors ?? 0) > 0)
+  const hasAnyFcsErrors = data.hours.some(h => (h.side_a_in_fcs_errors ?? 0) > 0 || (h.side_z_in_fcs_errors ?? 0) > 0)
   const hasAnyDiscards = data.hours.some(h => (h.side_a_in_discards ?? 0) > 0 || (h.side_a_out_discards ?? 0) > 0 || (h.side_z_in_discards ?? 0) > 0 || (h.side_z_out_discards ?? 0) > 0)
   const hasAnyCarrier = data.hours.some(h => (h.side_a_carrier_transitions ?? 0) > 0 || (h.side_z_carrier_transitions ?? 0) > 0)
 
   if (hasAnyPacketLoss) issueReasons.push('packet_loss')
   if (hasAnyHighLatency) issueReasons.push('high_latency')
   if (hasAnyErrors) issueReasons.push('interface_errors')
+  if (hasAnyFcsErrors) issueReasons.push('fcs_errors')
   if (hasAnyDiscards) issueReasons.push('discards')
   if (hasAnyCarrier) issueReasons.push('carrier_transitions')
 
@@ -88,6 +90,9 @@ export function SingleLinkStatusRow({ linkPk, timeRange = '24h' }: SingleLinkSta
           )}
           {issueReasons.includes('interface_errors') && (
             <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#dc2626' }}>Errors</span>
+          )}
+          {issueReasons.includes('fcs_errors') && (
+            <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(249, 115, 22, 0.15)', color: '#ea580c' }}>FCS Errors</span>
           )}
           {issueReasons.includes('discards') && (
             <span className="text-xs px-2 py-1 rounded font-medium" style={{ backgroundColor: 'rgba(20, 184, 166, 0.15)', color: '#0d9488' }}>Discards</span>

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -12,8 +12,8 @@ import { DeviceStatusTimelines } from '@/components/device-status-timelines'
 import { MetroStatusTimelines, type MetroHealthFilter, type MetroIssueFilter } from '@/components/metro-status-timelines'
 
 type TimeRange = '3h' | '6h' | '12h' | '24h' | '3d' | '7d'
-type IssueFilter = 'packet_loss' | 'high_latency' | 'no_data' | 'interface_errors' | 'discards' | 'carrier_transitions' | 'high_utilization' | 'no_issues'
-type DeviceIssueFilter = 'interface_errors' | 'discards' | 'carrier_transitions' | 'drained' | 'no_issues'
+type IssueFilter = 'packet_loss' | 'high_latency' | 'no_data' | 'interface_errors' | 'fcs_errors' | 'discards' | 'carrier_transitions' | 'high_utilization' | 'no_issues'
+type DeviceIssueFilter = 'interface_errors' | 'fcs_errors' | 'discards' | 'carrier_transitions' | 'drained' | 'no_issues'
 type HealthFilter = 'healthy' | 'degraded' | 'unhealthy' | 'disabled'
 
 const timeRangeLabels: Record<TimeRange, string> = {
@@ -60,6 +60,7 @@ interface IssueCounts {
   high_utilization: number
   no_data: number
   interface_errors: number
+  fcs_errors: number
   discards: number
   carrier_transitions: number
   no_issues: number
@@ -629,6 +630,7 @@ interface HealthIssueBreakdown {
   high_latency: number
   no_data: number
   interface_errors: number
+  fcs_errors: number
   discards: number
   carrier_transitions: number
   high_utilization: number
@@ -636,6 +638,7 @@ interface HealthIssueBreakdown {
 
 interface DeviceIssueBreakdown {
   interface_errors: number
+  fcs_errors: number
   discards: number
   carrier_transitions: number
   drained: number
@@ -677,11 +680,13 @@ function HealthFilterItem({
     { key: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-yellow-500' },
     { key: 'discards', label: 'Discards', color: 'bg-teal-500' },
     { key: 'interface_errors', label: 'Errors', color: 'bg-red-500' },
+    { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-500' },
     { key: 'no_data', label: 'No Data', color: 'bg-pink-500' },
   ]
 
   const deviceIssueLabels: { key: keyof DeviceIssueBreakdown; label: string; color: string }[] = [
     { key: 'interface_errors', label: 'Interface Errors', color: 'bg-fuchsia-500' },
+    { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600' },
     { key: 'discards', label: 'Discards', color: 'bg-rose-500' },
     { key: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-orange-500' },
   ]
@@ -781,6 +786,7 @@ interface HealthByIssue {
   high_latency: IssueHealthBreakdown
   no_data: IssueHealthBreakdown
   interface_errors: IssueHealthBreakdown
+  fcs_errors: IssueHealthBreakdown
   discards: IssueHealthBreakdown
   carrier_transitions: IssueHealthBreakdown
   high_utilization: IssueHealthBreakdown
@@ -899,7 +905,7 @@ function LinkIssuesFilterCard({
   healthByIssue?: HealthByIssue
   timeRange: TimeRange
 }) {
-  const allFilters: IssueFilter[] = ['packet_loss', 'high_latency', 'high_utilization', 'no_data', 'interface_errors', 'discards', 'carrier_transitions', 'no_issues']
+  const allFilters: IssueFilter[] = ['packet_loss', 'high_latency', 'high_utilization', 'no_data', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'no_issues']
 
   const toggleFilter = (filter: IssueFilter) => {
     if (selected.includes(filter)) {
@@ -920,6 +926,7 @@ function LinkIssuesFilterCard({
     { filter: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-yellow-500', description: 'Carrier transitions (interface up/down) on link endpoints.' },
     { filter: 'discards', label: 'Discards', color: 'bg-teal-500', description: 'Interface discards detected on link endpoints.' },
     { filter: 'interface_errors', label: 'Errors', color: 'bg-red-500', description: 'Interface errors detected on link endpoints.' },
+    { filter: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-500', description: 'FCS (Frame Check Sequence) errors detected on link endpoints.' },
     { filter: 'no_data', label: 'No Data', color: 'bg-pink-500', description: 'No telemetry received for this link.' },
     { filter: 'no_issues', label: 'No Issues', color: 'bg-cyan-500', description: 'Link with no detected issues in the time range.' },
   ]
@@ -1434,7 +1441,7 @@ function useBucketCount() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusResponse; linkHistory: any; criticalLinks: CriticalLinksResponse | undefined }) {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
-  const [issueFilters, setIssueFilters] = useState<IssueFilter[]>(['packet_loss', 'high_latency', 'high_utilization', 'interface_errors', 'discards', 'carrier_transitions'])
+  const [issueFilters, setIssueFilters] = useState<IssueFilter[]>(['packet_loss', 'high_latency', 'high_utilization', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions'])
   const [healthFilters, setHealthFilters] = useState<HealthFilter[]>(['healthy', 'degraded', 'unhealthy'])
   const [showDrained, setShowDrained] = useState(false)
 
@@ -1544,6 +1551,7 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
       high_utilization: 0,
       no_data: 0,
       interface_errors: 0,
+      fcs_errors: 0,
       discards: 0,
       carrier_transitions: 0,
     })
@@ -1569,7 +1577,8 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
       if (issues.includes('high_latency')) breakdown.high_latency++
       if (issues.includes('high_utilization')) breakdown.high_utilization++
       if (issues.includes('no_data')) breakdown.no_data++
-      if (issues.includes('interface_errors') || issues.includes('fcs_errors')) breakdown.interface_errors++
+      if (issues.includes('interface_errors')) breakdown.interface_errors++
+      if (issues.includes('fcs_errors')) breakdown.fcs_errors++
       if (issues.includes('discards')) breakdown.discards++
       if (issues.includes('carrier_transitions')) breakdown.carrier_transitions++
     }
@@ -1591,6 +1600,7 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
       high_utilization: emptyBreakdown(),
       no_data: emptyBreakdown(),
       interface_errors: emptyBreakdown(),
+      fcs_errors: emptyBreakdown(),
       discards: emptyBreakdown(),
       carrier_transitions: emptyBreakdown(),
       no_issues: emptyBreakdown(),
@@ -1611,7 +1621,8 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
         if (issues.includes('high_latency')) result.high_latency[health]++
         if (issues.includes('high_utilization')) result.high_utilization[health]++
         if (issues.includes('no_data')) result.no_data[health]++
-        if (issues.includes('interface_errors') || issues.includes('fcs_errors')) result.interface_errors[health]++
+        if (issues.includes('interface_errors')) result.interface_errors[health]++
+        if (issues.includes('fcs_errors')) result.fcs_errors[health]++
         if (issues.includes('discards')) result.discards[health]++
         if (issues.includes('carrier_transitions')) result.carrier_transitions[health]++
       }
@@ -1623,10 +1634,10 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
   // Issue counts from filter time range
   const issueCounts = useMemo((): IssueCounts => {
     if (visibleLinks.length === 0) {
-      return { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, interface_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
+      return { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
     }
 
-    const counts = { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, interface_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
+    const counts = { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
     const seenLinks = new Set<string>()
 
     for (const link of visibleLinks) {
@@ -1634,7 +1645,8 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
       if (link.issue_reasons?.includes('high_latency')) counts.high_latency++
       if (link.issue_reasons?.includes('high_utilization')) counts.high_utilization++
       if (link.issue_reasons?.includes('no_data')) counts.no_data++
-      if (link.issue_reasons?.includes('interface_errors') || link.issue_reasons?.includes('fcs_errors')) counts.interface_errors++
+      if (link.issue_reasons?.includes('interface_errors')) counts.interface_errors++
+      if (link.issue_reasons?.includes('fcs_errors')) counts.fcs_errors++
       if (link.issue_reasons?.includes('discards')) counts.discards++
       if (link.issue_reasons?.includes('carrier_transitions')) counts.carrier_transitions++
       if (link.issue_reasons?.length > 0 && !seenLinks.has(link.code)) {
@@ -1776,6 +1788,7 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
 // Device issue counts interface
 interface DeviceIssueCounts {
   interface_errors: number
+  fcs_errors: number
   discards: number
   carrier_transitions: number
   drained: number
@@ -1785,15 +1798,16 @@ interface DeviceIssueCounts {
 
 // Device issues breakdown per health category
 interface DeviceIssuesByHealth {
-  healthy: { interface_errors: number; discards: number; carrier_transitions: number; drained: number }
-  degraded: { interface_errors: number; discards: number; carrier_transitions: number; drained: number }
-  unhealthy: { interface_errors: number; discards: number; carrier_transitions: number; drained: number }
-  disabled: { interface_errors: number; discards: number; carrier_transitions: number; drained: number }
+  healthy: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number }
+  degraded: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number }
+  unhealthy: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number }
+  disabled: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number }
 }
 
 // Device health breakdown per issue type
 interface DeviceHealthByIssue {
   interface_errors: { healthy: number; degraded: number; unhealthy: number; disabled: number }
+  fcs_errors: { healthy: number; degraded: number; unhealthy: number; disabled: number }
   discards: { healthy: number; degraded: number; unhealthy: number; disabled: number }
   carrier_transitions: { healthy: number; degraded: number; unhealthy: number; disabled: number }
   drained: { healthy: number; degraded: number; unhealthy: number; disabled: number }
@@ -1928,7 +1942,7 @@ function DeviceIssuesFilterCard({
   healthByIssue?: DeviceHealthByIssue
   timeRange: TimeRange
 }) {
-  const allFilters: DeviceIssueFilter[] = ['interface_errors', 'discards', 'carrier_transitions', 'drained', 'no_issues']
+  const allFilters: DeviceIssueFilter[] = ['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained', 'no_issues']
 
   const toggleFilter = (filter: DeviceIssueFilter) => {
     if (selected.includes(filter)) {
@@ -1944,6 +1958,7 @@ function DeviceIssuesFilterCard({
 
   const grandTotal = (counts.total + counts.no_issues) || 1
   const interfaceErrorsPct = (counts.interface_errors / grandTotal) * 100
+  const fcsErrorsPct = (counts.fcs_errors / grandTotal) * 100
   const discardsPct = (counts.discards / grandTotal) * 100
   const carrierTransitionsPct = (counts.carrier_transitions / grandTotal) * 100
   const drainedPct = (counts.drained / grandTotal) * 100
@@ -1951,6 +1966,7 @@ function DeviceIssuesFilterCard({
 
   const items: { filter: DeviceIssueFilter; label: string; color: string; description: string }[] = [
     { filter: 'interface_errors', label: 'Interface Errors', color: 'bg-fuchsia-500', description: 'Device experiencing interface errors.' },
+    { filter: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600', description: 'Device experiencing FCS (Frame Check Sequence) errors.' },
     { filter: 'discards', label: 'Discards', color: 'bg-rose-500', description: 'Device experiencing interface discards.' },
     { filter: 'carrier_transitions', label: 'Link Flapping', color: 'bg-orange-500', description: 'Device experiencing carrier state changes (link up/down).' },
     { filter: 'drained', label: 'Drained', color: 'bg-slate-500 dark:bg-slate-600', description: 'Device is soft-drained, hard-drained, or suspended.' },
@@ -1984,6 +2000,12 @@ function DeviceIssuesFilterCard({
           <div
             className={`bg-fuchsia-500 h-full transition-all ${!selected.includes('interface_errors') ? 'opacity-30' : ''}`}
             style={{ width: `${interfaceErrorsPct}%` }}
+          />
+        )}
+        {fcsErrorsPct > 0 && (
+          <div
+            className={`bg-orange-600 h-full transition-all ${!selected.includes('fcs_errors') ? 'opacity-30' : ''}`}
+            style={{ width: `${fcsErrorsPct}%` }}
           />
         )}
         {discardsPct > 0 && (
@@ -2137,7 +2159,7 @@ function deviceUtilMatchesSearchFilters(device: DeviceUtilization, filters: Stat
 // Devices tab content
 function DevicesContent({ status }: { status: StatusResponse }) {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
-  const [issueFilters, setIssueFilters] = useState<DeviceIssueFilter[]>(['interface_errors', 'discards', 'carrier_transitions', 'drained'])
+  const [issueFilters, setIssueFilters] = useState<DeviceIssueFilter[]>(['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained'])
   const [healthFilters, setHealthFilters] = useState<HealthFilter[]>(['healthy', 'degraded', 'unhealthy', 'disabled'])
   const location = useLocation()
 
@@ -2249,7 +2271,7 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
   // Calculate issue breakdown per health category
   const issuesByHealth = useMemo((): DeviceIssuesByHealth => {
-    const emptyBreakdown = () => ({ interface_errors: 0, discards: 0, carrier_transitions: 0, drained: 0 })
+    const emptyBreakdown = () => ({ interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0 })
 
     const result: DeviceIssuesByHealth = {
       healthy: emptyBreakdown(),
@@ -2268,7 +2290,8 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       const breakdown = result[health as keyof DeviceIssuesByHealth]
       const issues = device.issue_reasons ?? []
 
-      if (issues.includes('interface_errors') || issues.includes('fcs_errors')) breakdown.interface_errors++
+      if (issues.includes('interface_errors')) breakdown.interface_errors++
+      if (issues.includes('fcs_errors')) breakdown.fcs_errors++
       if (issues.includes('discards')) breakdown.discards++
       if (issues.includes('carrier_transitions')) breakdown.carrier_transitions++
       if (issues.includes('drained')) breakdown.drained++
@@ -2283,6 +2306,7 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
     const result: DeviceHealthByIssue = {
       interface_errors: emptyBreakdown(),
+      fcs_errors: emptyBreakdown(),
       discards: emptyBreakdown(),
       carrier_transitions: emptyBreakdown(),
       drained: emptyBreakdown(),
@@ -2299,7 +2323,8 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       if (issues.length === 0) {
         result.no_issues[health]++
       } else {
-        if (issues.includes('interface_errors') || issues.includes('fcs_errors')) result.interface_errors[health]++
+        if (issues.includes('interface_errors')) result.interface_errors[health]++
+        if (issues.includes('fcs_errors')) result.fcs_errors[health]++
         if (issues.includes('discards')) result.discards[health]++
         if (issues.includes('carrier_transitions')) result.carrier_transitions[health]++
         if (issues.includes('drained')) result.drained[health]++
@@ -2312,14 +2337,15 @@ function DevicesContent({ status }: { status: StatusResponse }) {
   // Issue counts from filter time range
   const issueCounts = useMemo((): DeviceIssueCounts => {
     if (!filteredDeviceHistory?.devices) {
-      return { interface_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, no_issues: 0, total: 0 }
+      return { interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, no_issues: 0, total: 0 }
     }
 
-    const counts = { interface_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, no_issues: 0, total: 0 }
+    const counts = { interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, no_issues: 0, total: 0 }
     const seenDevices = new Set<string>()
 
     for (const device of filteredDeviceHistory.devices) {
-      if (device.issue_reasons?.includes('interface_errors') || device.issue_reasons?.includes('fcs_errors')) counts.interface_errors++
+      if (device.issue_reasons?.includes('interface_errors')) counts.interface_errors++
+      if (device.issue_reasons?.includes('fcs_errors')) counts.fcs_errors++
       if (device.issue_reasons?.includes('discards')) counts.discards++
       if (device.issue_reasons?.includes('carrier_transitions')) counts.carrier_transitions++
       if (device.issue_reasons?.includes('drained')) counts.drained++

--- a/web/src/components/status-timeline.tsx
+++ b/web/src/components/status-timeline.tsx
@@ -67,8 +67,10 @@ function hasInterfaceIssues(hour: LinkHourStatus): boolean {
   return (
     (hour.side_a_in_errors ?? 0) > 0 ||
     (hour.side_a_out_errors ?? 0) > 0 ||
+    (hour.side_a_in_fcs_errors ?? 0) > 0 ||
     (hour.side_z_in_errors ?? 0) > 0 ||
     (hour.side_z_out_errors ?? 0) > 0 ||
+    (hour.side_z_in_fcs_errors ?? 0) > 0 ||
     (hour.side_a_in_discards ?? 0) > 0 ||
     (hour.side_a_out_discards ?? 0) > 0 ||
     (hour.side_z_in_discards ?? 0) > 0 ||
@@ -133,10 +135,12 @@ function getStatusReasons(hour: LinkHourStatus, committedRttUs?: number): string
   if (hasInterfaceIssues(hour)) {
     const interfaceIssues: string[] = []
     const totalErrors = (hour.side_a_in_errors ?? 0) + (hour.side_a_out_errors ?? 0) + (hour.side_z_in_errors ?? 0) + (hour.side_z_out_errors ?? 0)
+    const totalFcsErrors = (hour.side_a_in_fcs_errors ?? 0) + (hour.side_z_in_fcs_errors ?? 0)
     const totalDiscards = (hour.side_a_in_discards ?? 0) + (hour.side_a_out_discards ?? 0) + (hour.side_z_in_discards ?? 0) + (hour.side_z_out_discards ?? 0)
     const totalCarrier = (hour.side_a_carrier_transitions ?? 0) + (hour.side_z_carrier_transitions ?? 0)
 
     if (totalErrors > 0) interfaceIssues.push(`${totalErrors} interface errors`)
+    if (totalFcsErrors > 0) interfaceIssues.push(`${totalFcsErrors} FCS errors`)
     if (totalDiscards > 0) interfaceIssues.push(`${totalDiscards} discards`)
     if (totalCarrier > 0) interfaceIssues.push(`${totalCarrier} carrier transitions`)
 
@@ -284,23 +288,26 @@ export function StatusTimeline({ hours: rawHours, committedRttUs, bucketMinutes 
                       {/* Interface issues */}
                       {(() => {
                         const sideAErrors = (hour.side_a_in_errors ?? 0) + (hour.side_a_out_errors ?? 0)
+                        const sideAFcsErrors = hour.side_a_in_fcs_errors ?? 0
                         const sideADiscards = (hour.side_a_in_discards ?? 0) + (hour.side_a_out_discards ?? 0)
                         const sideACarrier = hour.side_a_carrier_transitions ?? 0
                         const sideZErrors = (hour.side_z_in_errors ?? 0) + (hour.side_z_out_errors ?? 0)
+                        const sideZFcsErrors = hour.side_z_in_fcs_errors ?? 0
                         const sideZDiscards = (hour.side_z_in_discards ?? 0) + (hour.side_z_out_discards ?? 0)
                         const sideZCarrier = hour.side_z_carrier_transitions ?? 0
-                        const hasInterfaceIssues = sideAErrors > 0 || sideADiscards > 0 || sideACarrier > 0 ||
-                                                   sideZErrors > 0 || sideZDiscards > 0 || sideZCarrier > 0
+                        const hasInterfaceIssues = sideAErrors > 0 || sideAFcsErrors > 0 || sideADiscards > 0 || sideACarrier > 0 ||
+                                                   sideZErrors > 0 || sideZFcsErrors > 0 || sideZDiscards > 0 || sideZCarrier > 0
                         if (!hasInterfaceIssues) return null
                         return (
                           <div className="pt-2 mt-2 border-t border-border space-y-1.5">
                             <div className="text-[11px] font-medium text-foreground">Interface Issues</div>
-                            {(sideAErrors > 0 || sideADiscards > 0 || sideACarrier > 0) && (
+                            {(sideAErrors > 0 || sideAFcsErrors > 0 || sideADiscards > 0 || sideACarrier > 0) && (
                               <div className="text-[11px]">
                                 <span className="text-muted-foreground">A-Side: </span>
                                 <span className="font-mono">
                                   {[
                                     sideAErrors > 0 && <span key="err" className="text-red-500">{sideAErrors} errors</span>,
+                                    sideAFcsErrors > 0 && <span key="fcs" className="text-orange-500">{sideAFcsErrors} FCS errors</span>,
                                     sideADiscards > 0 && <span key="disc" className="text-teal-500">{sideADiscards} discards</span>,
                                     sideACarrier > 0 && <span key="carr" className="text-yellow-600">{sideACarrier} carrier</span>,
                                   ].filter(Boolean).map((el, i, arr) => (
@@ -309,12 +316,13 @@ export function StatusTimeline({ hours: rawHours, committedRttUs, bucketMinutes 
                                 </span>
                               </div>
                             )}
-                            {(sideZErrors > 0 || sideZDiscards > 0 || sideZCarrier > 0) && (
+                            {(sideZErrors > 0 || sideZFcsErrors > 0 || sideZDiscards > 0 || sideZCarrier > 0) && (
                               <div className="text-[11px]">
                                 <span className="text-muted-foreground">Z-Side: </span>
                                 <span className="font-mono">
                                   {[
                                     sideZErrors > 0 && <span key="err" className="text-red-500">{sideZErrors} errors</span>,
+                                    sideZFcsErrors > 0 && <span key="fcs" className="text-orange-500">{sideZFcsErrors} FCS errors</span>,
                                     sideZDiscards > 0 && <span key="disc" className="text-teal-500">{sideZDiscards} discards</span>,
                                     sideZCarrier > 0 && <span key="carr" className="text-yellow-600">{sideZCarrier} carrier</span>,
                                   ].filter(Boolean).map((el, i, arr) => (

--- a/web/src/components/topology/InterfaceCharts.tsx
+++ b/web/src/components/topology/InterfaceCharts.tsx
@@ -255,7 +255,7 @@ interface HealthColumnar {
 function buildHealthColumnar(
   historyData: Awaited<ReturnType<typeof fetchDeviceInterfaceHistory>>,
   interfaces: string[],
-  field: 'errors' | 'discards' | 'transitions',
+  field: 'errors' | 'fcs_errors' | 'discards' | 'transitions',
   bidirectional?: boolean
 ): HealthColumnar {
   const allTimes = new Set<string>()
@@ -320,6 +320,8 @@ function buildHealthColumnar(
       let value: number
       if (field === 'errors') {
         value = (h.in_errors || 0) + (h.out_errors || 0)
+      } else if (field === 'fcs_errors') {
+        value = h.in_fcs_errors || 0
       } else if (field === 'discards') {
         value = (h.in_discards || 0) + (h.out_discards || 0)
       } else {
@@ -380,11 +382,13 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
 
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const [errorHoveredIdx, setErrorHoveredIdx] = useState<number | null>(null)
+  const [fcsErrorHoveredIdx, setFcsErrorHoveredIdx] = useState<number | null>(null)
   const [discardHoveredIdx, setDiscardHoveredIdx] = useState<number | null>(null)
   const [transitionHoveredIdx, setTransitionHoveredIdx] = useState<number | null>(null)
 
   const trafficChartRef = useRef<HTMLDivElement>(null)
   const errorChartRef = useRef<HTMLDivElement>(null)
+  const fcsErrorChartRef = useRef<HTMLDivElement>(null)
   const discardChartRef = useRef<HTMLDivElement>(null)
   const transitionChartRef = useRef<HTMLDivElement>(null)
 
@@ -471,6 +475,11 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
     return buildHealthColumnar(historyData, interfaces, 'errors', true)
   }, [historyData, interfaces])
 
+  const fcsErrorHealth = useMemo(() => {
+    if (!historyData?.interfaces || interfaces.length === 0) return null
+    return buildHealthColumnar(historyData, interfaces, 'fcs_errors')
+  }, [historyData, interfaces])
+
   const discardHealth = useMemo(() => {
     if (!historyData?.interfaces || interfaces.length === 0) return null
     return buildHealthColumnar(historyData, interfaces, 'discards', true)
@@ -552,6 +561,9 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
   const handleErrorCursorIdx = useCallback((idx: number | null) => {
     setErrorHoveredIdx(idx)
   }, [])
+  const handleFcsErrorCursorIdx = useCallback((idx: number | null) => {
+    setFcsErrorHoveredIdx(idx)
+  }, [])
   const handleDiscardCursorIdx = useCallback((idx: number | null) => {
     setDiscardHoveredIdx(idx)
   }, [])
@@ -580,6 +592,15 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
     onCursorIdx: handleErrorCursorIdx,
   })
 
+  const { plotRef: fcsErrorPlotRef} = useUPlotChart({
+    containerRef: fcsErrorChartRef,
+    data: fcsErrorHealth?.data ?? ([[]] as uPlot.AlignedData),
+    series: healthSeries,
+    height: 144,
+    axes: healthAxes,
+    onCursorIdx: handleFcsErrorCursorIdx,
+  })
+
   const { plotRef: discardPlotRef} = useUPlotChart({
     containerRef: discardChartRef,
     data: discardHealth?.data ?? ([[]] as uPlot.AlignedData),
@@ -604,6 +625,7 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
   // Sync legend visibility to health charts
   const healthSeriesKeys = useMemo(() => [...interfaces], [interfaces])
   useUPlotLegendSync(errorPlotRef, legend, healthBidirectionalSeriesKeys)
+  useUPlotLegendSync(fcsErrorPlotRef, legend, healthSeriesKeys)
   useUPlotLegendSync(discardPlotRef, legend, healthBidirectionalSeriesKeys)
   useUPlotLegendSync(transitionPlotRef, legend, healthSeriesKeys)
 
@@ -670,6 +692,23 @@ export function InterfaceCharts({ entityType, entityPk, timeRange, interfaceLabe
             visibleSeries={visibleSeries}
             interfaceLabels={interfaceLabels}
             bidirectional
+          />
+        </div>
+      )}
+
+      {fcsErrorHealth?.hasData && (
+        <div className={className}>
+          <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
+            FCS Errors</div>
+          <div ref={fcsErrorChartRef} className="h-36" />
+          <HealthLegendTable
+            interfaces={interfaces}
+            colors={colors}
+            data={fcsErrorHealth.data}
+            hoveredIdx={fcsErrorHoveredIdx}
+            legend={legend}
+            visibleSeries={visibleSeries}
+            interfaceLabels={interfaceLabels}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary of Changes
- Add FCS errors as a standalone issue filter on both the links and devices tabs, separated from the generic "Interface Errors" category
- Add FCS errors as a toggleable metric in the interface issue charts (link-level and device-level expanded views)
- Add FCS error badges, tooltips, and chart sections across single device pages, single link pages, status timeline hover tooltips, and topology interface charts

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Core logic   |     7 | +159 / -40  | +119  |

All changes are frontend UI logic — adding a new metric dimension to existing chart/filter patterns.

<details>
<summary>Key files (click to expand)</summary>

- [`web/src/components/status-page.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-12bee06c52592c21bec763e5f07e448c7a42e68f926701bfbf6d004bfa09a8b3) — add `fcs_errors` to issue filter types, counts, breakdown interfaces, and progress bars on both links and devices tabs
- [`web/src/components/topology/InterfaceCharts.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-5845279bd1917d7af43c6bd52b00e27ca5e71f08fda0af3e036f8d9a9fa29276) — add FCS errors chart section with data computation, uPlot chart, and legend sync
- [`web/src/components/device-status-timelines.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-557c0b95e9aa13f305aac26015e856073e68692d5d062b08baf63616ce88822f) — add FCS errors to MetricType, chart data, tooltip, metric toggles, and device filter matching
- [`web/src/components/link-status-timelines.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-f4ebc8871bbe6b43492d78411c5fd933636a1f935a90e6cf2c73588dbfc01247) — add FCS errors to link interface chart metrics, tooltips, and side detection
- [`web/src/components/status-timeline.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-fb38c5d8987822f245f360c864c27f75d992d13ffbbf14c2846cf90264aba3df) — add FCS errors to `hasInterfaceIssues` check, status reasons, and per-side tooltip breakdown
- [`web/src/components/single-device-status-row.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-2fc4711323d82dcf4c8aebc0c3544f53cb7098d24b2d0b74e632cc71a7ec30ec) — add FCS error detection, badge, and LinkHourStatus adapter field
- [`web/src/components/single-link-status-row.tsx`](https://github.com/malbeclabs/lake/pull/195/files#diff-f38bd1bdf8f6671ebf44bc151bce17bdb98d3fafb1e5389d6446a028efdccd4c) — add FCS error detection and badge

</details>

## Testing Verification
- Verified all pages render without JS errors using Playwright (status links/devices/metros tabs, single device page, single link page)
- Confirmed FCS Errors filter appears in both link and device issue cards with correct counts
- Confirmed FCS Errors metric toggle appears in expanded device and link charts
- Confirmed FCS Errors badge displays on devices with FCS error data
- Frontend build passes (`bun run build`)