### PR TITLE
web, api: support deleted users in listing and detail pages

### DIFF
--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -28,6 +28,33 @@ type UserListItem struct {
 	TenantCode  string  `json:"tenant_code"`
 	InBps       float64 `json:"in_bps"`
 	OutBps      float64 `json:"out_bps"`
+	IsDeleted   bool    `json:"is_deleted"`
+}
+
+var userSortFields = map[string]string{
+	"owner":    "owner_pubkey",
+	"kind":     "kind",
+	"dzip":     "dz_ip",
+	"clientip": "client_ip",
+	"device":   "device_code",
+	"metro":    "metro_name",
+	"tenant":   "tenant_code",
+	"status":   "status",
+	"in":       "in_bps",
+	"out":      "out_bps",
+}
+
+var userFilterFields = map[string]FilterFieldConfig{
+	"owner":    {Column: "owner_pubkey", Type: FieldTypeText},
+	"kind":     {Column: "kind", Type: FieldTypeText},
+	"dzip":     {Column: "dz_ip", Type: FieldTypeText},
+	"clientip": {Column: "client_ip", Type: FieldTypeText},
+	"device":   {Column: "device_code", Type: FieldTypeText},
+	"metro":    {Column: "metro_name", Type: FieldTypeText},
+	"tenant":   {Column: "tenant_code", Type: FieldTypeText},
+	"status":   {Column: "status", Type: FieldTypeText},
+	"in":       {Column: "in_bps", Type: FieldTypeBandwidth},
+	"out":      {Column: "out_bps", Type: FieldTypeBandwidth},
 }
 
 func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
@@ -35,19 +62,52 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "owner", userSortFields)
+	filters := ParseFilters(r)
+	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
 	start := time.Now()
 
-	// Get total count
-	countQuery := `SELECT count(*) FROM dz_users_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("users count query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(userFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
+	}
+
+	orderBy := sort.OrderByClause(userSortFields)
+	if orderBy == "" {
+		orderBy = "ORDER BY owner_pubkey ASC"
+	}
+
+	var sourceCTE string
+	var isDeletedExpr string
+	var fromTable string
+	if includeDeleted {
+		sourceCTE = `all_users AS (
+			SELECT
+				argMax(pk, (snapshot_ts, ingested_at, op_id)) as pk,
+				argMax(owner_pubkey, (snapshot_ts, ingested_at, op_id)) as owner_pubkey,
+				argMax(status, (snapshot_ts, ingested_at, op_id)) as status,
+				argMax(kind, (snapshot_ts, ingested_at, op_id)) as kind,
+				argMax(dz_ip, (snapshot_ts, ingested_at, op_id)) as dz_ip,
+				argMax(client_ip, (snapshot_ts, ingested_at, op_id)) as client_ip,
+				argMax(device_pk, (snapshot_ts, ingested_at, op_id)) as device_pk,
+				argMax(tenant_pk, (snapshot_ts, ingested_at, op_id)) as tenant_pk,
+				argMax(is_deleted, (snapshot_ts, ingested_at, op_id)) as is_deleted
+			FROM dim_dz_users_history
+			GROUP BY entity_id
+			HAVING pk != ''
+		),`
+		isDeletedExpr = "u.is_deleted = 1 as is_deleted"
+		fromTable = "all_users"
+	} else {
+		sourceCTE = ""
+		isDeletedExpr = "false as is_deleted"
+		fromTable = "dz_users_current"
 	}
 
 	query := `
