### PR TITLE
web: subtle link styling and fixes on shreds pages

### DIFF
--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -39,7 +39,7 @@ var userSortFields = map[string]string{
 	"device":   "device_code",
 	"metro":    "metro_name",
 	"tenant":   "tenant_code",
-	"status":   "status",
+	"status":   "display_status",
 	"in":       "in_bps",
 	"out":      "out_bps",
 }
@@ -80,6 +80,7 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 
 	var sourceCTE string
 	var isDeletedExpr string
+	var isDeletedCond string
 	var fromTable string
 	if includeDeleted {
 		sourceCTE = `all_users AS (
@@ -97,11 +98,13 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 			GROUP BY entity_id
 			HAVING pk != ''
 		),`
-		isDeletedExpr = "u.is_deleted = 1 as is_deleted"
+		isDeletedCond = "u.is_deleted = 1"
+		isDeletedExpr = isDeletedCond + " as is_deleted"
 		fromTable = "all_users"
 	} else {
 		sourceCTE = ""
-		isDeletedExpr = "false as is_deleted"
+		isDeletedCond = "false"
+		isDeletedExpr = isDeletedCond + " as is_deleted"
 		fromTable = "dz_users_current"
 	}
 
@@ -133,7 +136,8 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 				COALESCE(t.code, '') as tenant_code,
 				COALESCE(tr.in_bps, 0) as in_bps,
 				COALESCE(tr.out_bps, 0) as out_bps,
-				` + isDeletedExpr + `
+				` + isDeletedExpr + `,
+				CASE WHEN ` + isDeletedCond + ` THEN 'deleted' ELSE u.status END as display_status
 			FROM ` + fromTable + ` u
 			LEFT JOIN dz_devices_current d ON u.device_pk = d.pk
 			LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk

--- a/web/src/components/devices-page.tsx
+++ b/web/src/components/devices-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Server, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
 import { fetchDevices } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
