### PR TITLE
status: show only drained links in overview banner

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -1018,10 +1018,8 @@ func fetchStatusData(ctx context.Context) *StatusResponse {
 		return rows.Err()
 	})
 
-	// Non-activated links (including delay-override drained and provisioning)
+	// Drained links (soft-drained or hard-drained)
 	g.Go(func() error {
-		// 1000ms delay override in nanoseconds indicates soft-drained
-		const delayOverrideSoftDrainedNs = 1_000_000_000
 		query := `
 			SELECT
 				l.pk,
@@ -1029,22 +1027,19 @@ func fetchStatusData(ctx context.Context) *StatusResponse {
 				l.link_type,
 				ma.code as side_a_metro,
 				mz.code as side_z_metro,
-				CASE
-					WHEN l.committed_rtt_ns = ? THEN 'provisioning'
-					WHEN l.status = 'activated' AND l.isis_delay_override_ns = ? THEN 'soft-drained'
-					ELSE l.status
-				END as status,
+				l.status,
 				formatDateTime(l.snapshot_ts, '%Y-%m-%dT%H:%i:%sZ', 'UTC') as since
 			FROM dz_links_current l
 			JOIN dz_devices_current da ON l.side_a_pk = da.pk
 			JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
 			JOIN dz_metros_current ma ON da.metro_pk = ma.pk
 			JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
-			WHERE l.status != 'activated' OR l.isis_delay_override_ns = ? OR l.committed_rtt_ns = ?
+			WHERE l.status IN ('soft-drained', 'hard-drained')
+			  AND l.committed_rtt_ns != ?
 			ORDER BY l.snapshot_ts DESC
 			LIMIT 50
 		`
-		rows, err := envDB(ctx).Query(ctx, query, committedRttProvisioningNs, delayOverrideSoftDrainedNs, delayOverrideSoftDrainedNs, committedRttProvisioningNs)
+		rows, err := envDB(ctx).Query(ctx, query, committedRttProvisioningNs)
 		if err != nil {
 			return err
 		}

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -115,14 +115,14 @@ function getStatusReasons(status: StatusResponse): string[] {
     .filter(([s]) => s !== 'activated')
     .reduce((sum, [, count]) => sum + count, 0)
   const nonActivatedLinks = Object.entries(status.network.links_by_status)
-    .filter(([s]) => s !== 'activated' && s !== 'provisioning')
+    .filter(([s]) => s === 'soft-drained' || s === 'hard-drained')
     .reduce((sum, [, count]) => sum + count, 0)
 
   if (nonActivatedDevices > 0) {
     reasons.push(`${nonActivatedDevices} device${nonActivatedDevices > 1 ? 's' : ''} not activated`)
   }
   if (nonActivatedLinks > 0) {
-    reasons.push(`${nonActivatedLinks} Link${nonActivatedLinks > 1 ? 's' : ''} Not Active`)
+    reasons.push(`${nonActivatedLinks} Drained Link${nonActivatedLinks > 1 ? 's' : ''}`)
   }
 
   return reasons
@@ -342,7 +342,7 @@ function IssueDetails({
       )}
       {nonActivatedLinks.length > 0 && (
         <div>
-          <div className="text-sm font-medium text-muted-foreground mb-2">Links Not Active</div>
+          <div className="text-sm font-medium text-muted-foreground mb-2">Drained Links</div>
           <div className="space-y-2">
             {nonActivatedLinks.map((link, idx) => (
               <button


### PR DESCRIPTION
## Summary of Changes
- Rename "Links Not Active" to "Drained Links" in the status overview banner and detail list
- Filter banner count and alerts list to only soft-drained and hard-drained links, excluding provisioning
- Simplify the alerts query to use the literal status field instead of CASE-derived statuses

## Testing Verification
- Manually verified banner count matches the expanded drained links list