### PR TITLE
web/api: show active incident types on drained links

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -175,13 +175,14 @@ type NonActivatedDevice struct {
 }
 
 type NonActivatedLink struct {
-	PK         string `json:"pk"`
-	Code       string `json:"code"`
-	LinkType   string `json:"link_type"`
-	SideAMetro string `json:"side_a_metro"`
-	SideZMetro string `json:"side_z_metro"`
-	Status     string `json:"status"`
-	Since      string `json:"since"` // ISO timestamp when entered this status
+	PK                  string   `json:"pk"`
+	Code                string   `json:"code"`
+	LinkType            string   `json:"link_type"`
+	SideAMetro          string   `json:"side_a_metro"`
+	SideZMetro          string   `json:"side_z_metro"`
+	Status              string   `json:"status"`
+	Since               string   `json:"since"` // ISO timestamp when entered this status
+	ActiveIncidentTypes []string `json:"active_incident_types,omitempty"`
 }
 
 type ISISDeviceIssue struct {
@@ -1107,8 +1108,51 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 			}
 			links = append(links, link)
 		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		// Enrich drained links (not provisioning) with active incident types
+		var drainedPKs []string
+		for _, l := range links {
+			if l.Status != "provisioning" {
+				drainedPKs = append(drainedPKs, l.PK)
+			}
+		}
+		if len(drainedPKs) > 0 {
+			incidentRows, err := a.envDB(ctx).Query(ctx,
+				`SELECT entity_pk, groupArray(distinct incident_type) AS incident_types
+				 FROM link_incidents_v
+				 WHERE entity_pk IN ?
+				   AND is_ongoing = 1
+				 GROUP BY entity_pk`,
+				drainedPKs,
+			)
+			if err == nil {
+				defer incidentRows.Close()
+				activeByPK := make(map[string][]string)
+				for incidentRows.Next() {
+					var pk string
+					var types []string
+					if err := incidentRows.Scan(&pk, &types); err != nil {
+						slog.Warn("status: failed to scan incident row", "err", err)
+						continue
+					}
+					activeByPK[pk] = types
+				}
+				if err := incidentRows.Err(); err != nil {
+					slog.Warn("status: incident rows iteration error", "err", err)
+				}
+				for i := range links {
+					if types, ok := activeByPK[links[i].PK]; ok {
+						links[i].ActiveIncidentTypes = types
+					}
+				}
+			}
+		}
+
 		resp.Alerts.Links = links
-		return rows.Err()
+		return nil
 	})
 
 	// ISIS device issues (overload, unreachable)

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -222,6 +222,32 @@ function formatDuration(since: string): string {
   return `${diffMins}m`
 }
 
+function drainIncidentLabel(incidentType: string): string {
+  const labels: Record<string, string> = {
+    packet_loss: 'Packet Loss',
+    isis_down: 'ISIS Down',
+    fcs: 'FCS Errors',
+    errors: 'Interface Errors',
+    discards: 'Discards',
+    carrier: 'Carrier Events',
+    no_data: 'No Data',
+  }
+  return labels[incidentType] ?? incidentType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function drainIncidentColor(incidentType: string): string {
+  const colors: Record<string, string> = {
+    packet_loss: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    isis_down:   'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    fcs:         'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    errors:      'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    discards:    'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    carrier:     'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    no_data:     'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  }
+  return colors[incidentType] ?? 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+}
+
 function IssueDetails({
   issues,
   nonActivatedLinks,
@@ -467,6 +493,24 @@ function IssueDetails({
                     <div className="text-xs text-muted-foreground">
                       {link.side_a_metro} → {link.side_z_metro} · {link.link_type}
                     </div>
+                    {link.status !== 'provisioning' && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {link.active_incident_types && link.active_incident_types.length > 0 ? (
+                          link.active_incident_types.map((t) => (
+                            <span
+                              key={t}
+                              className={`text-xs rounded-full px-2 py-0.5 font-medium ${drainIncidentColor(t)}`}
+                            >
+                              {drainIncidentLabel(t)}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-xs rounded-full px-2 py-0.5 font-medium bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                            Planned Maintenance
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="text-right">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1297,6 +1297,7 @@ export interface NonActivatedLink {
   side_z_metro: string
   status: string
   since: string
+  active_incident_types?: string[]
 }
 
 export interface ISISDeviceIssue {


### PR DESCRIPTION
## Summary of Changes
- Enriches the drained/non-activated links section in the status page with active incident type badges fetched from `link_incidents_v`
- Links with no active incidents show "Planned Maintenance" (grey); links with incidents show color-coded badges: red for `isis_down`, `packet_loss`, `fcs`, and interface errors; amber for `discards`, `carrier`, and `no_data`
- Adds `active_incident_types` field to `NonActivatedLink` in both the API response and the TypeScript interface

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     3 | +97 / -8    |  +89 |

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/status.go` — adds secondary query to enrich drained links with grouped incident types from `link_incidents_v`; uses `IN ?` array binding for ClickHouse
- `web/src/components/status-page.tsx` — renders incident badges with per-type color mapping and labels; falls back to "Planned Maintenance" when no incidents
- `web/src/lib/api.ts` — adds optional `active_incident_types` field to `NonActivatedLink` interface

</details>

## Testing Verification
- Verified with local ClickHouse: soft-drained links correctly show `packet_loss` badge; simulated `isis_down` row confirms red badge renders
- Confirmed "Planned Maintenance" badge renders for drained links with no active incidents
- Confirmed provisioning links show no badges