### PR TITLE
indexer: add missing contributor name mappings

### DIFF
--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -24,11 +24,13 @@ type Contributor struct {
 
 var (
 	contributorNamesByCode = map[string]string{
+		"allnodes": "Allnodes",
 		"jump_":    "Jump Crypto",
 		"dgt":      "Distributed Global",
 		"cherry":   "Cherry Servers",
 		"cdrw":     "Cumberland/DRW",
 		"glxy":     "Galaxy",
+		"infiber":  "InFiber",
 		"laconic":  "Laconic",
 		"latitude": "Latitude",
 		"rox":      "RockawayX",


### PR DESCRIPTION
## Summary of Changes

- Add name mappings for Allnodes (`allnodes`) and InFiber (`infiber`) contributors, which were showing as empty strings in ClickHouse

## Testing Verification

- Verified both contributors exist in `dz_contributors_current` with empty names