### PR TITLE
incidents: fix duplicate React keys in grouped incidents table

### DIFF
--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -1083,7 +1083,7 @@ function ActiveIncidentsTable({
             }
             const interfaces = Array.from(allInterfaces)
             return (
-              <tr key={group.link_pk} className="hover:bg-muted/30">
+              <tr key={`${group.link_pk}-${group.started_at}`} className="hover:bg-muted/30">
                 <td className="px-4 py-3">
                   <Link
                     to={`/dz/links/${encodeURIComponent(group.link_pk)}`}


### PR DESCRIPTION
## Summary of Changes

- Fix duplicate React keys in the active incidents table that caused phantom/duplicated rows when toggling type filter cards
- The grouped incidents table used `link_pk` as the row key, but `groupIncidentsByLink` can produce multiple temporal clusters for the same link — key now includes `started_at` for uniqueness

## Testing Verification

- Verified that toggling type filter cards no longer causes rows to accumulate or duplicate in the active incidents list