### PR TITLE
indexer: reattach workflow watcher after Temporal connectivity loss

### DIFF
--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -104,8 +104,17 @@ func Start(ctx context.Context, cfg Config) error {
 	log.Info("dzingest: workflow started", "id", wfID)
 
 	go func() {
-		if err := run.Get(ctx, nil); err != nil && ctx.Err() == nil {
-			log.Error("dzingest: workflow failed", "id", wfID, "error", err)
+		current := run
+		for {
+			if err := current.Get(ctx, nil); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Error("dzingest: workflow interrupted, reattaching", "id", wfID, "error", err)
+				current = tc.GetWorkflow(ctx, wfID, "")
+			} else {
+				return
+			}
 		}
 	}()
 

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -117,8 +117,17 @@ func Start(ctx context.Context, cfg Config) error {
 
 	// Watch the workflow in the background so failures surface in logs.
 	go func() {
-		if err := run.Get(ctx, nil); err != nil && ctx.Err() == nil {
-			log.Error("rollup: workflow failed", "id", wfID, "error", err)
+		current := run
+		for {
+			if err := current.Get(ctx, nil); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Error("rollup: workflow interrupted, reattaching", "id", wfID, "error", err)
+				current = tc.GetWorkflow(ctx, wfID, "")
+			} else {
+				return
+			}
 		}
 	}()
 

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -87,8 +87,17 @@ func Start(ctx context.Context, cfg Config) error {
 	log.Info("solingest: workflow started", "id", wfID)
 
 	go func() {
-		if err := run.Get(ctx, nil); err != nil && ctx.Err() == nil {
-			log.Error("solingest: workflow failed", "id", wfID, "error", err)
+		current := run
+		for {
+			if err := current.Get(ctx, nil); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Error("solingest: workflow interrupted, reattaching", "id", wfID, "error", err)
+				current = tc.GetWorkflow(ctx, wfID, "")
+			} else {
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
## Summary of Changes
- The watcher goroutine in `dzingest`, `solingest`, and `rollup` was a one-shot: if `run.Get()` failed for any reason, the goroutine exited silently and future workflow failures would go unlogged for the remainder of the indexer's lifetime
- Changed to a loop that reattaches to the current workflow execution (via `tc.GetWorkflow`) on error, so the watcher survives Temporal server restarts without terminating or disrupting the running workflow

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     3 | +33 / -6    |  +27 |

Small, focused change — identical fix applied to three workflow runner packages.