### PR TITLE
status: fix no_data filter hiding links with other active issues

### DIFF
--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -747,8 +747,8 @@ export function LinkStatusTimelines({
         : (link.issue_reasons ?? [])
       const hasIssues = issueReasons.length > 0
 
-      // When no_data filter is off, exclude links that have no_data as an issue
-      if (!noDataSelected && issueReasons.includes('no_data')) {
+      // When no_data filter is off, exclude links whose only issue is no_data
+      if (!noDataSelected && issueReasons.length === 1 && issueReasons[0] === 'no_data') {
         return false
       }
 


### PR DESCRIPTION
## Summary of Changes

- Only exclude links from Link Status History when `no_data` is their sole issue, not when they also have active issues like packet loss or high latency