### PR TITLE
status: fix one-sided data handling for soft-drained links

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -1798,7 +1798,9 @@ func fetchLinkHistoryData(ctx context.Context, timeRange string, requestedBucket
 				// can't send probes. For completed buckets, treat as unhealthy.
 				// For the collecting bucket, treat as no_data since we don't
 				// have enough data to classify health yet.
-				if drainStatus == "" && (stats.sideA == nil) != (stats.sideZ == nil) {
+				// Skip for hard-drained links (fully offline), but still apply
+				// for soft-drained links since their health color is visible.
+				if drainStatus != "hard-drained" && (stats.sideA == nil) != (stats.sideZ == nil) {
 					if isCollecting {
 						status = "no_data"
 					} else if status == "healthy" || status == "degraded" {

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -798,8 +798,14 @@ export function LinkStatusTimelines({
       const hasIssues = issueReasons.length > 0
 
       // When no_data filter is off, exclude links whose only issue is no_data
+      // UNLESS the link has non-healthy buckets (unhealthy/degraded from missing data)
       if (!noDataSelected && issueReasons.length === 1 && issueReasons[0] === 'no_data') {
-        return false
+        const hasNonHealthyBuckets = link.hours?.some(h =>
+          !h.collecting && (h.status === 'unhealthy' || h.status === 'degraded')
+        )
+        if (!hasNonHealthyBuckets) {
+          return false
+        }
       }
 
       // Hide currently drained links unless showDrained is enabled
@@ -813,7 +819,10 @@ export function LinkStatusTimelines({
       }
 
       const matchesIssue = hasIssues
-        ? issueReasons.some(reason => issueTypesSelected.includes(reason))
+        ? issueReasons.some(reason => issueTypesSelected.includes(reason)) ||
+          (issueReasons.length === 1 && issueReasons[0] === 'no_data' && link.hours?.some(h =>
+            !h.collecting && (h.status === 'unhealthy' || h.status === 'degraded')
+          ))
         : noIssuesSelected
 
       // Must match at least one health filter


### PR DESCRIPTION
## Summary of Changes

- Fix soft-drained links showing healthy (green) when one side has no data — the one-sided check now applies to soft-drained links and only skips hard-drained links
- Fix links with no_data as their only issue being hidden in shorter time ranges when they have unhealthy/degraded buckets from missing data

## Testing Verification

- Verified `au1c-dz01:la2r-dz01` now appears in 6h view with correct unhealthy status for one-sided buckets
- Confirmed hard-drained links still skip the one-sided check as intended