### PR TITLE
api: push has_issues filter into queries and fix no_data over-matching

### DIFF
--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -836,14 +836,17 @@ func (a *API) GetBulkLinkMetrics(w http.ResponseWriter, r *http.Request) {
 	params = parseBucketParamsCustom(startTime, now, 24)
 	params.TimeRange = timeRange
 
-	resp, err := a.fetchBulkLinkMetrics(ctx, params, include)
+	issuesOnly := q.Get("has_issues") == "true"
+	resp, err := a.fetchBulkLinkMetrics(ctx, params, include, issuesOnly)
 	if err != nil {
 		slog.Error("error fetching bulk link metrics", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	if q.Get("has_issues") == "true" {
+	// Final safety filter: the first-pass is intentionally over-inclusive,
+	// so apply the exact Go-level filter to remove any false positives.
+	if issuesOnly {
 		filterBulkLinkMetricsIssuesOnly(resp)
 	}
 
@@ -852,28 +855,50 @@ func (a *API) GetBulkLinkMetrics(w http.ResponseWriter, r *http.Request) {
 
 // filterBulkLinkMetricsIssuesOnly removes links that have no issues from the response.
 // Keeps links with non-healthy buckets, or that are currently drained/provisioning.
+// Links whose only issue is no_data (e.g., a transient rollup gap) are excluded
+// unless they also have degraded/unhealthy buckets — matching the frontend's default filter.
 func filterBulkLinkMetricsIssuesOnly(resp *BulkLinkMetricsResponse) {
 	for pk, link := range resp.Links {
-		keep := false
+		hasRealIssue := false
+		hasNoData := false
 		for _, b := range link.Buckets {
 			if b.Status == nil {
 				continue
 			}
 			if b.Status.DrainStatus != "" || b.Status.Provisioning {
-				keep = true
+				hasRealIssue = true
 				break
 			}
 			if b.Status.ISISDown {
-				keep = true
+				hasRealIssue = true
 				break
 			}
 			if !b.Status.Collecting && b.Status.Health != "healthy" && b.Status.Health != "" {
-				keep = true
-				break
+				if b.Status.Health == "no_data" {
+					hasNoData = true
+				} else {
+					hasRealIssue = true
+					break
+				}
 			}
 		}
-		if !keep {
+		if !hasRealIssue && !hasNoData {
 			delete(resp.Links, pk)
+			continue
+		}
+		// Links with only no_data: keep only if they also have degraded/unhealthy buckets
+		if !hasRealIssue && hasNoData {
+			hasSevere := false
+			for _, b := range link.Buckets {
+				if b.Status != nil && !b.Status.Collecting &&
+					(b.Status.Health == "unhealthy" || b.Status.Health == "degraded") {
+					hasSevere = true
+					break
+				}
+			}
+			if !hasSevere {
+				delete(resp.Links, pk)
+			}
 		}
 	}
 }
@@ -886,10 +911,12 @@ func (a *API) FetchBulkLinkMetricsData(ctx context.Context) (*BulkLinkMetricsRes
 	params := parseBucketParamsCustom(startTime, now, 24)
 	params.TimeRange = "24h"
 	include := parseLinkMetricsInclude("status,traffic")
-	return a.fetchBulkLinkMetrics(ctx, params, include)
+	return a.fetchBulkLinkMetrics(ctx, params, include, false)
 }
 
 // FetchBulkLinkMetricsIssuesData is the page cache variant that only includes links with issues.
+// It reuses FetchBulkLinkMetricsData (which fetches all links in a single pass) and post-filters,
+// since the page cache worker amortizes the cost and both cache entries share the same query work.
 func (a *API) FetchBulkLinkMetricsIssuesData(ctx context.Context) (*BulkLinkMetricsResponse, error) {
 	resp, err := a.FetchBulkLinkMetricsData(ctx)
 	if err != nil {
@@ -899,8 +926,68 @@ func (a *API) FetchBulkLinkMetricsIssuesData(ctx context.Context) (*BulkLinkMetr
 	return resp, nil
 }
 
-// fetchBulkLinkMetrics runs parallel queries for ALL links and assembles the bulk response.
-func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, include linkMetricsInclude) (*BulkLinkMetricsResponse, error) {
+// determineIssueLinkPKs identifies which links likely have issues based on
+// lightweight first-pass data. Intentionally over-inclusive (false positives OK)
+// to avoid missing any true issue links. The caller applies the exact Go-level
+// filter afterward.
+func determineIssueLinkPKs(
+	metaMap map[string]*statusLinkMeta,
+	rollupSummary map[string]*linkRollupSummary,
+	intfIssuePKs map[string]bool,
+	currentISISDown map[string]bool,
+	params bucketParams,
+) map[string]bool {
+	result := make(map[string]bool)
+
+	for pk, meta := range metaMap {
+		// Drained or provisioning links always count as having issues.
+		if health.IsDrainedStatus(meta.Status) || meta.CommittedRttNs == committedRttProvisioningNs {
+			result[pk] = true
+			continue
+		}
+
+		// Current ISIS down.
+		if currentISISDown[pk] {
+			result[pk] = true
+			continue
+		}
+
+		summary, inRollup := rollupSummary[pk]
+
+		// Any issue indicator from the rollup.
+		if inRollup && (summary.AnyISISDown || summary.AnyDrained) {
+			result[pk] = true
+			continue
+		}
+		if inRollup && (summary.MaxALossPct > 0 || summary.MaxZLossPct > 0) {
+			result[pk] = true
+			continue
+		}
+
+		// Latency overage check (over-inclusive: skips inter-metro WAN filter).
+		if inRollup {
+			committedRttUs := meta.CommittedRttUs
+			if committedRttUs > 0 {
+				if summary.MaxAAvgRttUs > committedRttUs*1.2 || summary.MaxZAvgRttUs > committedRttUs*1.2 {
+					result[pk] = true
+					continue
+				}
+			}
+		}
+	}
+
+	// Interface errors/discards/carrier transitions.
+	for pk := range intfIssuePKs {
+		result[pk] = true
+	}
+
+	return result
+}
+
+// fetchBulkLinkMetrics runs parallel queries and assembles the bulk response.
+// When issuesOnly is true, it runs a lightweight first pass to identify links
+// with issues, then fetches detailed data only for those links.
+func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, include linkMetricsInclude, issuesOnly bool) (*BulkLinkMetricsResponse, error) {
 	db := a.envDB(ctx)
 
 	var bucketDuration time.Duration
@@ -921,32 +1008,44 @@ func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, inc
 		currentISISDown map[string]bool
 	)
 
-	g, gctx := errgroup.WithContext(ctx)
+	// When issuesOnly, run lightweight first-pass queries to identify which
+	// links have issues, then run the expensive rollup queries only for those.
+	var issuePKSet map[string]bool
+	if issuesOnly {
+		var (
+			rollupSummary  map[string]*linkRollupSummary
+			intfIssuePKSet map[string]bool
+		)
 
-	// Fetch all link metadata (no PK filter)
-	g.Go(func() error {
-		var err error
-		metaMap, err = queryStatusLinkMeta(gctx, db)
-		if err != nil {
-			return fmt.Errorf("bulk link metadata: %w", err)
-		}
-		return nil
-	})
+		g, gctx := errgroup.WithContext(ctx)
 
-	// Latency/status rollup for all links (no PK filter)
-	if include.Latency || include.Status {
 		g.Go(func() error {
 			var err error
-			linkRollupMap, err = queryLinkRollup(gctx, db, params)
+			metaMap, err = queryStatusLinkMeta(gctx, db)
 			if err != nil {
-				return fmt.Errorf("bulk link rollup: %w", err)
+				return fmt.Errorf("bulk link metadata: %w", err)
 			}
 			return nil
 		})
-	}
 
-	// Real-time ISIS adjacency state for collecting bucket
-	if include.Status {
+		g.Go(func() error {
+			var err error
+			rollupSummary, err = queryLinkRollupSummary(gctx, db, params)
+			if err != nil {
+				return fmt.Errorf("link rollup summary: %w", err)
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			var err error
+			intfIssuePKSet, err = queryInterfaceIssueLinkPKs(gctx, db, params)
+			if err != nil {
+				return fmt.Errorf("interface issue link PKs: %w", err)
+			}
+			return nil
+		})
+
 		g.Go(func() error {
 			var err error
 			currentISISDown, err = queryCurrentISISDown(gctx, db)
@@ -956,24 +1055,115 @@ func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, inc
 			}
 			return nil
 		})
-	}
 
-	// Traffic (interface rollup) for all links (no PK filter)
-	if include.Traffic {
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+
+		// Determine which links have issues.
+		issuePKSet = determineIssueLinkPKs(metaMap, rollupSummary, intfIssuePKSet, currentISISDown, params)
+
+		if len(issuePKSet) == 0 {
+			bucketSecs := params.BucketSeconds
+			if bucketSecs == 0 {
+				bucketSecs = params.BucketMinutes * 60
+			}
+			return &BulkLinkMetricsResponse{
+				TimeRange:     params.TimeRange,
+				BucketSeconds: bucketSecs,
+				BucketCount:   params.BucketCount,
+				Links:         make(map[string]*LinkMetricsResponse),
+			}, nil
+		}
+
+		issuePKSlice := make([]string, 0, len(issuePKSet))
+		for pk := range issuePKSet {
+			issuePKSlice = append(issuePKSlice, pk)
+		}
+
+		// Phase 2: run full rollup queries filtered to issue links only.
+		g2, gctx2 := errgroup.WithContext(ctx)
+
+		if include.Latency || include.Status {
+			g2.Go(func() error {
+				var err error
+				linkRollupMap, err = queryLinkRollup(gctx2, db, params, issuePKSlice...)
+				if err != nil {
+					return fmt.Errorf("bulk link rollup: %w", err)
+				}
+				return nil
+			})
+		}
+
+		if include.Traffic {
+			g2.Go(func() error {
+				var err error
+				intfRows, err = queryInterfaceRollup(gctx2, db, params, interfaceRollupOpts{
+					GroupBy: groupByLinkSide,
+					LinkPKs: issuePKSlice,
+				})
+				if err != nil {
+					return fmt.Errorf("bulk interface rollup: %w", err)
+				}
+				return nil
+			})
+		}
+
+		if err := g2.Wait(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Original path: fetch everything for all links.
+		g, gctx := errgroup.WithContext(ctx)
+
 		g.Go(func() error {
 			var err error
-			intfRows, err = queryInterfaceRollup(gctx, db, params, interfaceRollupOpts{
-				GroupBy: groupByLinkSide,
-			})
+			metaMap, err = queryStatusLinkMeta(gctx, db)
 			if err != nil {
-				return fmt.Errorf("bulk interface rollup: %w", err)
+				return fmt.Errorf("bulk link metadata: %w", err)
 			}
 			return nil
 		})
-	}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
+		if include.Latency || include.Status {
+			g.Go(func() error {
+				var err error
+				linkRollupMap, err = queryLinkRollup(gctx, db, params)
+				if err != nil {
+					return fmt.Errorf("bulk link rollup: %w", err)
+				}
+				return nil
+			})
+		}
+
+		if include.Status {
+			g.Go(func() error {
+				var err error
+				currentISISDown, err = queryCurrentISISDown(gctx, db)
+				if err != nil {
+					slog.Warn("failed to query current ISIS state for bulk", "error", err)
+					currentISISDown = nil
+				}
+				return nil
+			})
+		}
+
+		if include.Traffic {
+			g.Go(func() error {
+				var err error
+				intfRows, err = queryInterfaceRollup(gctx, db, params, interfaceRollupOpts{
+					GroupBy: groupByLinkSide,
+				})
+				if err != nil {
+					return fmt.Errorf("bulk interface rollup: %w", err)
+				}
+				return nil
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Index interface rows by (link_pk, bucket, side)
@@ -992,9 +1182,17 @@ func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, inc
 		bucketSecs = params.BucketMinutes * 60
 	}
 
-	// Build per-link responses
-	links := make(map[string]*LinkMetricsResponse, len(metaMap))
+	// Build per-link responses. When issuesOnly, only assemble links in the
+	// issue set; other links were not fetched in the rollup queries.
+	linkCount := len(metaMap)
+	if len(issuePKSet) > 0 {
+		linkCount = len(issuePKSet)
+	}
+	links := make(map[string]*LinkMetricsResponse, linkCount)
 	for linkPK, meta := range metaMap {
+		if len(issuePKSet) > 0 && !issuePKSet[linkPK] {
+			continue
+		}
 		committedRtt := meta.CommittedRttUs
 
 		// For health classification, only consider latency on inter-metro WAN links

--- a/api/handlers/link_metrics_test.go
+++ b/api/handlers/link_metrics_test.go
@@ -1,0 +1,229 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedBulkLinkTestData sets up common dimension data for bulk link metrics tests.
+// Returns the truncated "now" time used for rollup bucket alignment.
+func seedBulkLinkTestData(t *testing.T, api *handlers.API) time.Time {
+	t.Helper()
+	seedMetro(t, api, "metro-a", "NYC")
+	seedMetro(t, api, "metro-z", "LAX")
+	seedContributor(t, api, "contrib-1", "acme")
+	seedDeviceMetadata(t, api, "dev-a", "DEV-A", "router", "contrib-1", "metro-a", 10, "activated")
+	seedDeviceMetadata(t, api, "dev-z", "DEV-Z", "router", "contrib-1", "metro-z", 10, "activated")
+	return time.Now().UTC().Truncate(5 * time.Minute)
+}
+
+// TestQueryLinkRollupSummary verifies the lightweight first-pass query
+// executes valid SQL and correctly scans ClickHouse types (Bool, UInt64, Float64).
+func TestQueryLinkRollupSummary(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := seedBulkLinkTestData(t, api)
+
+	seedLinkMetadata(t, api, "link-healthy", "NYC-LAX-H", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+	seedLinkMetadata(t, api, "link-loss", "NYC-LAX-L", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+	seedLinkMetadata(t, api, "link-isis", "NYC-LAX-I", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+
+	for i := 0; i < 6; i++ {
+		ts := now.Add(-time.Duration(6-i) * 5 * time.Minute)
+		seedLinkRollup(t, api, ts, "link-healthy", 100, 100, 0, 0, 90, 90, "activated", false, false)
+		seedLinkRollup(t, api, ts, "link-loss", 100, 100, 5.0, 3.0, 90, 90, "activated", false, false)
+		seedLinkRollup(t, api, ts, "link-isis", 100, 100, 0, 0, 90, 90, "activated", false, true)
+	}
+
+	params := handlers.ExportParseBucketParams("1h", 3)
+	result, err := handlers.ExportQueryLinkRollupSummary(t.Context(), api.DB, params)
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+
+	// Healthy link: no issue indicators
+	h := result["link-healthy"]
+	require.NotNil(t, h)
+	assert.False(t, h.AnyISISDown)
+	assert.False(t, h.AnyDrained)
+	assert.Equal(t, float64(0), h.MaxALossPct)
+	assert.Equal(t, float64(0), h.MaxZLossPct)
+	assert.Equal(t, uint64(6), h.BucketCount)
+
+	// Loss link: has loss indicators
+	l := result["link-loss"]
+	require.NotNil(t, l)
+	assert.False(t, l.AnyISISDown)
+	assert.InDelta(t, 5.0, l.MaxALossPct, 0.1)
+	assert.InDelta(t, 3.0, l.MaxZLossPct, 0.1)
+
+	// ISIS link: isis_down set
+	isis := result["link-isis"]
+	require.NotNil(t, isis)
+	assert.True(t, isis.AnyISISDown)
+}
+
+// TestQueryLinkRollupSummary_Empty verifies the query works with no data.
+func TestQueryLinkRollupSummary_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	params := handlers.ExportParseBucketParams("1h", 3)
+	result, err := handlers.ExportQueryLinkRollupSummary(t.Context(), api.DB, params)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestQueryInterfaceIssueLinkPKs verifies the first-pass interface error query
+// correctly identifies links with errors and excludes clean links.
+func TestQueryInterfaceIssueLinkPKs(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := time.Now().UTC().Truncate(5 * time.Minute)
+
+	// link-errors has interface errors, link-clean does not
+	seedInterfaceRollup(t, api, now.Add(-10*time.Minute), "dev-a", "Ethernet1/1", "link-errors", "A", 50, 10, 1_000_000, "activated")
+	seedInterfaceRollup(t, api, now.Add(-10*time.Minute), "dev-z", "Ethernet1/1", "link-clean", "Z", 0, 0, 500_000, "activated")
+
+	params := handlers.ExportParseBucketParams("1h", 3)
+	result, err := handlers.ExportQueryInterfaceIssueLinkPKs(t.Context(), api.DB, params)
+	require.NoError(t, err)
+
+	assert.True(t, result["link-errors"], "link with errors should be identified")
+	assert.False(t, result["link-clean"], "link without errors should not be identified")
+}
+
+// TestQueryInterfaceIssueLinkPKs_Empty verifies the query works with no data.
+func TestQueryInterfaceIssueLinkPKs_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	params := handlers.ExportParseBucketParams("1h", 3)
+	result, err := handlers.ExportQueryInterfaceIssueLinkPKs(t.Context(), api.DB, params)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestGetBulkLinkMetrics_IssuesOnly verifies the has_issues=true endpoint
+// returns only links with issues and applies the two-pass filter correctly.
+func TestGetBulkLinkMetrics_IssuesOnly(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := seedBulkLinkTestData(t, api)
+
+	// Healthy link: no issues
+	seedLinkMetadata(t, api, "link-healthy", "NYC-LAX-H", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+	// Link with packet loss
+	seedLinkMetadata(t, api, "link-loss", "NYC-LAX-L", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+
+	for i := 0; i < 12; i++ {
+		ts := now.Add(-time.Duration(12-i) * 5 * time.Minute)
+		seedLinkRollup(t, api, ts, "link-healthy", 100, 100, 0, 0, 90, 90, "activated", false, false)
+		seedLinkRollup(t, api, ts, "link-loss", 100, 100, 5.0, 0, 90, 90, "activated", false, false)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/link-metrics?range=24h&include=status&has_issues=true", nil)
+	rr := httptest.NewRecorder()
+	api.GetBulkLinkMetrics(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp handlers.BulkLinkMetricsResponse
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	// Only the link with loss should be returned
+	assert.Contains(t, resp.Links, "link-loss", "link with loss should be included")
+	assert.NotContains(t, resp.Links, "link-healthy", "healthy link should be excluded")
+}
+
+// TestGetBulkLinkMetrics_AllLinks verifies the endpoint without has_issues
+// returns all links including healthy ones.
+func TestGetBulkLinkMetrics_AllLinks(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := seedBulkLinkTestData(t, api)
+
+	seedLinkMetadata(t, api, "link-healthy", "NYC-LAX-H", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+	seedLinkMetadata(t, api, "link-loss", "NYC-LAX-L", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+
+	for i := 0; i < 12; i++ {
+		ts := now.Add(-time.Duration(12-i) * 5 * time.Minute)
+		seedLinkRollup(t, api, ts, "link-healthy", 100, 100, 0, 0, 90, 90, "activated", false, false)
+		seedLinkRollup(t, api, ts, "link-loss", 100, 100, 5.0, 0, 90, 90, "activated", false, false)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/link-metrics?range=24h&include=status", nil)
+	rr := httptest.NewRecorder()
+	api.GetBulkLinkMetrics(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp handlers.BulkLinkMetricsResponse
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	// Both links should be returned
+	assert.Contains(t, resp.Links, "link-healthy")
+	assert.Contains(t, resp.Links, "link-loss")
+}
+
+// TestGetBulkLinkMetrics_IssuesOnly_Empty verifies the endpoint returns an
+// empty response when no links have issues.
+func TestGetBulkLinkMetrics_IssuesOnly_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := seedBulkLinkTestData(t, api)
+
+	seedLinkMetadata(t, api, "link-healthy", "NYC-LAX-H", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "activated")
+
+	for i := 0; i < 12; i++ {
+		ts := now.Add(-time.Duration(12-i) * 5 * time.Minute)
+		seedLinkRollup(t, api, ts, "link-healthy", 100, 100, 0, 0, 90, 90, "activated", false, false)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/link-metrics?range=24h&include=status&has_issues=true", nil)
+	rr := httptest.NewRecorder()
+	api.GetBulkLinkMetrics(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp handlers.BulkLinkMetricsResponse
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Links)
+}
+
+// TestGetBulkLinkMetrics_DrainedLink verifies that drained links are included
+// in the issues-only response.
+func TestGetBulkLinkMetrics_DrainedLink(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	now := seedBulkLinkTestData(t, api)
+
+	seedLinkMetadata(t, api, "link-drained", "NYC-LAX-D", "WAN", "contrib-1", "dev-a", "dev-z", 10_000_000_000, 500_000, "soft-drained")
+
+	for i := 0; i < 12; i++ {
+		ts := now.Add(-time.Duration(12-i) * 5 * time.Minute)
+		seedLinkRollup(t, api, ts, "link-drained", 100, 100, 0, 0, 90, 90, "soft-drained", false, false)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/link-metrics?range=24h&include=status&has_issues=true", nil)
+	rr := httptest.NewRecorder()
+	api.GetBulkLinkMetrics(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp handlers.BulkLinkMetricsResponse
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Links, "link-drained", "drained link should be included in issues")
+}

--- a/api/handlers/status_rollup.go
+++ b/api/handlers/status_rollup.go
@@ -906,6 +906,118 @@ func queryInterfaceRollup(ctx context.Context, db driver.Conn, params bucketPara
 	return result, nil
 }
 
+// --- Issue link detection (first-pass queries) ---
+
+// linkRollupSummary holds per-link aggregate indicators from a lightweight
+// rollup scan used to identify links that may have issues.
+type linkRollupSummary struct {
+	LinkPK       string
+	BucketCount  uint64
+	AnyISISDown  bool
+	MaxALossPct  float64
+	MaxZLossPct  float64
+	AnyDrained   bool
+	MaxAAvgRttUs float64
+	MaxZAvgRttUs float64
+}
+
+// queryLinkRollupSummary runs a lightweight scan of link_rollup_5m to get
+// per-link issue indicators. Skips FINAL for speed since false positives
+// (from unmerged rows) are acceptable — the caller uses this to identify
+// candidate issue links, not for display.
+func queryLinkRollupSummary(ctx context.Context, db driver.Conn, params bucketParams) (map[string]*linkRollupSummary, error) {
+	var args []any
+	if params.StartTime != nil {
+		args = append(args, *params.StartTime)
+	} else {
+		args = append(args, time.Now().UTC().Add(-time.Duration(params.TotalMinutes)*time.Minute))
+	}
+
+	var endClause string
+	if params.EndTime != nil {
+		args = append(args, *params.EndTime)
+		endClause = fmt.Sprintf(" AND bucket_ts < $%d", len(args))
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			link_pk,
+			countDistinct(bucket_ts) as bucket_count,
+			max(isis_down) > 0 as any_isis_down,
+			max(a_loss_pct) as max_a_loss_pct,
+			max(z_loss_pct) as max_z_loss_pct,
+			max(status IN ('soft-drained', 'hard-drained')) as any_drained,
+			max(a_avg_rtt_us) as max_a_avg_rtt_us,
+			max(z_avg_rtt_us) as max_z_avg_rtt_us
+		FROM link_rollup_5m
+		WHERE bucket_ts >= $1%s
+		GROUP BY link_pk
+	`, endClause)
+
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("link rollup summary query: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]*linkRollupSummary)
+	for rows.Next() {
+		var s linkRollupSummary
+		if err := rows.Scan(
+			&s.LinkPK, &s.BucketCount,
+			&s.AnyISISDown, &s.MaxALossPct, &s.MaxZLossPct,
+			&s.AnyDrained, &s.MaxAAvgRttUs, &s.MaxZAvgRttUs,
+		); err != nil {
+			return nil, fmt.Errorf("link rollup summary scan: %w", err)
+		}
+		result[s.LinkPK] = &s
+	}
+	return result, rows.Err()
+}
+
+// queryInterfaceIssueLinkPKs returns distinct link PKs that have any interface
+// errors, discards, or carrier transitions in the time range. Skips FINAL for
+// speed since false positives are acceptable for issue detection.
+func queryInterfaceIssueLinkPKs(ctx context.Context, db driver.Conn, params bucketParams) (map[string]bool, error) {
+	var args []any
+	if params.StartTime != nil {
+		args = append(args, *params.StartTime)
+	} else {
+		args = append(args, time.Now().UTC().Add(-time.Duration(params.TotalMinutes)*time.Minute))
+	}
+
+	var endClause string
+	if params.EndTime != nil {
+		args = append(args, *params.EndTime)
+		endClause = fmt.Sprintf(" AND bucket_ts < $%d", len(args))
+	}
+
+	query := fmt.Sprintf(`
+		SELECT DISTINCT link_pk
+		FROM device_interface_rollup_5m
+		WHERE bucket_ts >= $1%s
+		  AND link_pk != ''
+		  AND (in_errors > 0 OR out_errors > 0 OR in_fcs_errors > 0
+		       OR in_discards > 0 OR out_discards > 0 OR carrier_transitions > 0)
+	`, endClause)
+
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interface issue link PKs query: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]bool)
+	for rows.Next() {
+		var pk string
+		if err := rows.Scan(&pk); err != nil {
+			return nil, fmt.Errorf("interface issue link PKs scan: %w", err)
+		}
+		result[pk] = true
+	}
+	return result, rows.Err()
+}
+
 // --- Helpers ---
 
 // bucketIntervalExpr returns a ClickHouse expression that truncates a timestamp

--- a/api/handlers/status_rollup_export_test.go
+++ b/api/handlers/status_rollup_export_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
@@ -11,6 +12,7 @@ import (
 type ExportLinkRollupRow = linkRollupRow
 type ExportLinkBucketKey = linkBucketKey
 type ExportInterfaceRollupRow = interfaceRollupRow
+type ExportLinkRollupSummary = linkRollupSummary
 
 type ExportInterfaceRollupOpts struct {
 	GroupBy    int
@@ -42,4 +44,16 @@ func ExportQueryInterfaceRollup(ctx context.Context, db driver.Conn, params buck
 		UserOnly:   opts.UserOnly,
 		ErrorsOnly: opts.ErrorsOnly,
 	})
+}
+
+func ExportParseBucketParamsCustom(startTime, endTime time.Time, requestedBuckets int) bucketParams {
+	return parseBucketParamsCustom(startTime, endTime, requestedBuckets)
+}
+
+func ExportQueryLinkRollupSummary(ctx context.Context, db driver.Conn, params bucketParams) (map[string]*linkRollupSummary, error) {
+	return queryLinkRollupSummary(ctx, db, params)
+}
+
+func ExportQueryInterfaceIssueLinkPKs(ctx context.Context, db driver.Conn, params bucketParams) (map[string]bool, error) {
+	return queryInterfaceIssueLinkPKs(ctx, db, params)
 }


### PR DESCRIPTION
## Summary of Changes
- Fix `filterBulkLinkMetricsIssuesOnly` which was keeping all 166 links because every link had a single transient `no_data` bucket from a rollup gap — now excludes links whose only non-healthy indicator is `no_data`, matching the frontend's default filter
- Add two-pass query architecture for `has_issues=true` requests: lightweight first-pass queries identify issue link PKs from rollup/interface tables, then full rollup queries run filtered to only those links via `IN (...)` — speeds up uncached non-24h time range switches (6h, 3h, etc.)
- Result: 166 links / 44MB / ~700ms → 15 links / 4MB / ~50ms on the status links timeline

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +350 / -40  | +310 |
| Tests        |     2 | +243 / -0   | +243 |
| **Total**    |     4 | +593 / -40  | +553 |

Mostly new query functions and filter logic, with integration tests covering the new code paths.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/link_metrics.go`](#diff-c80feaf3c1ccbfdfe173ab6d19c34d52b8e5994d34f039594fbc4d83339cfa6f) — two-pass `fetchBulkLinkMetrics` when `issuesOnly`, `determineIssueLinkPKs` first-pass logic, fixed `filterBulkLinkMetricsIssuesOnly` to not keep links with only `no_data` buckets
- [`api/handlers/status_rollup.go`](#diff-397b57187c82c4c607d20dccc8aa7a4002cdce86567821bd5818a0666399f86b) — `queryLinkRollupSummary` (lightweight per-link issue indicators from `link_rollup_5m`) and `queryInterfaceIssueLinkPKs` (distinct link PKs with interface errors)

</details>

## Testing Verification
- Added 8 integration tests covering: rollup summary scan types, interface error detection, issues-only endpoint filtering (loss, drained, empty), and unfiltered endpoint
- Verified against live API: cache HIT returns 15 links / 4MB in ~50ms vs previous 166 links / 44MB / ~700ms
- Confirmed `X-Cache: HIT` still works for 24h default view