### PR TITLE
indexer: handle influxdb resource exhausted errors and improve observability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/mod v0.34.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
+	google.golang.org/grpc v1.79.1
 )
 
 require (
@@ -183,7 +184,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
-	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -264,12 +264,13 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			v.log.Info("telemetry/usage: queried baselines from clickhouse", "unique_keys", totalKeys, "duration", chDuration.String())
 			baselines = chBaselines
 		} else {
-			v.log.Debug("telemetry/usage: no baseline data in clickhouse (0 rows), will query influxdb", "duration", chDuration.String())
+			v.log.Warn("telemetry/usage: no baseline data in clickhouse (0 rows), will query influxdb — this triggers expensive 10-year scans", "duration", chDuration.String())
 		}
 	}
 
 	if baselines == nil {
-		v.log.Debug("telemetry/usage: querying baselines from influxdb (clickhouse returned 0 baselines)")
+		metrics.InfluxBaselineFallbackTotal.WithLabelValues(v.cfg.DZEnv).Inc()
+		v.log.Warn("telemetry/usage: querying baselines from influxdb (clickhouse returned 0 baselines)")
 		baselineCtx, baselineCancel := context.WithTimeout(ctx, 120*time.Second)
 		defer baselineCancel()
 
@@ -922,76 +923,65 @@ func (v *View) queryBaselineCounters(ctx context.Context, windowStart time.Time)
 		{"out-errors", baselines.OutErrors},
 	}
 
-	v.log.Debug("telemetry/usage: querying baseline counters from influxdb", "counters", len(counterFields))
-	var wg sync.WaitGroup
-	errCh := make(chan error, len(counterFields))
+	// For sparse counters, use a 10-year window directly (they're sparse, so rows are rare).
+	// NOTE: These queries are expensive on InfluxDB — run sequentially to avoid saturating
+	// the InfluxDB query budget (25m total in 30s). This path only runs when ClickHouse
+	// has no baseline data, which should be rare in steady state.
+	lookbackStart := windowStart.Add(-10 * 365 * 24 * time.Hour)
+	v.log.Warn("telemetry/usage: querying baseline counters from influxdb (sequential to avoid rate limits)",
+		"counters", len(counterFields),
+		"from", lookbackStart.UTC(),
+		"to", windowStart.UTC(),
+		"lookback", "10y",
+	)
 
