### PR TITLE
topology: show drained links on map

### DIFF
--- a/api/handlers/topology.go
+++ b/api/handlers/topology.go
@@ -295,7 +295,7 @@ func (a *API) fetchTopologyData(ctx context.Context) (TopologyResponse, error) {
 					AND link_pk != ''
 				GROUP BY link_pk
 			) traffic ON l.pk = traffic.link_pk
-			WHERE l.status IN ('activated', 'drained', 'soft-drained')
+			WHERE l.status IN ('activated', 'soft-drained', 'hard-drained')
 		`
 		rows, err := a.envDB(ctx).Query(ctx, query)
 		if err != nil {

--- a/api/handlers/topology.go
+++ b/api/handlers/topology.go
@@ -295,7 +295,7 @@ func (a *API) fetchTopologyData(ctx context.Context) (TopologyResponse, error) {
 					AND link_pk != ''
 				GROUP BY link_pk
 			) traffic ON l.pk = traffic.link_pk
-			WHERE l.status = 'activated'
+			WHERE l.status IN ('activated', 'drained', 'soft-drained')
 		`
 		rows, err := a.envDB(ctx).Query(ctx, query)
 		if err != nil {

--- a/web/src/components/shared/LinkInfoContent.tsx
+++ b/web/src/components/shared/LinkInfoContent.tsx
@@ -94,7 +94,7 @@ const statusColors: Record<string, string> = {
   activated: 'text-muted-foreground',
   provisioning: 'text-blue-600 dark:text-blue-400',
   'soft-drained': 'text-amber-600 dark:text-amber-400',
-  drained: 'text-amber-600 dark:text-amber-400',
+  'hard-drained': 'text-amber-600 dark:text-amber-400',
   maintenance: 'text-amber-600 dark:text-amber-400',
   suspended: 'text-red-600 dark:text-red-400',
   offline: 'text-red-600 dark:text-red-400',

--- a/web/src/components/shared/LinkInfoContent.tsx
+++ b/web/src/components/shared/LinkInfoContent.tsx
@@ -93,7 +93,10 @@ function formatPercent(value: number): string {
 const statusColors: Record<string, string> = {
   activated: 'text-muted-foreground',
   provisioning: 'text-blue-600 dark:text-blue-400',
+  'soft-drained': 'text-amber-600 dark:text-amber-400',
+  drained: 'text-amber-600 dark:text-amber-400',
   maintenance: 'text-amber-600 dark:text-amber-400',
+  suspended: 'text-red-600 dark:text-red-400',
   offline: 'text-red-600 dark:text-red-400',
 }
 
@@ -132,6 +135,15 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
   if (compact) {
     return (
       <div className="space-y-4">
+        {/* Status badge for non-activated links */}
+        {link.status !== 'activated' && (
+          <div className="flex items-center gap-1.5">
+            <span className={`text-xs font-medium px-1.5 py-0.5 rounded bg-amber-500/15 ${statusColors[link.status] || 'text-muted-foreground'}`}>
+              {link.status}
+            </span>
+          </div>
+        )}
+
         {/* Endpoints with per-direction latency */}
         <div className="grid grid-cols-2 gap-3">
           <div className="p-2 bg-muted/30 rounded-lg">

--- a/web/src/components/shared/link-info-converters.ts
+++ b/web/src/components/shared/link-info-converters.ts
@@ -47,6 +47,7 @@ export function linkDetailToInfo(link: LinkDetail): LinkInfoData {
 export function topologyLinkToInfo(link: {
   pk: string
   code: string
+  status: string
   linkType: string
   bandwidthBps: number
   latencyUs: number
@@ -74,7 +75,7 @@ export function topologyLinkToInfo(link: {
   return {
     pk: link.pk,
     code: link.code,
-    status: 'activated', // Topology links are always activated
+    status: link.status,
     linkType: link.linkType,
     bandwidthBps: link.bandwidthBps,
     sideAPk: link.deviceAPk,

--- a/web/src/components/topology-globe.tsx
+++ b/web/src/components/topology-globe.tsx
@@ -1761,7 +1761,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
     if (multicastTreesMode && dimOtherLinks) return 'rgba(100,100,100,0.08)'
 
     // Drained/soft-drained: dim to signal inactive status
-    if (l.status === 'drained' || l.status === 'soft-drained') {
+    if (l.status === 'hard-drained' || l.status === 'soft-drained') {
       return 'rgba(107,114,128,0.4)'
     }
 
@@ -1807,7 +1807,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
         const criticality = linkCriticalityMap.get(l.pk)
         if (whatifRemovalMode && isRemovedLink) return 0.3
         if (criticalityOverlayEnabled && criticality) return 0.3
-        if (l.status === 'drained' || l.status === 'soft-drained') return 0.3
+        if (l.status === 'hard-drained' || l.status === 'soft-drained') return 0.3
       }
       return 0
     }
@@ -1826,7 +1826,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
         const criticality = linkCriticalityMap.get(l.pk)
         if (whatifRemovalMode && isRemovedLink) return 0.2
         if (criticalityOverlayEnabled && criticality) return 0.2
-        if (l.status === 'drained' || l.status === 'soft-drained') return 0.2
+        if (l.status === 'hard-drained' || l.status === 'soft-drained') return 0.2
       }
       return 0
     }

--- a/web/src/components/topology-globe.tsx
+++ b/web/src/components/topology-globe.tsx
@@ -126,6 +126,7 @@ interface GlobeArcLink {
   entityType: 'link'
   pk: string
   code: string
+  status: string
   linkType: string
   startLat: number
   startLng: number
@@ -778,7 +779,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
   const buildLinkInfo = useCallback((link: TopologyLink): LinkInfo => {
     const healthInfo = linkSlaStatus.get(link.pk)
     return {
-      pk: link.pk, code: link.code, linkType: link.link_type,
+      pk: link.pk, code: link.code, status: link.status, linkType: link.link_type,
       bandwidthBps: link.bandwidth_bps, latencyUs: link.latency_us,
       jitterUs: link.jitter_us ?? 0, latencyAtoZUs: link.latency_a_to_z_us,
       jitterAtoZUs: link.jitter_a_to_z_us ?? 0, latencyZtoAUs: link.latency_z_to_a_us,
@@ -1401,7 +1402,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
 
       arcs.push({
         entityType: 'link',
-        pk: link.pk, code: link.code, linkType: link.link_type,
+        pk: link.pk, code: link.code, status: link.status, linkType: link.link_type,
         startLat: startPos.lat, startLng: startPos.lng,
         endLat: endPos.lat, endLng: endPos.lng,
         bandwidthBps: link.bandwidth_bps, latencyUs: link.latency_us,
@@ -1759,6 +1760,11 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
     // (multicast-tree arcs handle per-publisher rendering separately)
     if (multicastTreesMode && dimOtherLinks) return 'rgba(100,100,100,0.08)'
 
+    // Drained/soft-drained: dim to signal inactive status
+    if (l.status === 'drained' || l.status === 'soft-drained') {
+      return 'rgba(107,114,128,0.4)'
+    }
+
     // Vibrant default gradient for the "living demo" aesthetic
     return ['rgba(0,255,204,0.6)', 'rgba(59,130,246,0.6)']
   }, [selectedItem, linkPathMap, selectedPathIndex, metroLinkPathMap, metroPathSelectedPairs, linkCriticalityMap, removalLink, whatifRemovalMode, linkHealthMode, linkSlaStatus, trafficFlowMode, linkMap, contributorLinksMode, contributorIndexMap, linkTypeMode, criticalityOverlayEnabled, criticalityColors, isisHealthMode, edgeHealthStatus, metroPathModeEnabled, multicastTreesMode, metroClusteringMode, metroIndexMap, dimOtherLinks, isDark, multicastDeviceRoleColorMap, hoveredHighlightPublisherPKs, hoveredDiscrepancyKey])
@@ -1801,6 +1807,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
         const criticality = linkCriticalityMap.get(l.pk)
         if (whatifRemovalMode && isRemovedLink) return 0.3
         if (criticalityOverlayEnabled && criticality) return 0.3
+        if (l.status === 'drained' || l.status === 'soft-drained') return 0.3
       }
       return 0
     }
@@ -1819,6 +1826,7 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
         const criticality = linkCriticalityMap.get(l.pk)
         if (whatifRemovalMode && isRemovedLink) return 0.2
         if (criticalityOverlayEnabled && criticality) return 0.2
+        if (l.status === 'drained' || l.status === 'soft-drained') return 0.2
       }
       return 0
     }

--- a/web/src/components/topology-graph.tsx
+++ b/web/src/components/topology-graph.tsx
@@ -386,6 +386,7 @@ export function TopologyGraph({
       map.set(link.pk, {
         pk: link.pk,
         code: link.code || `${link.side_a_code || 'Unknown'} — ${link.side_z_code || 'Unknown'}`,
+        status: link.status,
         linkType: link.link_type || 'unknown',
         bandwidthBps: link.bandwidth_bps ?? 0,
         latencyUs: link.latency_us ?? 0,

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -1671,7 +1671,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
       }
 
       // Drained/soft-drained links: always show dashed with reduced opacity
-      if (link.status === 'drained' || link.status === 'soft-drained') {
+      if (link.status === 'hard-drained' || link.status === 'soft-drained') {
         useDash = true
         displayOpacity = Math.min(displayOpacity, 0.4)
       }

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -147,6 +147,7 @@ function getStakeColor(stakeShare: number): string {
 interface HoveredLinkInfo {
   pk: string
   code: string
+  status: string
   linkType: string
   bandwidthBps: number
   latencyUs: number
@@ -1669,6 +1670,12 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
         displayOpacity = 1
       }
 
+      // Drained/soft-drained links: always show dashed with reduced opacity
+      if (link.status === 'drained' || link.status === 'soft-drained') {
+        useDash = true
+        displayOpacity = Math.min(displayOpacity, 0.4)
+      }
+
       // Dim all base links when multicast overlay is active (tree segments render on separate layer)
       if (multicastTreesMode && dimOtherLinks && !isSelected && !isHovered) {
         displayOpacity = 0.08
@@ -2137,6 +2144,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
     return {
       pk: link.pk,
       code: link.code,
+      status: link.status,
       linkType: link.link_type,
       bandwidthBps: link.bandwidth_bps,
       latencyUs: link.latency_us,
@@ -2644,6 +2652,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
         setHoveredLink({
           pk,
           code: props.code || '',
+          status: 'activated',
           linkType: 'Inter-Metro',
           bandwidthBps: 0,
           latencyUs: props.avgLatencyUs || 0,

--- a/web/src/components/topology/TopologyHoverPopover.tsx
+++ b/web/src/components/topology/TopologyHoverPopover.tsx
@@ -123,9 +123,9 @@ function LinkHoverContent({ link }: { link: LinkInfo }) {
     <div className="space-y-1">
       <div className="font-medium flex items-center gap-1.5">
         {link.code}
-        {(link.status === 'drained' || link.status === 'soft-drained') && (
+        {(link.status === 'hard-drained' || link.status === 'soft-drained') && (
           <span className="text-[10px] font-normal px-1 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
-            {link.status === 'soft-drained' ? 'soft-drained' : 'drained'}
+            {link.status}
           </span>
         )}
       </div>

--- a/web/src/components/topology/TopologyHoverPopover.tsx
+++ b/web/src/components/topology/TopologyHoverPopover.tsx
@@ -121,7 +121,14 @@ function LinkHoverContent({ link }: { link: LinkInfo }) {
 
   return (
     <div className="space-y-1">
-      <div className="font-medium">{link.code}</div>
+      <div className="font-medium flex items-center gap-1.5">
+        {link.code}
+        {(link.status === 'drained' || link.status === 'soft-drained') && (
+          <span className="text-[10px] font-normal px-1 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
+            {link.status === 'soft-drained' ? 'soft-drained' : 'drained'}
+          </span>
+        )}
+      </div>
       <div className="text-[10px] text-muted-foreground">
         {link.deviceACode}{link.interfaceAName && <span className="font-mono"> ({link.interfaceAName})</span>}
         {' ↔ '}

--- a/web/src/components/topology/details/LinkDetails.tsx
+++ b/web/src/components/topology/details/LinkDetails.tsx
@@ -26,7 +26,7 @@ export function LinkDetailsHeader({ link }: LinkDetailsProps) {
         <EntityLink to={`/dz/links/${link.pk}`} state={{ backLabel: 'topology' }}>
           {link.code}
         </EntityLink>
-        {(link.status === 'drained' || link.status === 'soft-drained') && (
+        {(link.status === 'hard-drained' || link.status === 'soft-drained') && (
           <span className="text-[10px] font-normal px-1 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
             {link.status}
           </span>

--- a/web/src/components/topology/details/LinkDetails.tsx
+++ b/web/src/components/topology/details/LinkDetails.tsx
@@ -22,10 +22,15 @@ export function LinkDetailsHeader({ link }: LinkDetailsProps) {
       <div className="text-xs text-muted-foreground uppercase tracking-wider">
         link
       </div>
-      <div className="text-sm font-medium min-w-0 flex-1">
+      <div className="text-sm font-medium min-w-0 flex-1 flex items-center gap-1.5">
         <EntityLink to={`/dz/links/${link.pk}`} state={{ backLabel: 'topology' }}>
           {link.code}
         </EntityLink>
+        {(link.status === 'drained' || link.status === 'soft-drained') && (
+          <span className="text-[10px] font-normal px-1 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
+            {link.status}
+          </span>
+        )}
       </div>
       <div className="text-xs text-muted-foreground mt-0.5">
         <EntityLink to={`/dz/devices/${link.deviceAPk}`}>{link.deviceACode}</EntityLink>

--- a/web/src/components/topology/types.ts
+++ b/web/src/components/topology/types.ts
@@ -4,6 +4,7 @@
 export interface LinkInfo {
   pk: string
   code: string
+  status: string
   linkType: string
   bandwidthBps: number
   latencyUs: number


### PR DESCRIPTION
## Summary of Changes
- Include drained and soft-drained links in the topology API response (previously filtered to activated only)
- Render drained links with dashed lines and reduced opacity across map and globe views, composing cleanly with all existing color-based overlays
- Show amber status badges in the hover popover, detail panel header, and compact detail view for drained/soft-drained links
- Add missing `drained`, `soft-drained`, and `suspended` entries to the shared status color map

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     6 | +46 / -4    |  +42 |
| Scaffolding  |     3 | +4 / -2     |   +2 |
| **Total**    |     9 | +50 / -6    |  +44 |

Mostly visual rendering logic across the three topology views, plus minor type plumbing to thread `status` through.

<details>
<summary>Key files (click to expand)</summary>

- [`web/src/components/shared/LinkInfoContent.tsx`](https://github.com/malbeclabs/lake/pull/423/files#diff-47c9652479bac76ad4999be4d695ca4963572cb1851262b13d3816a61b7677b7) — add status badge in compact mode for non-activated links; expand status color map with drained/soft-drained/suspended
- [`web/src/components/topology-globe.tsx`](https://github.com/malbeclabs/lake/pull/423/files#diff-9633cf77060a30502d526b23394c9edb449acbd1d7811388b5839ddee5472e30) — add `status` to GlobeArcLink; dim drained arcs to gray and apply dash pattern in getArcDashLength/getArcDashGap
- [`web/src/components/topology-map.tsx`](https://github.com/malbeclabs/lake/pull/423/files#diff-444bd742f75ed6dcff36de0540f721d485b35bc1fc39231d6393ebb50161cad1) — apply dashed lines + capped opacity for drained/soft-drained links after the overlay color cascade
- [`web/src/components/topology/TopologyHoverPopover.tsx`](https://github.com/malbeclabs/lake/pull/423/files#diff-51602b2ea589b4719243d69d53e12e70055556e51712c0688b4ab394c974c24d) — show amber "drained"/"soft-drained" badge next to link code on hover
- [`web/src/components/topology/details/LinkDetails.tsx`](https://github.com/malbeclabs/lake/pull/423/files#diff-1508797486670d51029d98a3ad3167d592b9d931a873cf32a25848b7d2e8bfcb) — show amber status badge in panel header for drained links
- [`api/handlers/topology.go`](https://github.com/malbeclabs/lake/pull/423/files#diff-2b2a9728dca9bbde602f39796c084c975811f1f4334ec186f017a3eaa9d4cff6) — widen link query filter from `status = 'activated'` to `IN ('activated', 'drained', 'soft-drained')`

</details>

## Testing Verification
- Verified Go API and TypeScript both build cleanly
- Visual treatment (dashed + dimmed) composes with all existing overlays — color signals the overlay meaning, dash signals drain status