@@ -319,11 +319,15 @@ export function DevicesPage() {
                     <td className="px-4 py-3 text-sm text-muted-foreground capitalize">
                       {device.device_type?.replace(/_/g, ' ')}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      {device.contributor_code || '—'}
+                    <td className="px-4 py-3 text-sm">
+                      {device.contributor_pk
+                        ? <Link to={`/dz/contributors/${device.contributor_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{device.contributor_code}</Link>
+                        : <span className="text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      {device.metro_code || '—'}
+                    <td className="px-4 py-3 text-sm">
+                      {device.metro_pk
+                        ? <Link to={`/dz/metros/${device.metro_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{device.metro_code}</Link>
+                        : <span className="text-muted-foreground">—</span>}
                     </td>
                     <td className={`px-4 py-3 text-sm capitalize ${statusColors[device.status] || ''}`}>
                       {device.status}

--- a/web/src/components/links-page.tsx
+++ b/web/src/components/links-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, Link2, AlertCircle, ChevronDown, ChevronUp, X } from 'lucide-react'
 import { fetchLinks } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
@@ -366,20 +366,20 @@ export function LinksPage() {
                     <td className="px-4 py-3 text-sm text-muted-foreground">
                       {link.link_type}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      {link.contributor_code || '—'}
+                    <td className="px-4 py-3 text-sm">
+                      {link.contributor_pk
+                        ? <Link to={`/dz/contributors/${link.contributor_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{link.contributor_code}</Link>
+                        : <span className="text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">
-                      {link.side_a_code ? <CopyableText text={link.side_a_code} className="font-mono" /> : <span className="font-mono">—</span>}
-                      {link.side_a_metro && (
-                        <span className="ml-1 text-xs">({link.side_a_metro})</span>
-                      )}
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {link.side_a_code
+                        ? <><Link to={`/dz/devices/${link.side_a_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{link.side_a_code}</Link>{link.side_a_metro && <span className="ml-1 text-xs text-muted-foreground">({link.side_a_metro})</span>}</>
+                        : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">
-                      {link.side_z_code ? <CopyableText text={link.side_z_code} className="font-mono" /> : <span className="font-mono">—</span>}
-                      {link.side_z_metro && (
-                        <span className="ml-1 text-xs">({link.side_z_metro})</span>
-                      )}
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {link.side_z_code
+                        ? <><Link to={`/dz/devices/${link.side_z_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{link.side_z_code}</Link>{link.side_z_metro && <span className="ml-1 text-xs text-muted-foreground">({link.side_z_metro})</span>}</>
+                        : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
                     <td className={`px-4 py-3 text-sm capitalize ${statusColors[link.status] || ''}`}>
                       {link.status}

--- a/web/src/components/shreds-page.tsx
+++ b/web/src/components/shreds-page.tsx
@@ -546,15 +546,15 @@ export function ShredsSeatsPage() {
                     </td>
                     <td className="px-4 py-3 text-sm whitespace-nowrap group/cell">
                       <span className="inline-flex items-center gap-1">
-                        <Link to={`/dz/devices/${seat.device_key}`} className="text-blue-500 hover:underline font-mono text-xs" title={seat.device_key}>
+                        <Link to={`/dz/devices/${seat.device_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={seat.device_key}>
                           {seat.device_code || truncatePK(seat.device_key)}
                         </Link>
-                        <CopyIcon text={seat.device_key} />
+                        <CopyIcon text={seat.device_code || seat.device_key} />
                       </span>
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {seat.metro_pk ? (
-                        <Link to={`/dz/metros/${seat.metro_pk}`} className="text-blue-500 hover:underline font-mono text-xs" title={seat.metro_pk}>
+                        <Link to={`/dz/metros/${seat.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={seat.metro_pk}>
                           {seat.metro_code || truncatePK(seat.metro_pk)}
                         </Link>
                       ) : <span className="text-muted-foreground">{'\u2014'}</span>}
@@ -562,7 +562,7 @@ export function ShredsSeatsPage() {
                     <td className="px-4 py-3 text-sm font-mono group/cell">
                       <span className="inline-flex items-center gap-1">
                         {seat.user_pk ? (
-                          <Link to={`/dz/users/${seat.user_pk}`} className="text-blue-500 hover:underline" title={seat.user_pk}>
+                          <Link to={`/dz/users/${seat.user_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" title={seat.user_pk}>
                             {seat.client_ip}
                           </Link>
                         ) : seat.client_ip}
@@ -732,14 +732,14 @@ export function ShredsDevicesPage() {
                   <tr key={d.device_key} className="border-b border-border last:border-b-0 hover:bg-muted transition-colors">
                     <td className="px-4 py-3 text-sm group/cell">
                       <span className="inline-flex items-center gap-1">
-                        <Link to={`/dz/devices/${d.device_key}`} className="text-blue-500 hover:underline font-mono text-xs" title={d.device_key}>
+                        <Link to={`/dz/devices/${d.device_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={d.device_key}>
                           {d.device_code || truncatePK(d.device_key)}
                         </Link>
                         <CopyIcon text={d.device_key} />
                       </span>
                     </td>
                     <td className="px-4 py-3 text-sm">
-                      <Link to={`/dz/metros/${d.metro_exchange_key}`} className="text-blue-500 hover:underline font-mono text-xs" title={d.metro_exchange_key}>
+                      <Link to={`/dz/metros/${d.metro_exchange_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={d.metro_exchange_key}>
                         {d.metro_code || truncatePK(d.metro_exchange_key)}
                       </Link>
                     </td>
@@ -1223,11 +1223,11 @@ export function ShredsEscrowEventsPage() {
                       {new Date(e.event_ts).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                     </td>
                     <td className="px-4 py-3">
-                      <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border ${eventTypeBadgeColors[e.event_type] || eventTypeBadgeColors.unknown}`}>
+                      <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border whitespace-nowrap ${eventTypeBadgeColors[e.event_type] || eventTypeBadgeColors.unknown}`}>
                         {eventTypeLabels[e.event_type] || e.event_type}
                       </span>
                       {e.status === 'failed' && (
-                        <span className="ml-1 inline-flex items-center text-xs px-1.5 py-0.5 rounded-md bg-red-500/10 text-red-600 dark:text-red-400 border border-red-500/20">
+                        <span className="ml-1 inline-flex items-center text-xs px-1.5 py-0.5 rounded-md bg-red-500/10 text-red-600 dark:text-red-400 border border-red-500/20 whitespace-nowrap">
                           FAILED
                         </span>
                       )}
@@ -1236,7 +1236,7 @@ export function ShredsEscrowEventsPage() {
                       <span className="inline-flex items-center gap-1.5 group/cell">
                         <Link
                           to={`/dz/shreds/subscribers?search=seat:${e.client_seat_pk}&status=active,expiring,pending,inactive,closed`}
-                          className="text-blue-600 dark:text-blue-400 hover:underline"
+                          className="text-foreground/85 hover:text-foreground hover:underline"
                         >
                           {truncatePK(e.client_seat_pk)}
                         </Link>
@@ -1277,7 +1277,7 @@ export function ShredsEscrowEventsPage() {
                         href={e.solscan_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                        className="inline-flex items-center gap-1 text-xs text-foreground/85 hover:text-foreground hover:underline"
                         title={e.tx_signature}
                       >
                         {truncatePK(e.tx_signature)}

--- a/web/src/components/users-page.tsx
+++ b/web/src/components/users-page.tsx
@@ -342,10 +342,14 @@ export function UsersPage() {
                       {user.dz_ip ? <CopyableText text={user.dz_ip} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
                     <td className="px-4 py-3 text-sm whitespace-nowrap">
-                      {user.device_code ? <CopyableText text={user.device_code} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
+                      {user.device_pk
+                        ? <Link to={`/dz/devices/${user.device_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{user.device_code}</Link>
+                        : <span className="font-mono text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      {user.metro_name || user.metro_code || '—'}
+                    <td className="px-4 py-3 text-sm">
+                      {user.metro_pk
+                        ? <Link to={`/dz/metros/${user.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{user.metro_name || user.metro_code}</Link>
+                        : <span className="text-muted-foreground">—</span>}
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {user.tenant_code

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3034,6 +3034,7 @@ export interface User {
   client_ip: string
   device_pk: string
   device_code: string
+  metro_pk: string
   metro_code: string
   metro_name: string
   tenant_pk: string


### PR DESCRIPTION
## Summary of Changes
- Replace bright blue drill-down links on the shreds subscribers, devices, and activity pages with a subtle `text-foreground/85` style that is distinguishable as interactive without being visually dominant
- Fix the device copy icon in the subscribers table to copy the device code instead of the pubkey
- Add `whitespace-nowrap` to event type and FAILED status badges on the activity page to prevent word wrapping