### PR TITLE
web, api: add p50/p90/p95/p99 percentile modes to traffic charts

### DIFF
--- a/api/handlers/device_metrics.go
+++ b/api/handlers/device_metrics.go
@@ -48,8 +48,16 @@ type DeviceInterfaceTraffic struct {
 	UserPK             string  `json:"user_pk,omitempty"`
 	CYOAType           string  `json:"cyoa_type,omitempty"`
 	InBps              float64 `json:"in_bps"`
-	OutBps             float64 `json:"out_bps"`
+	P50InBps           float64 `json:"p50_in_bps"`
+	P90InBps           float64 `json:"p90_in_bps"`
+	P95InBps           float64 `json:"p95_in_bps"`
+	P99InBps           float64 `json:"p99_in_bps"`
 	MaxInBps           float64 `json:"max_in_bps"`
+	OutBps             float64 `json:"out_bps"`
+	P50OutBps          float64 `json:"p50_out_bps"`
+	P90OutBps          float64 `json:"p90_out_bps"`
+	P95OutBps          float64 `json:"p95_out_bps"`
+	P99OutBps          float64 `json:"p99_out_bps"`
 	MaxOutBps          float64 `json:"max_out_bps"`
 	InErrors           uint64  `json:"in_errors"`
 	OutErrors          uint64  `json:"out_errors"`
@@ -72,12 +80,28 @@ type DeviceMetricsStatus struct {
 // DeviceMetricsTraffic holds aggregated throughput and interface counters.
 type DeviceMetricsTraffic struct {
 	InBps              float64 `json:"in_bps"`
-	OutBps             float64 `json:"out_bps"`
+	P50InBps           float64 `json:"p50_in_bps"`
+	P90InBps           float64 `json:"p90_in_bps"`
+	P95InBps           float64 `json:"p95_in_bps"`
+	P99InBps           float64 `json:"p99_in_bps"`
 	MaxInBps           float64 `json:"max_in_bps"`
+	OutBps             float64 `json:"out_bps"`
+	P50OutBps          float64 `json:"p50_out_bps"`
+	P90OutBps          float64 `json:"p90_out_bps"`
+	P95OutBps          float64 `json:"p95_out_bps"`
+	P99OutBps          float64 `json:"p99_out_bps"`
 	MaxOutBps          float64 `json:"max_out_bps"`
 	InPps              float64 `json:"in_pps"`
-	OutPps             float64 `json:"out_pps"`
+	P50InPps           float64 `json:"p50_in_pps"`
+	P90InPps           float64 `json:"p90_in_pps"`
+	P95InPps           float64 `json:"p95_in_pps"`
+	P99InPps           float64 `json:"p99_in_pps"`
 	MaxInPps           float64 `json:"max_in_pps"`
+	OutPps             float64 `json:"out_pps"`
+	P50OutPps          float64 `json:"p50_out_pps"`
+	P90OutPps          float64 `json:"p90_out_pps"`
+	P95OutPps          float64 `json:"p95_out_pps"`
+	P99OutPps          float64 `json:"p99_out_pps"`
 	MaxOutPps          float64 `json:"max_out_pps"`
 	InErrors           uint64  `json:"in_errors"`
 	OutErrors          uint64  `json:"out_errors"`
@@ -402,12 +426,28 @@ func (a *API) fetchDeviceMetrics(ctx context.Context, devicePK string, params bu
 		if include.Traffic && row != nil {
 			bucket.Traffic = &DeviceMetricsTraffic{
 				InBps:              row.AvgInBps,
-				OutBps:             row.AvgOutBps,
+				P50InBps:           row.P50InBps,
+				P90InBps:           row.P90InBps,
+				P95InBps:           row.P95InBps,
+				P99InBps:           row.P99InBps,
 				MaxInBps:           row.MaxInBps,
+				OutBps:             row.AvgOutBps,
+				P50OutBps:          row.P50OutBps,
+				P90OutBps:          row.P90OutBps,
+				P95OutBps:          row.P95OutBps,
+				P99OutBps:          row.P99OutBps,
 				MaxOutBps:          row.MaxOutBps,
 				InPps:              row.AvgInPps,
-				OutPps:             row.AvgOutPps,
+				P50InPps:           row.P50InPps,
+				P90InPps:           row.P90InPps,
+				P95InPps:           row.P95InPps,
+				P99InPps:           row.P99InPps,
 				MaxInPps:           row.MaxInPps,
+				OutPps:             row.AvgOutPps,
+				P50OutPps:          row.P50OutPps,
+				P90OutPps:          row.P90OutPps,
+				P95OutPps:          row.P95OutPps,
+				P99OutPps:          row.P99OutPps,
 				MaxOutPps:          row.MaxOutPps,
 				InErrors:           row.InErrors,
 				OutErrors:          row.OutErrors,
@@ -431,8 +471,16 @@ func (a *API) fetchDeviceMetrics(ctx context.Context, devicePK string, params bu
 						UserPK:             ir.UserPK,
 						CYOAType:           cyoaTypes[ir.Intf],
 						InBps:              ir.AvgInBps,
-						OutBps:             ir.AvgOutBps,
+						P50InBps:           ir.P50InBps,
+						P90InBps:           ir.P90InBps,
+						P95InBps:           ir.P95InBps,
+						P99InBps:           ir.P99InBps,
 						MaxInBps:           ir.MaxInBps,
+						OutBps:             ir.AvgOutBps,
+						P50OutBps:          ir.P50OutBps,
+						P90OutBps:          ir.P90OutBps,
+						P95OutBps:          ir.P95OutBps,
+						P99OutBps:          ir.P99OutBps,
 						MaxOutBps:          ir.MaxOutBps,
 						InErrors:           ir.InErrors,
 						OutErrors:          ir.OutErrors,
@@ -728,12 +776,28 @@ func (a *API) fetchBulkDeviceMetrics(ctx context.Context, params bucketParams, i
 			if include.Traffic && row != nil {
 				bucket.Traffic = &DeviceMetricsTraffic{
 					InBps:              row.AvgInBps,
-					OutBps:             row.AvgOutBps,
+					P50InBps:           row.P50InBps,
+					P90InBps:           row.P90InBps,
+					P95InBps:           row.P95InBps,
+					P99InBps:           row.P99InBps,
 					MaxInBps:           row.MaxInBps,
+					OutBps:             row.AvgOutBps,
+					P50OutBps:          row.P50OutBps,
+					P90OutBps:          row.P90OutBps,
+					P95OutBps:          row.P95OutBps,
+					P99OutBps:          row.P99OutBps,
 					MaxOutBps:          row.MaxOutBps,
 					InPps:              row.AvgInPps,
-					OutPps:             row.AvgOutPps,
+					P50InPps:           row.P50InPps,
+					P90InPps:           row.P90InPps,
+					P95InPps:           row.P95InPps,
+					P99InPps:           row.P99InPps,
 					MaxInPps:           row.MaxInPps,
+					OutPps:             row.AvgOutPps,
+					P50OutPps:          row.P50OutPps,
+					P90OutPps:          row.P90OutPps,
+					P95OutPps:          row.P95OutPps,
+					P99OutPps:          row.P99OutPps,
 					MaxOutPps:          row.MaxOutPps,
 					InErrors:           row.InErrors,
 					OutErrors:          row.OutErrors,

--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -97,20 +97,52 @@ type LinkMetricsLatency struct {
 // LinkMetricsTraffic holds per-side throughput and interface counters plus utilization.
 type LinkMetricsTraffic struct {
 	SideAInBps              float64 `json:"side_a_in_bps"`
-	SideAOutBps             float64 `json:"side_a_out_bps"`
-	SideZInBps              float64 `json:"side_z_in_bps"`
-	SideZOutBps             float64 `json:"side_z_out_bps"`
+	SideAP50InBps           float64 `json:"side_a_p50_in_bps"`
+	SideAP90InBps           float64 `json:"side_a_p90_in_bps"`
+	SideAP95InBps           float64 `json:"side_a_p95_in_bps"`
+	SideAP99InBps           float64 `json:"side_a_p99_in_bps"`
 	SideAMaxInBps           float64 `json:"side_a_max_in_bps"`
+	SideAOutBps             float64 `json:"side_a_out_bps"`
+	SideAP50OutBps          float64 `json:"side_a_p50_out_bps"`
+	SideAP90OutBps          float64 `json:"side_a_p90_out_bps"`
+	SideAP95OutBps          float64 `json:"side_a_p95_out_bps"`
+	SideAP99OutBps          float64 `json:"side_a_p99_out_bps"`
 	SideAMaxOutBps          float64 `json:"side_a_max_out_bps"`
+	SideZInBps              float64 `json:"side_z_in_bps"`
+	SideZP50InBps           float64 `json:"side_z_p50_in_bps"`
+	SideZP90InBps           float64 `json:"side_z_p90_in_bps"`
+	SideZP95InBps           float64 `json:"side_z_p95_in_bps"`
+	SideZP99InBps           float64 `json:"side_z_p99_in_bps"`
 	SideZMaxInBps           float64 `json:"side_z_max_in_bps"`
+	SideZOutBps             float64 `json:"side_z_out_bps"`
+	SideZP50OutBps          float64 `json:"side_z_p50_out_bps"`
+	SideZP90OutBps          float64 `json:"side_z_p90_out_bps"`
+	SideZP95OutBps          float64 `json:"side_z_p95_out_bps"`
+	SideZP99OutBps          float64 `json:"side_z_p99_out_bps"`
 	SideZMaxOutBps          float64 `json:"side_z_max_out_bps"`
 	SideAInPps              float64 `json:"side_a_in_pps"`
-	SideAOutPps             float64 `json:"side_a_out_pps"`
-	SideZInPps              float64 `json:"side_z_in_pps"`
-	SideZOutPps             float64 `json:"side_z_out_pps"`
+	SideAP50InPps           float64 `json:"side_a_p50_in_pps"`
+	SideAP90InPps           float64 `json:"side_a_p90_in_pps"`
+	SideAP95InPps           float64 `json:"side_a_p95_in_pps"`
+	SideAP99InPps           float64 `json:"side_a_p99_in_pps"`
 	SideAMaxInPps           float64 `json:"side_a_max_in_pps"`
+	SideAOutPps             float64 `json:"side_a_out_pps"`
+	SideAP50OutPps          float64 `json:"side_a_p50_out_pps"`
+	SideAP90OutPps          float64 `json:"side_a_p90_out_pps"`
+	SideAP95OutPps          float64 `json:"side_a_p95_out_pps"`
+	SideAP99OutPps          float64 `json:"side_a_p99_out_pps"`
 	SideAMaxOutPps          float64 `json:"side_a_max_out_pps"`
+	SideZInPps              float64 `json:"side_z_in_pps"`
+	SideZP50InPps           float64 `json:"side_z_p50_in_pps"`
+	SideZP90InPps           float64 `json:"side_z_p90_in_pps"`
+	SideZP95InPps           float64 `json:"side_z_p95_in_pps"`
+	SideZP99InPps           float64 `json:"side_z_p99_in_pps"`
 	SideZMaxInPps           float64 `json:"side_z_max_in_pps"`
+	SideZOutPps             float64 `json:"side_z_out_pps"`
+	SideZP50OutPps          float64 `json:"side_z_p50_out_pps"`
+	SideZP90OutPps          float64 `json:"side_z_p90_out_pps"`
+	SideZP95OutPps          float64 `json:"side_z_p95_out_pps"`
+	SideZP99OutPps          float64 `json:"side_z_p99_out_pps"`
 	SideZMaxOutPps          float64 `json:"side_z_max_out_pps"`
 	SideAInErrors           uint64  `json:"side_a_in_errors"`
 	SideAOutErrors          uint64  `json:"side_a_out_errors"`
@@ -672,12 +704,28 @@ func buildLinkMetricsTraffic(
 	t := &LinkMetricsTraffic{}
 	if hasA {
 		t.SideAInBps = a.AvgInBps
-		t.SideAOutBps = a.AvgOutBps
+		t.SideAP50InBps = a.P50InBps
+		t.SideAP90InBps = a.P90InBps
+		t.SideAP95InBps = a.P95InBps
+		t.SideAP99InBps = a.P99InBps
 		t.SideAMaxInBps = a.MaxInBps
+		t.SideAOutBps = a.AvgOutBps
+		t.SideAP50OutBps = a.P50OutBps
+		t.SideAP90OutBps = a.P90OutBps
+		t.SideAP95OutBps = a.P95OutBps
+		t.SideAP99OutBps = a.P99OutBps
 		t.SideAMaxOutBps = a.MaxOutBps
 		t.SideAInPps = a.AvgInPps
-		t.SideAOutPps = a.AvgOutPps
+		t.SideAP50InPps = a.P50InPps
+		t.SideAP90InPps = a.P90InPps
+		t.SideAP95InPps = a.P95InPps
+		t.SideAP99InPps = a.P99InPps
 		t.SideAMaxInPps = a.MaxInPps
+		t.SideAOutPps = a.AvgOutPps
+		t.SideAP50OutPps = a.P50OutPps
+		t.SideAP90OutPps = a.P90OutPps
+		t.SideAP95OutPps = a.P95OutPps
+		t.SideAP99OutPps = a.P99OutPps
 		t.SideAMaxOutPps = a.MaxOutPps
 		t.SideAInErrors = a.InErrors
 		t.SideAOutErrors = a.OutErrors
@@ -688,12 +736,28 @@ func buildLinkMetricsTraffic(
 	}
 	if hasZ {
 		t.SideZInBps = z.AvgInBps
-		t.SideZOutBps = z.AvgOutBps
+		t.SideZP50InBps = z.P50InBps
+		t.SideZP90InBps = z.P90InBps
+		t.SideZP95InBps = z.P95InBps
+		t.SideZP99InBps = z.P99InBps
 		t.SideZMaxInBps = z.MaxInBps
+		t.SideZOutBps = z.AvgOutBps
+		t.SideZP50OutBps = z.P50OutBps
+		t.SideZP90OutBps = z.P90OutBps
+		t.SideZP95OutBps = z.P95OutBps
+		t.SideZP99OutBps = z.P99OutBps
 		t.SideZMaxOutBps = z.MaxOutBps
 		t.SideZInPps = z.AvgInPps
-		t.SideZOutPps = z.AvgOutPps
+		t.SideZP50InPps = z.P50InPps
+		t.SideZP90InPps = z.P90InPps
+		t.SideZP95InPps = z.P95InPps
+		t.SideZP99InPps = z.P99InPps
 		t.SideZMaxInPps = z.MaxInPps
+		t.SideZOutPps = z.AvgOutPps
+		t.SideZP50OutPps = z.P50OutPps
+		t.SideZP90OutPps = z.P90OutPps
+		t.SideZP95OutPps = z.P95OutPps
+		t.SideZP99OutPps = z.P99OutPps
 		t.SideZMaxOutPps = z.MaxOutPps
 		t.SideZInErrors = z.InErrors
 		t.SideZOutErrors = z.OutErrors

--- a/api/handlers/status_rollup.go
+++ b/api/handlers/status_rollup.go
@@ -698,12 +698,28 @@ type interfaceRollupRow struct {
 
 	// Traffic rates (sample-weighted avg across sub-buckets)
 	AvgInBps  float64
+	P50InBps  float64
+	P90InBps  float64
+	P95InBps  float64
+	P99InBps  float64
 	MaxInBps  float64
 	AvgOutBps float64
+	P50OutBps float64
+	P90OutBps float64
+	P95OutBps float64
+	P99OutBps float64
 	MaxOutBps float64
 	AvgInPps  float64
+	P50InPps  float64
+	P90InPps  float64
+	P95InPps  float64
+	P99InPps  float64
 	MaxInPps  float64
 	AvgOutPps float64
+	P50OutPps float64
+	P90OutPps float64
+	P95OutPps float64
+	P99OutPps float64
 	MaxOutPps float64
 
 	// Entity state
@@ -795,14 +811,30 @@ func queryInterfaceRollup(ctx context.Context, db driver.Conn, params bucketPara
 			sum(in_discards) as total_in_discards,
 			sum(out_discards) as total_out_discards,
 			sum(carrier_transitions) as total_carrier_transitions,
-			-- Traffic rates: avg and max
+			-- Traffic rates: avg, percentiles, and max
 			avg(avg_in_bps) as avg_in_bps,
+			max(p50_in_bps) as p50_in_bps,
+			max(p90_in_bps) as p90_in_bps,
+			max(p95_in_bps) as p95_in_bps,
+			max(p99_in_bps) as p99_in_bps,
 			max(max_in_bps) as max_in_bps,
 			avg(avg_out_bps) as avg_out_bps,
+			max(p50_out_bps) as p50_out_bps,
+			max(p90_out_bps) as p90_out_bps,
+			max(p95_out_bps) as p95_out_bps,
+			max(p99_out_bps) as p99_out_bps,
 			max(max_out_bps) as max_out_bps,
 			avg(avg_in_pps) as avg_in_pps,
+			max(p50_in_pps) as p50_in_pps,
+			max(p90_in_pps) as p90_in_pps,
+			max(p95_in_pps) as p95_in_pps,
+			max(p99_in_pps) as p99_in_pps,
 			max(max_in_pps) as max_in_pps,
 			avg(avg_out_pps) as avg_out_pps,
+			max(p50_out_pps) as p50_out_pps,
+			max(p90_out_pps) as p90_out_pps,
+			max(p95_out_pps) as p95_out_pps,
+			max(p99_out_pps) as p99_out_pps,
 			max(max_out_pps) as max_out_pps,
 			-- Entity state
 			argMax(status, bucket_ts) as agg_status,
@@ -855,8 +887,10 @@ func queryInterfaceRollup(ctx context.Context, db driver.Conn, params bucketPara
 			&r.BucketTS,
 			&r.LinkPK, &r.LinkSide, &r.DevicePK, &r.Intf,
 			&r.InErrors, &r.OutErrors, &r.InFcsErrors, &r.InDiscards, &r.OutDiscards, &r.CarrierTransitions,
-			&r.AvgInBps, &r.MaxInBps, &r.AvgOutBps, &r.MaxOutBps,
-			&r.AvgInPps, &r.MaxInPps, &r.AvgOutPps, &r.MaxOutPps,
+			&r.AvgInBps, &r.P50InBps, &r.P90InBps, &r.P95InBps, &r.P99InBps, &r.MaxInBps,
+			&r.AvgOutBps, &r.P50OutBps, &r.P90OutBps, &r.P95OutBps, &r.P99OutBps, &r.MaxOutBps,
+			&r.AvgInPps, &r.P50InPps, &r.P90InPps, &r.P95InPps, &r.P99InPps, &r.MaxInPps,
+			&r.AvgOutPps, &r.P50OutPps, &r.P90OutPps, &r.P95OutPps, &r.P99OutPps, &r.MaxOutPps,
 			&r.Status, &r.ISISOverload, &r.ISISUnreachable, &r.WasDrained,
 			&r.UserPK,
 		); err != nil {

--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -16,7 +16,7 @@ interface DeviceTrafficChartProps {
   onCursorTime?: (time: number | null) => void
 }
 
-type AggMode = 'avg' | 'peak'
+type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'max'
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316']
 
@@ -117,8 +117,10 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
         const key = `${intf}:${ts}`
         const d = dataMap.get(key)
         if (d) {
-          const inVal = aggMode === 'peak' ? d.max_in_bps : d.in_bps
-          const outVal = aggMode === 'peak' ? d.max_out_bps : d.out_bps
+          const inKey = aggMode === 'max' ? 'max_in_bps' : aggMode === 'avg' ? 'in_bps' : `${aggMode}_in_bps`
+          const outKey = aggMode === 'max' ? 'max_out_bps' : aggMode === 'avg' ? 'out_bps' : `${aggMode}_out_bps`
+          const inVal = (d as unknown as Record<string, number>)[inKey]
+          const outVal = (d as unknown as Record<string, number>)[outKey]
           inVals.push(inVal || null)
           outVals.push(outVal ? -outVal : null)
         } else {
@@ -384,7 +386,11 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
         className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
       >
         <option value="avg">Avg</option>
-        <option value="peak">Peak</option>
+        <option value="p50">P50</option>
+        <option value="p90">P90</option>
+        <option value="p95">P95</option>
+        <option value="p99">P99</option>
+        <option value="max">Max</option>
       </select>
     </div>
   )

--- a/web/src/components/link-charts/LinkTrafficChart.tsx
+++ b/web/src/components/link-charts/LinkTrafficChart.tsx
@@ -18,7 +18,7 @@ interface LinkTrafficChartProps {
   onCursorTime?: (time: number | null) => void
 }
 
-type AggMode = 'avg' | 'peak'
+type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'max'
 type MetricMode = 'bps' | 'pps'
 
 function formatBps(value: number): string {
@@ -37,9 +37,16 @@ function formatPps(value: number): string {
 }
 
 function getTrafficValue(t: LinkMetricsTraffic, side: 'a' | 'z', dir: 'in' | 'out', agg: AggMode, metric: MetricMode): number {
-  const prefix = agg === 'peak' ? (metric === 'bps' ? `side_${side}_max_${dir}_bps` : `side_${side}_max_${dir}_pps`) :
-    (metric === 'bps' ? `side_${side}_${dir}_bps` : `side_${side}_${dir}_pps`)
-  return (t as unknown as Record<string, number>)[prefix] ?? 0
+  const suffix = metric === 'bps' ? 'bps' : 'pps'
+  let key: string
+  if (agg === 'max') {
+    key = `side_${side}_max_${dir}_${suffix}`
+  } else if (agg === 'avg') {
+    key = `side_${side}_${dir}_${suffix}`
+  } else {
+    key = `side_${side}_${agg}_${dir}_${suffix}`
+  }
+  return (t as unknown as Record<string, number>)[key] ?? 0
 }
 
 export function LinkTrafficChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkTrafficChartProps) {
@@ -247,7 +254,11 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
             className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
           >
             <option value="avg">Avg</option>
-            <option value="peak">Peak</option>
+            <option value="p50">P50</option>
+            <option value="p90">P90</option>
+            <option value="p95">P95</option>
+            <option value="p99">P99</option>
+            <option value="max">Max</option>
           </select>
           <select
             value={metricMode}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5110,20 +5110,52 @@ export interface LinkMetricsLatency {
 
 export interface LinkMetricsTraffic {
   side_a_in_bps: number
-  side_a_out_bps: number
-  side_z_in_bps: number
-  side_z_out_bps: number
+  side_a_p50_in_bps: number
+  side_a_p90_in_bps: number
+  side_a_p95_in_bps: number
+  side_a_p99_in_bps: number
   side_a_max_in_bps: number
+  side_a_out_bps: number
+  side_a_p50_out_bps: number
+  side_a_p90_out_bps: number
+  side_a_p95_out_bps: number
+  side_a_p99_out_bps: number
   side_a_max_out_bps: number
+  side_z_in_bps: number
+  side_z_p50_in_bps: number
+  side_z_p90_in_bps: number
+  side_z_p95_in_bps: number
+  side_z_p99_in_bps: number
   side_z_max_in_bps: number
+  side_z_out_bps: number
+  side_z_p50_out_bps: number
+  side_z_p90_out_bps: number
+  side_z_p95_out_bps: number
+  side_z_p99_out_bps: number
   side_z_max_out_bps: number
   side_a_in_pps: number
-  side_a_out_pps: number
-  side_z_in_pps: number
-  side_z_out_pps: number
+  side_a_p50_in_pps: number
+  side_a_p90_in_pps: number
+  side_a_p95_in_pps: number
+  side_a_p99_in_pps: number
   side_a_max_in_pps: number
+  side_a_out_pps: number
+  side_a_p50_out_pps: number
+  side_a_p90_out_pps: number
+  side_a_p95_out_pps: number
+  side_a_p99_out_pps: number
   side_a_max_out_pps: number
+  side_z_in_pps: number
+  side_z_p50_in_pps: number
+  side_z_p90_in_pps: number
+  side_z_p95_in_pps: number
+  side_z_p99_in_pps: number
   side_z_max_in_pps: number
+  side_z_out_pps: number
+  side_z_p50_out_pps: number
+  side_z_p90_out_pps: number
+  side_z_p95_out_pps: number
+  side_z_p99_out_pps: number
   side_z_max_out_pps: number
   side_a_in_errors: number
   side_a_out_errors: number
@@ -5224,12 +5256,28 @@ export interface DeviceMetricsStatus {
 
 export interface DeviceMetricsTraffic {
   in_bps: number
-  out_bps: number
+  p50_in_bps: number
+  p90_in_bps: number
+  p95_in_bps: number
+  p99_in_bps: number
   max_in_bps: number
+  out_bps: number
+  p50_out_bps: number
+  p90_out_bps: number
+  p95_out_bps: number
+  p99_out_bps: number
   max_out_bps: number
   in_pps: number
-  out_pps: number
+  p50_in_pps: number
+  p90_in_pps: number
+  p95_in_pps: number
+  p99_in_pps: number
   max_in_pps: number
+  out_pps: number
+  p50_out_pps: number
+  p90_out_pps: number
+  p95_out_pps: number
+  p99_out_pps: number
   max_out_pps: number
   in_errors: number
   out_errors: number
@@ -5247,8 +5295,16 @@ export interface DeviceInterfaceTraffic {
   user_pk?: string
   cyoa_type?: string
   in_bps: number
-  out_bps: number
+  p50_in_bps: number
+  p90_in_bps: number
+  p95_in_bps: number
+  p99_in_bps: number
   max_in_bps: number
+  out_bps: number
+  p50_out_bps: number
+  p90_out_bps: number
+  p95_out_bps: number
+  p99_out_bps: number
   max_out_bps: number
   in_errors: number
   out_errors: number


### PR DESCRIPTION
## Summary of Changes
- Traffic charts on link and device detail pages now offer P50, P90, P95, P99, and Max aggregation modes in addition to Avg, matching the controls already available on latency/jitter charts
- The percentile columns were already present in `device_interface_rollup_5m` and computed from raw samples via `quantileIf()` — this change threads them through the API response structs and frontend data path so they can be selected in the UI

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     5 | +199 / -30   | +169 |
| Scaffolding  |     1 | +65 / -9     |  +56 |
| **Total**    |     6 | +274 / -39   | +235 |

Mostly mechanical field additions flowing data that already existed in the database up through the API and into chart controls.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/device_metrics.go` — added p50–p99 fields to `DeviceMetricsTraffic` and `DeviceInterfaceTraffic`, populated in both single-device and bulk handlers
- `api/handlers/link_metrics.go` — added p50–p99 fields to `LinkMetricsTraffic`, populated in `buildLinkMetricsTraffic` (shared by single and bulk link endpoints)
- `api/handlers/status_rollup.go` — added p50–p99 fields to `interfaceRollupRow`, expanded SQL query to select `max(pNN_*)` from rollup table, updated scan
- `web/src/components/link-charts/LinkTrafficChart.tsx` — extended `AggMode`, updated `getTrafficValue()` key construction, added P50–P99/Max dropdown options
- `web/src/components/device-charts/DeviceTrafficChart.tsx` — same AggMode and key-lookup changes as link chart, added dropdown options
- `web/src/lib/api.ts` — added percentile fields to `LinkMetricsTraffic`, `DeviceMetricsTraffic`, and `DeviceInterfaceTraffic` TypeScript interfaces

</details>