### PR TITLE
api: suppress context canceled noise in link metrics handler

### DIFF
--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -305,7 +305,7 @@ func (a *API) GetLinkMetrics(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := a.fetchLinkMetrics(ctx, linkPK, params, include)
 	if err != nil {
-		slog.Error("error fetching link metrics", "error", err, "link_pk", linkPK)
+		logError("error fetching link metrics", "error", err, "link_pk", linkPK)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary of Changes
- Replace `slog.Error` with the existing `logError` helper in the link metrics handler so client-disconnect errors (`context canceled`) are silently dropped instead of logged as errors

## Testing Verification
- Verified `logError` already handles `context canceled` via both `errors.Is` and string-based fallback in `isClientDisconnect`