### PR TITLE
testing: silence migration logs in test helpers

### DIFF
--- a/api/testing/clickhouse.go
+++ b/api/testing/clickhouse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -246,8 +247,8 @@ func SetupTestClickHouseWithMigrations(t *testing.T, db *ClickHouseDB) {
 	err = adminConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", databaseName))
 	require.NoError(t, err, "failed to create test database")
 
-	// Run migrations
-	err = chmigrations.RunMigrations(ctx, slog.Default(), chmigrations.MigrationConfig{
+	// Run migrations (use discard logger to avoid noisy output in CI)
+	err = chmigrations.RunMigrations(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), chmigrations.MigrationConfig{
 		Addr:     db.addr,
 		Database: databaseName,
 		Username: db.cfg.Username,

--- a/api/testing/neo4j.go
+++ b/api/testing/neo4j.go
@@ -3,6 +3,7 @@ package apitesting
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -156,8 +157,8 @@ func SetupTestNeo4jWithData(t *testing.T, db *Neo4jDB, seedFunc func(ctx context
 	_, err = result.Consume(ctx)
 	require.NoError(t, err, "failed to consume clear result")
 
-	// Run migrations
-	err = neo4j.RunMigrations(ctx, slog.Default(), neo4j.MigrationConfig{
+	// Run migrations (use discard logger to avoid noisy output in CI)
+	err = neo4j.RunMigrations(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), neo4j.MigrationConfig{
 		URI:      db.boltURL,
 		Database: neo4j.DefaultDatabase,
 		Username: db.cfg.Username,

--- a/api/testing/postgres.go
+++ b/api/testing/postgres.go
@@ -130,6 +130,7 @@ func SetupTestDB(t *testing.T, db *DB) {
 	err = goose.SetDialect("postgres")
 	require.NoError(t, err, "failed to set goose dialect")
 
+	goose.SetLogger(goose.NopLogger())
 	err = goose.Up(sqlDB, "migrations")
 	require.NoError(t, err, "failed to run migrations")
 	sqlDB.Close()

--- a/indexer/pkg/neo4j/testing/db.go
+++ b/indexer/pkg/neo4j/testing/db.go
@@ -3,6 +3,7 @@ package neo4jtesting
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -113,7 +114,7 @@ func newTestClient(t *testing.T, db *DB, readOnly bool) (neo4j.Client, error) {
 	session.Close(t.Context())
 
 	// Run migrations to initialize schema
-	if err := neo4j.RunMigrations(t.Context(), slog.Default(), neo4j.MigrationConfig{
+	if err := neo4j.RunMigrations(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), neo4j.MigrationConfig{
 		URI:      db.boltURL,
 		Database: neo4j.DefaultDatabase,
 		Username: db.cfg.Username,


### PR DESCRIPTION
## Summary of Changes

- Silence migration log output in test setup functions to reduce CI noise
- Use discard loggers for ClickHouse, Neo4j, and PostgreSQL migration runs during tests
- Admin commands and indexer startup continue to show migration output as before

## Testing Verification

- Verified all affected packages compile