-		WITH traffic_rates AS (
+		WITH ` + sourceCTE + `
+		traffic_rates AS (
 			SELECT
 				user_pk,
 				SUM(avg_in_bps) as in_bps,
@@ -56,32 +116,42 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 			WHERE bucket_ts = (SELECT max(bucket_ts) FROM device_interface_rollup_5m)
 				AND user_pk != ''
 			GROUP BY user_pk
+		),
+		users_data AS (
+			SELECT
+				u.pk as pk,
+				COALESCE(u.owner_pubkey, '') as owner_pubkey,
+				u.status as status,
+				COALESCE(u.kind, '') as kind,
+				COALESCE(u.dz_ip, '') as dz_ip,
+				COALESCE(u.client_ip, '') as client_ip,
+				COALESCE(u.device_pk, '') as device_pk,
+				COALESCE(d.code, '') as device_code,
+				COALESCE(m.code, '') as metro_code,
+				COALESCE(m.name, '') as metro_name,
+				COALESCE(u.tenant_pk, '') as tenant_pk,
+				COALESCE(t.code, '') as tenant_code,
+				COALESCE(tr.in_bps, 0) as in_bps,
+				COALESCE(tr.out_bps, 0) as out_bps,
+				` + isDeletedExpr + `
+			FROM ` + fromTable + ` u
+			LEFT JOIN dz_devices_current d ON u.device_pk = d.pk
+			LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
+			LEFT JOIN dz_tenants_current t ON u.tenant_pk = t.pk
+			LEFT JOIN traffic_rates tr ON u.pk = tr.user_pk
 		)
 		SELECT
-			u.pk,
-			COALESCE(u.owner_pubkey, '') as owner_pubkey,
-			u.status,
-			COALESCE(u.kind, '') as kind,
-			COALESCE(u.dz_ip, '') as dz_ip,
-			COALESCE(u.client_ip, '') as client_ip,
-			COALESCE(u.device_pk, '') as device_pk,
-			COALESCE(d.code, '') as device_code,
-			COALESCE(m.code, '') as metro_code,
-			COALESCE(m.name, '') as metro_name,
-			COALESCE(u.tenant_pk, '') as tenant_pk,
-			COALESCE(t.code, '') as tenant_code,
-			COALESCE(tr.in_bps, 0) as in_bps,
-			COALESCE(tr.out_bps, 0) as out_bps
-		FROM dz_users_current u
-		LEFT JOIN dz_devices_current d ON u.device_pk = d.pk
-		LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
-		LEFT JOIN dz_tenants_current t ON u.tenant_pk = t.pk
-		LEFT JOIN traffic_rates tr ON u.pk = tr.user_pk
-		ORDER BY u.owner_pubkey
-		LIMIT ? OFFSET ?
-	`
+			pk, owner_pubkey, status, kind, dz_ip, client_ip, device_pk,
+			device_code, metro_code, metro_name, tenant_pk, tenant_code,
+			in_bps, out_bps, is_deleted,
+			count() OVER () as _total
+		FROM users_data
+		WHERE 1=1` + whereFilter + `
+		` + orderBy + `
+		LIMIT ? OFFSET ?`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	queryArgs := append(filterArgs, pagination.Limit, pagination.Offset)
+	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -93,6 +163,7 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var users []UserListItem
+	var total uint64
 	for rows.Next() {
 		var u UserListItem
 		if err := rows.Scan(
@@ -110,6 +181,8 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 			&u.TenantCode,
 			&u.InBps,
 			&u.OutBps,
+			&u.IsDeleted,
+			&total,
 		); err != nil {
 			logError("users row scan failed", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -124,7 +197,6 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return empty array instead of null
 	if users == nil {
 		users = []UserListItem{}
 	}
@@ -166,6 +238,7 @@ type UserDetail struct {
 	VotePubkey      string  `json:"vote_pubkey"`
 	StakeSol        float64 `json:"stake_sol"`
 	StakeWeightPct  float64 `json:"stake_weight_pct"`
+	IsDeleted       bool    `json:"is_deleted"`
 }
 
 func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +253,25 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now()
 	query := `
-		WITH traffic_rates AS (
+		WITH latest_user AS (
+			SELECT
+				argMax(pk, (snapshot_ts, ingested_at, op_id)) as pk,
+				argMax(owner_pubkey, (snapshot_ts, ingested_at, op_id)) as owner_pubkey,
+				argMax(status, (snapshot_ts, ingested_at, op_id)) as status,
+				argMax(kind, (snapshot_ts, ingested_at, op_id)) as kind,
+				argMax(dz_ip, (snapshot_ts, ingested_at, op_id)) as dz_ip,
+				argMax(client_ip, (snapshot_ts, ingested_at, op_id)) as client_ip,
+				argMax(tunnel_id, (snapshot_ts, ingested_at, op_id)) as tunnel_id,
+				argMax(device_pk, (snapshot_ts, ingested_at, op_id)) as device_pk,
+				argMax(tenant_pk, (snapshot_ts, ingested_at, op_id)) as tenant_pk,
+				argMax(is_deleted, (snapshot_ts, ingested_at, op_id)) as is_deleted
+			FROM dim_dz_users_history
+			WHERE pk = ?
+			GROUP BY entity_id
+			HAVING pk != ''
+			LIMIT 1
+		),
+		traffic_rates AS (
 			SELECT
 				user_pk,
 				SUM(avg_in_bps) as in_bps,
@@ -228,8 +319,9 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 			COALESCE(si.node_pubkey, '') as node_pubkey,
 			COALESCE(si.vote_pubkey, '') as vote_pubkey,
 			COALESCE(si.stake_sol, 0) as stake_sol,
-			CASE WHEN ts.total_lamports > 0 THEN si.stake_lamports * 100.0 / ts.total_lamports ELSE 0 END as stake_weight_pct
-		FROM dz_users_current u
+			CASE WHEN ts.total_lamports > 0 THEN si.stake_lamports * 100.0 / ts.total_lamports ELSE 0 END as stake_weight_pct,
+			u.is_deleted = 1 as is_deleted
+		FROM latest_user u
 		LEFT JOIN dz_devices_current d ON u.device_pk = d.pk
 		LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
 		LEFT JOIN dz_contributors_current c ON d.contributor_pk = c.pk
@@ -237,7 +329,6 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 		LEFT JOIN traffic_rates tr ON u.pk = tr.user_pk
 		LEFT JOIN solana_info si ON u.client_ip = si.gossip_ip
 		CROSS JOIN total_stake ts
-		WHERE u.pk = ?
 	`
 
 	var user UserDetail
@@ -265,6 +356,7 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 		&user.VotePubkey,
 		&user.StakeSol,
 		&user.StakeWeightPct,
+		&user.IsDeleted,
 	)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -265,8 +265,7 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 				argMax(device_pk, (snapshot_ts, ingested_at, op_id)) as device_pk,
 				argMax(tenant_pk, (snapshot_ts, ingested_at, op_id)) as tenant_pk,
 				argMax(is_deleted, (snapshot_ts, ingested_at, op_id)) as is_deleted
-			FROM dim_dz_users_history
-			WHERE pk = ?
+			FROM (SELECT * FROM dim_dz_users_history WHERE pk = ?)
 			GROUP BY entity_id
 			HAVING pk != ''
 			LIMIT 1

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -426,7 +426,12 @@ export function UserDetailPage() {
         <div className="flex items-center gap-3 mb-8">
           <Users className="h-8 w-8 text-muted-foreground" />
           <div>
-            <h1 className="text-2xl font-medium font-mono">{user.pk.slice(0, 8)}...{user.pk.slice(-4)}</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-medium font-mono">{user.pk.slice(0, 8)}...{user.pk.slice(-4)}</h1>
+              {user.is_deleted && (
+                <span className="text-xs px-2 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">Deleted</span>
+              )}
+            </div>
             <div className="text-sm text-muted-foreground">{user.kind || 'Unknown type'}</div>
           </div>
         </div>

--- a/web/src/components/users-page.tsx
+++ b/web/src/components/users-page.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Users, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
 import { Link } from 'react-router-dom'
-import { fetchAllPaginated, fetchUsers } from '@/lib/api'
+import { fetchUsers } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -34,76 +34,12 @@ function truncatePubkey(pubkey: string): string {
   return `${pubkey.slice(0, 6)}...${pubkey.slice(-4)}`
 }
 
-type SortField =
-  | 'owner'
-  | 'kind'
-  | 'dzIp'
-  | 'clientIp'
-  | 'device'
-  | 'metro'
-  | 'tenant'
-  | 'status'
-  | 'in'
-  | 'out'
-
+type SortField = 'owner' | 'kind' | 'dzip' | 'clientip' | 'device' | 'metro' | 'tenant' | 'status' | 'in' | 'out'
 type SortDirection = 'asc' | 'desc'
 
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
+// Valid filter field names as accepted by the API
+const validFilterFields = ['owner', 'kind', 'dzip', 'clientip', 'device', 'metro', 'tenant', 'status', 'in', 'out']
 
-type UnitMap = Record<string, number>
-
-const numericSearchFields: SortField[] = ['in', 'out']
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function parseNumericFilterWithUnits(
-  input: string,
-  unitMap: UnitMap,
-  defaultUnit: string
-): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)([a-zA-Z]+)?$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  const unitRaw = match[3]?.toLowerCase()
-  const unit = unitRaw ?? defaultUnit
-  const multiplier = unitMap[unit]
-  if (!multiplier) return null
-  return { op, value: Number(match[2]) * multiplier }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
-
-// Parse search filters from URL param
-function parseSearchFilters(searchParam: string): string[] {
-  if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
-}
-
-// Valid filter fields for users
-const validFilterFields = ['owner', 'kind', 'ip', 'dzIp', 'clientIp', 'device', 'metro', 'tenant', 'status', 'in', 'out']
-
-// Field prefixes for inline filter
 const userFieldPrefixes = [
   { prefix: 'owner:', description: 'Filter by owner pubkey' },
   { prefix: 'kind:', description: 'Filter by user kind' },
@@ -117,22 +53,23 @@ const userFieldPrefixes = [
   { prefix: 'out:', description: 'Filter by outbound traffic (e.g., >1gbps)' },
 ]
 
-// Fields that support autocomplete
 const userAutocompleteFields: (string | { field: string; minChars: number })[] = ['status', 'kind', 'metro', { field: 'device', minChars: 2 }]
 
-// Parse a filter string into field and value
-function parseFilter(filter: string): { field: string; value: string } {
+function parseSearchFilters(searchParam: string): string[] {
+  if (!searchParam) return []
+  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+}
+
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
-    // Handle camelCase and alias fields
-    const normalizedField = field === 'dzip' ? 'dzIp' : field === 'clientip' ? 'clientIp' : field
-    if (validFilterFields.includes(normalizedField) && value) {
-      return { field: normalizedField, value }
+    if (validFilterFields.includes(field) && value) {
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function UsersPage() {
@@ -140,7 +77,16 @@ export function UsersPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [liveFilter, setLiveFilter] = useState('')
 
-  // Derive pagination from URL
+  const showDeleted = searchParams.get('deleted') === '1'
+  const toggleDeleted = useCallback(() => {
+    setSearchParams(prev => {
+      const newParams = new URLSearchParams(prev)
+      if (showDeleted) { newParams.delete('deleted') } else { newParams.set('deleted', '1') }
+      newParams.delete('page')
+      return newParams
+    })
+  }, [showDeleted, setSearchParams])
+
   const page = parseInt(searchParams.get('page') || '1')
   const offset = (page - 1) * PAGE_SIZE
   const setOffset = useCallback((newOffset: number) => {
@@ -152,16 +98,31 @@ export function UsersPage() {
     })
   }, [setSearchParams])
 
-  // Get sort config from URL (default: owner asc)
   const sortField = (searchParams.get('sort') || 'owner') as SortField
   const sortDirection = (searchParams.get('dir') || 'asc') as SortDirection
 
-  // Get search filters from URL
   const searchParam = searchParams.get('search') || ''
   const searchFilters = parseSearchFilters(searchParam)
 
-  // Combine committed filters with live filter
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
+  const allFilters = liveFilter ? [...searchFilters, liveFilter] : searchFilters
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
+  const { data: response, isLoading, error } = useQuery({
+    queryKey: ['users', offset, sortField, sortDirection, filterKey, showDeleted],
+    queryFn: () => fetchUsers(
+      PAGE_SIZE,
+      offset,
+      sortField,
+      sortDirection,
+      filterParams.length > 0 ? filterParams : undefined,
+      showDeleted
+    ),
+    refetchInterval: 30000,
+    placeholderData: keepPreviousData,
+  })
+
+  const users = response?.items ?? []
 
   const removeFilter = useCallback((filterToRemove: string) => {
     const newFilters = searchFilters.filter(f => f !== filterToRemove)
@@ -184,137 +145,6 @@ export function UsersPage() {
     })
   }, [setSearchParams])
 
-  const { data: response, isLoading, error } = useQuery({
-    queryKey: ['users', 'all'],
-    queryFn: () => fetchAllPaginated(fetchUsers, PAGE_SIZE),
-    refetchInterval: 30000,
-  })
-  const users = response?.items
-  const filteredUsers = useMemo(() => {
-    if (!users) return []
-    if (!activeFilterRaw) return users
-
-    // Parse filter inside memo to ensure fresh parsing on each recompute
-    const filter = parseFilter(activeFilterRaw)
-    const searchField = filter.field as SortField | 'all'
-    const needle = filter.value.trim().toLowerCase()
-    if (!needle) return users
-
-    const numericFilter = parseNumericFilter(filter.value)
-    if (searchField !== 'all' && numericSearchFields.includes(searchField as SortField)) {
-      const unitFilter = parseNumericFilterWithUnits(
-        filter.value,
-        { gbps: 1e9, mbps: 1e6, bps: 1 },
-        'gbps'
-      )
-      const effectiveFilter = unitFilter ?? numericFilter
-      if (!effectiveFilter) {
-        return users
-      }
-      const getNumericValue = (user: typeof users[number]) => {
-        switch (searchField) {
-          case 'in':
-            return user.in_bps
-          case 'out':
-            return user.out_bps
-          default:
-            return 0
-        }
-      }
-      return users.filter(user => matchesNumericFilter(getNumericValue(user), effectiveFilter))
-    }
-
-    // Text search
-    const getSearchValue = (user: typeof users[number], field: string) => {
-      switch (field) {
-        case 'owner':
-          return user.owner_pubkey || ''
-        case 'kind':
-          return user.kind || ''
-        case 'ip':
-          return `${user.dz_ip || ''} ${user.client_ip || ''}`.trim()
-        case 'dzIp':
-          return user.dz_ip || ''
-        case 'clientIp':
-          return user.client_ip || ''
-        case 'device':
-          return user.device_code || ''
-        case 'metro':
-          return `${user.metro_name || ''} ${user.metro_code || ''}`.trim()
-        case 'tenant':
-          return user.tenant_code || ''
-        case 'status':
-          return user.status
-        default:
-          return ''
-      }
-    }
-
-    if (searchField === 'all') {
-      // Search across all text fields
-      return users.filter(user => {
-        const textFields = ['owner', 'kind', 'ip', 'device', 'metro', 'tenant', 'status']
-        return textFields.some(field => getSearchValue(user, field).toLowerCase().includes(needle))
-      })
-    }
-
-    return users.filter(user => getSearchValue(user, searchField).toLowerCase().includes(needle))
-  }, [users, activeFilterRaw])
-  const sortedUsers = useMemo(() => {
-    if (!filteredUsers) return []
-    // Deduplicate by pk to prevent any possible duplicate rows
-    const seen = new Set<string>()
-    const uniqueUsers = filteredUsers.filter(user => {
-      if (seen.has(user.pk)) return false
-      seen.add(user.pk)
-      return true
-    })
-    const sorted = [...uniqueUsers].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'owner':
-          cmp = (a.owner_pubkey || '').localeCompare(b.owner_pubkey || '')
-          break
-        case 'kind':
-          cmp = (a.kind || '').localeCompare(b.kind || '')
-          break
-        case 'dzIp':
-          cmp = (a.dz_ip || '').localeCompare(b.dz_ip || '')
-          break
-        case 'clientIp':
-          cmp = (a.client_ip || '').localeCompare(b.client_ip || '')
-          break
-        case 'device':
-          cmp = (a.device_code || '').localeCompare(b.device_code || '')
-          break
-        case 'metro': {
-          const aMetro = a.metro_name || a.metro_code || ''
-          const bMetro = b.metro_name || b.metro_code || ''
-          cmp = aMetro.localeCompare(bMetro)
-          break
-        }
-        case 'tenant':
-          cmp = (a.tenant_code || '').localeCompare(b.tenant_code || '')
-          break
-        case 'status':
-          cmp = a.status.localeCompare(b.status)
-          break
-        case 'in':
-          cmp = a.in_bps - b.in_bps
-          break
-        case 'out':
-          cmp = a.out_bps - b.out_bps
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-    return sorted
-  }, [filteredUsers, sortField, sortDirection])
-  const pagedUsers = useMemo(
-    () => sortedUsers.slice(offset, offset + PAGE_SIZE),
-    [sortedUsers, offset]
-  )
-
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
@@ -324,6 +154,7 @@ export function UsersPage() {
         newParams.set('sort', field)
         newParams.set('dir', 'asc')
       }
+      newParams.delete('page')
       return newParams
     })
   }
@@ -340,16 +171,17 @@ export function UsersPage() {
     return sortDirection === 'asc' ? 'ascending' : 'descending'
   }
 
-  const prevFilterRef = useRef(activeFilterRaw)
+  // Reset to first page when filter changes
+  const prevFilterRef = useRef(filterKey)
   useEffect(() => {
-    if (prevFilterRef.current === activeFilterRaw) return
-    prevFilterRef.current = activeFilterRaw
+    if (prevFilterRef.current === filterKey) return
+    prevFilterRef.current = filterKey
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
     })
-  }, [activeFilterRaw, setSearchParams])
+  }, [filterKey, setSearchParams])
 
   if (isLoading) {
     return (
@@ -398,6 +230,16 @@ export function UsersPage() {
                   Clear all
                 </button>
               )}
+              <button
+                onClick={toggleDeleted}
+                className={`text-xs px-2 py-1 rounded-md border transition-colors ${
+                  showDeleted
+                    ? 'bg-gray-500/15 text-gray-500 border-gray-500/30 hover:bg-gray-500/25'
+                    : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+                }`}
+              >
+                {showDeleted ? 'Hide deleted' : 'Show deleted'}
+              </button>
               <InlineFilter
                 fieldPrefixes={userFieldPrefixes}
                 entity="users"
@@ -427,16 +269,16 @@ export function UsersPage() {
                       <SortIcon field="kind" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('clientIp')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('clientIp')}>
+                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('clientip')}>
+                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('clientip')}>
                       Client IP
