### PR TITLE
status: show provisioning links in disabled table and improve collecting cells

### DIFF
--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -532,7 +532,7 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
 
   // Check if there are issues to show
   const linkIssues = statusData.links.issues || []
-  const nonActivatedLinks = statusData.alerts?.links || []
+  const nonActivatedLinks = (statusData.alerts?.links || []).filter(l => l.status !== 'provisioning')
   const deviceIssues = statusData.interfaces?.issues || []
   const nonActivatedDevices = statusData.alerts?.devices || []
   const hasExpandableContent = linkIssues.length > 0 || nonActivatedLinks.length > 0 || deviceIssues.length > 0 || nonActivatedDevices.length > 0


### PR DESCRIPTION
## Summary of Changes
- Include provisioning links (committed_rtt_ns = 1000ms sentinel) in the disabled links table at the bottom of the status page, alongside soft/hard-drained links
- Filter provisioning links out of the status overview banner's "Drained Links" section
- When the current (collecting) timeline bucket has no data yet, inherit the previous bucket's color instead of showing an empty cell

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +15 / -11   |  +4  |

Small targeted changes across API query and three frontend components.

<details>
<summary>Key files (click to expand)</summary>

- [`web/src/components/device-status-timelines.tsx`](https://github.com/malbeclabs/lake/pull/229/files#diff-557c0b95e9aa13f305aac26015e856073e68692d5d062b08baf63616ce88822f) — inherit previous cell color for collecting no-data buckets in device timelines
- [`web/src/components/status-timeline.tsx`](https://github.com/malbeclabs/lake/pull/229/files#diff-fb38c5d8987822f245f360c864c27f75d992d13ffbbf14c2846cf90264aba3df) — same collecting cell fix for link status timelines
- [`api/handlers/status.go`](https://github.com/malbeclabs/lake/pull/229/files#diff-afaf57cf7a44a29e294e1ed67683693015f2e35430817c693c496fc9b1c3ddd3) — expand disabled links query to include provisioning links with effective status
- [`web/src/components/status-page.tsx`](https://github.com/malbeclabs/lake/pull/229/files#diff-12bee06c52592c21bec763e5f07e448c7a42e68f926701bfbf6d004bfa09a8b3) — filter provisioning links from overview banner

</details>

## Testing Verification
- Verified provisioning links appear in the disabled links table with "Provisioning" status
- Verified provisioning links do not appear in the overview banner's "Drained Links" section
- Verified collecting timeline cells inherit previous bucket color when no data yet
- Frontend build passes