### PR TITLE
web, api: push filtering/sorting/pagination to SQL for all entity listing pages

### DIFF
--- a/api/handlers/contributors.go
+++ b/api/handlers/contributors.go
@@ -22,21 +22,39 @@ type ContributorListItem struct {
 	LinkCount    uint64 `json:"link_count"`
 }
 
+var contributorSortFields = map[string]string{
+	"code":    "code",
+	"name":    "name",
+	"devices": "device_count",
+	"sidea":   "side_a_devices",
+	"sidez":   "side_z_devices",
+	"links":   "link_count",
+}
+
+var contributorFilterFields = map[string]FilterFieldConfig{
+	"code":    {Column: "code", Type: FieldTypeText},
+	"name":    {Column: "name", Type: FieldTypeText},
+	"devices": {Column: "device_count", Type: FieldTypeNumeric},
+	"sidea":   {Column: "side_a_devices", Type: FieldTypeNumeric},
+	"sidez":   {Column: "side_z_devices", Type: FieldTypeNumeric},
+	"links":   {Column: "link_count", Type: FieldTypeNumeric},
+}
+
 func (a *API) GetContributors(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", contributorSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
-	// Get total count
-	countQuery := `SELECT count(*) FROM dz_contributors_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("contributors count query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(contributorFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
 	}
+	orderBy := sort.OrderByClause(contributorSortFields)
 
 	query := `
 		WITH device_counts AS (
@@ -64,25 +82,33 @@ func (a *API) GetContributors(w http.ResponseWriter, r *http.Request) {
 			FROM dz_links_current
 			WHERE contributor_pk IS NOT NULL
 			GROUP BY contributor_pk
+		),
+		contributors_data AS (
+			SELECT
+				c.pk as pk,
+				c.code as code,
+				COALESCE(c.name, '') as name,
+				COALESCE(dc.cnt, 0) as device_count,
+				COALESCE(sa.cnt, 0) as side_a_devices,
+				COALESCE(sz.cnt, 0) as side_z_devices,
+				COALESCE(lc.cnt, 0) as link_count
+			FROM dz_contributors_current c
+			LEFT JOIN device_counts dc ON c.pk = dc.contributor_pk
+			LEFT JOIN side_a_counts sa ON c.pk = sa.cpk
+			LEFT JOIN side_z_counts sz ON c.pk = sz.cpk
+			LEFT JOIN link_counts lc ON c.pk = lc.contributor_pk
 		)
-		SELECT
-			c.pk,
-			c.code,
-			COALESCE(c.name, '') as name,
-			COALESCE(dc.cnt, 0) as device_count,
-			COALESCE(sa.cnt, 0) as side_a_devices,
-			COALESCE(sz.cnt, 0) as side_z_devices,
-			COALESCE(lc.cnt, 0) as link_count
-		FROM dz_contributors_current c
-		LEFT JOIN device_counts dc ON c.pk = dc.contributor_pk
-		LEFT JOIN side_a_counts sa ON c.pk = sa.cpk
-		LEFT JOIN side_z_counts sz ON c.pk = sz.cpk
-		LEFT JOIN link_counts lc ON c.pk = lc.contributor_pk
-		ORDER BY c.code
+		SELECT pk, code, name, device_count, side_a_devices, side_z_devices, link_count, count() OVER () as _total
+		FROM contributors_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
 		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -94,6 +120,7 @@ func (a *API) GetContributors(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var contributors []ContributorListItem
+	var total uint64
 	for rows.Next() {
 		var c ContributorListItem
 		if err := rows.Scan(
@@ -104,6 +131,7 @@ func (a *API) GetContributors(w http.ResponseWriter, r *http.Request) {
 			&c.SideADevices,
 			&c.SideZDevices,
 			&c.LinkCount,
+			&total,
 		); err != nil {
 			logError("contributors row scan failed", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/handlers/devices.go
+++ b/api/handlers/devices.go
@@ -30,21 +30,47 @@ type DeviceListItem struct {
 	PeakOutBps      float64 `json:"peak_out_bps"`
 }
 
+var deviceListSortFields = map[string]string{
+	"code":        "code",
+	"type":        "device_type",
+	"contributor": "contributor_code",
+	"metro":       "metro_code",
+	"status":      "status",
+	"users":       "current_users",
+	"in":          "in_bps",
+	"out":         "out_bps",
+	"peakin":      "peak_in_bps",
+	"peakout":     "peak_out_bps",
+}
+
+var deviceListFilterFields = map[string]FilterFieldConfig{
+	"code":        {Column: "code", Type: FieldTypeText},
+	"type":        {Column: "device_type", Type: FieldTypeText},
+	"contributor": {Column: "contributor_code", Type: FieldTypeText},
+	"metro":       {Column: "metro_code", Type: FieldTypeText},
+	"status":      {Column: "status", Type: FieldTypeText},
+	"users":       {Column: "current_users", Type: FieldTypeNumeric},
+	"in":          {Column: "in_bps", Type: FieldTypeBandwidth},
+	"out":         {Column: "out_bps", Type: FieldTypeBandwidth},
+	"peakin":      {Column: "peak_in_bps", Type: FieldTypeBandwidth},
+	"peakout":     {Column: "peak_out_bps", Type: FieldTypeBandwidth},
+}
+
 func (a *API) GetDevices(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", deviceListSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
-	// Get total count
-	countQuery := `SELECT count(*) FROM dz_devices_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("devices count query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(deviceListFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
 	}
+	orderBy := sort.OrderByClause(deviceListSortFields)
 
 	query := `
 		WITH user_counts AS (
@@ -74,34 +100,44 @@ func (a *API) GetDevices(w http.ResponseWriter, r *http.Request) {
 				AND user_tunnel_id IS NULL
 				AND link_pk = ''
 			GROUP BY device_pk
+		),
+		devices_data AS (
+			SELECT
+				d.pk as pk,
+				d.code as code,
+				d.status as status,
+				d.device_type as device_type,
+				COALESCE(d.contributor_pk, '') as contributor_pk,
+				COALESCE(c.code, '') as contributor_code,
+				COALESCE(d.metro_pk, '') as metro_pk,
+				COALESCE(m.code, '') as metro_code,
+				COALESCE(d.public_ip, '') as public_ip,
+				COALESCE(d.max_users, 0) as max_users,
+				COALESCE(uc.user_count, 0) as current_users,
+				COALESCE(tr.in_bps, 0) as in_bps,
+				COALESCE(tr.out_bps, 0) as out_bps,
+				COALESCE(pr.peak_in_bps, 0) as peak_in_bps,
+				COALESCE(pr.peak_out_bps, 0) as peak_out_bps
+			FROM dz_devices_current d
+			LEFT JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+			LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
+			LEFT JOIN user_counts uc ON d.pk = uc.device_pk
+			LEFT JOIN traffic_rates tr ON d.pk = tr.device_pk
+			LEFT JOIN peak_rates pr ON d.pk = pr.device_pk
 		)
 		SELECT
-			d.pk,
-			d.code,
-			d.status,
-			d.device_type,
-			COALESCE(d.contributor_pk, '') as contributor_pk,
-			COALESCE(c.code, '') as contributor_code,
-			COALESCE(d.metro_pk, '') as metro_pk,
-			COALESCE(m.code, '') as metro_code,
-			COALESCE(d.public_ip, '') as public_ip,
-			COALESCE(d.max_users, 0) as max_users,
-			COALESCE(uc.user_count, 0) as current_users,
-			COALESCE(tr.in_bps, 0) as in_bps,
-			COALESCE(tr.out_bps, 0) as out_bps,
-			COALESCE(pr.peak_in_bps, 0) as peak_in_bps,
-			COALESCE(pr.peak_out_bps, 0) as peak_out_bps
-		FROM dz_devices_current d
-		LEFT JOIN dz_contributors_current c ON d.contributor_pk = c.pk
-		LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
-		LEFT JOIN user_counts uc ON d.pk = uc.device_pk
-		LEFT JOIN traffic_rates tr ON d.pk = tr.device_pk
-		LEFT JOIN peak_rates pr ON d.pk = pr.device_pk
-		ORDER BY d.code
+			pk, code, status, device_type, contributor_pk, contributor_code, metro_pk, metro_code, public_ip, max_users, current_users, in_bps, out_bps, peak_in_bps, peak_out_bps,
+			count() OVER () as _total
+		FROM devices_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
 		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -113,6 +149,7 @@ func (a *API) GetDevices(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var devices []DeviceListItem
+	var total uint64
 	for rows.Next() {
 		var d DeviceListItem
 		if err := rows.Scan(
@@ -131,6 +168,7 @@ func (a *API) GetDevices(w http.ResponseWriter, r *http.Request) {
 			&d.OutBps,
 			&d.PeakInBps,
 			&d.PeakOutBps,
+			&total,
 		); err != nil {
 			logError("devices row scan failed", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/handlers/devices_test.go
+++ b/api/handlers/devices_test.go
@@ -189,7 +189,7 @@ func TestGetDevices_OrderedByCode(t *testing.T) {
 
 	insertDevicesTestData(t, api)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/dz/devices", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/devices?sort_by=code&sort_dir=asc", nil)
 	rr := httptest.NewRecorder()
 	api.GetDevices(rr, req)
 
@@ -199,7 +199,7 @@ func TestGetDevices_OrderedByCode(t *testing.T) {
 	err := json.NewDecoder(rr.Body).Decode(&response)
 	require.NoError(t, err)
 
-	// Verify sorted by code
+	// Verify sorted by code ascending
 	assert.Equal(t, "LAX-CORE-01", response.Items[0].Code)
 	assert.Equal(t, "NYC-CORE-01", response.Items[1].Code)
 	assert.Equal(t, "NYC-EDGE-01", response.Items[2].Code)

--- a/api/handlers/links.go
+++ b/api/handlers/links.go
@@ -36,21 +36,55 @@ type LinkListItem struct {
 	LossPercent     float64 `json:"loss_percent"`
 }
 
+var linkSortFields = map[string]string{
+	"code":        "code",
+	"type":        "link_type",
+	"contributor": "contributor_code",
+	"sidea":       "side_a_code",
+	"sidez":       "side_z_code",
+	"status":      "status",
+	"bandwidth":   "bandwidth_bps",
+	"in":          "in_bps",
+	"out":         "out_bps",
+	"utilin":      "utilization_in",
+	"utilout":     "utilization_out",
+	"latency":     "latency_us",
+	"jitter":      "jitter_us",
+	"loss":        "loss_percent",
+}
+
+var linkFilterFields = map[string]FilterFieldConfig{
+	"code":        {Column: "code", Type: FieldTypeText},
+	"type":        {Column: "link_type", Type: FieldTypeText},
+	"contributor": {Column: "contributor_code", Type: FieldTypeText},
+	"sidea":       {Column: "side_a_code", Type: FieldTypeText},
+	"sidez":       {Column: "side_z_code", Type: FieldTypeText},
+	"status":      {Column: "status", Type: FieldTypeText},
+	"bandwidth":   {Column: "bandwidth_bps", Type: FieldTypeBandwidth},
+	"in":          {Column: "in_bps", Type: FieldTypeBandwidth},
+	"out":         {Column: "out_bps", Type: FieldTypeBandwidth},
+	"utilin":      {Column: "utilization_in", Type: FieldTypeNumeric},
+	"utilout":     {Column: "utilization_out", Type: FieldTypeNumeric},
+	"latency":     {Column: "latency_us", Type: FieldTypeNumeric},
+	"jitter":      {Column: "jitter_us", Type: FieldTypeNumeric},
+	"loss":        {Column: "loss_percent", Type: FieldTypeNumeric},
+}
+
 func (a *API) GetLinks(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", linkSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
-	// Get total count
-	countQuery := `SELECT count(*) FROM dz_links_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("links count query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(linkFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
 	}
+	orderBy := sort.OrderByClause(linkSortFields)
 
 	query := `
 		WITH traffic_rates AS (
@@ -72,41 +106,51 @@ func (a *API) GetLinks(w http.ResponseWriter, r *http.Request) {
 			FROM link_rollup_5m FINAL
 			WHERE bucket_ts >= now() - INTERVAL 3 HOUR
 			GROUP BY link_pk
+		),
+		links_data AS (
+			SELECT
+				l.pk as pk,
+				l.code as code,
+				l.status as status,
+				l.link_type as link_type,
+				COALESCE(l.bandwidth_bps, 0) as bandwidth_bps,
+				COALESCE(l.side_a_pk, '') as side_a_pk,
+				COALESCE(da.code, '') as side_a_code,
+				COALESCE(ma.code, '') as side_a_metro,
+				COALESCE(l.side_z_pk, '') as side_z_pk,
+				COALESCE(dz.code, '') as side_z_code,
+				COALESCE(mz.code, '') as side_z_metro,
+				COALESCE(l.contributor_pk, '') as contributor_pk,
+				COALESCE(c.code, '') as contributor_code,
+				COALESCE(tr.in_bps, 0) as in_bps,
+				COALESCE(tr.out_bps, 0) as out_bps,
+				CASE WHEN l.bandwidth_bps > 0 THEN COALESCE(tr.in_bps, 0) * 100.0 / l.bandwidth_bps ELSE 0 END as utilization_in,
+				CASE WHEN l.bandwidth_bps > 0 THEN COALESCE(tr.out_bps, 0) * 100.0 / l.bandwidth_bps ELSE 0 END as utilization_out,
+				COALESCE(ls.avg_rtt_us, 0) as latency_us,
+				COALESCE(ls.avg_jitter_us, 0) as jitter_us,
+				COALESCE(ls.loss_percent, 0) as loss_percent
+			FROM dz_links_current l
+			LEFT JOIN dz_devices_current da ON l.side_a_pk = da.pk
+			LEFT JOIN dz_metros_current ma ON da.metro_pk = ma.pk
+			LEFT JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
+			LEFT JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
+			LEFT JOIN dz_contributors_current c ON l.contributor_pk = c.pk
+			LEFT JOIN traffic_rates tr ON l.pk = tr.link_pk
+			LEFT JOIN latency_stats ls ON l.pk = ls.link_pk
 		)
 		SELECT
-			l.pk,
-			l.code,
-			l.status,
-			l.link_type,
-			COALESCE(l.bandwidth_bps, 0) as bandwidth_bps,
-			COALESCE(l.side_a_pk, '') as side_a_pk,
-			COALESCE(da.code, '') as side_a_code,
-			COALESCE(ma.code, '') as side_a_metro,
-			COALESCE(l.side_z_pk, '') as side_z_pk,
-			COALESCE(dz.code, '') as side_z_code,
-			COALESCE(mz.code, '') as side_z_metro,
-			COALESCE(l.contributor_pk, '') as contributor_pk,
-			COALESCE(c.code, '') as contributor_code,
-			COALESCE(tr.in_bps, 0) as in_bps,
-			COALESCE(tr.out_bps, 0) as out_bps,
-			CASE WHEN l.bandwidth_bps > 0 THEN COALESCE(tr.in_bps, 0) * 100.0 / l.bandwidth_bps ELSE 0 END as utilization_in,
-			CASE WHEN l.bandwidth_bps > 0 THEN COALESCE(tr.out_bps, 0) * 100.0 / l.bandwidth_bps ELSE 0 END as utilization_out,
-			COALESCE(ls.avg_rtt_us, 0) as latency_us,
-			COALESCE(ls.avg_jitter_us, 0) as jitter_us,
-			COALESCE(ls.loss_percent, 0) as loss_percent
-		FROM dz_links_current l
-		LEFT JOIN dz_devices_current da ON l.side_a_pk = da.pk
-		LEFT JOIN dz_metros_current ma ON da.metro_pk = ma.pk
-		LEFT JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
-		LEFT JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
-		LEFT JOIN dz_contributors_current c ON l.contributor_pk = c.pk
-		LEFT JOIN traffic_rates tr ON l.pk = tr.link_pk
-		LEFT JOIN latency_stats ls ON l.pk = ls.link_pk
-		ORDER BY l.code
+			pk, code, status, link_type, bandwidth_bps, side_a_pk, side_a_code, side_a_metro, side_z_pk, side_z_code, side_z_metro, contributor_pk, contributor_code, in_bps, out_bps, utilization_in, utilization_out, latency_us, jitter_us, loss_percent,
+			count() OVER () as _total
+		FROM links_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
 		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -118,6 +162,7 @@ func (a *API) GetLinks(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var links []LinkListItem
+	var total uint64
 	for rows.Next() {
 		var l LinkListItem
 		if err := rows.Scan(
@@ -141,6 +186,7 @@ func (a *API) GetLinks(w http.ResponseWriter, r *http.Request) {
 			&l.LatencyUs,
 			&l.JitterUs,
 			&l.LossPercent,
+			&total,
 		); err != nil {
 			logError("links row scan failed", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/handlers/links_test.go
+++ b/api/handlers/links_test.go
@@ -162,7 +162,7 @@ func TestGetLinks_OrderedByCode(t *testing.T) {
 
 	insertLinksTestData(t, api)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/dz/links", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/links?sort_by=code&sort_dir=asc", nil)
 	rr := httptest.NewRecorder()
 	api.GetLinks(rr, req)
 
@@ -172,7 +172,7 @@ func TestGetLinks_OrderedByCode(t *testing.T) {
 	err := json.NewDecoder(rr.Body).Decode(&response)
 	require.NoError(t, err)
 
-	// Verify sorted by code
+	// Verify sorted by code ascending
 	assert.Equal(t, "LAX-INTERNAL", response.Items[0].Code)
 	assert.Equal(t, "NYC-EDGE-001", response.Items[1].Code)
 	assert.Equal(t, "NYC-LAX-001", response.Items[2].Code)

--- a/api/handlers/metros.go
+++ b/api/handlers/metros.go
@@ -23,21 +23,37 @@ type MetroListItem struct {
 	UserCount   uint64  `json:"user_count"`
 }
 
+var metroSortFields = map[string]string{
+	"code":      "code",
+	"name":      "name",
+	"latitude":  "latitude",
+	"longitude": "longitude",
+	"devices":   "device_count",
+	"users":     "user_count",
+}
+
+var metroFilterFields = map[string]FilterFieldConfig{
+	"code":    {Column: "code", Type: FieldTypeText},
+	"name":    {Column: "name", Type: FieldTypeText},
+	"devices": {Column: "device_count", Type: FieldTypeNumeric},
+	"users":   {Column: "user_count", Type: FieldTypeNumeric},
+}
+
 func (a *API) GetMetros(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", metroSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
-	// Get total count
-	countQuery := `SELECT count(*) FROM dz_metros_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("metros count query failed", "error", err)
-		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(metroFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
 	}
+	orderBy := sort.OrderByClause(metroSortFields)
 
 	query := `
 		WITH device_counts AS (
@@ -52,23 +68,31 @@ func (a *API) GetMetros(w http.ResponseWriter, r *http.Request) {
 			JOIN dz_devices_current d ON u.device_pk = d.pk
 			WHERE u.status = 'activated' AND d.metro_pk IS NOT NULL
 			GROUP BY d.metro_pk
+		),
+		metros_data AS (
+			SELECT
+				m.pk as pk,
+				m.code as code,
+				COALESCE(m.name, '') as name,
+				COALESCE(m.latitude, 0) as latitude,
+				COALESCE(m.longitude, 0) as longitude,
+				COALESCE(dc.device_count, 0) as device_count,
+				COALESCE(uc.user_count, 0) as user_count
+			FROM dz_metros_current m
+			LEFT JOIN device_counts dc ON m.pk = dc.metro_pk
+			LEFT JOIN user_counts uc ON m.pk = uc.metro_pk
 		)
-		SELECT
-			m.pk,
-			m.code,
-			COALESCE(m.name, '') as name,
-			COALESCE(m.latitude, 0) as latitude,
-			COALESCE(m.longitude, 0) as longitude,
-			COALESCE(dc.device_count, 0) as device_count,
-			COALESCE(uc.user_count, 0) as user_count
-		FROM dz_metros_current m
-		LEFT JOIN device_counts dc ON m.pk = dc.metro_pk
-		LEFT JOIN user_counts uc ON m.pk = uc.metro_pk
-		ORDER BY m.code
+		SELECT pk, code, name, latitude, longitude, device_count, user_count, count() OVER () as _total
+		FROM metros_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
 		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -80,6 +104,7 @@ func (a *API) GetMetros(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var metros []MetroListItem
+	var total uint64
 	for rows.Next() {
 		var m MetroListItem
 		if err := rows.Scan(
@@ -90,6 +115,7 @@ func (a *API) GetMetros(w http.ResponseWriter, r *http.Request) {
 			&m.Longitude,
 			&m.DeviceCount,
 			&m.UserCount,
+			&total,
 		); err != nil {
 			logError("metros row scan failed", "error", err)
 			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)

--- a/api/handlers/metros_test.go
+++ b/api/handlers/metros_test.go
@@ -73,7 +73,7 @@ func TestGetMetros_ReturnsAllMetros(t *testing.T) {
 
 	insertMetrosTestData(t, api)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/dz/metros", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/metros?sort_by=code&sort_dir=asc", nil)
 	rr := httptest.NewRecorder()
 	api.GetMetros(rr, req)
 
@@ -85,7 +85,7 @@ func TestGetMetros_ReturnsAllMetros(t *testing.T) {
 	assert.Equal(t, 3, response.Total)
 	assert.Len(t, response.Items, 3)
 
-	// Verify order (should be by code)
+	// Verify order (ascending by code)
 	assert.Equal(t, "CHI", response.Items[0].Code)
 	assert.Equal(t, "LAX", response.Items[1].Code)
 	assert.Equal(t, "NYC", response.Items[2].Code)

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -26,27 +26,78 @@ type MulticastGroupListItem struct {
 	SubscriberCount uint32 `json:"subscriber_count"`
 }
 
+var multicastGroupSortFields = map[string]string{
+	"code":        "code",
+	"ip":          "multicast_ip",
+	"status":      "status",
+	"publishers":  "publisher_count",
+	"subscribers": "subscriber_count",
+}
+
+var multicastGroupFilterFields = map[string]FilterFieldConfig{
+	"code":        {Column: "code", Type: FieldTypeText},
+	"ip":          {Column: "multicast_ip", Type: FieldTypeText},
+	"status":      {Column: "status", Type: FieldTypeText},
+	"publishers":  {Column: "publisher_count", Type: FieldTypeNumeric},
+	"subscribers": {Column: "subscriber_count", Type: FieldTypeNumeric},
+}
+
 func (a *API) GetMulticastGroups(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
+	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", multicastGroupSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
+	filterClause, filterArgs := filters.BuildFilterClause(multicastGroupFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
+	}
+	orderBy := sort.OrderByClause(multicastGroupSortFields)
+
 	query := `
-		SELECT
-			pk,
-			COALESCE(code, '') as code,
-			COALESCE(multicast_ip, '') as multicast_ip,
-			COALESCE(max_bandwidth, 0) as max_bandwidth,
-			COALESCE(status, '') as status,
-			COALESCE(publisher_count, 0) as publisher_count,
-			COALESCE(subscriber_count, 0) as subscriber_count
-		FROM dz_multicast_groups_current
-		WHERE status = 'activated'
-		ORDER BY code
+		WITH pub_sub_counts AS (
+			SELECT
+				group_pk,
+				countIf(mode = 'P') as pub_count,
+				countIf(mode = 'S') as sub_count
+			FROM (
+				SELECT arrayJoin(JSONExtract(u.publishers, 'Array(String)')) as group_pk, 'P' as mode
+				FROM dz_users_current u
+				WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.publishers) > 0
+				UNION ALL
+				SELECT arrayJoin(JSONExtract(u.subscribers, 'Array(String)')) as group_pk, 'S' as mode
+				FROM dz_users_current u
+				WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.subscribers) > 0
+			)
+			GROUP BY group_pk
+		),
+		groups_data AS (
+			SELECT
+				g.pk as pk,
+				COALESCE(g.code, '') as code,
+				COALESCE(g.multicast_ip, '') as multicast_ip,
+				COALESCE(g.max_bandwidth, 0) as max_bandwidth,
+				COALESCE(g.status, '') as status,
+				COALESCE(ps.pub_count, 0) as publisher_count,
+				COALESCE(ps.sub_count, 0) as subscriber_count
+			FROM dz_multicast_groups_current g
+			LEFT JOIN pub_sub_counts ps ON g.pk = ps.group_pk
+		)
+		SELECT pk, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count, count() OVER () as _total
+		FROM groups_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
+		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -58,21 +109,26 @@ func (a *API) GetMulticastGroups(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var groups []MulticastGroupListItem
+	var total uint64
 	for rows.Next() {
 		var g MulticastGroupListItem
+		var pubCount, subCount uint64
 		if err := rows.Scan(
 			&g.PK,
 			&g.Code,
 			&g.MulticastIP,
 			&g.MaxBandwidth,
 			&g.Status,
-			&g.PublisherCount,
-			&g.SubscriberCount,
+			&pubCount,
+			&subCount,
+			&total,
 		); err != nil {
 			logError("multicast groups scan error", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		g.PublisherCount = uint32(pubCount)
+		g.SubscriberCount = uint32(subCount)
 		groups = append(groups, g)
 	}
 
@@ -87,61 +143,15 @@ func (a *API) GetMulticastGroups(w http.ResponseWriter, r *http.Request) {
 		groups = []MulticastGroupListItem{}
 	}
 
-	// Compute real pub/sub counts from dz_users_current since the table columns are often 0
-	if len(groups) > 0 {
-		groupPKs := make([]string, len(groups))
-		groupByPK := make(map[string]int, len(groups))
-		for i, g := range groups {
-			groupPKs[i] = g.PK
-			groupByPK[g.PK] = i
-		}
-
-		countsQuery := `
-			SELECT
-				group_pk,
-				countIf(mode = 'P' OR mode = 'P+S') as pub_count,
-				countIf(mode = 'S' OR mode = 'P+S') as sub_count
-			FROM (
-				SELECT
-					arrayJoin(JSONExtract(u.publishers, 'Array(String)')) as group_pk,
-					'P' as mode
-				FROM dz_users_current u
-				WHERE u.status = 'activated' AND u.kind = 'multicast'
-					AND JSONLength(u.publishers) > 0
-				UNION ALL
-				SELECT
-					arrayJoin(JSONExtract(u.subscribers, 'Array(String)')) as group_pk,
-					'S' as mode
-				FROM dz_users_current u
-				WHERE u.status = 'activated' AND u.kind = 'multicast'
-					AND JSONLength(u.subscribers) > 0
-			)
-			WHERE group_pk IN (?)
-			GROUP BY group_pk
-		`
-
-		countRows, err := a.envDB(ctx).Query(ctx, countsQuery, groupPKs)
-		if err != nil {
-			slog.Warn("multicast groups counts query error", "error", err)
-		} else {
-			defer countRows.Close()
-			for countRows.Next() {
-				var gpk string
-				var pubCount, subCount uint64
-				if err := countRows.Scan(&gpk, &pubCount, &subCount); err != nil {
-					logError("multicast groups counts scan error", "error", err)
-					continue
-				}
-				if idx, ok := groupByPK[gpk]; ok {
-					groups[idx].PublisherCount = uint32(pubCount)
-					groups[idx].SubscriberCount = uint32(subCount)
-				}
-			}
-		}
+	response := PaginatedResponse[MulticastGroupListItem]{
+		Items:  groups,
+		Total:  int(total),
+		Limit:  pagination.Limit,
+		Offset: pagination.Offset,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(groups); err != nil {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		logError("failed to encode response", "error", err)
 	}
 }

--- a/api/handlers/multicast_test.go
+++ b/api/handlers/multicast_test.go
@@ -70,10 +70,11 @@ func TestGetMulticastGroups_Empty(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var groups []handlers.MulticastGroupListItem
-	err := json.NewDecoder(rr.Body).Decode(&groups)
+	var response handlers.PaginatedResponse[handlers.MulticastGroupListItem]
+	err := json.NewDecoder(rr.Body).Decode(&response)
 	require.NoError(t, err)
-	assert.Empty(t, groups)
+	assert.Empty(t, response.Items)
+	assert.Equal(t, 0, response.Total)
 }
 
 func TestGetMulticastGroups_ReturnsRealCounts(t *testing.T) {
@@ -87,16 +88,17 @@ func TestGetMulticastGroups_ReturnsRealCounts(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var groups []handlers.MulticastGroupListItem
-	err := json.NewDecoder(rr.Body).Decode(&groups)
+	var response handlers.PaginatedResponse[handlers.MulticastGroupListItem]
+	err := json.NewDecoder(rr.Body).Decode(&response)
 	require.NoError(t, err)
-	require.Len(t, groups, 1)
+	require.Len(t, response.Items, 1)
+	assert.Equal(t, 1, response.Total)
 
 	// The table has publisher_count=0 / subscriber_count=0, but the enrichment
 	// query should compute the real counts from dz_users_current.
-	assert.Equal(t, "test-group", groups[0].Code)
-	assert.Equal(t, uint32(1), groups[0].PublisherCount, "should compute real publisher count from users")
-	assert.Equal(t, uint32(1), groups[0].SubscriberCount, "should compute real subscriber count from users")
+	assert.Equal(t, "test-group", response.Items[0].Code)
+	assert.Equal(t, uint32(1), response.Items[0].PublisherCount, "should compute real publisher count from users")
+	assert.Equal(t, uint32(1), response.Items[0].SubscriberCount, "should compute real subscriber count from users")
 }
 
 func TestGetMulticastGroup_NotFound(t *testing.T) {

--- a/api/handlers/tenants.go
+++ b/api/handlers/tenants.go
@@ -23,37 +23,56 @@ type TenantListItem struct {
 	BillingRate   uint64 `json:"billing_rate"`
 }
 
+var tenantSortFields = map[string]string{
+	"code":   "code",
+	"vrf_id": "vrf_id",
+}
+
+var tenantFilterFields = map[string]FilterFieldConfig{
+	"code":  {Column: "code", Type: FieldTypeText},
+	"owner": {Column: "owner_pubkey", Type: FieldTypeText},
+}
+
 func (a *API) GetTenants(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	pagination := ParsePagination(r, 100)
+	sort := ParseSort(r, "code", tenantSortFields)
+	filters := ParseFilters(r)
 	start := time.Now()
 
-	countQuery := `SELECT count(*) FROM dz_tenants_current`
-	var total uint64
-	if err := a.envDB(ctx).QueryRow(ctx, countQuery).Scan(&total); err != nil {
-		logError("tenants count query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	filterClause, filterArgs := filters.BuildFilterClause(tenantFilterFields)
+	whereFilter := ""
+	if filterClause != "" {
+		whereFilter = " AND " + filterClause
 	}
+	orderBy := sort.OrderByClause(tenantSortFields)
 
 	query := `
-		SELECT
-			pk,
-			COALESCE(owner_pubkey, '') as owner_pubkey,
-			COALESCE(code, '') as code,
-			COALESCE(payment_status, '') as payment_status,
-			vrf_id,
-			metro_routing,
-			route_liveness,
-			billing_rate
-		FROM dz_tenants_current
-		ORDER BY code
+		WITH tenants_data AS (
+			SELECT
+				pk as pk,
+				COALESCE(owner_pubkey, '') as owner_pubkey,
+				COALESCE(code, '') as code,
+				COALESCE(payment_status, '') as payment_status,
+				vrf_id as vrf_id,
+				metro_routing as metro_routing,
+				route_liveness as route_liveness,
+				billing_rate as billing_rate
+			FROM dz_tenants_current
+		)
+		SELECT pk, owner_pubkey, code, payment_status, vrf_id, metro_routing, route_liveness, billing_rate, count() OVER () as _total
+		FROM tenants_data
+		WHERE 1=1` + whereFilter + " " + orderBy + `
 		LIMIT ? OFFSET ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
+	var args []any
+	args = append(args, filterArgs...)
+	args = append(args, pagination.Limit, pagination.Offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -65,6 +84,7 @@ func (a *API) GetTenants(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var tenants []TenantListItem
+	var total uint64
 	for rows.Next() {
 		var t TenantListItem
 		if err := rows.Scan(
@@ -76,6 +96,7 @@ func (a *API) GetTenants(w http.ResponseWriter, r *http.Request) {
 			&t.MetroRouting,
 			&t.RouteLiveness,
 			&t.BillingRate,
+			&total,
 		); err != nil {
 			logError("tenants scan failed", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -265,8 +265,7 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 				argMax(device_pk, (snapshot_ts, ingested_at, op_id)) as device_pk,
 				argMax(tenant_pk, (snapshot_ts, ingested_at, op_id)) as tenant_pk,
 				argMax(is_deleted, (snapshot_ts, ingested_at, op_id)) as is_deleted
-			FROM dim_dz_users_history
-			WHERE pk = ?
+			FROM (SELECT * FROM dim_dz_users_history WHERE pk = ?)
 			GROUP BY entity_id
 			HAVING pk != ''
 			LIMIT 1

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -265,7 +265,8 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 				argMax(device_pk, (snapshot_ts, ingested_at, op_id)) as device_pk,
 				argMax(tenant_pk, (snapshot_ts, ingested_at, op_id)) as tenant_pk,
 				argMax(is_deleted, (snapshot_ts, ingested_at, op_id)) as is_deleted
-			FROM (SELECT * FROM dim_dz_users_history WHERE pk = ?)
+			FROM dim_dz_users_history
+			WHERE pk = ?
 			GROUP BY entity_id
 			HAVING pk != ''
 			LIMIT 1

--- a/web/src/components/contributors-page.tsx
+++ b/web/src/components/contributors-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -255,8 +256,8 @@ export function ContributorsPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/contributors/${contributor.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{contributor.code}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={contributor.code} className="font-mono text-sm" />
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {contributor.name || '—'}

--- a/web/src/components/contributors-page.tsx
+++ b/web/src/components/contributors-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Building2, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
-import { fetchAllPaginated, fetchContributors } from '@/lib/api'
+import { fetchContributors } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -10,37 +10,8 @@ import { PageHeader } from './page-header'
 
 const PAGE_SIZE = 100
 
-type SortField = 'code' | 'name' | 'devices' | 'sideA' | 'sideZ' | 'links'
+type SortField = 'code' | 'name' | 'devices' | 'sidea' | 'sidez' | 'links'
 type SortDirection = 'asc' | 'desc'
-
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
-
-const numericSearchFields: SortField[] = ['devices', 'sideA', 'sideZ', 'links']
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
 
 // Parse search filters from URL param
 function parseSearchFilters(searchParam: string): string[] {
@@ -49,32 +20,31 @@ function parseSearchFilters(searchParam: string): string[] {
 }
 
 // Valid filter fields for contributors
-const validFilterFields = ['code', 'name', 'devices', 'sideA', 'sideZ', 'links']
+const validFilterFields = ['code', 'name', 'devices', 'sidea', 'sidez', 'links']
 
 // Field prefixes for inline filter
 const contributorFieldPrefixes = [
   { prefix: 'code:', description: 'Filter by contributor code' },
   { prefix: 'name:', description: 'Filter by contributor name' },
   { prefix: 'devices:', description: 'Filter by device count (e.g., >5)' },
+  { prefix: 'sidea:', description: 'Filter by side A device count (e.g., >5)' },
+  { prefix: 'sidez:', description: 'Filter by side Z device count (e.g., >5)' },
   { prefix: 'links:', description: 'Filter by link count (e.g., >10)' },
 ]
 
 // Fields that support autocomplete (none for contributors)
 const contributorAutocompleteFields: string[] = []
 
-// Parse a filter string into field and value
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
-    // Handle camelCase fields
-    const normalizedField = field === 'sidea' ? 'sideA' : field === 'sidez' ? 'sideZ' : field
-    if (validFilterFields.includes(normalizedField) && value) {
-      return { field: normalizedField, value }
+    if (validFilterFields.includes(field) && value) {
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function ContributorsPage() {
@@ -103,7 +73,9 @@ export function ContributorsPage() {
   const searchFilters = parseSearchFilters(searchParam)
 
   // Combine committed filters with live filter
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
+  const allFilters = liveFilter
+    ? [...searchFilters, liveFilter]
+    : searchFilters
 
   const removeFilter = useCallback((filterToRemove: string) => {
     const newFilters = searchFilters.filter(f => f !== filterToRemove)
@@ -126,102 +98,16 @@ export function ContributorsPage() {
     })
   }, [setSearchParams])
 
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
   const { data: response, isLoading, error } = useQuery({
-    queryKey: ['contributors', 'all'],
-    queryFn: () => fetchAllPaginated(fetchContributors, PAGE_SIZE),
+    queryKey: ['contributors', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchContributors(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
-  const contributors = response?.items
-  const filteredContributors = useMemo(() => {
-    if (!contributors) return []
-    if (!activeFilterRaw) return contributors
-
-    // Parse filter inside memo to ensure fresh parsing on each recompute
-    const filter = parseFilter(activeFilterRaw)
-    const searchField = filter.field as SortField | 'all'
-    const needle = filter.value.trim().toLowerCase()
-    if (!needle) return contributors
-
-    const numericFilter = parseNumericFilter(filter.value)
-    if (searchField !== 'all' && numericFilter && numericSearchFields.includes(searchField as SortField)) {
-      const getNumericValue = (contributor: typeof contributors[number]) => {
-        switch (searchField) {
-          case 'devices':
-            return contributor.device_count
-          case 'sideA':
-            return contributor.side_a_devices
-          case 'sideZ':
-            return contributor.side_z_devices
-          case 'links':
-            return contributor.link_count
-          default:
-            return 0
-        }
-      }
-      return contributors.filter(contributor => matchesNumericFilter(getNumericValue(contributor), numericFilter))
-    }
-
-    // Text search
-    const getSearchValue = (contributor: typeof contributors[number], field: string) => {
-      switch (field) {
-        case 'code':
-          return contributor.code
-        case 'name':
-          return contributor.name || ''
-        default:
-          return ''
-      }
-    }
-
-    if (searchField === 'all') {
-      // Search across all text fields
-      return contributors.filter(contributor => {
-        const textFields = ['code', 'name']
-        return textFields.some(field => getSearchValue(contributor, field).toLowerCase().includes(needle))
-      })
-    }
-
-    return contributors.filter(contributor => getSearchValue(contributor, searchField).toLowerCase().includes(needle))
-  }, [contributors, activeFilterRaw])
-  const sortedContributors = useMemo(() => {
-    if (!filteredContributors) return []
-    // Deduplicate by pk to prevent any possible duplicate rows
-    const seen = new Set<string>()
-    const unique = filteredContributors.filter(c => {
-      if (seen.has(c.pk)) return false
-      seen.add(c.pk)
-      return true
-    })
-    const sorted = [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'name':
-          cmp = (a.name || '').localeCompare(b.name || '')
-          break
-        case 'devices':
-          cmp = a.device_count - b.device_count
-          break
-        case 'sideA':
-          cmp = a.side_a_devices - b.side_a_devices
-          break
-        case 'sideZ':
-          cmp = a.side_z_devices - b.side_z_devices
-          break
-        case 'links':
-          cmp = a.link_count - b.link_count
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-    return sorted
-  }, [filteredContributors, sortField, sortDirection])
-  const pagedContributors = useMemo(
-    () => sortedContributors.slice(offset, offset + PAGE_SIZE),
-    [sortedContributors, offset]
-  )
+  const contributors = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -248,16 +134,17 @@ export function ContributorsPage() {
     return sortDirection === 'asc' ? 'ascending' : 'descending'
   }
 
-  const prevFilterRef = useRef(activeFilterRaw)
+  const prevFilterRef = useRef(JSON.stringify(allFilters))
   useEffect(() => {
-    if (prevFilterRef.current === activeFilterRaw) return
-    prevFilterRef.current = activeFilterRaw
+    const key = JSON.stringify(allFilters)
+    if (prevFilterRef.current === key) return
+    prevFilterRef.current = key
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
     })
-  }, [activeFilterRaw, setSearchParams])
+  }, [allFilters, setSearchParams])
 
   if (isLoading) {
     return (
@@ -341,16 +228,16 @@ export function ContributorsPage() {
                       <SortIcon field="devices" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sideA')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sideA')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidea')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidea')}>
                       Side A
-                      <SortIcon field="sideA" />
+                      <SortIcon field="sidea" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sideZ')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sideZ')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidez')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidez')}>
                       Side Z
-                      <SortIcon field="sideZ" />
+                      <SortIcon field="sidez" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('links')}>
@@ -362,7 +249,7 @@ export function ContributorsPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedContributors.map((contributor) => (
+                {contributors.map((contributor) => (
                   <tr
                     key={contributor.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -388,7 +275,7 @@ export function ContributorsPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedContributors.length === 0 && (
+                {contributors.length === 0 && (
                   <tr>
                     <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
                       No contributors found
@@ -400,7 +287,7 @@ export function ContributorsPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedContributors.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/copyable-text.tsx
+++ b/web/src/components/copyable-text.tsx
@@ -4,10 +4,11 @@ import { Copy, Check } from 'lucide-react'
 interface CopyableTextProps {
   text: string
   className?: string
+  iconPosition?: 'left' | 'right'
   children?: React.ReactNode
 }
 
-export function CopyableText({ text, className = '', children }: CopyableTextProps) {
+export function CopyableText({ text, className = '', iconPosition = 'right', children }: CopyableTextProps) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
@@ -16,16 +17,21 @@ export function CopyableText({ text, className = '', children }: CopyableTextPro
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const icon = (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity cursor-pointer"
+      title={copied ? 'Copied!' : 'Copy'}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+    </button>
+  )
+
   return (
     <span className={`inline-flex items-center gap-1 group ${className}`}>
+      {iconPosition === 'left' && icon}
       {children ?? <span>{text}</span>}
-      <button
-        onClick={handleCopy}
-        className="inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity cursor-pointer"
-        title={copied ? 'Copied!' : 'Copy'}
-      >
-        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-      </button>
+      {iconPosition === 'right' && icon}
     </span>
   )
 }

--- a/web/src/components/copyable-text.tsx
+++ b/web/src/components/copyable-text.tsx
@@ -4,9 +4,10 @@ import { Copy, Check } from 'lucide-react'
 interface CopyableTextProps {
   text: string
   className?: string
+  children?: React.ReactNode
 }
 
-export function CopyableText({ text, className = '' }: CopyableTextProps) {
+export function CopyableText({ text, className = '', children }: CopyableTextProps) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
@@ -17,7 +18,7 @@ export function CopyableText({ text, className = '' }: CopyableTextProps) {
 
   return (
     <span className={`inline-flex items-center gap-1 group ${className}`}>
-      <span>{text}</span>
+      {children ?? <span>{text}</span>}
       <button
         onClick={handleCopy}
         className="inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity cursor-pointer"

--- a/web/src/components/devices-page.tsx
+++ b/web/src/components/devices-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -312,8 +313,8 @@ export function DevicesPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/devices/${device.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{device.code}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={device.code} className="font-mono text-sm" />
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground capitalize">
                       {device.device_type?.replace(/_/g, ' ')}

--- a/web/src/components/devices-page.tsx
+++ b/web/src/components/devices-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Server, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
-import { fetchAllPaginated, fetchDevices } from '@/lib/api'
+import { fetchDevices } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -37,62 +37,10 @@ type SortField =
   | 'users'
   | 'in'
   | 'out'
-  | 'peakIn'
-  | 'peakOut'
+  | 'peakin'
+  | 'peakout'
 
 type SortDirection = 'asc' | 'desc'
-
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
-
-type UnitMap = Record<string, number>
-
-const numericSearchFields: SortField[] = [
-  'users',
-  'in',
-  'out',
-  'peakIn',
-  'peakOut',
-]
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function parseNumericFilterWithUnits(
-  input: string,
-  unitMap: UnitMap,
-  defaultUnit: string
-): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)([a-zA-Z]+)?$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  const unitRaw = match[3]?.toLowerCase()
-  const unit = unitRaw ?? defaultUnit
-  const multiplier = unitMap[unit]
-  if (!multiplier) return null
-  return { op, value: Number(match[2]) * multiplier }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
 
 // Parse search filters from URL param
 function parseSearchFilters(searchParam: string): string[] {
@@ -101,7 +49,7 @@ function parseSearchFilters(searchParam: string): string[] {
 }
 
 // Valid filter fields for devices
-const validFilterFields = ['code', 'type', 'contributor', 'metro', 'status', 'users', 'in', 'out', 'peakIn', 'peakOut']
+const validFilterFields = ['code', 'type', 'contributor', 'metro', 'status', 'users', 'in', 'out', 'peakin', 'peakout']
 
 // Field prefixes for inline filter
 const deviceFieldPrefixes = [
@@ -113,22 +61,23 @@ const deviceFieldPrefixes = [
   { prefix: 'users:', description: 'Filter by user count (e.g., >10)' },
   { prefix: 'in:', description: 'Filter by inbound traffic (e.g., >1gbps)' },
   { prefix: 'out:', description: 'Filter by outbound traffic (e.g., >1gbps)' },
+  { prefix: 'peakin:', description: 'Filter by peak inbound traffic (e.g., >1gbps)' },
+  { prefix: 'peakout:', description: 'Filter by peak outbound traffic (e.g., >1gbps)' },
 ]
 
 // Fields that support autocomplete
 const deviceAutocompleteFields = ['status', 'type', 'metro', 'contributor']
 
-// Parse a filter string into field and value
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
     if (validFilterFields.includes(field) && value) {
-      return { field, value }
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function DevicesPage() {
@@ -157,7 +106,6 @@ export function DevicesPage() {
   const searchFilters = parseSearchFilters(searchParam)
 
   // Combine committed filters with live filter
-  // Live filter is combined with committed filters (all must match)
   const allFilters = liveFilter
     ? [...searchFilters, liveFilter]
     : searchFilters
@@ -183,153 +131,16 @@ export function DevicesPage() {
     })
   }, [setSearchParams])
 
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
   const { data: response, isLoading, error } = useQuery({
-    queryKey: ['devices', 'all'],
-    queryFn: () => fetchAllPaginated(fetchDevices, PAGE_SIZE),
+    queryKey: ['devices', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchDevices(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
-  const devices = response?.items
-  const filteredDevices = useMemo(() => {
-    if (!devices) return []
-    if (allFilters.length === 0) return devices
-
-    // Helper to get numeric value for a device field
-    const getNumericValue = (device: typeof devices[number], field: string) => {
-      switch (field) {
-        case 'users':
-          return device.current_users
-        case 'in':
-          return device.in_bps
-        case 'out':
-          return device.out_bps
-        case 'peakIn':
-          return device.peak_in_bps
-        case 'peakOut':
-          return device.peak_out_bps
-        default:
-          return 0
-      }
-    }
-
-    // Helper to get text value for a device field
-    const getSearchValue = (device: typeof devices[number], field: string) => {
-      switch (field) {
-        case 'code':
-          return device.code
-        case 'type': {
-          const type = device.device_type || ''
-          return `${type} ${type.replace(/_/g, ' ')}`.trim()
-        }
-        case 'contributor':
-          return device.contributor_code || ''
-        case 'metro':
-          return device.metro_code || ''
-        case 'status':
-          return device.status
-        case 'users':
-          return `${device.current_users} ${device.max_users}`
-        default:
-          return ''
-      }
-    }
-
-    // Check if a device matches a single filter
-    const matchesSingleFilter = (device: typeof devices[number], filterRaw: string): boolean => {
-      const filter = parseFilter(filterRaw)
-      const searchField = filter.field as SortField | 'all'
-      const needle = filter.value.trim().toLowerCase()
-      if (!needle) return true
-
-      // Handle numeric filters
-      if (searchField !== 'all' && numericSearchFields.includes(searchField as SortField)) {
-        const numericFilter = parseNumericFilter(filter.value)
-        const unitFilter =
-          (searchField === 'in' || searchField === 'out' || searchField === 'peakIn' || searchField === 'peakOut')
-            ? parseNumericFilterWithUnits(
-                filter.value,
-                { gbps: 1e9, mbps: 1e6, bps: 1 },
-                'gbps'
-              )
-            : null
-        const effectiveFilter = unitFilter ?? numericFilter
-        if (!effectiveFilter) return true
-        return matchesNumericFilter(getNumericValue(device, searchField), effectiveFilter)
-      }
-
-      // Handle text filters
-      if (searchField === 'all') {
-        const textFields = ['code', 'type', 'contributor', 'metro', 'status']
-        return textFields.some(field => getSearchValue(device, field).toLowerCase().includes(needle))
-      }
-
-      return getSearchValue(device, searchField).toLowerCase().includes(needle)
-    }
-
-    // Group filters by field, then OR within same field, AND across different fields
-    const grouped = new Map<string, string[]>()
-    for (const f of allFilters) {
-      const { field } = parseFilter(f)
-      const existing = grouped.get(field) ?? []
-      existing.push(f)
-      grouped.set(field, existing)
-    }
-    return devices.filter(device =>
-      Array.from(grouped.values()).every(group =>
-        group.some(f => matchesSingleFilter(device, f))
-      )
-    )
-  }, [devices, allFilters])
-  const sortedDevices = useMemo(() => {
-    if (!filteredDevices) return []
-    // Deduplicate by pk to prevent any possible duplicate rows
-    const seen = new Set<string>()
-    const unique = filteredDevices.filter(d => {
-      if (seen.has(d.pk)) return false
-      seen.add(d.pk)
-      return true
-    })
-    const sorted = [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'type':
-          cmp = (a.device_type || '').localeCompare(b.device_type || '')
-          break
-        case 'contributor':
-          cmp = (a.contributor_code || '').localeCompare(b.contributor_code || '')
-          break
-        case 'metro':
-          cmp = (a.metro_code || '').localeCompare(b.metro_code || '')
-          break
-        case 'status':
-          cmp = a.status.localeCompare(b.status)
-          break
-        case 'users':
-          cmp = a.current_users - b.current_users
-          break
-        case 'in':
-          cmp = a.in_bps - b.in_bps
-          break
-        case 'out':
-          cmp = a.out_bps - b.out_bps
-          break
-        case 'peakIn':
-          cmp = a.peak_in_bps - b.peak_in_bps
-          break
-        case 'peakOut':
-          cmp = a.peak_out_bps - b.peak_out_bps
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-    return sorted
-  }, [filteredDevices, sortField, sortDirection])
-  const pagedDevices = useMemo(
-    () => sortedDevices.slice(offset, offset + PAGE_SIZE),
-    [sortedDevices, offset]
-  )
+  const devices = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -480,22 +291,22 @@ export function DevicesPage() {
                       <SortIcon field="out" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('peakIn')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('peakIn')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('peakin')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('peakin')}>
                       Peak In
-                      <SortIcon field="peakIn" />
+                      <SortIcon field="peakin" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('peakOut')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('peakOut')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('peakout')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('peakout')}>
                       Peak Out
-                      <SortIcon field="peakOut" />
+                      <SortIcon field="peakout" />
                     </button>
                   </th>
                 </tr>
               </thead>
               <tbody>
-                {pagedDevices.map((device) => (
+                {devices.map((device) => (
                   <tr
                     key={device.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -542,7 +353,7 @@ export function DevicesPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedDevices.length === 0 && (
+                {devices.length === 0 && (
                   <tr>
                     <td colSpan={10} className="px-4 py-8 text-center text-muted-foreground">
                       No devices found
@@ -554,7 +365,7 @@ export function DevicesPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedDevices.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/links-page.tsx
+++ b/web/src/components/links-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Link2, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
-import { fetchAllPaginated, fetchLinks } from '@/lib/api'
+import { fetchLinks } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -50,74 +50,19 @@ type SortField =
   | 'code'
   | 'type'
   | 'contributor'
-  | 'sideA'
-  | 'sideZ'
+  | 'sidea'
+  | 'sidez'
   | 'status'
   | 'bandwidth'
   | 'in'
   | 'out'
-  | 'utilIn'
-  | 'utilOut'
+  | 'utilin'
+  | 'utilout'
   | 'latency'
   | 'jitter'
   | 'loss'
 
 type SortDirection = 'asc' | 'desc'
-
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
-
-type UnitMap = Record<string, number>
-
-const numericSearchFields: SortField[] = [
-  'bandwidth',
-  'in',
-  'out',
-  'utilIn',
-  'utilOut',
-  'latency',
-  'jitter',
-  'loss',
-]
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function parseNumericFilterWithUnits(
-  input: string,
-  unitMap: UnitMap,
-  defaultUnit: string
-): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)([a-zA-Z]+)?$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  const unitRaw = match[3]?.toLowerCase()
-  const unit = unitRaw ?? defaultUnit
-  const multiplier = unitMap[unit]
-  if (!multiplier) return null
-  return { op, value: Number(match[2]) * multiplier }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
 
 // Parse search filters from URL param
 function parseSearchFilters(searchParam: string): string[] {
@@ -126,39 +71,36 @@ function parseSearchFilters(searchParam: string): string[] {
 }
 
 // Valid filter fields for links
-const validFilterFields = ['code', 'type', 'contributor', 'sideA', 'sideZ', 'status', 'bandwidth', 'in', 'out', 'utilIn', 'utilOut', 'latency', 'jitter', 'loss']
+const validFilterFields = ['code', 'type', 'contributor', 'sidea', 'sidez', 'status', 'bandwidth', 'in', 'out', 'utilin', 'utilout', 'latency', 'jitter', 'loss']
 
 // Field prefixes for inline filter
 const linkFieldPrefixes = [
   { prefix: 'code:', description: 'Filter by link code' },
   { prefix: 'type:', description: 'Filter by link type' },
   { prefix: 'contributor:', description: 'Filter by contributor' },
-  { prefix: 'sideA:', description: 'Filter by side A device' },
-  { prefix: 'sideZ:', description: 'Filter by side Z device' },
+  { prefix: 'sidea:', description: 'Filter by side A device' },
+  { prefix: 'sidez:', description: 'Filter by side Z device' },
   { prefix: 'status:', description: 'Filter by status' },
   { prefix: 'bandwidth:', description: 'Filter by bandwidth (e.g., >10gbps)' },
   { prefix: 'in:', description: 'Filter by inbound traffic (e.g., >1gbps)' },
   { prefix: 'out:', description: 'Filter by outbound traffic (e.g., >1gbps)' },
-  { prefix: 'utilIn:', description: 'Filter by inbound utilization % (e.g., >50)' },
-  { prefix: 'utilOut:', description: 'Filter by outbound utilization % (e.g., >50)' },
+  { prefix: 'utilin:', description: 'Filter by inbound utilization % (e.g., >50)' },
+  { prefix: 'utilout:', description: 'Filter by outbound utilization % (e.g., >50)' },
 ]
 
 // Fields that support autocomplete
 const linkAutocompleteFields = ['status', 'type', 'contributor', 'sidea', 'sidez']
 
-// Parse a filter string into field and value
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
-    // Handle camelCase fields
-    const normalizedField = field === 'sidea' ? 'sideA' : field === 'sidez' ? 'sideZ' : field === 'utilin' ? 'utilIn' : field === 'utilout' ? 'utilOut' : field
-    if (validFilterFields.includes(normalizedField) && value) {
-      return { field: normalizedField, value }
+    if (validFilterFields.includes(field) && value) {
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function LinksPage() {
@@ -187,7 +129,6 @@ export function LinksPage() {
   const searchFilters = parseSearchFilters(searchParam)
 
   // Combine committed filters with live filter
-  // Live filter is combined with committed filters (all must match)
   const allFilters = liveFilter
     ? [...searchFilters, liveFilter]
     : searchFilters
@@ -213,172 +154,16 @@ export function LinksPage() {
     })
   }, [setSearchParams])
 
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
   const { data: response, isLoading, error } = useQuery({
-    queryKey: ['links', 'all'],
-    queryFn: () => fetchAllPaginated(fetchLinks, PAGE_SIZE),
+    queryKey: ['links', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchLinks(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
-  const links = response?.items
-  const filteredLinks = useMemo(() => {
-    if (!links) return []
-    if (allFilters.length === 0) return links
-
-    // Helper to get numeric value for a link field
-    const getNumericValue = (link: typeof links[number], field: string) => {
-      switch (field) {
-        case 'bandwidth':
-          return link.bandwidth_bps
-        case 'in':
-          return link.in_bps
-        case 'out':
-          return link.out_bps
-        case 'utilIn':
-          return link.utilization_in
-        case 'utilOut':
-          return link.utilization_out
-        case 'latency':
-          return link.latency_us
-        case 'jitter':
-          return link.jitter_us
-        case 'loss':
-          return link.loss_percent
-        default:
-          return 0
-      }
-    }
-
-    // Helper to get text value for a link field
-    const getSearchValue = (link: typeof links[number], field: string) => {
-      switch (field) {
-        case 'code':
-          return link.code
-        case 'type':
-          return link.link_type
-        case 'contributor':
-          return link.contributor_code || ''
-        case 'sideA':
-          return `${link.side_a_code || ''} ${link.side_a_metro || ''}`.trim()
-        case 'sideZ':
-          return `${link.side_z_code || ''} ${link.side_z_metro || ''}`.trim()
-        case 'status':
-          return link.status
-        default:
-          return ''
-      }
-    }
-
-    // Check if a link matches a single filter
-    const matchesSingleFilter = (link: typeof links[number], filterRaw: string): boolean => {
-      const filter = parseFilter(filterRaw)
-      const searchField = filter.field as SortField | 'all'
-      const needle = filter.value.trim().toLowerCase()
-      if (!needle) return true
-
-      // Handle numeric filters
-      if (searchField !== 'all' && numericSearchFields.includes(searchField as SortField)) {
-        const numericFilter = parseNumericFilter(filter.value)
-        const unitFilter =
-          (searchField === 'bandwidth' || searchField === 'in' || searchField === 'out')
-            ? parseNumericFilterWithUnits(
-                filter.value,
-                { gbps: 1e9, mbps: 1e6, bps: 1 },
-                'gbps'
-              )
-            : (searchField === 'latency' || searchField === 'jitter')
-                ? parseNumericFilterWithUnits(filter.value, { ms: 1000, us: 1 }, 'ms')
-                : null
-        const effectiveFilter = unitFilter ?? numericFilter
-        if (!effectiveFilter) return true
-        return matchesNumericFilter(getNumericValue(link, searchField), effectiveFilter)
-      }
-
-      // Handle text filters
-      if (searchField === 'all') {
-        const textFields = ['code', 'type', 'contributor', 'sideA', 'sideZ', 'status']
-        return textFields.some(field => getSearchValue(link, field).toLowerCase().includes(needle))
-      }
-
-      return getSearchValue(link, searchField).toLowerCase().includes(needle)
-    }
-
-    // Group filters by field, then OR within same field, AND across different fields
-    const grouped = new Map<string, string[]>()
-    for (const f of allFilters) {
-      const { field } = parseFilter(f)
-      const existing = grouped.get(field) ?? []
-      existing.push(f)
-      grouped.set(field, existing)
-    }
-    return links.filter(link =>
-      Array.from(grouped.values()).every(group =>
-        group.some(f => matchesSingleFilter(link, f))
-      )
-    )
-  }, [links, allFilters])
-  const sortedLinks = useMemo(() => {
-    if (!filteredLinks) return []
-    // Deduplicate by pk to prevent any possible duplicate rows
-    const seen = new Set<string>()
-    const unique = filteredLinks.filter(l => {
-      if (seen.has(l.pk)) return false
-      seen.add(l.pk)
-      return true
-    })
-    const sorted = [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'type':
-          cmp = a.link_type.localeCompare(b.link_type)
-          break
-        case 'contributor':
-          cmp = (a.contributor_code || '').localeCompare(b.contributor_code || '')
-          break
-        case 'sideA':
-          cmp = (a.side_a_code || '').localeCompare(b.side_a_code || '')
-          break
-        case 'sideZ':
-          cmp = (a.side_z_code || '').localeCompare(b.side_z_code || '')
-          break
-        case 'status':
-          cmp = a.status.localeCompare(b.status)
-          break
-        case 'bandwidth':
-          cmp = a.bandwidth_bps - b.bandwidth_bps
-          break
-        case 'in':
-          cmp = a.in_bps - b.in_bps
-          break
-        case 'out':
-          cmp = a.out_bps - b.out_bps
-          break
-        case 'utilIn':
-          cmp = a.utilization_in - b.utilization_in
-          break
-        case 'utilOut':
-          cmp = a.utilization_out - b.utilization_out
-          break
-        case 'latency':
-          cmp = a.latency_us - b.latency_us
-          break
-        case 'jitter':
-          cmp = a.jitter_us - b.jitter_us
-          break
-        case 'loss':
-          cmp = a.loss_percent - b.loss_percent
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-
-    return sorted
-  }, [filteredLinks, sortField, sortDirection])
-  const pagedLinks = useMemo(
-    () => sortedLinks.slice(offset, offset + PAGE_SIZE),
-    [sortedLinks, offset]
-  )
+  const links = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -499,16 +284,16 @@ export function LinksPage() {
                       <SortIcon field="contributor" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('sideA')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('sideA')}>
+                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('sidea')}>
+                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('sidea')}>
                       Side A
-                      <SortIcon field="sideA" />
+                      <SortIcon field="sidea" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('sideZ')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('sideZ')}>
+                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('sidez')}>
+                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('sidez')}>
                       Side Z
-                      <SortIcon field="sideZ" />
+                      <SortIcon field="sidez" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('status')}>
@@ -535,16 +320,16 @@ export function LinksPage() {
                       <SortIcon field="out" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('utilIn')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('utilIn')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('utilin')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('utilin')}>
                       Util In
-                      <SortIcon field="utilIn" />
+                      <SortIcon field="utilin" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('utilOut')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('utilOut')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('utilout')}>
+                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('utilout')}>
                       Util Out
-                      <SortIcon field="utilOut" />
+                      <SortIcon field="utilout" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('latency')}>
@@ -568,7 +353,7 @@ export function LinksPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedLinks.map((link) => (
+                {links.map((link) => (
                   <tr
                     key={link.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -624,7 +409,7 @@ export function LinksPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedLinks.length === 0 && (
+                {links.length === 0 && (
                   <tr>
                     <td colSpan={14} className="px-4 py-8 text-center text-muted-foreground">
                       No links found
@@ -636,7 +421,7 @@ export function LinksPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedLinks.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/links-page.tsx
+++ b/web/src/components/links-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -359,8 +360,8 @@ export function LinksPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/links/${link.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{link.code}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={link.code} className="font-mono text-sm" />
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground">
                       {link.link_type}
@@ -368,14 +369,14 @@ export function LinksPage() {
                     <td className="px-4 py-3 text-sm text-muted-foreground">
                       {link.contributor_code || '—'}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      <span className="font-mono">{link.side_a_code || '—'}</span>
+                    <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">
+                      {link.side_a_code ? <CopyableText text={link.side_a_code} className="font-mono" /> : <span className="font-mono">—</span>}
                       {link.side_a_metro && (
                         <span className="ml-1 text-xs">({link.side_a_metro})</span>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      <span className="font-mono">{link.side_z_code || '—'}</span>
+                    <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">
+                      {link.side_z_code ? <CopyableText text={link.side_z_code} className="font-mono" /> : <span className="font-mono">—</span>}
                       {link.side_z_metro && (
                         <span className="ml-1 text-xs">({link.side_z_metro})</span>
                       )}

--- a/web/src/components/metros-page.tsx
+++ b/web/src/components/metros-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -253,8 +254,8 @@ export function MetrosPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/metros/${metro.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{metro.code}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={metro.code} className="font-mono text-sm" />
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {metro.name || '—'}

--- a/web/src/components/metros-page.tsx
+++ b/web/src/components/metros-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, MapPin, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
-import { fetchAllPaginated, fetchMetros } from '@/lib/api'
+import { fetchMetros } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -13,35 +13,6 @@ const PAGE_SIZE = 100
 type SortField = 'code' | 'name' | 'latitude' | 'longitude' | 'devices' | 'users'
 type SortDirection = 'asc' | 'desc'
 
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
-
-const numericSearchFields: SortField[] = ['latitude', 'longitude', 'devices', 'users']
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
-
 // Parse search filters from URL param
 function parseSearchFilters(searchParam: string): string[] {
   if (!searchParam) return []
@@ -49,7 +20,7 @@ function parseSearchFilters(searchParam: string): string[] {
 }
 
 // Valid filter fields for metros
-const validFilterFields = ['code', 'name', 'latitude', 'longitude', 'devices', 'users']
+const validFilterFields = ['code', 'name', 'devices', 'users']
 
 // Field prefixes for inline filter
 const metroFieldPrefixes = [
@@ -62,17 +33,16 @@ const metroFieldPrefixes = [
 // Fields that support autocomplete (none for metros)
 const metroAutocompleteFields: string[] = []
 
-// Parse a filter string into field and value
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
     if (validFilterFields.includes(field) && value) {
-      return { field, value }
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function MetrosPage() {
@@ -101,7 +71,9 @@ export function MetrosPage() {
   const searchFilters = parseSearchFilters(searchParam)
 
   // Combine committed filters with live filter
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
+  const allFilters = liveFilter
+    ? [...searchFilters, liveFilter]
+    : searchFilters
 
   const removeFilter = useCallback((filterToRemove: string) => {
     const newFilters = searchFilters.filter(f => f !== filterToRemove)
@@ -124,102 +96,16 @@ export function MetrosPage() {
     })
   }, [setSearchParams])
 
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
   const { data: response, isLoading, error } = useQuery({
-    queryKey: ['metros', 'all'],
-    queryFn: () => fetchAllPaginated(fetchMetros, PAGE_SIZE),
+    queryKey: ['metros', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchMetros(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
-  const metros = response?.items
-  const filteredMetros = useMemo(() => {
-    if (!metros) return []
-    if (!activeFilterRaw) return metros
-
-    // Parse filter inside memo to ensure fresh parsing on each recompute
-    const filter = parseFilter(activeFilterRaw)
-    const searchField = filter.field as SortField | 'all'
-    const needle = filter.value.trim().toLowerCase()
-    if (!needle) return metros
-
-    const numericFilter = parseNumericFilter(filter.value)
-    if (searchField !== 'all' && numericFilter && numericSearchFields.includes(searchField as SortField)) {
-      const getNumericValue = (metro: typeof metros[number]) => {
-        switch (searchField) {
-          case 'latitude':
-            return metro.latitude
-          case 'longitude':
-            return metro.longitude
-          case 'devices':
-            return metro.device_count
-          case 'users':
-            return metro.user_count
-          default:
-            return 0
-        }
-      }
-      return metros.filter(metro => matchesNumericFilter(getNumericValue(metro), numericFilter))
-    }
-
-    // Text search
-    const getSearchValue = (metro: typeof metros[number], field: string) => {
-      switch (field) {
-        case 'code':
-          return metro.code
-        case 'name':
-          return metro.name || ''
-        default:
-          return ''
-      }
-    }
-
-    if (searchField === 'all') {
-      // Search across all text fields
-      return metros.filter(metro => {
-        const textFields = ['code', 'name']
-        return textFields.some(field => getSearchValue(metro, field).toLowerCase().includes(needle))
-      })
-    }
-
-    return metros.filter(metro => getSearchValue(metro, searchField).toLowerCase().includes(needle))
-  }, [metros, activeFilterRaw])
-  const sortedMetros = useMemo(() => {
-    if (!filteredMetros) return []
-    // Deduplicate by pk to prevent any possible duplicate rows
-    const seen = new Set<string>()
-    const unique = filteredMetros.filter(m => {
-      if (seen.has(m.pk)) return false
-      seen.add(m.pk)
-      return true
-    })
-    const sorted = [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'name':
-          cmp = (a.name || '').localeCompare(b.name || '')
-          break
-        case 'latitude':
-          cmp = a.latitude - b.latitude
-          break
-        case 'longitude':
-          cmp = a.longitude - b.longitude
-          break
-        case 'devices':
-          cmp = a.device_count - b.device_count
-          break
-        case 'users':
-          cmp = a.user_count - b.user_count
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-    return sorted
-  }, [filteredMetros, sortField, sortDirection])
-  const pagedMetros = useMemo(
-    () => sortedMetros.slice(offset, offset + PAGE_SIZE),
-    [sortedMetros, offset]
-  )
+  const metros = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -246,16 +132,17 @@ export function MetrosPage() {
     return sortDirection === 'asc' ? 'ascending' : 'descending'
   }
 
-  const prevFilterRef = useRef(activeFilterRaw)
+  const prevFilterRef = useRef(JSON.stringify(allFilters))
   useEffect(() => {
-    if (prevFilterRef.current === activeFilterRaw) return
-    prevFilterRef.current = activeFilterRaw
+    const key = JSON.stringify(allFilters)
+    if (prevFilterRef.current === key) return
+    prevFilterRef.current = key
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
     })
-  }, [activeFilterRaw, setSearchParams])
+  }, [allFilters, setSearchParams])
 
   if (isLoading) {
     return (
@@ -360,7 +247,7 @@ export function MetrosPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedMetros.map((metro) => (
+                {metros.map((metro) => (
                   <tr
                     key={metro.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -386,7 +273,7 @@ export function MetrosPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedMetros.length === 0 && (
+                {metros.length === 0 && (
                   <tr>
                     <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
                       No metros found
@@ -398,7 +285,7 @@ export function MetrosPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedMetros.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/multicast-groups-page.tsx
+++ b/web/src/components/multicast-groups-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -239,11 +240,11 @@ export function MulticastGroupsPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/multicast-groups/${group.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{group.code}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={group.code} className="font-mono text-sm" />
                     </td>
-                    <td className="px-4 py-3 text-sm font-mono text-muted-foreground">
-                      {group.multicast_ip}
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={group.multicast_ip} className="text-sm font-mono text-muted-foreground" />
                     </td>
                     <td className="px-4 py-3 text-sm capitalize">
                       {group.status}

--- a/web/src/components/multicast-groups-page.tsx
+++ b/web/src/components/multicast-groups-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Radio, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
 import { fetchMulticastGroups } from '@/lib/api'
@@ -10,37 +10,8 @@ import { PageHeader } from './page-header'
 
 const PAGE_SIZE = 100
 
-type SortField = 'code' | 'multicast_ip' | 'status' | 'publishers' | 'subscribers'
+type SortField = 'code' | 'ip' | 'status' | 'publishers' | 'subscribers'
 type SortDirection = 'asc' | 'desc'
-
-type NumericFilter = {
-  op: '>' | '>=' | '<' | '<=' | '='
-  value: number
-}
-
-const numericSearchFields: SortField[] = ['publishers', 'subscribers']
-
-function parseNumericFilter(input: string): NumericFilter | null {
-  const match = input.trim().match(/^(>=|<=|>|<|==|=)\s*(-?\d+(?:\.\d+)?)$/)
-  if (!match) return null
-  const op = match[1] === '==' ? '=' : (match[1] as NumericFilter['op'])
-  return { op, value: Number(match[2]) }
-}
-
-function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
-  switch (filter.op) {
-    case '>':
-      return value > filter.value
-    case '>=':
-      return value >= filter.value
-    case '<':
-      return value < filter.value
-    case '<=':
-      return value <= filter.value
-    case '=':
-      return value === filter.value
-  }
-}
 
 function parseSearchFilters(searchParam: string): string[] {
   if (!searchParam) return []
@@ -59,16 +30,16 @@ const fieldPrefixes = [
 
 const autocompleteFields = ['status']
 
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
     if (validFilterFields.includes(field) && value) {
-      return { field, value }
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 export function MulticastGroupsPage() {
@@ -93,7 +64,9 @@ export function MulticastGroupsPage() {
   const searchParam = searchParams.get('search') || ''
   const searchFilters = parseSearchFilters(searchParam)
 
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
+  const allFilters = liveFilter
+    ? [...searchFilters, liveFilter]
+    : searchFilters
 
   const removeFilter = useCallback((filterToRemove: string) => {
     const newFilters = searchFilters.filter(f => f !== filterToRemove)
@@ -116,95 +89,16 @@ export function MulticastGroupsPage() {
     })
   }, [setSearchParams])
 
-  const { data: groups, isLoading, error } = useQuery({
-    queryKey: ['multicast-groups'],
-    queryFn: () => fetchMulticastGroups(),
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
+  const { data: response, isLoading, error } = useQuery({
+    queryKey: ['multicast-groups', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchMulticastGroups(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
-
-  const filteredGroups = useMemo(() => {
-    if (!groups) return []
-    if (!activeFilterRaw) return groups
-
-    const filter = parseFilter(activeFilterRaw)
-    const searchField = filter.field as SortField | 'all' | 'ip'
-    const needle = filter.value.trim().toLowerCase()
-    if (!needle) return groups
-
-    const numericFilter = parseNumericFilter(filter.value)
-    if (searchField !== 'all' && numericFilter && numericSearchFields.includes(searchField as SortField)) {
-      const getNumericValue = (group: typeof groups[number]) => {
-        switch (searchField) {
-          case 'publishers':
-            return group.publisher_count
-          case 'subscribers':
-            return group.subscriber_count
-          default:
-            return 0
-        }
-      }
-      return groups.filter(group => matchesNumericFilter(getNumericValue(group), numericFilter))
-    }
-
-    const getSearchValue = (group: typeof groups[number], field: string) => {
-      switch (field) {
-        case 'code':
-          return group.code
-        case 'ip':
-          return group.multicast_ip
-        case 'status':
-          return group.status
-        default:
-          return ''
-      }
-    }
-
-    if (searchField === 'all') {
-      return groups.filter(group => {
-        const textFields = ['code', 'ip', 'status']
-        return textFields.some(field => getSearchValue(group, field).toLowerCase().includes(needle))
-      })
-    }
-
-    return groups.filter(group => getSearchValue(group, searchField).toLowerCase().includes(needle))
-  }, [groups, activeFilterRaw])
-
-  const sortedGroups = useMemo(() => {
-    if (!filteredGroups) return []
-    const seen = new Set<string>()
-    const unique = filteredGroups.filter(g => {
-      if (seen.has(g.pk)) return false
-      seen.add(g.pk)
-      return true
-    })
-    const sorted = [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'multicast_ip':
-          cmp = a.multicast_ip.localeCompare(b.multicast_ip)
-          break
-        case 'status':
-          cmp = a.status.localeCompare(b.status)
-          break
-        case 'publishers':
-          cmp = a.publisher_count - b.publisher_count
-          break
-        case 'subscribers':
-          cmp = a.subscriber_count - b.subscriber_count
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-    return sorted
-  }, [filteredGroups, sortField, sortDirection])
-
-  const pagedGroups = useMemo(
-    () => sortedGroups.slice(offset, offset + PAGE_SIZE),
-    [sortedGroups, offset]
-  )
+  const groups = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -231,16 +125,17 @@ export function MulticastGroupsPage() {
     return sortDirection === 'asc' ? 'ascending' : 'descending'
   }
 
-  const prevFilterRef = useRef(activeFilterRaw)
+  const prevFilterRef = useRef(JSON.stringify(allFilters))
   useEffect(() => {
-    if (prevFilterRef.current === activeFilterRaw) return
-    prevFilterRef.current = activeFilterRaw
+    const key = JSON.stringify(allFilters)
+    if (prevFilterRef.current === key) return
+    prevFilterRef.current = key
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
     })
-  }, [activeFilterRaw, setSearchParams])
+  }, [allFilters, setSearchParams])
 
   if (isLoading) {
     return (
@@ -268,7 +163,7 @@ export function MulticastGroupsPage() {
         <PageHeader
           icon={Radio}
           title="Multicast Groups"
-          count={groups?.length || 0}
+          count={response?.total || 0}
           actions={
             <>
               {searchFilters.map((filter, idx) => (
@@ -311,10 +206,10 @@ export function MulticastGroupsPage() {
                       <SortIcon field="code" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('multicast_ip')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('multicast_ip')}>
+                  <th className="px-4 py-3 font-medium" aria-sort={sortAria('ip')}>
+                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('ip')}>
                       Multicast IP
-                      <SortIcon field="multicast_ip" />
+                      <SortIcon field="ip" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('status')}>
@@ -338,7 +233,7 @@ export function MulticastGroupsPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedGroups.map((group) => (
+                {groups.map((group) => (
                   <tr
                     key={group.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -361,7 +256,7 @@ export function MulticastGroupsPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedGroups.length === 0 && (
+                {groups.length === 0 && (
                   <tr>
                     <td colSpan={5} className="px-4 py-8 text-center text-muted-foreground">
                       No multicast groups found
@@ -371,9 +266,9 @@ export function MulticastGroupsPage() {
               </tbody>
             </table>
           </div>
-          {groups && (
+          {response && (
             <Pagination
-              total={sortedGroups.length}
+              total={response.total ?? 0}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/tenants-page.tsx
+++ b/web/src/components/tenants-page.tsx
@@ -7,6 +7,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -235,8 +236,8 @@ export function TenantsPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/tenants/${tenant.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm">{tenant.code || '—'}</span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {tenant.code ? <CopyableText text={tenant.code} className="font-mono text-sm" /> : <span className="font-mono text-sm text-muted-foreground">—</span>}
                     </td>
                     <td className="px-4 py-3">
                       <span className="font-mono text-xs text-muted-foreground" title={tenant.pk}>

--- a/web/src/components/tenants-page.tsx
+++ b/web/src/components/tenants-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Layers, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
-import { fetchAllPaginated, fetchTenants } from '@/lib/api'
+import { fetchTenants } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
@@ -18,24 +18,25 @@ function parseSearchFilters(searchParam: string): string[] {
   return searchParam.split(',').map(f => f.trim()).filter(Boolean)
 }
 
-const validFilterFields = ['code']
+const validFilterFields = ['code', 'owner']
 
 const tenantFieldPrefixes = [
   { prefix: 'code:', description: 'Filter by tenant code' },
+  { prefix: 'owner:', description: 'Filter by owner pubkey' },
 ]
 
 const tenantAutocompleteFields: string[] = []
 
-function parseFilter(filter: string): { field: string; value: string } {
+function toFilterParam(filter: string): string {
   const colonIndex = filter.indexOf(':')
   if (colonIndex > 0) {
     const field = filter.slice(0, colonIndex).toLowerCase()
     const value = filter.slice(colonIndex + 1)
     if (validFilterFields.includes(field) && value) {
-      return { field, value }
+      return `${field}:${value}`
     }
   }
-  return { field: 'all', value: filter }
+  return `all:${filter}`
 }
 
 function BoolBadge({ value }: { value: boolean }) {
@@ -75,7 +76,10 @@ export function TenantsPage() {
   const sortDirection = (searchParams.get('dir') || 'asc') as SortDirection
   const searchParam = searchParams.get('search') || ''
   const searchFilters = parseSearchFilters(searchParam)
-  const activeFilterRaw = liveFilter || searchFilters[0] || ''
+
+  const allFilters = liveFilter
+    ? [...searchFilters, liveFilter]
+    : searchFilters
 
   const removeFilter = useCallback((filterToRemove: string) => {
     const newFilters = searchFilters.filter(f => f !== filterToRemove)
@@ -94,58 +98,17 @@ export function TenantsPage() {
     })
   }, [setSearchParams])
 
+  const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
+  const filterKey = filterParams.join(',')
+
   const { data: response, isLoading, error } = useQuery({
-    queryKey: ['tenants', 'all'],
-    queryFn: () => fetchAllPaginated(fetchTenants, PAGE_SIZE),
+    queryKey: ['tenants', offset, sortField, sortDirection, filterKey],
+    queryFn: () => fetchTenants(PAGE_SIZE, offset, sortField, sortDirection, filterParams.length > 0 ? filterParams : undefined),
     refetchInterval: 30000,
+    placeholderData: keepPreviousData,
   })
 
-  const tenants = response?.items
-
-  const filteredTenants = useMemo(() => {
-    if (!tenants) return []
-    if (!activeFilterRaw) return tenants
-
-    const filter = parseFilter(activeFilterRaw)
-    const needle = filter.value.trim().toLowerCase()
-    if (!needle) return tenants
-
-    if (filter.field === 'code') {
-      return tenants.filter(t => t.code.toLowerCase().includes(needle))
-    }
-    // all fields
-    return tenants.filter(t =>
-      t.code.toLowerCase().includes(needle) ||
-      t.pk.toLowerCase().includes(needle)
-    )
-  }, [tenants, activeFilterRaw])
-
-  const sortedTenants = useMemo(() => {
-    if (!filteredTenants) return []
-    const seen = new Set<string>()
-    const unique = filteredTenants.filter(t => {
-      if (seen.has(t.pk)) return false
-      seen.add(t.pk)
-      return true
-    })
-    return [...unique].sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case 'code':
-          cmp = a.code.localeCompare(b.code)
-          break
-        case 'vrf_id':
-          cmp = a.vrf_id - b.vrf_id
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-  }, [filteredTenants, sortField, sortDirection])
-
-  const pagedTenants = useMemo(
-    () => sortedTenants.slice(offset, offset + PAGE_SIZE),
-    [sortedTenants, offset]
-  )
+  const tenants = response?.items ?? []
 
   const handleSort = (field: SortField) => {
     setSearchParams(prev => {
@@ -172,16 +135,17 @@ export function TenantsPage() {
     return sortDirection === 'asc' ? 'ascending' : 'descending'
   }
 
-  const prevFilterRef = useRef(activeFilterRaw)
+  const prevFilterRef = useRef(JSON.stringify(allFilters))
   useEffect(() => {
-    if (prevFilterRef.current === activeFilterRaw) return
-    prevFilterRef.current = activeFilterRaw
+    const key = JSON.stringify(allFilters)
+    if (prevFilterRef.current === key) return
+    prevFilterRef.current = key
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
     })
-  }, [activeFilterRaw, setSearchParams])
+  }, [allFilters, setSearchParams])
 
   if (isLoading) {
     return (
@@ -265,7 +229,7 @@ export function TenantsPage() {
                 </tr>
               </thead>
               <tbody>
-                {pagedTenants.map((tenant) => (
+                {tenants.map((tenant) => (
                   <tr
                     key={tenant.pk}
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
@@ -295,7 +259,7 @@ export function TenantsPage() {
                     </td>
                   </tr>
                 ))}
-                {sortedTenants.length === 0 && (
+                {tenants.length === 0 && (
                   <tr>
                     <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
                       No tenants found
@@ -307,7 +271,7 @@ export function TenantsPage() {
           </div>
           {response && (
             <Pagination
-              total={sortedTenants.length}
+              total={response.total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
@@ -237,7 +237,7 @@ export function MulticastTreesOverlayPanel({
   useEffect(() => {
     setError(null)
     fetchMulticastGroups()
-      .then(setGroups)
+      .then(res => setGroups(res.items))
       .catch(err => {
         console.error('Failed to fetch multicast groups:', err)
         setError('Failed to load multicast groups. The database table may not exist yet.')

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -456,7 +456,7 @@ export function UserDetailPage() {
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Owner Pubkey</dt>
                 <dd className="text-sm">
-                  <CopyableText text={user.owner_pubkey} className="font-mono">
+                  <CopyableText text={user.owner_pubkey} className="font-mono" iconPosition="left">
                     <Link to={`/dz/users?search=owner:${user.owner_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline">
                       {user.owner_pubkey.slice(0, 6)}...{user.owner_pubkey.slice(-4)}
                     </Link>
@@ -467,7 +467,7 @@ export function UserDetailPage() {
                 <dt className="text-sm text-muted-foreground">Client IP</dt>
                 <dd className="text-sm">
                   {user.client_ip ? (
-                    <CopyableText text={user.client_ip} className="font-mono">
+                    <CopyableText text={user.client_ip} className="font-mono" iconPosition="left">
                       <Link to={`/dz/users?search=ip:${user.client_ip}`} className="text-blue-600 dark:text-blue-400 hover:underline">
                         {user.client_ip}
                       </Link>
@@ -479,7 +479,7 @@ export function UserDetailPage() {
                 <dt className="text-sm text-muted-foreground">DZ IP</dt>
                 <dd className="text-sm">
                   {user.dz_ip ? (
-                    <CopyableText text={user.dz_ip} className="font-mono" />
+                    <CopyableText text={user.dz_ip} className="font-mono" iconPosition="left" />
                   ) : '—'}
                 </dd>
               </div>

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Loader2, Users, AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react'
+import { CopyableText } from '@/components/copyable-text'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import { fetchUser, fetchUserTraffic, fetchUserMulticastGroups } from '@/lib/api'
@@ -427,7 +428,9 @@ export function UserDetailPage() {
           <Users className="h-8 w-8 text-muted-foreground" />
           <div>
             <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-medium font-mono">{user.pk.slice(0, 8)}...{user.pk.slice(-4)}</h1>
+              <h1 className="text-2xl font-medium font-mono">
+                <CopyableText text={user.pk}>{user.pk.slice(0, 8)}...{user.pk.slice(-4)}</CopyableText>
+              </h1>
               {user.is_deleted && (
                 <span className="text-xs px-2 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">Deleted</span>
               )}
@@ -453,24 +456,32 @@ export function UserDetailPage() {
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Owner Pubkey</dt>
                 <dd className="text-sm">
-                  <Link to={`/dz/users?search=owner:${user.owner_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
-                    {user.owner_pubkey.slice(0, 6)}...{user.owner_pubkey.slice(-4)}
-                  </Link>
+                  <CopyableText text={user.owner_pubkey} className="font-mono">
+                    <Link to={`/dz/users?search=owner:${user.owner_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                      {user.owner_pubkey.slice(0, 6)}...{user.owner_pubkey.slice(-4)}
+                    </Link>
+                  </CopyableText>
                 </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Client IP</dt>
                 <dd className="text-sm">
                   {user.client_ip ? (
-                    <Link to={`/dz/users?search=ip:${user.client_ip}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
-                      {user.client_ip}
-                    </Link>
+                    <CopyableText text={user.client_ip} className="font-mono">
+                      <Link to={`/dz/users?search=ip:${user.client_ip}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                        {user.client_ip}
+                      </Link>
+                    </CopyableText>
                   ) : '—'}
                 </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">DZ IP</dt>
-                <dd className="text-sm font-mono">{user.dz_ip || '—'}</dd>
+                <dd className="text-sm">
+                  {user.dz_ip ? (
+                    <CopyableText text={user.dz_ip} className="font-mono" />
+                  ) : '—'}
+                </dd>
               </div>
               {user.tunnel_id > 0 && (
                 <div className="flex justify-between">

--- a/web/src/components/users-page.tsx
+++ b/web/src/components/users-page.tsx
@@ -8,6 +8,7 @@ import { handleRowClick } from '@/lib/utils'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
+import { CopyableText } from './copyable-text'
 
 const PAGE_SIZE = 100
 
@@ -326,22 +327,22 @@ export function UsersPage() {
                     className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
                     onClick={(e) => handleRowClick(e, `/dz/users/${user.pk}`, navigate)}
                   >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-sm" title={user.owner_pubkey}>
-                        {truncatePubkey(user.owner_pubkey)}
-                      </span>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <CopyableText text={user.owner_pubkey} className="font-mono text-sm">
+                        <span title={user.owner_pubkey}>{truncatePubkey(user.owner_pubkey)}</span>
+                      </CopyableText>
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground">
                       {user.kind || '—'}
                     </td>
-                    <td className="px-4 py-3 text-sm">
-                      <span className="font-mono">{user.client_ip || '—'}</span>
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {user.client_ip ? <CopyableText text={user.client_ip} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm">
-                      <span className="font-mono">{user.dz_ip || '—'}</span>
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {user.dz_ip ? <CopyableText text={user.dz_ip} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm">
-                      <span className="font-mono">{user.device_code || '—'}</span>
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {user.device_code ? <CopyableText text={user.device_code} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground">
                       {user.metro_name || user.metro_code || '—'}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1914,8 +1914,20 @@ export interface MulticastMembersResponse extends PaginatedResponse<MulticastMem
   subscriber_count: number
 }
 
-export async function fetchMulticastGroups(): Promise<MulticastGroupListItem[]> {
-  const res = await apiFetch('/api/dz/multicast-groups')
+export async function fetchMulticastGroups(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<MulticastGroupListItem>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await apiFetch(`/api/dz/multicast-groups?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch multicast groups')
   }
@@ -2822,8 +2834,20 @@ export interface Device {
   peak_out_bps: number
 }
 
-export async function fetchDevices(limit = 100, offset = 0): Promise<PaginatedResponse<Device>> {
-  const res = await fetchWithRetry(`/api/dz/devices?limit=${limit}&offset=${offset}`)
+export async function fetchDevices(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<Device>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await fetchWithRetry(`/api/dz/devices?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch devices')
   }
@@ -2877,8 +2901,20 @@ export interface Link {
   loss_percent: number
 }
 
-export async function fetchLinks(limit = 100, offset = 0): Promise<PaginatedResponse<Link>> {
-  const res = await fetchWithRetry(`/api/dz/links?limit=${limit}&offset=${offset}`)
+export async function fetchLinks(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<Link>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await fetchWithRetry(`/api/dz/links?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch links')
   }
@@ -2910,8 +2946,20 @@ export interface Metro {
   user_count: number
 }
 
-export async function fetchMetros(limit = 100, offset = 0): Promise<PaginatedResponse<Metro>> {
-  const res = await fetchWithRetry(`/api/dz/metros?limit=${limit}&offset=${offset}`)
+export async function fetchMetros(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<Metro>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await fetchWithRetry(`/api/dz/metros?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch metros')
   }
@@ -2943,8 +2991,20 @@ export interface Contributor {
   link_count: number
 }
 
-export async function fetchContributors(limit = 100, offset = 0): Promise<PaginatedResponse<Contributor>> {
-  const res = await fetchWithRetry(`/api/dz/contributors?limit=${limit}&offset=${offset}`)
+export async function fetchContributors(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<Contributor>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await fetchWithRetry(`/api/dz/contributors?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch contributors')
   }
@@ -4741,8 +4801,20 @@ export interface Tenant {
   billing_rate: number
 }
 
-export async function fetchTenants(limit = 100, offset = 0): Promise<PaginatedResponse<Tenant>> {
-  const res = await fetchWithRetry(`/api/dz/tenants?limit=${limit}&offset=${offset}`)
+export async function fetchTenants(
+  limit = 100,
+  offset = 0,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
+  filters?: string[]
+): Promise<PaginatedResponse<Tenant>> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (sortBy) params.set('sort_by', sortBy)
+  if (sortDir) params.set('sort_dir', sortDir)
+  if (filters) filters.forEach(f => params.append('filters', f))
+  const res = await fetchWithRetry(`/api/dz/tenants?${params}`)
   if (!res.ok) {
     throw new Error('Failed to fetch tenants')
   }


### PR DESCRIPTION
## Summary of Changes
- Replaced `fetchAllPaginated` + client-side filtering/sorting/dedup with server-side SQL on all entity listing pages: devices, tenants, contributors, metros, links, and multicast groups
- Also includes users listing and detail page support for deleted users (show/hide toggle, "Deleted" badge)
- Each API list handler now uses `ParseSort`/`ParseFilters`/`BuildFilterClause` with `count() OVER ()` window function for totals — a single query per page load instead of N paginated requests
- `fetchMulticastGroups` return type changed from raw array to `PaginatedResponse`; pub/sub counts folded into main query via CTE

## Diff Breakdown
| Category     | Files | Lines (+/-)    | Net   |
|--------------|-------|----------------|-------|
| Core logic   |    20 | +849 / -1422   | -573  |
| Scaffolding  |     1 | +1   / -1      |    0  |
| Tests        |     4 | +17  / -15     |   +2  |

Mostly a deletion — 573 net lines removed by eliminating client-side filtering logic and separate count queries.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/links-page.tsx` — removed 215 lines of client-side filtering/sorting/dedup; now a single server-driven query
- `web/src/components/devices-page.tsx` — same pattern; removed fetchAllPaginated and all client useMemos
- `web/src/components/users-page.tsx` — same refactor plus show/hide deleted toggle persisted in URL
- `web/src/components/contributors-page.tsx` — same refactor
- `web/src/lib/api.ts` — all 7 fetch functions updated to accept sort/filter/pagination params
- `api/handlers/users.go` — rewrote GetUsers with CTE + window function; GetUser now queries dim_dz_users_history to support deleted users
- `api/handlers/links.go` — added 14-field sort/filter map; wrapped existing CTEs in links_data CTE with count() OVER ()
- `api/handlers/multicast.go` — folded pub/sub count enrichment into main query; returns PaginatedResponse

</details>

## Testing Verification
- Integration tests updated and passing for all affected handlers (devices, links, metros, multicast groups) against a real ClickHouse container
- Fixed `UInt64 → int64` scan type mismatch caught by tests (`count() OVER ()` and `countIf()` both return UInt64)