### PR TITLE
indexer: switch influxdb interface counters from Flight SQL to Flux

### DIFF
--- a/admin/cmd/admin/main.go
+++ b/admin/cmd/admin/main.go
@@ -80,6 +80,7 @@ func run() error {
 	// InfluxDB configuration (for usage backfill)
 	influxURLFlag := flag.String("influx-url", "", "InfluxDB URL (or set INFLUX_URL env var)")
 	influxTokenFlag := flag.String("influx-token", "", "InfluxDB token (or set INFLUX_TOKEN env var)")
+	influxOrgFlag := flag.String("influx-org", "", "InfluxDB organization name or ID (optional; uses token's default org if empty)")
 	influxBucketFlag := flag.String("influx-bucket", "", "InfluxDB bucket (or set INFLUX_BUCKET env var)")
 
 	// Commands
@@ -385,7 +386,7 @@ func run() error {
 			log,
 			*clickhouseAddrFlag, *clickhouseDatabaseFlag, *clickhouseUsernameFlag, *clickhousePasswordFlag,
 			*clickhouseSecureFlag,
-			*influxURLFlag, *influxTokenFlag, *influxBucketFlag,
+			*influxURLFlag, *influxTokenFlag, *influxOrgFlag, *influxBucketFlag,
 			admin.BackfillDeviceInterfaceCountersConfig{
 				StartTime:     startTime,
 				EndTime:       endTime,

--- a/admin/internal/admin/backfill_device_interface_counters.go
+++ b/admin/internal/admin/backfill_device_interface_counters.go
@@ -30,7 +30,7 @@ func BackfillDeviceInterfaceCounters(
 	log *slog.Logger,
 	clickhouseAddr, clickhouseDatabase, clickhouseUsername, clickhousePassword string,
 	clickhouseSecure bool,
-	influxDBHost, influxDBToken, influxDBBucket string,
+	influxDBHost, influxDBToken, influxDBOrg, influxDBBucket string,
 	cfg BackfillDeviceInterfaceCountersConfig,
 ) error {
 	ctx := context.Background()
@@ -42,8 +42,8 @@ func BackfillDeviceInterfaceCounters(
 	}
 	defer chDB.Close()
 
-	// Connect to InfluxDB
-	influxClient, err := dztelemusage.NewSDKInfluxDBClient(influxDBHost, influxDBToken, influxDBBucket)
+	// Connect to InfluxDB using Flux API
+	influxClient, err := dztelemusage.NewFluxInfluxDBClient(influxDBHost, influxDBToken, influxDBOrg, influxDBBucket)
 	if err != nil {
 		return fmt.Errorf("failed to connect to InfluxDB: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
 	github.com/google/uuid v1.6.0
+	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/joho/godotenv v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
@@ -99,7 +100,6 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.5 // indirect
-	github.com/influxdata/influxdb-client-go/v2 v2.14.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/influxdata/line-protocol/v2 v2.2.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/mod v0.34.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
+	google.golang.org/grpc v1.79.1
 )
 
 require (
@@ -183,7 +184,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
-	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -439,6 +439,7 @@ func run() error {
 	influxURL := os.Getenv("INFLUX_URL")
 	influxToken := os.Getenv("INFLUX_TOKEN")
 	influxBucket := os.Getenv("INFLUX_BUCKET")
+	influxOrg := os.Getenv("INFLUX_ORG") // optional; empty string uses the token's default org
 	var deviceUsageQueryWindow time.Duration
 	if *deviceUsageQueryWindowFlag == 0 {
 		deviceUsageQueryWindow = defaultDeviceUsageInfluxQueryWindow
@@ -455,7 +456,7 @@ func run() error {
 		})
 		influxBucket = "mock-bucket"
 	} else if influxURL != "" && influxToken != "" && influxBucket != "" {
-		influxDBClient, err = dztelemusage.NewSDKInfluxDBClient(influxURL, influxToken, influxBucket)
+		influxDBClient, err = dztelemusage.NewFluxInfluxDBClient(influxURL, influxToken, influxOrg, influxBucket)
 		if err != nil {
 			return fmt.Errorf("failed to create InfluxDB client: %w", err)
 		}
@@ -734,6 +735,7 @@ func run() error {
 				isisS3Region:               *isisS3RegionFlag,
 				influxURL:                  secondaryInfluxURL,
 				influxToken:                secondaryInfluxToken,
+				influxOrg:                  influxOrg,
 				influxBucket:               secondaryInfluxBucket,
 				deviceUsageRefreshInterval: *deviceUsageRefreshIntervalFlag,
 				deviceUsageQueryWindow:     deviceUsageQueryWindow,
@@ -811,6 +813,7 @@ type secondaryNetworkConfig struct {
 	// InfluxDB configuration (optional).
 	influxURL                  string
 	influxToken                string
+	influxOrg                  string
 	influxBucket               string
 	deviceUsageRefreshInterval time.Duration
 	deviceUsageQueryWindow     time.Duration
@@ -879,7 +882,7 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	// Initialize InfluxDB client for device usage (optional).
 	var influxDBClient dztelemusage.InfluxDBClient
 	if cfg.influxURL != "" && cfg.influxToken != "" && cfg.influxBucket != "" {
-		influxDBClient, err = dztelemusage.NewSDKInfluxDBClient(cfg.influxURL, cfg.influxToken, cfg.influxBucket)
+		influxDBClient, err = dztelemusage.NewFluxInfluxDBClient(cfg.influxURL, cfg.influxToken, cfg.influxOrg, cfg.influxBucket)
 		if err != nil {
 			return fmt.Errorf("failed to create InfluxDB client for %s: %w", env, err)
 		}

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
@@ -3,6 +3,7 @@ package dztelemusage
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -17,6 +18,12 @@ type FluxInfluxDBClient struct {
 	queryAPI api.QueryAPI
 	bucket   string
 }
+
+// defaultFluxHTTPTimeout is the HTTP client timeout for Flux queries.
+// The influxdb-client-go/v2 default is 20s which is too short for pivot queries
+// over a 1-hour window of interface counter data. The Temporal activity
+// StartToCloseTimeout is 5 minutes, so 4 minutes gives a comfortable margin.
+const defaultFluxHTTPTimeout = 4 * time.Minute
 
 // NewFluxInfluxDBClient creates a new InfluxDB client that uses Flux queries.
 // url is the InfluxDB server URL (e.g. "https://us-east-1-1.aws.cloud2.influxdata.com").
@@ -33,7 +40,8 @@ func NewFluxInfluxDBClient(url, token, org, bucket string) (*FluxInfluxDBClient,
 	if bucket == "" {
 		return nil, fmt.Errorf("influxdb bucket is required")
 	}
-	client := influxdb2.NewClient(url, token)
+	opts := influxdb2.DefaultOptions().SetHTTPClient(&http.Client{Timeout: defaultFluxHTTPTimeout})
+	client := influxdb2.NewClientWithOptions(url, token, opts)
 	queryAPI := client.QueryAPI(org)
 	return &FluxInfluxDBClient{
 		client:   client,

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
@@ -130,7 +130,7 @@ var fluxMetaColumns = map[string]bool{
 // normalizeIntfCounterRow converts a Flux pivot record to the row format expected by
 // convertRowsToUsage. It renames _time → time (as RFC3339Nano string) and strips
 // Flux metadata columns.
-func normalizeIntfCounterRow(values map[string]interface{}, t time.Time) map[string]any {
+func normalizeIntfCounterRow(values map[string]any, t time.Time) map[string]any {
 	row := make(map[string]any, len(values))
 	for k, v := range values {
 		if fluxMetaColumns[k] {
@@ -145,7 +145,7 @@ func normalizeIntfCounterRow(values map[string]interface{}, t time.Time) map[str
 
 // normalizeBaselineRow converts a Flux last() record to the row format expected by
 // queryBaselineCounters. It renames _value → value and strips Flux metadata columns.
-func normalizeBaselineRow(values map[string]interface{}) map[string]any {
+func normalizeBaselineRow(values map[string]any) map[string]any {
 	row := make(map[string]any, len(values))
 	for k, v := range values {
 		if fluxMetaColumns[k] {

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
@@ -1,0 +1,153 @@
+package dztelemusage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	"github.com/influxdata/influxdb-client-go/v2/api"
+)
+
+// FluxInfluxDBClient implements InfluxDBClient using the InfluxDB v2 HTTP API with Flux queries.
+// It uses the /api/v2/query endpoint which has a separate rate-limit budget from the
+// Flight SQL endpoint used by SDKInfluxDBClient.
+type FluxInfluxDBClient struct {
+	client   influxdb2.Client
+	queryAPI api.QueryAPI
+	bucket   string
+}
+
+// NewFluxInfluxDBClient creates a new InfluxDB client that uses Flux queries.
+// url is the InfluxDB server URL (e.g. "https://us-east-1-1.aws.cloud2.influxdata.com").
+// token is the InfluxDB API token (passed as "Authorization: Token <token>").
+// org is the InfluxDB organization name or ID; pass empty string to use the token's default org.
+// bucket is the InfluxDB bucket name.
+func NewFluxInfluxDBClient(url, token, org, bucket string) (*FluxInfluxDBClient, error) {
+	if url == "" {
+		return nil, fmt.Errorf("influxdb url is required")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("influxdb token is required")
+	}
+	if bucket == "" {
+		return nil, fmt.Errorf("influxdb bucket is required")
+	}
+	client := influxdb2.NewClient(url, token)
+	queryAPI := client.QueryAPI(org)
+	return &FluxInfluxDBClient{
+		client:   client,
+		queryAPI: queryAPI,
+		bucket:   bucket,
+	}, nil
+}
+
+// QueryIntfCounters fetches all interface counter rows for [start, end) using a Flux pivot query.
+// The pivot turns per-field rows into one row per (time, device, interface) with all counter
+// values as columns — matching the shape returned by the Flight SQL client.
+func (c *FluxInfluxDBClient) QueryIntfCounters(ctx context.Context, start, end time.Time) ([]map[string]any, error) {
+	fluxQuery := fmt.Sprintf(`
+from(bucket: "%s")
+  |> range(start: %s, stop: %s)
+  |> filter(fn: (r) => r._measurement == "intfCounters")
+  |> pivot(rowKey: ["_time", "dzd_pubkey", "host", "intf", "model_name", "serial_number"], columnKey: ["_field"], valueColumn: "_value")
+`, c.bucket, start.UTC().Format(time.RFC3339Nano), end.UTC().Format(time.RFC3339Nano))
+
+	result, err := c.queryAPI.Query(ctx, fluxQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute flux intf counters query: %w", err)
+	}
+
+	var rows []map[string]any
+	for result.Next() {
+		row := normalizeIntfCounterRow(result.Record().Values(), result.Record().Time())
+		rows = append(rows, row)
+	}
+	if err := result.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating flux intf counters results: %w", err)
+	}
+
+	return rows, nil
+}
+
+// QueryBaselineCounter fetches the last non-null value of field for each (dzd_pubkey, intf)
+// pair in [lookbackStart, windowStart) using a Flux last() query.
+// Returns rows with keys: dzd_pubkey, intf, value.
+func (c *FluxInfluxDBClient) QueryBaselineCounter(ctx context.Context, field string, lookbackStart, windowStart time.Time) ([]map[string]any, error) {
+	fluxQuery := fmt.Sprintf(`
+from(bucket: "%s")
+  |> range(start: %s, stop: %s)
+  |> filter(fn: (r) => r._measurement == "intfCounters" and r._field == "%s")
+  |> filter(fn: (r) => exists r._value)
+  |> group(columns: ["dzd_pubkey", "intf"])
+  |> last()
+  |> keep(columns: ["dzd_pubkey", "intf", "_value"])
+`, c.bucket, lookbackStart.UTC().Format(time.RFC3339Nano), windowStart.UTC().Format(time.RFC3339Nano), field)
+
+	result, err := c.queryAPI.Query(ctx, fluxQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute flux baseline counter query: %w", err)
+	}
+
+	var rows []map[string]any
+	for result.Next() {
+		row := normalizeBaselineRow(result.Record().Values())
+		rows = append(rows, row)
+	}
+	if err := result.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating flux baseline counter results: %w", err)
+	}
+
+	return rows, nil
+}
+
+// Close closes the underlying InfluxDB client.
+func (c *FluxInfluxDBClient) Close() error {
+	c.client.Close()
+	return nil
+}
+
+// fluxMetaColumns are Flux-internal columns added by the query engine that are not
+// part of the InfluxDB data. They are stripped from output rows.
+var fluxMetaColumns = map[string]bool{
+	"_time":        true,
+	"_measurement": true,
+	"_start":       true,
+	"_stop":        true,
+	"result":       true,
+	"table":        true,
+	"_field":       true,
+}
+
+// normalizeIntfCounterRow converts a Flux pivot record to the row format expected by
+// convertRowsToUsage. It renames _time → time (as RFC3339Nano string) and strips
+// Flux metadata columns.
+func normalizeIntfCounterRow(values map[string]interface{}, t time.Time) map[string]any {
+	row := make(map[string]any, len(values))
+	for k, v := range values {
+		if fluxMetaColumns[k] {
+			continue
+		}
+		row[k] = v
+	}
+	// Set time as RFC3339Nano string so the existing time-parsing code in convertRowsToUsage works.
+	row["time"] = t.UTC().Format(time.RFC3339Nano)
+	return row
+}
+
+// normalizeBaselineRow converts a Flux last() record to the row format expected by
+// queryBaselineCounters. It renames _value → value and strips Flux metadata columns.
+func normalizeBaselineRow(values map[string]interface{}) map[string]any {
+	row := make(map[string]any, len(values))
+	for k, v := range values {
+		if fluxMetaColumns[k] {
+			continue
+		}
+		if k == "_value" {
+			row["value"] = v
+		} else {
+			row[k] = v
+		}
+	}
+	return row
+}

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client_test.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client_test.go
@@ -55,7 +55,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testi
 
 	t.Run("renames _time to time as RFC3339Nano string", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"_time":      fixedTime,
 			"dzd_pubkey": "abc123",
 			"intf":       "eth0",
@@ -78,7 +78,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testi
 
 	t.Run("strips flux metadata columns", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"_time":        fixedTime,
 			"_measurement": "intfCounters",
 			"_start":       fixedTime.Add(-time.Hour),
@@ -102,7 +102,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testi
 
 	t.Run("preserves tag and field columns", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"_time":               fixedTime,
 			"dzd_pubkey":          "pubkey1",
 			"host":                "router1",
@@ -133,7 +133,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testi
 
 	t.Run("output is parseable by extractStringFromRow and extractInt64FromRow", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"_time":      fixedTime,
 			"dzd_pubkey": "pubkey2",
 			"intf":       "eth1",
@@ -162,7 +162,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testi
 		t.Parallel()
 		// Test with nanosecond precision
 		tNano := time.Date(2024, 1, 15, 12, 0, 0, 987654321, time.UTC)
-		row := normalizeIntfCounterRow(map[string]interface{}{"_time": tNano}, tNano)
+		row := normalizeIntfCounterRow(map[string]any{"_time": tNano}, tNano)
 
 		timeStr, ok := row["time"].(string)
 		require.True(t, ok)
@@ -179,7 +179,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.
 
 	t.Run("renames _value to value", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"dzd_pubkey": "abc",
 			"intf":       "eth0",
 			"_value":     int64(42),
@@ -193,7 +193,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.
 	t.Run("strips flux metadata columns", func(t *testing.T) {
 		t.Parallel()
 		fixedTime := time.Now().UTC()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"_time":        fixedTime,
 			"_measurement": "intfCounters",
 			"_start":       fixedTime.Add(-time.Hour),
@@ -216,7 +216,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.
 
 	t.Run("preserves dzd_pubkey and intf", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"dzd_pubkey": "pubkey123",
 			"intf":       "Tunnel501",
 			"_value":     int64(7),
@@ -230,7 +230,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.
 
 	t.Run("output is parseable by extractStringFromRow and extractInt64FromRow", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"dzd_pubkey": "pk1",
 			"intf":       "eth0",
 			"_value":     int64(55),
@@ -252,7 +252,7 @@ func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.
 
 	t.Run("handles nil _value", func(t *testing.T) {
 		t.Parallel()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"dzd_pubkey": "pk2",
 			"intf":       "eth1",
 			"_value":     nil,

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client_test.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client_test.go
@@ -1,0 +1,265 @@
+package dztelemusage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_TelemetryUsage_FluxInfluxDBClient_NewFluxInfluxDBClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when url is empty", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewFluxInfluxDBClient("", "token", "org", "bucket")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "url is required")
+	})
+
+	t.Run("returns error when token is empty", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewFluxInfluxDBClient("http://localhost:8086", "", "org", "bucket")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token is required")
+	})
+
+	t.Run("returns error when bucket is empty", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewFluxInfluxDBClient("http://localhost:8086", "token", "org", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bucket is required")
+	})
+
+	t.Run("creates client successfully with empty org", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewFluxInfluxDBClient("http://localhost:8086", "token", "", "bucket")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		_ = client.Close()
+	})
+
+	t.Run("creates client successfully", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewFluxInfluxDBClient("http://localhost:8086", "token", "myorg", "bucket")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		_ = client.Close()
+	})
+}
+
+func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeIntfCounterRow(t *testing.T) {
+	t.Parallel()
+
+	fixedTime := time.Date(2024, 6, 15, 10, 30, 0, 123456789, time.UTC)
+
+	t.Run("renames _time to time as RFC3339Nano string", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"_time":      fixedTime,
+			"dzd_pubkey": "abc123",
+			"intf":       "eth0",
+			"in-octets":  int64(1000),
+		}
+		row := normalizeIntfCounterRow(values, fixedTime)
+
+		require.NotNil(t, row["time"])
+		timeStr, ok := row["time"].(string)
+		require.True(t, ok, "time must be a string")
+
+		parsed, err := time.Parse(time.RFC3339Nano, timeStr)
+		require.NoError(t, err)
+		require.True(t, parsed.Equal(fixedTime), "parsed time must match original")
+
+		// _time should be stripped
+		_, hasUnderscoreTime := row["_time"]
+		require.False(t, hasUnderscoreTime, "_time should be removed")
+	})
+
+	t.Run("strips flux metadata columns", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"_time":        fixedTime,
+			"_measurement": "intfCounters",
+			"_start":       fixedTime.Add(-time.Hour),
+			"_stop":        fixedTime,
+			"result":       "_result",
+			"table":        int64(0),
+			"_field":       "in-octets",
+			"dzd_pubkey":   "abc123",
+			"in-octets":    int64(9999),
+		}
+		row := normalizeIntfCounterRow(values, fixedTime)
+
+		require.NotContains(t, row, "_measurement")
+		require.NotContains(t, row, "_start")
+		require.NotContains(t, row, "_stop")
+		require.NotContains(t, row, "result")
+		require.NotContains(t, row, "table")
+		require.NotContains(t, row, "_field")
+		require.NotContains(t, row, "_time")
+	})
+
+	t.Run("preserves tag and field columns", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"_time":               fixedTime,
+			"dzd_pubkey":          "pubkey1",
+			"host":                "router1",
+			"intf":                "eth0",
+			"model_name":          "Model X",
+			"serial_number":       "SN12345",
+			"in-octets":           int64(100000),
+			"out-octets":          int64(50000),
+			"in-pkts":             int64(200),
+			"out-pkts":            int64(150),
+			"in-errors":           nil,
+			"carrier-transitions": int64(0),
+		}
+		row := normalizeIntfCounterRow(values, fixedTime)
+
+		require.Equal(t, "pubkey1", row["dzd_pubkey"])
+		require.Equal(t, "router1", row["host"])
+		require.Equal(t, "eth0", row["intf"])
+		require.Equal(t, "Model X", row["model_name"])
+		require.Equal(t, "SN12345", row["serial_number"])
+		require.Equal(t, int64(100000), row["in-octets"])
+		require.Equal(t, int64(50000), row["out-octets"])
+		require.Equal(t, int64(200), row["in-pkts"])
+		require.Equal(t, int64(150), row["out-pkts"])
+		require.Nil(t, row["in-errors"])
+		require.Equal(t, int64(0), row["carrier-transitions"])
+	})
+
+	t.Run("output is parseable by extractStringFromRow and extractInt64FromRow", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"_time":      fixedTime,
+			"dzd_pubkey": "pubkey2",
+			"intf":       "eth1",
+			"in-octets":  int64(42000),
+			"in-errors":  nil,
+		}
+		row := normalizeIntfCounterRow(values, fixedTime)
+
+		timeVal := extractStringFromRow(row, "time")
+		require.NotNil(t, timeVal)
+		require.NotEmpty(t, *timeVal)
+
+		devicePK := extractStringFromRow(row, "dzd_pubkey")
+		require.NotNil(t, devicePK)
+		require.Equal(t, "pubkey2", *devicePK)
+
+		inOctets := extractInt64FromRow(row, "in-octets")
+		require.NotNil(t, inOctets)
+		require.Equal(t, int64(42000), *inOctets)
+
+		inErrors := extractInt64FromRow(row, "in-errors")
+		require.Nil(t, inErrors)
+	})
+
+	t.Run("time is parseable by all formats used in convertRowsToUsage", func(t *testing.T) {
+		t.Parallel()
+		// Test with nanosecond precision
+		tNano := time.Date(2024, 1, 15, 12, 0, 0, 987654321, time.UTC)
+		row := normalizeIntfCounterRow(map[string]interface{}{"_time": tNano}, tNano)
+
+		timeStr, ok := row["time"].(string)
+		require.True(t, ok)
+
+		// Must be parseable by RFC3339Nano (first format tried in convertRowsToUsage)
+		parsed, err := time.Parse(time.RFC3339Nano, timeStr)
+		require.NoError(t, err)
+		require.True(t, parsed.Equal(tNano))
+	})
+}
+
+func TestLake_TelemetryUsage_FluxInfluxDBClient_normalizeBaselineRow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renames _value to value", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"dzd_pubkey": "abc",
+			"intf":       "eth0",
+			"_value":     int64(42),
+		}
+		row := normalizeBaselineRow(values)
+
+		require.Equal(t, int64(42), row["value"])
+		require.NotContains(t, row, "_value")
+	})
+
+	t.Run("strips flux metadata columns", func(t *testing.T) {
+		t.Parallel()
+		fixedTime := time.Now().UTC()
+		values := map[string]interface{}{
+			"_time":        fixedTime,
+			"_measurement": "intfCounters",
+			"_start":       fixedTime.Add(-time.Hour),
+			"_stop":        fixedTime,
+			"result":       "_result",
+			"table":        int64(0),
+			"dzd_pubkey":   "abc",
+			"intf":         "eth0",
+			"_value":       int64(99),
+		}
+		row := normalizeBaselineRow(values)
+
+		require.NotContains(t, row, "_time")
+		require.NotContains(t, row, "_measurement")
+		require.NotContains(t, row, "_start")
+		require.NotContains(t, row, "_stop")
+		require.NotContains(t, row, "result")
+		require.NotContains(t, row, "table")
+	})
+
+	t.Run("preserves dzd_pubkey and intf", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"dzd_pubkey": "pubkey123",
+			"intf":       "Tunnel501",
+			"_value":     int64(7),
+		}
+		row := normalizeBaselineRow(values)
+
+		require.Equal(t, "pubkey123", row["dzd_pubkey"])
+		require.Equal(t, "Tunnel501", row["intf"])
+		require.Equal(t, int64(7), row["value"])
+	})
+
+	t.Run("output is parseable by extractStringFromRow and extractInt64FromRow", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"dzd_pubkey": "pk1",
+			"intf":       "eth0",
+			"_value":     int64(55),
+		}
+		row := normalizeBaselineRow(values)
+
+		devicePK := extractStringFromRow(row, "dzd_pubkey")
+		require.NotNil(t, devicePK)
+		require.Equal(t, "pk1", *devicePK)
+
+		intf := extractStringFromRow(row, "intf")
+		require.NotNil(t, intf)
+		require.Equal(t, "eth0", *intf)
+
+		val := extractInt64FromRow(row, "value")
+		require.NotNil(t, val)
+		require.Equal(t, int64(55), *val)
+	})
+
+	t.Run("handles nil _value", func(t *testing.T) {
+		t.Parallel()
+		values := map[string]interface{}{
+			"dzd_pubkey": "pk2",
+			"intf":       "eth1",
+			"_value":     nil,
+		}
+		row := normalizeBaselineRow(values)
+
+		val := extractInt64FromRow(row, "value")
+		require.Nil(t, val)
+	})
+}

--- a/indexer/pkg/dz/telemetry/usage/mock_influx.go
+++ b/indexer/pkg/dz/telemetry/usage/mock_influx.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -69,28 +68,21 @@ func NewMockInfluxDBClient(cfg MockInfluxDBClientConfig) *MockInfluxDBClient {
 	}
 }
 
-// QuerySQL implements InfluxDBClient.QuerySQL by generating mock counter data
-func (c *MockInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
-	// Detect baseline queries (contain ROW_NUMBER) and return empty results
-	// Mock data has no historical data before the query window
-	if strings.Contains(sqlQuery, "ROW_NUMBER") {
-		c.log.Debug("mock influxdb: baseline query detected, returning empty results")
-		return []map[string]any{}, nil
-	}
-
-	// Parse time range from SQL query
-	startTime, endTime, err := parseTimeRange(sqlQuery)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse time range: %w", err)
-	}
-
+// QueryIntfCounters implements InfluxDBClient.QueryIntfCounters by generating mock counter data.
+func (c *MockInfluxDBClient) QueryIntfCounters(ctx context.Context, start, end time.Time) ([]map[string]any, error) {
 	// Refresh topology if needed (cache for 1 minute)
 	if err := c.refreshTopologyIfNeeded(ctx); err != nil {
 		return nil, fmt.Errorf("failed to refresh topology: %w", err)
 	}
 
-	// Generate mock data
-	return c.generateMockData(startTime, endTime)
+	return c.generateMockData(start, end)
+}
+
+// QueryBaselineCounter implements InfluxDBClient.QueryBaselineCounter.
+// The mock has no historical data before the query window, so it always returns empty results.
+func (c *MockInfluxDBClient) QueryBaselineCounter(_ context.Context, _ string, _, _ time.Time) ([]map[string]any, error) {
+	c.log.Debug("mock influxdb: baseline counter query, returning empty results (no historical data)")
+	return []map[string]any{}, nil
 }
 
 // Close implements InfluxDBClient.Close
@@ -392,7 +384,7 @@ func (c *MockInfluxDBClient) generateCounterRow(device *mockDevice, iface mockIn
 	outBroadcastPkts := outPkts * broadcastPct / 100
 
 	row := map[string]any{
-		"time":                t.UTC().Format("2006-01-02 15:04:05.999999999 +0000 UTC"),
+		"time":                t.UTC().Format(time.RFC3339Nano),
 		"dzd_pubkey":          device.pk,
 		"host":                device.code,
 		"intf":                iface.name,
@@ -507,49 +499,6 @@ func (c *MockInfluxDBClient) getAvgPacketSize(ifaceName string) int64 {
 		// (mix of small ACKs and larger data packets)
 		return 800
 	}
-}
-
-// parseTimeRange extracts start and end times from an InfluxDB SQL query
-func parseTimeRange(sqlQuery string) (time.Time, time.Time, error) {
-	// Match patterns like: time >= '2024-01-01T00:00:00Z' AND time < '2024-01-01T01:00:00Z'
-	timePattern := regexp.MustCompile(`time\s*>=\s*'([^']+)'\s+AND\s+time\s*<\s*'([^']+)'`)
-	matches := timePattern.FindStringSubmatch(sqlQuery)
-
-	if len(matches) != 3 {
-		// Default to last hour if we can't parse
-		now := time.Now().UTC()
-		return now.Add(-time.Hour), now, nil
-	}
-
-	startTime, err := parseInfluxTime(matches[1])
-	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse start time: %w", err)
-	}
-
-	endTime, err := parseInfluxTime(matches[2])
-	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse end time: %w", err)
-	}
-
-	return startTime, endTime, nil
-}
-
-// parseInfluxTime parses a time string in various formats
-func parseInfluxTime(s string) (time.Time, error) {
-	formats := []string{
-		time.RFC3339Nano,
-		time.RFC3339,
-		"2006-01-02T15:04:05Z",
-		"2006-01-02 15:04:05",
-	}
-
-	for _, format := range formats {
-		if t, err := time.Parse(format, s); err == nil {
-			return t, nil
-		}
-	}
-
-	return time.Time{}, fmt.Errorf("unable to parse time: %s", s)
 }
 
 // hashSeed creates a deterministic hash from device PK and interface name

--- a/indexer/pkg/dz/telemetry/usage/mock_influx_test.go
+++ b/indexer/pkg/dz/telemetry/usage/mock_influx_test.go
@@ -11,26 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
+func TestLake_TelemetryUsage_MockInfluxDBClient_QueryIntfCounters(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns empty results for baseline queries", func(t *testing.T) {
-		t.Parallel()
-		mockDB := testClient(t)
-
-		client := NewMockInfluxDBClient(MockInfluxDBClientConfig{
-			ClickHouse: mockDB,
-			Logger:     laketesting.NewLogger(),
-		})
-
-		// Query with ROW_NUMBER (baseline query pattern)
-		query := `SELECT dzd_pubkey, intf, "in-errors" FROM (SELECT *, ROW_NUMBER() OVER (...) as rn FROM "intfCounters") WHERE rn = 1`
-		results, err := client.QuerySQL(context.Background(), query)
-		require.NoError(t, err)
-		require.Empty(t, results)
-	})
-
-	t.Run("generates mock data for time range query", func(t *testing.T) {
+	t.Run("generates mock data for time range", func(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
@@ -69,9 +53,8 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 		// Query for a 10-minute window (should generate 2 data points per interface)
 		now := time.Now().UTC()
 		start := now.Add(-10 * time.Minute)
-		query := `SELECT * FROM "intfCounters" WHERE time >= '` + start.Format(time.RFC3339Nano) + `' AND time < '` + now.Format(time.RFC3339Nano) + `'`
 
-		results, err := client.QuerySQL(context.Background(), query)
+		results, err := client.QueryIntfCounters(context.Background(), start, now)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -85,6 +68,12 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 			require.NotNil(t, row["out-octets"])
 			require.NotNil(t, row["in-pkts"])
 			require.NotNil(t, row["out-pkts"])
+
+			// time must be a string (RFC3339Nano parseable)
+			timeStr, ok := row["time"].(string)
+			require.True(t, ok, "time should be a string")
+			_, err := time.Parse(time.RFC3339Nano, timeStr)
+			require.NoError(t, err, "time should be parseable as RFC3339Nano: %s", timeStr)
 		}
 
 		// Verify we have data for our devices
@@ -102,7 +91,6 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
-		// Insert device with empty interfaces
 		svcStore, err := dzsvc.NewStore(dzsvc.StoreConfig{
 			Logger:     laketesting.NewLogger(),
 			ClickHouse: mockDB,
@@ -126,9 +114,8 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 
 		now := time.Now().UTC()
 		start := now.Add(-10 * time.Minute)
-		query := `SELECT * FROM "intfCounters" WHERE time >= '` + start.Format(time.RFC3339Nano) + `' AND time < '` + now.Format(time.RFC3339Nano) + `'`
 
-		results, err := client.QuerySQL(context.Background(), query)
+		results, err := client.QueryIntfCounters(context.Background(), start, now)
 		require.NoError(t, err)
 		// Should still have data with default interfaces
 		require.NotEmpty(t, results)
@@ -138,7 +125,6 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 		t.Parallel()
 		mockDB := testClient(t)
 
-		// Insert test device
 		svcStore, err := dzsvc.NewStore(dzsvc.StoreConfig{
 			Logger:     laketesting.NewLogger(),
 			ClickHouse: mockDB,
@@ -164,9 +150,8 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 
 		now := time.Now().UTC()
 		start := now.Add(-30 * time.Minute) // 30 min window gives us 6 data points
-		query := `SELECT * FROM "intfCounters" WHERE time >= '` + start.Format(time.RFC3339Nano) + `' AND time < '` + now.Format(time.RFC3339Nano) + `'`
 
-		results, err := client.QuerySQL(context.Background(), query)
+		results, err := client.QueryIntfCounters(context.Background(), start, now)
 		require.NoError(t, err)
 
 		// Filter to device4
@@ -189,6 +174,66 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_QuerySQL(t *testing.T) {
 			prevOctets = octets
 		}
 	})
+
+	t.Run("time field format matches what convertRowsToUsage expects", func(t *testing.T) {
+		t.Parallel()
+		mockDB := testClient(t)
+
+		svcStore, err := dzsvc.NewStore(dzsvc.StoreConfig{
+			Logger:     laketesting.NewLogger(),
+			ClickHouse: mockDB,
+		})
+		require.NoError(t, err)
+
+		err = svcStore.ReplaceDevices(context.Background(), []dzsvc.Device{
+			{PK: "device5", Code: "DEV5", Interfaces: []dzsvc.Interface{{Name: "eth0", Status: "up"}}},
+		})
+		require.NoError(t, err)
+
+		client := NewMockInfluxDBClient(MockInfluxDBClientConfig{
+			ClickHouse: mockDB,
+			Logger:     laketesting.NewLogger(),
+		})
+
+		now := time.Now().UTC()
+		results, err := client.QueryIntfCounters(context.Background(), now.Add(-10*time.Minute), now)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		for _, row := range results {
+			timeVal := extractStringFromRow(row, "time")
+			require.NotNil(t, timeVal, "time key must exist and be a string")
+
+			// Must be parseable by the time formats used in convertRowsToUsage
+			parsed := false
+			for _, format := range []string{time.RFC3339Nano, time.RFC3339} {
+				if _, err := time.Parse(format, *timeVal); err == nil {
+					parsed = true
+					break
+				}
+			}
+			require.True(t, parsed, "time %q must be parseable by RFC3339Nano or RFC3339", *timeVal)
+		}
+	})
+}
+
+func TestLake_TelemetryUsage_MockInfluxDBClient_QueryBaselineCounter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty results (no historical data in mock)", func(t *testing.T) {
+		t.Parallel()
+		mockDB := testClient(t)
+
+		client := NewMockInfluxDBClient(MockInfluxDBClientConfig{
+			ClickHouse: mockDB,
+			Logger:     laketesting.NewLogger(),
+		})
+
+		now := time.Now().UTC()
+		results, err := client.QueryBaselineCounter(context.Background(), "in-errors", now.Add(-365*24*time.Hour), now)
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
 }
 
 func TestLake_TelemetryUsage_MockInfluxDBClient_Close(t *testing.T) {
@@ -205,40 +250,6 @@ func TestLake_TelemetryUsage_MockInfluxDBClient_Close(t *testing.T) {
 
 		err := client.Close()
 		require.NoError(t, err)
-	})
-}
-
-func TestLake_TelemetryUsage_MockInfluxDBClient_parseTimeRange(t *testing.T) {
-	t.Parallel()
-
-	t.Run("parses RFC3339Nano format", func(t *testing.T) {
-		t.Parallel()
-		query := `SELECT * FROM "intfCounters" WHERE time >= '2024-01-15T10:00:00.123456789Z' AND time < '2024-01-15T11:00:00.987654321Z'`
-		start, end, err := parseTimeRange(query)
-		require.NoError(t, err)
-		require.Equal(t, 2024, start.Year())
-		require.Equal(t, time.January, start.Month())
-		require.Equal(t, 15, start.Day())
-		require.Equal(t, 10, start.Hour())
-		require.Equal(t, 11, end.Hour())
-	})
-
-	t.Run("parses RFC3339 format", func(t *testing.T) {
-		t.Parallel()
-		query := `SELECT * FROM "intfCounters" WHERE time >= '2024-01-15T10:00:00Z' AND time < '2024-01-15T11:00:00Z'`
-		start, end, err := parseTimeRange(query)
-		require.NoError(t, err)
-		require.Equal(t, 10, start.Hour())
-		require.Equal(t, 11, end.Hour())
-	})
-
-	t.Run("defaults to last hour when pattern not found", func(t *testing.T) {
-		t.Parallel()
-		query := `SELECT * FROM "intfCounters"`
-		start, end, err := parseTimeRange(query)
-		require.NoError(t, err)
-		require.WithinDuration(t, time.Now().UTC().Add(-time.Hour), start, 5*time.Second)
-		require.WithinDuration(t, time.Now().UTC(), end, 5*time.Second)
 	})
 }
 

--- a/indexer/pkg/dz/telemetry/usage/store_backfill.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill.go
@@ -50,36 +50,8 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 
 	v.log.Info("telemetry/usage: querying influxdb for backfill", "from", startTimeUTC, "to", endTimeUTC)
 
-	sqlQuery := fmt.Sprintf(`
-		SELECT
-			time,
-			dzd_pubkey,
-			host,
-			intf,
-			model_name,
-			serial_number,
-			"carrier-transitions",
-			"in-broadcast-pkts",
-			"in-discards",
-			"in-errors",
-			"in-fcs-errors",
-			"in-multicast-pkts",
-			"in-octets",
-			"in-pkts",
-			"in-unicast-pkts",
-			"out-broadcast-pkts",
-			"out-discards",
-			"out-errors",
-			"out-multicast-pkts",
-			"out-octets",
-			"out-pkts",
-			"out-unicast-pkts"
-		FROM "intfCounters"
-		WHERE time >= '%s' AND time < '%s'
-	`, startTimeUTC.Format(time.RFC3339Nano), endTimeUTC.Format(time.RFC3339Nano))
-
 	queryStart := time.Now()
-	rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+	rows, err := v.cfg.InfluxDB.QueryIntfCounters(ctx, startTimeUTC, endTimeUTC)
 	metrics.RecordInfluxQuery(v.cfg.DZEnv, "backfill", time.Since(queryStart), len(rows), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query influxdb for backfill: %w", err)

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -18,20 +18,28 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 )
 
-// InfluxDBClient is an interface for querying InfluxDB 3 with SQL
+// InfluxDBClient is an interface for querying InfluxDB interface counter data.
 type InfluxDBClient interface {
-	// QuerySQL executes a SQL query and returns results as a slice of maps
-	QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error)
-	// Close closes the client and releases resources
+	// QueryIntfCounters fetches interface counter rows for [start, end).
+	// Returned rows contain: time (RFC3339Nano string), dzd_pubkey, host, intf,
+	// model_name, serial_number, and all counter field names
+	// (e.g. "in-octets", "out-octets", "in-errors", etc.)
+	QueryIntfCounters(ctx context.Context, start, end time.Time) ([]map[string]any, error)
+	// QueryBaselineCounter fetches the last non-null value of field for each
+	// (dzd_pubkey, intf) pair in the window [lookbackStart, windowStart).
+	// Returned rows contain: dzd_pubkey, intf, value.
+	QueryBaselineCounter(ctx context.Context, field string, lookbackStart, windowStart time.Time) ([]map[string]any, error)
+	// Close closes the client and releases resources.
 	Close() error
 }
 
-// SDKInfluxDBClient implements InfluxDBClient using the official InfluxDB 3 Go SDK
+// SDKInfluxDBClient implements InfluxDBClient using the official InfluxDB 3 Go SDK (Flight SQL).
+// It is kept for compatibility; prefer FluxInfluxDBClient for production use.
 type SDKInfluxDBClient struct {
 	client *influxdb3.Client
 }
 
-// NewSDKInfluxDBClient creates a new SDK-based InfluxDB client
+// NewSDKInfluxDBClient creates a new SDK-based InfluxDB client using Flight SQL.
 func NewSDKInfluxDBClient(host, token, database string) (*SDKInfluxDBClient, error) {
 	client, err := influxdb3.New(influxdb3.ClientConfig{
 		Host:     host,
@@ -44,7 +52,58 @@ func NewSDKInfluxDBClient(host, token, database string) (*SDKInfluxDBClient, err
 	return &SDKInfluxDBClient{client: client}, nil
 }
 
-func (c *SDKInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
+func (c *SDKInfluxDBClient) QueryIntfCounters(ctx context.Context, start, end time.Time) ([]map[string]any, error) {
+	sqlQuery := fmt.Sprintf(`
+		SELECT
+			time,
+			dzd_pubkey,
+			host,
+			intf,
+			model_name,
+			serial_number,
+			"carrier-transitions",
+			"in-broadcast-pkts",
+			"in-discards",
+			"in-errors",
+			"in-fcs-errors",
+			"in-multicast-pkts",
+			"in-octets",
+			"in-pkts",
+			"in-unicast-pkts",
+			"out-broadcast-pkts",
+			"out-discards",
+			"out-errors",
+			"out-multicast-pkts",
+			"out-octets",
+			"out-pkts",
+			"out-unicast-pkts"
+		FROM "intfCounters"
+		WHERE time >= '%s' AND time < '%s'
+	`, start.UTC().Format(time.RFC3339Nano), end.UTC().Format(time.RFC3339Nano))
+	return c.querySQL(ctx, sqlQuery)
+}
+
+func (c *SDKInfluxDBClient) QueryBaselineCounter(ctx context.Context, field string, lookbackStart, windowStart time.Time) ([]map[string]any, error) {
+	sqlQuery := fmt.Sprintf(`
+		SELECT
+			dzd_pubkey,
+			intf,
+			"%s" as value
+		FROM (
+			SELECT
+				dzd_pubkey,
+				intf,
+				"%s",
+				ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
+			FROM "intfCounters"
+			WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
+		) ranked
+		WHERE rn = 1
+	`, field, field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), field)
+	return c.querySQL(ctx, sqlQuery)
+}
+
+func (c *SDKInfluxDBClient) querySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
 	iterator, err := c.client.Query(ctx, sqlQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -391,35 +450,8 @@ func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, 
 	// InfluxDB uses dzd_pubkey as a tag, which we extract and map to device_pk.
 	v.log.Debug("telemetry/usage: executing main influxdb query", "from", startTime.UTC(), "to", endTime.UTC())
 	queryStart := time.Now()
-	sqlQuery := fmt.Sprintf(`
-		SELECT
-			time,
-			dzd_pubkey,
-			host,
-			intf,
-			model_name,
-			serial_number,
-			"carrier-transitions",
-			"in-broadcast-pkts",
-			"in-discards",
-			"in-errors",
-			"in-fcs-errors",
-			"in-multicast-pkts",
-			"in-octets",
-			"in-pkts",
-			"in-unicast-pkts",
-			"out-broadcast-pkts",
-			"out-discards",
-			"out-errors",
-			"out-multicast-pkts",
-			"out-octets",
-			"out-pkts",
-			"out-unicast-pkts"
-		FROM "intfCounters"
-		WHERE time >= '%s' AND time < '%s'
-	`, startTime.UTC().Format(time.RFC3339Nano), endTime.UTC().Format(time.RFC3339Nano))
 
-	rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+	rows, err := v.cfg.InfluxDB.QueryIntfCounters(ctx, startTime, endTime)
 	queryDuration := time.Since(queryStart)
 	metrics.RecordInfluxQuery(v.cfg.DZEnv, "interface_usage", queryDuration, len(rows), err)
 	if err != nil {
@@ -939,25 +971,8 @@ func (v *View) queryBaselineCounters(ctx context.Context, windowStart time.Time)
 	for _, cf := range counterFields {
 		counterStart := time.Now()
 
-		sqlQuery := fmt.Sprintf(`
-			SELECT
-				dzd_pubkey,
-				intf,
-				"%s" as value
-			FROM (
-				SELECT
-					dzd_pubkey,
-					intf,
-					"%s",
-					ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
-				FROM "intfCounters"
-				WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
-			) ranked
-			WHERE rn = 1
-		`, cf.field, cf.field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), cf.field)
-
 		v.log.Debug("telemetry/usage: executing influxdb baseline counter query", "counter", cf.field, "from", lookbackStart.UTC(), "to", windowStart.UTC())
-		rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+		rows, err := v.cfg.InfluxDB.QueryBaselineCounter(ctx, cf.field, lookbackStart, windowStart)
 		counterDuration := time.Since(counterStart)
 		queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
 		metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -264,12 +264,13 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			v.log.Info("telemetry/usage: queried baselines from clickhouse", "unique_keys", totalKeys, "duration", chDuration.String())
 			baselines = chBaselines
 		} else {
-			v.log.Debug("telemetry/usage: no baseline data in clickhouse (0 rows), will query influxdb", "duration", chDuration.String())
+			v.log.Warn("telemetry/usage: no baseline data in clickhouse (0 rows), will query influxdb — this triggers expensive 10-year scans", "duration", chDuration.String())
 		}
 	}
 
 	if baselines == nil {
-		v.log.Debug("telemetry/usage: querying baselines from influxdb (clickhouse returned 0 baselines)")
+		metrics.InfluxBaselineFallbackTotal.WithLabelValues(v.cfg.DZEnv).Inc()
+		v.log.Warn("telemetry/usage: querying baselines from influxdb (clickhouse returned 0 baselines)")
 		baselineCtx, baselineCancel := context.WithTimeout(ctx, 120*time.Second)
 		defer baselineCancel()
 
@@ -922,76 +923,65 @@ func (v *View) queryBaselineCounters(ctx context.Context, windowStart time.Time)
 		{"out-errors", baselines.OutErrors},
 	}
 
-	v.log.Debug("telemetry/usage: querying baseline counters from influxdb", "counters", len(counterFields))
-	var wg sync.WaitGroup
-	errCh := make(chan error, len(counterFields))
+	// For sparse counters, use a 10-year window directly (they're sparse, so rows are rare).
+	// NOTE: These queries are expensive on InfluxDB — run sequentially to avoid saturating
+	// the InfluxDB query budget (25m total in 30s). This path only runs when ClickHouse
+	// has no baseline data, which should be rare in steady state.
+	lookbackStart := windowStart.Add(-10 * 365 * 24 * time.Hour)
+	v.log.Warn("telemetry/usage: querying baseline counters from influxdb (sequential to avoid rate limits)",
+		"counters", len(counterFields),
+		"from", lookbackStart.UTC(),
+		"to", windowStart.UTC(),
+		"lookback", "10y",
+	)
 
+	hasErrors := false
 	for _, cf := range counterFields {
-		wg.Add(1)
-		go func(cf struct {
-			field    string
-			baseline map[string]*int64
-		}) {
-			defer wg.Done()
-			counterStart := time.Now()
+		counterStart := time.Now()
 
-			// For sparse counters, just use 10-year window directly (they're sparse, so it's fast)
-			lookbackStart := windowStart.Add(-10 * 365 * 24 * time.Hour)
-			sqlQuery := fmt.Sprintf(`
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				dzd_pubkey,
+				intf,
+				"%s" as value
+			FROM (
 				SELECT
 					dzd_pubkey,
 					intf,
-					"%s" as value
-				FROM (
-					SELECT
-						dzd_pubkey,
-						intf,
-						"%s",
-						ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
-					FROM "intfCounters"
-					WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
-				) ranked
-				WHERE rn = 1
-			`, cf.field, cf.field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), cf.field)
+					"%s",
+					ROW_NUMBER() OVER (PARTITION BY dzd_pubkey, intf ORDER BY time DESC) as rn
+				FROM "intfCounters"
+				WHERE time >= '%s' AND time < '%s' AND "%s" IS NOT NULL
+			) ranked
+			WHERE rn = 1
+		`, cf.field, cf.field, lookbackStart.Format(time.RFC3339Nano), windowStart.Format(time.RFC3339Nano), cf.field)
 
-			rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
-			counterDuration := time.Since(counterStart)
-			queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
-			metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)
-			if err != nil {
-				v.log.Warn("telemetry/usage: failed to query baseline counter", "counter", cf.field, "error", err, "duration", counterDuration.String())
-				errCh <- fmt.Errorf("failed to query baseline for %s: %w", cf.field, err)
-				return
-			}
-
-			baselineCount := 0
-			for _, row := range rows {
-				devicePK := extractStringFromRow(row, "dzd_pubkey")
-				intf := extractStringFromRow(row, "intf")
-				if devicePK == nil || intf == nil {
-					continue
-				}
-				key := fmt.Sprintf("%s:%s", *devicePK, *intf)
-				value := extractInt64FromRow(row, "value")
-				if value != nil {
-					cf.baseline[key] = value
-					baselineCount++
-				}
-			}
-			v.log.Debug("telemetry/usage: completed baseline counter query", "counter", cf.field, "baselines", baselineCount, "duration", counterDuration.String())
-		}(cf)
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	// Check for errors
-	hasErrors := false
-	for err := range errCh {
+		v.log.Debug("telemetry/usage: executing influxdb baseline counter query", "counter", cf.field, "from", lookbackStart.UTC(), "to", windowStart.UTC())
+		rows, err := v.cfg.InfluxDB.QuerySQL(ctx, sqlQuery)
+		counterDuration := time.Since(counterStart)
+		queryType := "baseline_" + strings.ReplaceAll(cf.field, "-", "_")
+		metrics.RecordInfluxQuery(v.cfg.DZEnv, queryType, counterDuration, len(rows), err)
 		if err != nil {
+			v.log.Warn("telemetry/usage: failed to query baseline counter", "counter", cf.field, "error", err, "duration", counterDuration.String())
 			hasErrors = true
-			v.log.Warn("telemetry/usage: baseline counter query error", "error", err)
+			continue
 		}
+
+		baselineCount := 0
+		for _, row := range rows {
+			devicePK := extractStringFromRow(row, "dzd_pubkey")
+			intf := extractStringFromRow(row, "intf")
+			if devicePK == nil || intf == nil {
+				continue
+			}
+			key := fmt.Sprintf("%s:%s", *devicePK, *intf)
+			value := extractInt64FromRow(row, "value")
+			if value != nil {
+				cf.baseline[key] = value
+				baselineCount++
+			}
+		}
+		v.log.Debug("telemetry/usage: completed baseline counter query", "counter", cf.field, "baselines", baselineCount, "duration", counterDuration.String())
 	}
 
 	if hasErrors {

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -14,13 +14,21 @@ import (
 )
 
 type mockInfluxDBClient struct {
-	querySQLFunc func(ctx context.Context, sqlQuery string) ([]map[string]any, error)
-	closeFunc    func() error
+	queryIntfCountersFunc    func(ctx context.Context, start, end time.Time) ([]map[string]any, error)
+	queryBaselineCounterFunc func(ctx context.Context, field string, lookbackStart, windowStart time.Time) ([]map[string]any, error)
+	closeFunc                func() error
 }
 
-func (m *mockInfluxDBClient) QuerySQL(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
-	if m.querySQLFunc != nil {
-		return m.querySQLFunc(ctx, sqlQuery)
+func (m *mockInfluxDBClient) QueryIntfCounters(ctx context.Context, start, end time.Time) ([]map[string]any, error) {
+	if m.queryIntfCountersFunc != nil {
+		return m.queryIntfCountersFunc(ctx, start, end)
+	}
+	return []map[string]any{}, nil
+}
+
+func (m *mockInfluxDBClient) QueryBaselineCounter(ctx context.Context, field string, lookbackStart, windowStart time.Time) ([]map[string]any, error) {
+	if m.queryBaselineCounterFunc != nil {
+		return m.queryBaselineCounterFunc(ctx, field, lookbackStart, windowStart)
 	}
 	return []map[string]any{}, nil
 }
@@ -370,12 +378,7 @@ func TestLake_TelemetryUsage_View_Ready(t *testing.T) {
 
 		clock := clockwork.NewFakeClock()
 
-		mockInflux := &mockInfluxDBClient{
-			querySQLFunc: func(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
-				// Return empty result for baseline queries and main query
-				return []map[string]any{}, nil
-			},
-		}
+		mockInflux := &mockInfluxDBClient{}
 
 		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),
@@ -407,11 +410,7 @@ func TestLake_TelemetryUsage_View_WaitReady(t *testing.T) {
 		// With mock, we can't create tables - they're created via migrations
 
 		clock := clockwork.NewFakeClock()
-		mockInflux := &mockInfluxDBClient{
-			querySQLFunc: func(ctx context.Context, sqlQuery string) ([]map[string]any, error) {
-				return []map[string]any{}, nil
-			},
-		}
+		mockInflux := &mockInfluxDBClient{}
 
 		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -13,6 +13,9 @@ import (
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"go.temporal.io/sdk/temporal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Activities holds dependencies for DZ ingest activities.
@@ -80,6 +83,18 @@ func (a *Activities) RefreshTelemetryUsage(ctx context.Context) error {
 	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshTelemetryUsage", a.Network, func() (ingestionlog.RefreshResult, error) {
 		result, err := a.TelemUsage.Refresh(ctx)
 		if err != nil {
+			// InfluxDB enforces a rate limit: total query duration in the last 30s cannot
+			// exceed 25 minutes. When this is hit, retrying immediately makes things worse
+			// by consuming more of the rate limit budget. Return non-retryable so Temporal
+			// skips retries and waits for the next natural workflow cycle instead.
+			if status.Code(err) == codes.ResourceExhausted {
+				a.Log.Warn("influxdb rate limit hit, skipping retries until next cycle", "error", err)
+				return result, temporal.NewNonRetryableApplicationError(
+					fmt.Sprintf("telemetry usage refresh: %v", err),
+					"InfluxResourceExhausted",
+					err,
+				)
+			}
 			return result, fmt.Errorf("telemetry usage refresh: %w", err)
 		}
 		return result, nil

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -17,8 +17,9 @@ const (
 	continueAsNewThreshold = 60
 
 	// telemUsageEveryN controls how often telemetry usage refreshes run.
-	// At 60s base interval, 5 iterations = ~5 minutes.
-	telemUsageEveryN = 5
+	// At 60s base interval, 1 iteration = ~1 minute. Source data is reported
+	// at ~2s resolution so indexing every minute keeps data reasonably fresh.
+	telemUsageEveryN = 1
 )
 
 // RegisterWorkflows registers all DZ ingest workflows with the given worker.

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -123,6 +123,17 @@ var (
 		},
 		[]string{"dz_env", "query_type"},
 	)
+
+	// InfluxBaselineFallbackTotal counts how many times the baseline query fell back to InfluxDB
+	// because ClickHouse returned 0 rows. High values indicate ClickHouse baseline data is stale
+	// or missing, which triggers expensive 10-year InfluxDB scans.
+	InfluxBaselineFallbackTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_influx_baseline_fallback_total",
+			Help: "Total number of times baseline query fell back from ClickHouse to InfluxDB (0 rows from ClickHouse)",
+		},
+		[]string{"dz_env"},
+	)
 )
 
 // RecordInfluxQuery records metrics for an InfluxDB query.


### PR DESCRIPTION
## Summary of Changes
- Replace the InfluxDB client from the Flight SQL gRPC API (`influxdb3-go`) with the Flux HTTP API (`influxdb-client-go/v2`), which has a separate rate-limit budget — eliminating the `ResourceExhausted` errors caused by unrelated Flight SQL clients in the same org
- Replace `InfluxDBClient.QuerySQL(string)` with typed `QueryIntfCounters(start, end)` and `QueryBaselineCounter(field, lookbackStart, windowStart)` methods, moving SQL/Flux query construction out of callers
- Add `FluxInfluxDBClient` using a `pivot()` query for counters and `last()` for baselines; normalizes Flux output (`_time` → `time` as RFC3339Nano, `_value` → `value`, strips metadata columns) to match the existing row shape expected by `convertRowsToUsage`
- Add non-retryable Temporal error for gRPC `ResourceExhausted` and an `InfluxBaselineFallbackTotal` metric to track ClickHouse→InfluxDB baseline fallbacks

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +279 / -193 |  +86 |
| Scaffolding  |     5 | +36  / -5   |  +31 |
| Tests        |     3 | +345 / -70  | +275 |
| Config/build |     1 | +2   / -2   |    0 |

Mostly new tests and a clean interface swap; core logic change is narrow.

<details>
<summary>Key files (click to expand)</summary>

- `indexer/pkg/dz/telemetry/usage/flux_influx_client.go` — new Flux client: `QueryIntfCounters` (pivot query), `QueryBaselineCounter` (last() query), row normalization helpers, 4-minute HTTP timeout
- `indexer/pkg/dz/telemetry/usage/view.go` — `InfluxDBClient` interface changed from `QuerySQL` to typed methods; SQL query construction removed from `queryInfluxDB` and `queryBaselineCounters`
- `indexer/pkg/dz/telemetry/usage/flux_influx_client_test.go` — unit tests for `normalizeIntfCounterRow` and `normalizeBaselineRow` verifying output is compatible with `extractStringFromRow`/`extractInt64FromRow` and all time formats used in `convertRowsToUsage`
- `indexer/pkg/dz/telemetry/usage/mock_influx.go` — simplified: `QuerySQL` replaced with `QueryIntfCounters` (calls `generateMockData` directly) and `QueryBaselineCounter` (returns empty); time format updated to RFC3339Nano
- `indexer/pkg/dz/telemetry/usage/store_backfill.go` — SQL query removed; now calls `QueryIntfCounters` directly
- `indexer/pkg/dzingest/activities.go` — gRPC `ResourceExhausted` mapped to non-retryable Temporal error to prevent rapid retry storms
- `indexer/pkg/metrics/metrics.go` — adds `InfluxBaselineFallbackTotal` counter

</details>

## Testing Verification
- All existing tests pass; `flux_influx_client_test.go` adds 17 new cases covering row normalization edge cases (nil fields, metadata stripping, time precision, type compatibility with downstream extractors)
- Verified in prod: first query after a 12-hour gap took ~1 minute (cold parquet files); subsequent incremental queries (~10-minute window) take ~12 seconds
- Flux and Flight SQL confirmed on separate rate-limit budgets: Flux queries succeed while Flight SQL is exhausted