### PR TITLE
status: mark devices unhealthy when not sending latency probes

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -2062,6 +2062,7 @@ type DeviceHourStatus struct {
 	OutDiscards        uint64  `json:"out_discards"`
 	CarrierTransitions uint64  `json:"carrier_transitions"`
 	DrainStatus        string  `json:"drain_status,omitempty"` // "", "soft-drained", "hard-drained", "suspended"
+	NoProbes           bool    `json:"no_probes,omitempty"`    // true when device has interface data but no latency probes
 }
 
 type DeviceHistory struct {
@@ -2257,6 +2258,46 @@ func fetchDeviceHistoryData(ctx context.Context, timeRange string, requestedBuck
 		return nil, fmt.Errorf("interface rows iteration error: %w", err)
 	}
 
+	// Get latency probe presence per device per bucket.
+	// Used to detect devices that have interface data but aren't sending probes.
+	probeQuery := `
+		SELECT
+			origin_device_pk,
+			` + bucketInterval + ` as bucket,
+			count(*) as samples
+		FROM fact_dz_device_link_latency
+		WHERE event_ts > now() - INTERVAL ? HOUR
+		GROUP BY origin_device_pk, bucket
+		ORDER BY origin_device_pk, bucket
+	`
+	probeRows, err := envDB(ctx).Query(ctx, probeQuery, totalHours)
+	if err != nil {
+		return nil, fmt.Errorf("device probe query error: %w", err)
+	}
+	defer probeRows.Close()
+
+	type deviceBucketProbeKey struct {
+		devicePK string
+		bucket   string
+	}
+	deviceProbes := make(map[deviceBucketProbeKey]bool)
+
+	for probeRows.Next() {
+		var devicePK string
+		var bucket time.Time
+		var samples uint64
+		if err := probeRows.Scan(&devicePK, &bucket, &samples); err != nil {
+			return nil, fmt.Errorf("probe scan error: %w", err)
+		}
+		if samples > 0 {
+			key := deviceBucketProbeKey{devicePK: devicePK, bucket: bucket.UTC().Format(time.RFC3339)}
+			deviceProbes[key] = true
+		}
+	}
+	if err := probeRows.Err(); err != nil {
+		return nil, fmt.Errorf("probe rows iteration error: %w", err)
+	}
+
 	// Get historical device status per bucket
 	var historyBucketInterval string
 	if bucketMinutes >= 60 && bucketMinutes%60 == 0 {
@@ -2394,6 +2435,18 @@ func fetchDeviceHistoryData(ctx context.Context, timeRange string, requestedBuck
 			// Check if we have interface data for this bucket
 			if stats, ok := bucketMap[key]; ok {
 				status := classifyDeviceStatus(stats.inErrors+stats.outErrors+stats.inFcsErrors, stats.inDiscards+stats.outDiscards, stats.carrierTransitions)
+
+				// If device has interface data but no latency probes, mark unhealthy.
+				// Skip collecting bucket since probes may not have arrived yet.
+				probeKey := deviceBucketProbeKey{devicePK: pk, bucket: key}
+				noProbes := !isCollecting && !deviceProbes[probeKey]
+				if noProbes {
+					if status == "healthy" || status == "degraded" {
+						status = "unhealthy"
+					}
+					issueReasons["no_probes"] = true
+				}
+
 				hourStatuses = append(hourStatuses, DeviceHourStatus{
 					Hour:               key,
 					Status:             status,
@@ -2405,6 +2458,7 @@ func fetchDeviceHistoryData(ctx context.Context, timeRange string, requestedBuck
 					InDiscards:         stats.inDiscards,
 					OutDiscards:        stats.outDiscards,
 					CarrierTransitions: stats.carrierTransitions,
+					NoProbes:           noProbes,
 				})
 			} else {
 				// No interface data for this bucket — show as no_data.
@@ -3446,6 +3500,34 @@ func fetchSingleDeviceHistoryData(ctx context.Context, devicePK string, timeRang
 		}
 	}
 
+	// Get latency probe presence per bucket for this device
+	probeQuery := `
+		SELECT
+			` + bucketInterval + ` as bucket,
+			count(*) as samples
+		FROM fact_dz_device_link_latency
+		WHERE origin_device_pk = ? AND event_ts > now() - INTERVAL ? HOUR
+		GROUP BY bucket
+		ORDER BY bucket
+	`
+	probeRows, err := envDB(ctx).Query(ctx, probeQuery, devicePK, totalHours)
+	if err != nil {
+		return nil, fmt.Errorf("device probe query error: %w", err)
+	}
+	defer probeRows.Close()
+
+	deviceProbes := make(map[string]bool)
+	for probeRows.Next() {
+		var bucket time.Time
+		var samples uint64
+		if err := probeRows.Scan(&bucket, &samples); err != nil {
+			return nil, fmt.Errorf("probe scan error: %w", err)
+		}
+		if samples > 0 {
+			deviceProbes[bucket.UTC().Format(time.RFC3339)] = true
+		}
+	}
+
 	// Get historical device status per bucket
 	var historyBucketInterval string
 	if bucketMinutes >= 60 && bucketMinutes%60 == 0 {
@@ -3515,6 +3597,16 @@ func fetchSingleDeviceHistoryData(ctx context.Context, devicePK string, timeRang
 		// Check if we have interface data for this bucket
 		if stats, ok := bucketMap[key]; ok {
 			deviceStatus := classifyDeviceStatus(stats.inErrors+stats.outErrors+stats.inFcsErrors, stats.inDiscards+stats.outDiscards, stats.carrierTransitions)
+
+			// If device has interface data but no latency probes, mark unhealthy.
+			noProbes := !isCollecting && !deviceProbes[key]
+			if noProbes {
+				if deviceStatus == "healthy" || deviceStatus == "degraded" {
+					deviceStatus = "unhealthy"
+				}
+				issueReasons["no_probes"] = true
+			}
+
 			hourStatuses = append(hourStatuses, DeviceHourStatus{
 				Hour:               key,
 				Status:             deviceStatus,
@@ -3526,6 +3618,7 @@ func fetchSingleDeviceHistoryData(ctx context.Context, devicePK string, timeRang
 				InDiscards:         stats.inDiscards,
 				OutDiscards:        stats.outDiscards,
 				CarrierTransitions: stats.carrierTransitions,
+				NoProbes:           noProbes,
 			})
 		} else {
 			// No interface data for this bucket — show as no_data.

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -241,10 +241,15 @@ function DeviceStatusTimeline({ hours, bucketMinutes = 60, timeRange = '24h' }: 
                           </span>
                         </div>
                       )}
+                      {hour.no_probes && (
+                        <div className="flex justify-between gap-4">
+                          <span className="text-red-500">Not sending latency probes</span>
+                        </div>
+                      )}
                       {hour.in_errors === 0 && hour.out_errors === 0 &&
                        hour.in_fcs_errors === 0 &&
                        hour.in_discards === 0 && hour.out_discards === 0 &&
-                       hour.carrier_transitions === 0 && hour.max_users === 0 && (
+                       hour.carrier_transitions === 0 && !hour.no_probes && hour.max_users === 0 && (
                         <div className="text-xs">No issues detected</div>
                       )}
                     </div>
@@ -941,8 +946,8 @@ export function DeviceStatusTimelines({
         : (device.issue_reasons ?? [])
       const hasIssues = issueReasons.length > 0
 
-      // Devices with only no_data are shown based on health filter (no separate issue toggle)
-      const hasOnlyNoData = issueReasons.length === 1 && issueReasons[0] === 'no_data'
+      // Devices with only no_data or no_probes are shown based on health filter (no separate issue toggle)
+      const hasOnlyNoData = issueReasons.length > 0 && issueReasons.every(r => r === 'no_data' || r === 'no_probes')
       const matchesIssue = hasOnlyNoData
         ? true
         : hasIssues

--- a/web/src/components/single-device-status-row.tsx
+++ b/web/src/components/single-device-status-row.tsx
@@ -51,6 +51,7 @@ function deviceHourToLinkHour(hour: DeviceHourStatus) {
     side_z_out_discards: 0,
     side_a_carrier_transitions: hour.carrier_transitions,
     side_z_carrier_transitions: 0,
+    no_probes: hour.no_probes,
   }
 }
 

--- a/web/src/components/status-timeline.tsx
+++ b/web/src/components/status-timeline.tsx
@@ -127,6 +127,10 @@ function getStatusReasons(hour: LinkHourStatus, committedRttUs?: number): string
 
   if (hour.status === 'no_data') return reasons
 
+  if (hour.no_probes) {
+    reasons.push('Not sending latency probes')
+  }
+
   // Check packet loss (using severity terms from methodology)
   if (hour.avg_loss_pct >= LOSS_EXTENDED_PCT) {
     reasons.push('Extended packet loss (≥95%)')

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1355,6 +1355,8 @@ export interface LinkHourStatus {
   // Utilization (traffic rate / capacity)
   utilization_in_pct?: number
   utilization_out_pct?: number
+  // Device-specific: no latency probes detected
+  no_probes?: boolean
 }
 
 export interface LinkHistory {
@@ -1432,6 +1434,7 @@ export interface DeviceHourStatus {
   in_discards: number
   out_discards: number
   carrier_transitions: number
+  no_probes?: boolean
 }
 
 export interface DeviceHistory {


### PR DESCRIPTION
## Summary of Changes

- Devices with interface counter data but no latency probe data are now marked unhealthy instead of healthy
- Tooltip shows "Not sending latency probes" as the reason when hovering affected buckets

## Testing Verification

- Verified Go and TypeScript builds pass