### PR TITLE
api: fix burstiness query crash when filtering by contributor or metro

### DIFF
--- a/api/handlers/traffic_dashboard.go
+++ b/api/handlers/traffic_dashboard.go
@@ -921,7 +921,7 @@ func BuildDrilldownQuery(timeFilter, bucketInterval, devicePk, intfFilter string
 // BuildBurstinessQuery builds the ClickHouse query for the burstiness endpoint.
 // Reads from device_interface_rollup_5m. Each rollup row already represents one
 // 5-minute bucket with max throughput, so we compute P50/P99 across buckets directly.
-func BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL string, needsUserJoin, needsInterfaceJoin bool, threshold float64, minBps, minPeakBps float64, limit, offset int) string {
+func BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL string, needsUserJoin, needsInterfaceJoin, needsMetroJoin, needsContributorJoin bool, threshold float64, minBps, minPeakBps float64, limit, offset int) string {
 	// Validate sort direction
 	dir := "DESC"
 	if sortDir == "ASC" {
@@ -952,6 +952,16 @@ func BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilter
 		intfJoinSQL = "\n\t\t\tLEFT JOIN dz_device_interfaces_current di ON f.device_pk = di.device_pk AND f.intf = di.intf"
 	}
 
+	var metroJoinSQL string
+	if needsMetroJoin {
+		metroJoinSQL = "\n\t\t\tLEFT JOIN dz_metros_current m ON d.metro_pk = m.pk"
+	}
+
+	var contributorJoinSQL string
+	if needsContributorJoin {
+		contributorJoinSQL = "\n\t\t\tLEFT JOIN dz_contributors_current co ON d.contributor_pk = co.pk"
+	}
+
 	// Two-pass query: first compute per-interface baselines, then count spikes.
 	// A spike is a 5-min bucket where max throughput exceeds 2x the median (P50).
 	// The spike threshold is the greater of 2*P50 and the absolute min_bps floor.
@@ -966,7 +976,7 @@ func BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilter
 				quantile(0.95)(greatest(f.max_in_bps, f.max_out_bps)) AS p95_bps
 			FROM device_interface_rollup_5m f
 			INNER JOIN dz_devices_current d ON f.device_pk = d.pk
-			LEFT JOIN dz_links_current l ON f.link_pk = l.pk%s%s
+			LEFT JOIN dz_links_current l ON f.link_pk = l.pk%s%s%s%s
 			WHERE f.%s
 				%s
 				%s
@@ -1010,7 +1020,7 @@ func BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilter
 		FROM spike_results
 		ORDER BY %s %s
 		LIMIT %d OFFSET %d`,
-		userJoinSQL, intfJoinSQL, timeFilter, intfTypeSQL, filterSQL, intfFilterSQL, userKindFilter,
+		userJoinSQL, intfJoinSQL, metroJoinSQL, contributorJoinSQL, timeFilter, intfTypeSQL, filterSQL, intfFilterSQL, userKindFilter,
 		minBps,
 		timeFilter,
 		minPeakBps, orderCol, dir, limit, offset)
@@ -1669,9 +1679,9 @@ func (a *API) GetTrafficDashboardBurstiness(w http.ResponseWriter, r *http.Reque
 	}
 	sortDir := strings.ToUpper(r.URL.Query().Get("dir"))
 
-	filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL, _, _, _, _, needsUserJoin, needsInterfaceJoin := buildDimensionFilters(r)
+	filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL, _, _, needsMetroJoin, needsContributorJoin, needsUserJoin, needsInterfaceJoin := buildDimensionFilters(r)
 
-	query := BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL, needsUserJoin, needsInterfaceJoin, threshold, minBps, minPeakBps, limit, offset)
+	query := BuildBurstinessQuery(timeFilter, sortMetric, sortDir, filterSQL, intfFilterSQL, intfTypeSQL, userKindSQL, needsUserJoin, needsInterfaceJoin, needsMetroJoin, needsContributorJoin, threshold, minBps, minPeakBps, limit, offset)
 
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)

--- a/api/handlers/traffic_dashboard_test.go
+++ b/api/handlers/traffic_dashboard_test.go
@@ -1120,6 +1120,69 @@ func TestTrafficDashboardBurstiness_Empty(t *testing.T) {
 	assert.Empty(t, resp.Entities)
 }
 
+func TestTrafficDashboardBurstiness_WithContributorAndMetroFilter(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDashboardData(t, api)
+
+	tests := []struct {
+		name      string
+		query     string
+		wantIntfs []string
+	}{
+		{
+			name:      "contributor_ACME",
+			query:     "?time_range=1h&contributor=ACME",
+			wantIntfs: []string{"Port-Channel1000"},
+		},
+		{
+			name:      "contributor_BETA",
+			query:     "?time_range=1h&contributor=BETA",
+			wantIntfs: []string{"Ethernet1/1"},
+		},
+		{
+			name:      "contributor_nonexistent",
+			query:     "?time_range=1h&contributor=NOPE",
+			wantIntfs: nil,
+		},
+		{
+			name:      "metro_FRA",
+			query:     "?time_range=1h&metro=FRA",
+			wantIntfs: []string{"Port-Channel1000"},
+		},
+		{
+			name:      "metro_AMS",
+			query:     "?time_range=1h&metro=AMS",
+			wantIntfs: []string{"Ethernet1/1"},
+		},
+		{
+			name:      "metro_nonexistent",
+			query:     "?time_range=1h&metro=NYC",
+			wantIntfs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/traffic/dashboard/burstiness"+tt.query, nil)
+			rr := httptest.NewRecorder()
+
+			api.GetTrafficDashboardBurstiness(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+			var resp handlers.BurstinessResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+			var gotIntfs []string
+			for _, e := range resp.Entities {
+				gotIntfs = append(gotIntfs, e.Intf)
+			}
+			assert.ElementsMatch(t, tt.wantIntfs, gotIntfs)
+		})
+	}
+}
+
 // --- Health endpoint tests ---
 
 // seedHealthData inserts data with nonzero error/discard/carrier values for health testing.


### PR DESCRIPTION
## Summary of Changes
- The `baselines` CTE in `BuildBurstinessQuery` was missing `LEFT JOIN` clauses for `dz_contributors_current` and `dz_metros_current`, so passing `?contributor=` or `?metro=` caused ClickHouse to misinterpret the table alias as a database name (`Database co does not exist`)
- Pass `needsMetroJoin` and `needsContributorJoin` flags into `BuildBurstinessQuery` (previously discarded at the call site) and conditionally add those joins to the `baselines` CTE when the filter is active
- Add `TestTrafficDashboardBurstiness_WithContributorAndMetroFilter` covering both filter params with match, alternate-value, and nonexistent-value cases

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     1 | +15 / -5    |  +10 |
| Tests      |     1 | +63 / -0    |  +63 |

Small targeted fix with proportionally large test coverage.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/traffic_dashboard.go` — adds `needsMetroJoin`/`needsContributorJoin` params to `BuildBurstinessQuery` and injects the missing joins into the `baselines` CTE; updates call site to capture and forward the flags
- `api/handlers/traffic_dashboard_test.go` — new test exercising `?contributor=` and `?metro=` on the burstiness endpoint, with both matching and nonexistent filter values

</details>

## Testing Verification
- `TestTrafficDashboardBurstiness_WithContributorAndMetroFilter` added and passing (6 subtests: contributor match, alternate contributor, nonexistent contributor, metro match, alternate metro, nonexistent metro)