### PR TITLE
indexer: add prometheus metrics for influx queries

### DIFF
--- a/indexer/pkg/dz/telemetry/usage/store_backfill.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 )
 
 // BackfillResult contains the results of a backfill operation
@@ -76,7 +78,9 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 		WHERE time >= '%s' AND time < '%s'
 	`, startTimeUTC.Format(time.RFC3339Nano), endTimeUTC.Format(time.RFC3339Nano))
 
+	queryStart := time.Now()
 	rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+	metrics.RecordInfluxQuery(v.cfg.DZEnv, "backfill", time.Since(queryStart), len(rows), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query influxdb for backfill: %w", err)
 	}

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -95,6 +95,7 @@ type ViewConfig struct {
 	ClickHouse      clickhouse.Client
 	RefreshInterval time.Duration
 	QueryWindow     time.Duration // How far back to query from InfluxDB
+	DZEnv           string        // DZ network environment (e.g. "mainnet-beta", "testnet", "devnet")
 }
 
 func (cfg *ViewConfig) Validate() error {
@@ -419,6 +420,7 @@ func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, 
 
 	rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
 	queryDuration := time.Since(queryStart)
+	metrics.RecordInfluxQuery(v.cfg.DZEnv, "interface_usage", queryDuration, len(rows), err)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, err
@@ -954,6 +956,8 @@ func (v *View) queryBaselineCounters(ctx context.Context, windowStart time.Time)
 
 			rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
 			counterDuration := time.Since(counterStart)
+			queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
+			metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)
 			if err != nil {
 				v.log.Warn("telemetry/usage: failed to query baseline counter", "counter", cf.field, "error", err, "duration", counterDuration.String())
 				errCh <- fmt.Errorf("failed to query baseline for %s: %w", cf.field, err)

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -199,6 +199,7 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 			InfluxDB:        cfg.DeviceUsageInfluxClient,
 			Bucket:          cfg.DeviceUsageInfluxBucket,
 			QueryWindow:     cfg.DeviceUsageInfluxQueryWindow,
+			DZEnv:           cfg.DZEnv,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create telemetry usage view: %w", err)

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -97,7 +97,55 @@ var (
 		},
 		[]string{"operation_type", "status"},
 	)
+
+	InfluxQueriesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_influx_queries_total",
+			Help: "Total number of InfluxDB queries",
+		},
+		[]string{"dz_env", "query_type", "status"},
+	)
+
+	InfluxQueryDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "doublezero_data_indexer_influx_query_duration_seconds",
+			Help:    "Duration of InfluxDB queries",
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 12), // 0.1s to ~410s
+		},
+		[]string{"dz_env", "query_type"},
+	)
+
+	InfluxQueryRowsReturned = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "doublezero_data_indexer_influx_query_rows_returned",
+			Help:    "Number of rows returned by InfluxDB queries",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 12), // 1 to ~4M rows
+		},
+		[]string{"dz_env", "query_type"},
+	)
 )
+
+// RecordInfluxQuery records metrics for an InfluxDB query.
+// dzEnv is the DZ network environment (e.g. "mainnet-beta", "testnet", "devnet").
+// queryType describes the kind of query (e.g. "interface_usage", "baseline_in_errors", "backfill").
+func RecordInfluxQuery(dzEnv, queryType string, duration time.Duration, rows int, err error) {
+	status := "success"
+	if err != nil {
+		switch {
+		case context.DeadlineExceeded == err || isDeadlineExceeded(err):
+			status = "timeout"
+		case context.Canceled == err || isCanceled(err):
+			status = "cancelled"
+		default:
+			status = "error"
+		}
+	}
+	InfluxQueriesTotal.WithLabelValues(dzEnv, queryType, status).Inc()
+	InfluxQueryDuration.WithLabelValues(dzEnv, queryType).Observe(duration.Seconds())
+	if err == nil {
+		InfluxQueryRowsReturned.WithLabelValues(dzEnv, queryType).Observe(float64(rows))
+	}
+}
 
 // RecordDatabaseQuery records metrics for a ClickHouse query.
 func RecordDatabaseQuery(duration time.Duration, err error) {


### PR DESCRIPTION
## Summary of Changes
- Adds three new Prometheus metrics tracking InfluxDB query activity: `doublezero_data_indexer_influx_queries_total`, `doublezero_data_indexer_influx_query_duration_seconds`, and `doublezero_data_indexer_influx_query_rows_returned`
- All three metrics are broken down by `dz_env` (e.g. `mainnet-beta`, `testnet`, `devnet`) and `query_type`, which distinguishes the main interface usage query, the five parallel sparse-counter baseline queries, and backfill queries
- Status label on the counter distinguishes `success`, `error`, `timeout`, and `cancelled` outcomes

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net |
|-------------|-------|-------------|-----|
| Scaffolding |     4 | +57 / -0    | +57 |

Pure instrumentation — no business logic changes.

## Testing Verification
- `go build ./indexer/...` passes cleanly
- `query_type` values emitted: `interface_usage`, `baseline_in_discards`, `baseline_in_errors`, `baseline_in_fcs_errors`, `baseline_out_discards`, `baseline_out_errors`, `backfill`