### PR TITLE
status: rename link flapping to carrier transitions on devices page

### DIFF
--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -776,7 +776,7 @@ function DeviceRow({ device, devicesWithIssues, bucketMinutes, dataTimeRange, bu
                 )}
                 {issueReasons.includes('carrier_transitions') && (
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-orange-500/15 text-orange-600 dark:text-orange-400">
-                    Link Flapping
+                    Carrier Transitions
                   </span>
                 )}
                 {issueReasons.includes('drained') && (

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -1968,7 +1968,7 @@ function DeviceIssuesFilterCard({
     { filter: 'interface_errors', label: 'Interface Errors', color: 'bg-fuchsia-500', description: 'Device experiencing interface errors.' },
     { filter: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600', description: 'Device experiencing FCS (Frame Check Sequence) errors.' },
     { filter: 'discards', label: 'Discards', color: 'bg-rose-500', description: 'Device experiencing interface discards.' },
-    { filter: 'carrier_transitions', label: 'Link Flapping', color: 'bg-orange-500', description: 'Device experiencing carrier state changes (link up/down).' },
+    { filter: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-orange-500', description: 'Device experiencing carrier state changes (link up/down).' },
     { filter: 'drained', label: 'Drained', color: 'bg-slate-500 dark:bg-slate-600', description: 'Device is soft-drained, hard-drained, or suspended.' },
     { filter: 'no_issues', label: 'No Issues', color: 'bg-cyan-500', description: 'Device with no detected issues in the time range.' },
   ]


### PR DESCRIPTION
## Summary of Changes
- Rename "Link Flapping" label to "Carrier Transitions" on the status/devices page filter card and device timeline badges, matching the terminology used elsewhere

## Testing Verification
- Visual inspection of label text in both components