-                      <SortIcon field="clientIp" />
+                      <SortIcon field="clientip" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('dzIp')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('dzIp')}>
+                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('dzip')}>
+                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('dzip')}>
                       DZ IP
-                      <SortIcon field="dzIp" />
+                      <SortIcon field="dzip" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('device')}>
@@ -478,7 +320,7 @@ export function UsersPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedUsers.map((user) => (
+                {users.map((user) => (
                   <tr
                     key={user.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -510,8 +352,11 @@ export function UsersPage() {
                         : <span className="text-muted-foreground">—</span>
                       }
                     </td>
-                    <td className={`px-4 py-3 text-sm capitalize ${statusColors[user.status] || ''}`}>
-                      {user.status}
+                    <td className="px-4 py-3 text-sm">
+                      {user.is_deleted
+                        ? <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">Deleted</span>
+                        : <span className={`capitalize ${statusColors[user.status] || ''}`}>{user.status}</span>
+                      }
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right text-muted-foreground">
                       {formatBps(user.in_bps)}
@@ -521,7 +366,7 @@ export function UsersPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedUsers.length === 0 && (
+                {users.length === 0 && (
                   <tr>
                     <td colSpan={10} className="px-4 py-8 text-center text-muted-foreground">
                       No users found
@@ -533,7 +378,7 @@ export function UsersPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedUsers.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2980,10 +2980,25 @@ export interface User {
   tenant_code: string
   in_bps: number
   out_bps: number
+  is_deleted: boolean
 }
 
-export async function fetchUsers(limit = 100, offset = 0): Promise<PaginatedResponse<User>> {
-  const res = await fetchWithRetry(`/api/dz/users?limit=${limit}&offset=${offset}`)
+export async function fetchUsers(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[],
+  includeDeleted = false
+): Promise<PaginatedResponse<User>> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) })
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) {
+    for (const f of filters) params.append('filters', f)
+  }
+  if (includeDeleted) params.set('include_deleted', 'true')
+  const res = await fetchWithRetry(`/api/dz/users?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch users')
   }
@@ -3001,6 +3016,7 @@ export interface UserDetail extends User {
   vote_pubkey: string
   stake_sol: number
   stake_weight_pct: number
+  is_deleted: boolean
 }
 
 export async function fetchUser(pk: string): Promise<UserDetail> {


### PR DESCRIPTION
## Summary of Changes
- User detail pages now load for deleted users — queries `dim_dz_users_history` via `argMax` fallback instead of returning 404, and shows a gray **Deleted** badge in the header
- Users listing gains a **Show/Hide deleted** toggle that fetches deleted users server-side (`include_deleted=true`); deleted rows show a **Deleted** badge in the Status column instead of their last known status
- `GetUsers` fully pushed to SQL: server-side filtering, sorting, and pagination using the same `ParseFilters`/`ParseSort` infrastructure as the validators endpoint — eliminates all client-side filtering, sorting, and deduplication from the frontend, and removes the `fetchAllPaginated` multi-request pattern that was hitting the rate limiter

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net  |
|--------------|-------|---------------|------|
| Core logic   |     4 | +227 / -269   |  -42 |
| **Total**    |     4 | +227 / -269   |  -42 |

Net negative — the client-side filtering/sorting code removed from the frontend outweighs the new API logic added.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/users.go`](https://github.com/malbeclabs/lake/pull/425/files#diff-b37aaa639ab7a185adbfd347429ee0e2d97f8d299f2b7ca3adb90b51ee4df4b2) — rewrites `GetUsers` with server-side filter/sort/pagination and `count() OVER ()` for totals; adds `include_deleted` path using `dim_dz_users_history` aggregation; updates `GetUser` to fall back to history for deleted users
- [`web/src/components/users-page.tsx`](https://github.com/malbeclabs/lake/pull/425/files#diff-5d1817bf09e4233eb7f9681210164a3e414b828d1920254a1246aad5e6499ce5) — removes ~200 lines of client-side filter/sort/dedup; replaces `fetchAllPaginated` with a single server-paged `useQuery`; adds Show/Hide deleted toggle persisted in URL
- [`web/src/lib/api.ts`](https://github.com/malbeclabs/lake/pull/425/files#diff-af490ef10b2e4da7f8055bd843c240828a9e8bcd6e6244b55888fe13f8ce8f7a) — adds `is_deleted` to `User` and `UserDetail` types; updates `fetchUsers` signature to accept sort, filters, and `includeDeleted` params
- [`web/src/components/user-detail-page.tsx`](https://github.com/malbeclabs/lake/pull/425/files#diff-fd6bd5fee0f2ffee199e113860843a93020814c203f3cd5c776c74016f1642ae) — renders Deleted badge in header when `user.is_deleted` is true

</details>

## Testing Verification
- Navigating directly to a deleted user's detail page loads successfully with the Deleted badge visible
- Show deleted toggle on the users listing fetches and displays deleted users with the Deleted badge in the Status column; Hide deleted returns to the normal view
- Filters, sort, and pagination all operate server-side with a single request per page change