+	hasErrors := false
 	for _, cf := range counterFields {
-		wg.Add(1)
-		go func(cf struct {
-			field    string
-			baseline map[string]*int64
-		}) {
-			defer wg.Done()
-			counterStart := time.Now()
+		counterStart := time.Now()
 
-			// For sparse counters, just use 10-year window directly (they're sparse, so it's fast)
-			lookbackStart := windowStart.Add(-10 * 365 * 24 * time.Hour)
-			sqlQuery := fmt.Sprintf(`
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				dzd_pubkey,
+				intf,
+				"%s" as value
+			FROM (
 				SELECT
 					dzd_pubkey,
 					intf,
-					"%s" as value
-				FROM (
-					SELECT
-						dzd_pubkey,
-						intf,
-						"%s",
-						ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
-					FROM "intfCounters"
-					WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
-				) ranked
-				WHERE rn = 1
-			`, cf.field, cf.field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), cf.field)
+					"%s",
+					ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
+				FROM "intfCounters"
+				WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
+			) ranked
+			WHERE rn = 1
+		`, cf.field, cf.field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), cf.field)
 
-			rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
-			counterDuration := time.Since(counterStart)
-			queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
-			metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)
-			if err != nil {
-				v.log.Warn("telemetry/usage: failed to query baseline counter", "counter", cf.field, "error", err, "duration", counterDuration.String())
-				errCh <- fmt.Errorf("failed to query baseline for %s: %w", cf.field, err)
-				return
-			}
-
-			baselineCount := 0
-			for _, row := range rows {
-				devicePK := extractStringFromRow(row, "dzd_pubkey")
-				intf := extractStringFromRow(row, "intf")
-				if devicePK == nil || intf == nil {
-					continue
-				}
-				key := fmt.Sprintf("%s:%s", *devicePK, *intf)
-				value := extractInt64FromRow(row, "value")
-				if value != nil {
-					cf.baseline[key] = value
-					baselineCount++
-				}
-			}
-			v.log.Debug("telemetry/usage: completed baseline counter query", "counter", cf.field, "baselines", baselineCount, "duration", counterDuration.String())
-		}(cf)
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	// Check for errors
-	hasErrors := false
-	for err := range errCh {
+		v.log.Debug("telemetry/usage: executing influxdb baseline counter query", "counter", cf.field, "from", lookbackStart.UTC(), "to", windowStart.UTC())
+		rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+		counterDuration := time.Since(counterStart)
+		queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
+		metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)
 		if err != nil {
+			v.log.Warn("telemetry/usage: failed to query baseline counter", "counter", cf.field, "error", err, "duration", counterDuration.String())
 			hasErrors = true
-			v.log.Warn("telemetry/usage: baseline counter query error", "error", err)
+			continue
 		}
+
+		baselineCount := 0
+		for _, row := range rows {
+			devicePK := extractStringFromRow(row, "dzd_pubkey")
+			intf := extractStringFromRow(row, "intf")
+			if devicePK == nil || intf == nil {
+				continue
+			}
+			key := fmt.Sprintf("%s:%s", *devicePK, *intf)
+			value := extractInt64FromRow(row, "value")
+			if value != nil {
+				cf.baseline[key] = value
+				baselineCount++
+			}
+		}
+		v.log.Debug("telemetry/usage: completed baseline counter query", "counter", cf.field, "baselines", baselineCount, "duration", counterDuration.String())
 	}
 
 	if hasErrors {

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -13,6 +13,9 @@ import (
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"go.temporal.io/sdk/temporal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Activities holds dependencies for DZ ingest activities.
@@ -80,6 +83,18 @@ func (a *Activities) RefreshTelemetryUsage(ctx context.Context) error {
 	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshTelemetryUsage", a.Network, func() (ingestionlog.RefreshResult, error) {
 		result, err := a.TelemUsage.Refresh(ctx)
 		if err != nil {
+			// InfluxDB enforces a rate limit: total query duration in the last 30s cannot
+			// exceed 25 minutes. When this is hit, retrying immediately makes things worse
+			// by consuming more of the rate limit budget. Return non-retryable so Temporal
+			// skips retries and waits for the next natural workflow cycle instead.
+			if status.Code(err) == codes.ResourceExhausted {
+				a.Log.Warn("influxdb rate limit hit, skipping retries until next cycle", "error", err)
+				return result, temporal.NewNonRetryableApplicationError(
+					fmt.Sprintf("telemetry usage refresh: %v", err),
+					"InfluxResourceExhausted",
+					err,
+				)
+			}
 			return result, fmt.Errorf("telemetry usage refresh: %w", err)
 		}
 		return result, nil

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -123,6 +123,17 @@ var (
 		},
 		[]string{"dz_env", "query_type"},
 	)
+
+	// InfluxBaselineFallbackTotal counts how many times the baseline query fell back to InfluxDB
+	// because ClickHouse returned 0 rows. High values indicate ClickHouse baseline data is stale
+	// or missing, which triggers expensive 10-year InfluxDB scans.
+	InfluxBaselineFallbackTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_influx_baseline_fallback_total",
+			Help: "Total number of times baseline query fell back from ClickHouse to InfluxDB (0 rows from ClickHouse)",
+		},
+		[]string{"dz_env"},
+	)
 )
 
 // RecordInfluxQuery records metrics for an InfluxDB query.


### PR DESCRIPTION
## Summary of Changes
- Add non-retryable Temporal error wrapping for gRPC `ResourceExhausted` responses from InfluxDB — stops rapid retries from piling onto an already-exhausted rate limit budget (25 min / 30 sec window), letting the next natural 5-minute workflow cycle retry instead
- Serialize the 5 parallel InfluxDB baseline counter queries (each a 10-year lookback) to run sequentially, reducing peak concurrency that could saturate the budget when ClickHouse has no baseline data
- Promote the InfluxDB baseline fallback log from `Debug` → `Warn` so it's visible in production when ClickHouse returns 0 rows and the expensive InfluxDB path triggers
- Add `doublezero_data_indexer_influx_baseline_fallback_total` Prometheus counter to track how often the ClickHouse baseline misses and forces the 10-year InfluxDB scan

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     3 | +80 / -64    |  +16 |
| Config/build |     1 | +1 / -1      |   +0 |
| **Total**    |     4 | +81 / -65    |  +16 |

Small net addition — mostly rework of the baseline query loop plus new error handling.

<details>
<summary>Key files (click to expand)</summary>

- `indexer/pkg/dz/telemetry/usage/view.go` — serialize baseline InfluxDB queries, promote fallback log to warn, add time-range logging upfront
- `indexer/pkg/dzingest/activities.go` — detect `codes.ResourceExhausted` and return `temporal.NewNonRetryableApplicationError`
- `indexer/pkg/metrics/metrics.go` — add `influx_baseline_fallback_total` counter

</details>