### PR TITLE
feat: improve UI and responsiveness across components

### DIFF
--- a/web/src/components/chart-config-panel.tsx
+++ b/web/src/components/chart-config-panel.tsx
@@ -1,6 +1,7 @@
 import { BarChart3, LineChart, PieChart, AreaChart, ScatterChart } from 'lucide-react'
 import type { ChartType, VisualizationConfig, ColumnAnalysis } from '@/lib/visualization'
 import { getCompatibleChartTypes } from '@/lib/visualization'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 interface ChartConfigPanelProps {
   columns: string[]
@@ -25,7 +26,12 @@ const chartTypeLabels: Record<ChartType, string> = {
   scatter: 'Scatter',
 }
 
-export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChange }: ChartConfigPanelProps) {
+export function ChartConfigPanel({
+  columns,
+  columnAnalysis,
+  config,
+  onConfigChange,
+}: ChartConfigPanelProps) {
   const compatibleTypes = getCompatibleChartTypes(columnAnalysis)
 
   // Get columns suitable for X axis (categorical or temporal preferred)
@@ -52,7 +58,7 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
       if (currentYAxis.includes(yAxis)) {
         // Remove if already selected (but keep at least one)
         if (currentYAxis.length > 1) {
-          onConfigChange({ ...config, yAxis: currentYAxis.filter(y => y !== yAxis) })
+          onConfigChange({ ...config, yAxis: currentYAxis.filter((y) => y !== yAxis) })
         }
       } else {
         // Add to selection (max 4)
@@ -64,7 +70,7 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
   }
 
   const getColumnTypeIcon = (col: string) => {
-    const analysis = columnAnalysis.find(c => c.name === col)
+    const analysis = columnAnalysis.find((c) => c.name === col)
     if (!analysis) return null
 
     switch (analysis.dataType) {
@@ -85,7 +91,7 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
       <div className="flex items-center gap-2">
         <span className="text-muted-foreground text-xs font-medium">Type</span>
         <div className="flex items-center gap-1">
-          {(['bar', 'line', 'pie', 'area', 'scatter'] as ChartType[]).map(type => {
+          {(['bar', 'line', 'pie', 'area', 'scatter'] as ChartType[]).map((type) => {
             const isCompatible = compatibleTypes.includes(type)
             const isSelected = config.chartType === type
             return (
@@ -98,8 +104,8 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
                   isSelected
                     ? 'bg-foreground text-background'
                     : isCompatible
-                    ? 'bg-card hover:bg-muted text-foreground'
-                    : 'bg-muted text-muted-foreground cursor-not-allowed opacity-50'
+                      ? 'bg-card hover:bg-muted text-foreground'
+                      : 'bg-muted text-muted-foreground cursor-not-allowed opacity-50'
                 }`}
               >
                 {chartTypeIcons[type]}
@@ -112,17 +118,11 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
       {/* X Axis Selector */}
       <div className="flex items-center gap-2">
         <span className="text-muted-foreground text-xs font-medium">X Axis</span>
-        <select
+        <SmallDropdown
           value={config.xAxis}
-          onChange={(e) => handleXAxisChange(e.target.value)}
-          className="px-2 py-1 rounded border border-border bg-card text-sm focus:outline-none focus:ring-1 focus:ring-accent"
-        >
-          {xAxisOptions.map(col => (
-            <option key={col} value={col}>
-              {col}
-            </option>
-          ))}
-        </select>
+          options={xAxisOptions.map((col) => ({ value: col, label: col }))}
+          onChange={handleXAxisChange}
+        />
         {getColumnTypeIcon(config.xAxis)}
       </div>
 
@@ -132,36 +132,34 @@ export function ChartConfigPanel({ columns, columnAnalysis, config, onConfigChan
           Y Axis {config.chartType !== 'pie' && config.chartType !== 'scatter' && '(multi)'}
         </span>
         {config.chartType === 'pie' || config.chartType === 'scatter' ? (
-          <select
+          <SmallDropdown
             value={config.yAxis[0] || ''}
-            onChange={(e) => handleYAxisChange(e.target.value)}
-            className="px-2 py-1 rounded border border-border bg-card text-sm focus:outline-none focus:ring-1 focus:ring-accent"
-          >
-            {yAxisOptions.filter(col => col !== config.xAxis).map(col => (
-              <option key={col} value={col}>
-                {col}
-              </option>
-            ))}
-          </select>
+            options={yAxisOptions
+              .filter((col) => col !== config.xAxis)
+              .map((col) => ({ value: col, label: col }))}
+            onChange={handleYAxisChange}
+          />
         ) : (
           <div className="flex flex-wrap gap-1">
-            {yAxisOptions.filter(col => col !== config.xAxis).map(col => {
-              const isSelected = config.yAxis.includes(col)
-              return (
-                <button
-                  key={col}
-                  onClick={() => handleYAxisChange(col)}
-                  className={`px-2 py-0.5 rounded text-xs transition-colors flex items-center gap-1 ${
-                    isSelected
-                      ? 'bg-foreground text-background'
-                      : 'bg-card border border-border hover:bg-muted'
-                  }`}
-                >
-                  {getColumnTypeIcon(col)}
-                  <span className="truncate max-w-[80px]">{col}</span>
-                </button>
-              )
-            })}
+            {yAxisOptions
+              .filter((col) => col !== config.xAxis)
+              .map((col) => {
+                const isSelected = config.yAxis.includes(col)
+                return (
+                  <button
+                    key={col}
+                    onClick={() => handleYAxisChange(col)}
+                    className={`px-2 py-0.5 rounded text-xs transition-colors flex items-center gap-1 ${
+                      isSelected
+                        ? 'bg-foreground text-background'
+                        : 'bg-card border border-border hover:bg-muted'
+                    }`}
+                  >
+                    {getColumnTypeIcon(col)}
+                    <span className="truncate max-w-[80px]">{col}</span>
+                  </button>
+                )
+              })}
           </div>
         )}
       </div>

--- a/web/src/components/copyable-text.tsx
+++ b/web/src/components/copyable-text.tsx
@@ -8,7 +8,12 @@ interface CopyableTextProps {
   children?: React.ReactNode
 }
 
-export function CopyableText({ text, className = '', iconPosition = 'right', children }: CopyableTextProps) {
+export function CopyableText({
+  text,
+  className = '',
+  iconPosition = 'right',
+  children,
+}: CopyableTextProps) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
@@ -17,20 +22,23 @@ export function CopyableText({ text, className = '', iconPosition = 'right', chi
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const iconClass = children
+    ? 'hidden sm:inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity cursor-pointer shrink-0'
+    : 'inline-flex items-center justify-center h-4 w-4 text-muted-foreground hover:text-foreground transition-opacity cursor-pointer shrink-0'
+
   const icon = (
-    <button
-      onClick={handleCopy}
-      className="inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity cursor-pointer"
-      title={copied ? 'Copied!' : 'Copy'}
-    >
+    <button onClick={handleCopy} className={iconClass} title={copied ? 'Copied!' : 'Copy'}>
       {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
     </button>
   )
 
   return (
-    <span className={`inline-flex items-center gap-1 group ${className}`}>
+    <span
+      className={`inline-flex items-center gap-1 group min-w-0 max-w-full cursor-pointer ${className}`}
+      onClick={handleCopy}
+    >
       {iconPosition === 'left' && icon}
-      {children ?? <span>{text}</span>}
+      {children ?? <span className="min-w-0 break-all">{text}</span>}
       {iconPosition === 'right' && icon}
     </span>
   )

--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import uPlot from 'uplot'
 import { Loader2 } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
@@ -18,7 +19,16 @@ interface DeviceTrafficChartProps {
 
 type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'max'
 
-const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316']
+const COLORS = [
+  '#3b82f6',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#f97316',
+]
 
 function formatBps(value: number): string {
   const abs = Math.abs(value)
@@ -72,35 +82,61 @@ interface CategoryChartProps {
   onCursorTime?: (time: number | null) => void
 }
 
-function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interfaceLabels, interfaceTypes, aggMode, loading, className, bucketSeconds, highlightTimeRange, onCursorTime }: CategoryChartProps) {
+function CategoryChart({
+  title,
+  interfaces,
+  bucketTimestamps,
+  dataMap,
+  interfaceLabels,
+  interfaceTypes,
+  aggMode,
+  loading,
+  className,
+  bucketSeconds,
+  highlightTimeRange,
+  onCursorTime,
+}: CategoryChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
   const chartRef = useRef<HTMLDivElement>(null)
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
   const uPlotDataRef = useRef<uPlot.AlignedData>([[]])
-  const handleCursorIdx = useCallback((idx: number | null) => {
-    setHoveredIdx(idx)
-    if (onCursorTime) {
-      const ts = idx != null ? (uPlotDataRef.current[0] as number[])?.[idx] ?? null : null
-      onCursorTime(ts)
-    }
-  }, [onCursorTime])
+  const handleCursorIdx = useCallback(
+    (idx: number | null) => {
+      setHoveredIdx(idx)
+      if (onCursorTime) {
+        const ts = idx != null ? ((uPlotDataRef.current[0] as number[])?.[idx] ?? null) : null
+        onCursorTime(ts)
+      }
+    },
+    [onCursorTime],
+  )
 
   const legend = useChartLegend()
 
-  const scales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const scales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
-  const axes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map((v) => formatBpsAxis(v)) },
-  ], [])
+  const axes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      { values: (_u: uPlot, vals: number[]) => vals.map((v) => formatBpsAxis(v)) },
+    ],
+    [],
+  )
 
   const { uPlotData, uPlotSeries, seriesKeys } = useMemo(() => {
     if (bucketTimestamps.length === 0 || interfaces.length === 0) {
-      return { uPlotData: [[]] as uPlot.AlignedData, uPlotSeries: [] as uPlot.Series[], seriesKeys: [] as string[] }
+      return {
+        uPlotData: [[]] as uPlot.AlignedData,
+        uPlotSeries: [] as uPlot.Series[],
+        seriesKeys: [] as string[],
+      }
     }
 
     const arrays: (number | null)[][] = [bucketTimestamps as unknown as (number | null)[]]
@@ -117,8 +153,10 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
         const key = `${intf}:${ts}`
         const d = dataMap.get(key)
         if (d) {
-          const inKey = aggMode === 'max' ? 'max_in_bps' : aggMode === 'avg' ? 'in_bps' : `${aggMode}_in_bps`
-          const outKey = aggMode === 'max' ? 'max_out_bps' : aggMode === 'avg' ? 'out_bps' : `${aggMode}_out_bps`
+          const inKey =
+            aggMode === 'max' ? 'max_in_bps' : aggMode === 'avg' ? 'in_bps' : `${aggMode}_in_bps`
+          const outKey =
+            aggMode === 'max' ? 'max_out_bps' : aggMode === 'avg' ? 'out_bps' : `${aggMode}_out_bps`
           const inVal = (d as unknown as Record<string, number>)[inKey]
           const outVal = (d as unknown as Record<string, number>)[outKey]
           inVals.push(inVal || null)
@@ -132,7 +170,13 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
       arrays.push(inVals)
       arrays.push(outVals)
       series.push({ label: `${intf}:in`, stroke: color, width: 1.5, points: { show: false } })
-      series.push({ label: `${intf}:out`, stroke: color, width: 1.5, dash: [4, 2], points: { show: false } })
+      series.push({
+        label: `${intf}:out`,
+        stroke: color,
+        width: 1.5,
+        dash: [4, 2],
+        points: { show: false },
+      })
       keys.push(intf, intf) // both in/out map to same legend key
     }
 
@@ -146,20 +190,25 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
 
-  const drawHooks = useMemo(() => [(u: uPlot) => {
-    const range = highlightTimeRangeRef.current
-    if (!range) return
-    const ctx = u.ctx
-    const left = u.valToPos(range.start, 'x', true)
-    const right = u.valToPos(range.end, 'x', true)
-    if (left == null || right == null) return
-    const top = u.bbox.top
-    const height = u.bbox.height
-    ctx.save()
-    ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
-    ctx.fillRect(left, top, right - left, height)
-    ctx.restore()
-  }], [])
+  const drawHooks = useMemo(
+    () => [
+      (u: uPlot) => {
+        const range = highlightTimeRangeRef.current
+        if (!range) return
+        const ctx = u.ctx
+        const left = u.valToPos(range.start, 'x', true)
+        const right = u.valToPos(range.end, 'x', true)
+        if (left == null || right == null) return
+        const top = u.bbox.top
+        const height = u.bbox.height
+        ctx.save()
+        ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
+        ctx.fillRect(left, top, right - left, height)
+        ctx.restore()
+      },
+    ],
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartRef,
@@ -189,19 +238,21 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
     return new Set(interfaces)
   }, [legend.selectedSeries, interfaces])
 
-  const hoveredTime = useMemo(() =>
-    formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, bucketSeconds < 60),
-    [uPlotData, hoveredIdx, bucketSeconds])
+  const hoveredTime = useMemo(
+    () => formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, bucketSeconds < 60),
+    [uPlotData, hoveredIdx, bucketSeconds],
+  )
 
-  const hasAnyData = uPlotData[0].length > 0 && uPlotData.slice(1).some(
-    (s) => (s as (number | null)[]).some((v) => v != null))
+  const hasAnyData =
+    uPlotData[0].length > 0 &&
+    uPlotData.slice(1).some((s) => (s as (number | null)[]).some((v) => v != null))
 
   // Active interfaces: those with any non-null in or out data
   const activeInterfaces = useMemo(() => {
     return interfaces.filter((_, i) => {
       const inSeries = uPlotData[i * 2 + 1] as (number | null)[]
       const outSeries = uPlotData[i * 2 + 2] as (number | null)[]
-      return (inSeries?.some((v) => v != null) || outSeries?.some((v) => v != null))
+      return inSeries?.some((v) => v != null) || outSeries?.some((v) => v != null)
     })
   }, [interfaces, uPlotData])
 
@@ -211,7 +262,9 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
         <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
           <span>{title}</span>
         </div>
-        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">No data for this time range</div>
+        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">
+          No data for this time range
+        </div>
       </div>
     )
   }
@@ -234,8 +287,12 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
       <div className="flex flex-col text-xs px-2 pt-1 pb-2">
         <div className="flex items-center px-1 mb-1">
           <span className="text-xs text-muted-foreground flex-1 min-w-0">Interface</span>
-          <span className="text-xs text-muted-foreground w-24 text-right whitespace-nowrap">Max</span>
-          <span className="text-xs text-muted-foreground w-24 text-right whitespace-nowrap">{hoveredTime ?? 'Value'}</span>
+          <span className="text-xs text-muted-foreground w-24 text-right whitespace-nowrap">
+            Max
+          </span>
+          <span className="text-xs text-muted-foreground w-24 text-right whitespace-nowrap">
+            {hoveredTime ?? 'Value'}
+          </span>
         </div>
         <div className="max-h-32 overflow-y-auto space-y-0.5">
           {activeInterfaces.map((intf) => {
@@ -244,16 +301,21 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
             const isVisible = visibleSeries.has(intf)
 
             // Current value (hovered or latest)
-            const idx = hoveredIdx != null && hoveredIdx < bucketTimestamps.length ? hoveredIdx : bucketTimestamps.length - 1
+            const idx =
+              hoveredIdx != null && hoveredIdx < bucketTimestamps.length
+                ? hoveredIdx
+                : bucketTimestamps.length - 1
             const inVal = (uPlotData[i * 2 + 1] as (number | null)[])?.[idx]
             const outVal = (uPlotData[i * 2 + 2] as (number | null)[])?.[idx]
 
             // Max value across range
-            let maxIn = 0, maxOut = 0
+            let maxIn = 0,
+              maxOut = 0
             const inS = uPlotData[i * 2 + 1] as (number | null)[]
             const outS = uPlotData[i * 2 + 2] as (number | null)[]
             if (inS) for (const v of inS) if (v != null && v > maxIn) maxIn = v
-            if (outS) for (const v of outS) if (v != null && Math.abs(v) > maxOut) maxOut = Math.abs(v)
+            if (outS)
+              for (const v of outS) if (v != null && Math.abs(v) > maxOut) maxOut = Math.abs(v)
 
             return (
               <div key={intf}>
@@ -264,22 +326,38 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
                   onMouseLeave={legend.handleMouseLeave}
                 >
                   <div className="flex items-center gap-1.5 min-w-0 flex-1">
-                    <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: color }} />
-                    <span className="font-mono text-foreground truncate">{interfaceLabels?.get(intf) ?? intf} Rx</span>
+                    <span
+                      className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span className="font-mono text-foreground truncate">
+                      {interfaceLabels?.get(intf) ?? intf} Rx
+                    </span>
                     {(() => {
                       const t = interfaceTypes?.get(intf)
                       if (!t) return null
-                      return <>
-                        {t.cyoa_type && t.cyoa_type !== 'none' && t.cyoa_type !== '' && (
-                          <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-amber-500/15 text-amber-400 flex-shrink-0">CYOA</span>
-                        )}
-                        {(!t.cyoa_type || t.cyoa_type === 'none' || t.cyoa_type === '') && t.link_pk && (
-                          <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-blue-500/15 text-blue-400 flex-shrink-0">link</span>
-                        )}
-                        {(!t.cyoa_type || t.cyoa_type === 'none' || t.cyoa_type === '') && !t.link_pk && intf.startsWith('Loopback') && (
-                          <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-purple-500/15 text-purple-400 flex-shrink-0">lo</span>
-                        )}
-                      </>
+                      return (
+                        <>
+                          {t.cyoa_type && t.cyoa_type !== 'none' && t.cyoa_type !== '' && (
+                            <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-amber-500/15 text-amber-400 flex-shrink-0">
+                              CYOA
+                            </span>
+                          )}
+                          {(!t.cyoa_type || t.cyoa_type === 'none' || t.cyoa_type === '') &&
+                            t.link_pk && (
+                              <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-blue-500/15 text-blue-400 flex-shrink-0">
+                                link
+                              </span>
+                            )}
+                          {(!t.cyoa_type || t.cyoa_type === 'none' || t.cyoa_type === '') &&
+                            !t.link_pk &&
+                            intf.startsWith('Loopback') && (
+                              <span className="px-1 py-0.5 rounded text-[9px] leading-none bg-purple-500/15 text-purple-400 flex-shrink-0">
+                                lo
+                              </span>
+                            )}
+                        </>
+                      )
                     })()}
                   </div>
                   <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-24 text-right">
@@ -297,9 +375,19 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
                 >
                   <div className="flex items-center gap-1.5 min-w-0 flex-1">
                     <svg className="w-2.5 h-2.5 flex-shrink-0" viewBox="0 0 10 10">
-                      <line x1="0" y1="5" x2="10" y2="5" stroke={color} strokeWidth="3" strokeDasharray="3 2" />
+                      <line
+                        x1="0"
+                        y1="5"
+                        x2="10"
+                        y2="5"
+                        stroke={color}
+                        strokeWidth="3"
+                        strokeDasharray="3 2"
+                      />
                     </svg>
-                    <span className="font-mono text-foreground truncate">{interfaceLabels?.get(intf) ?? intf} Tx</span>
+                    <span className="font-mono text-foreground truncate">
+                      {interfaceLabels?.get(intf) ?? intf} Tx
+                    </span>
                   </div>
                   <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-24 text-right">
                     {formatBps(maxOut)}
@@ -317,7 +405,13 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
   )
 }
 
-export function DeviceTrafficChart({ data, className, loading, highlightTimeRange, onCursorTime }: DeviceTrafficChartProps) {
+export function DeviceTrafficChart({
+  data,
+  className,
+  loading,
+  highlightTimeRange,
+  onCursorTime,
+}: DeviceTrafficChartProps) {
   const [aggMode, setAggMode] = useState<AggMode>('avg')
 
   // Collect all interface data across buckets, classify, and build lookup
@@ -364,7 +458,13 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
         interfaces: Array.from(catIntfs[c]).sort(),
       }))
 
-    return { categories: cats, bucketTimestamps: timestamps, dataMap: map, interfaceLabels: labels, interfaceTypes: types }
+    return {
+      categories: cats,
+      bucketTimestamps: timestamps,
+      dataMap: map,
+      interfaceLabels: labels,
+      interfaceTypes: types,
+    }
   }, [data])
 
   if (categories.length === 0) {
@@ -373,33 +473,33 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
         <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
           <span>Traffic</span>
         </div>
-        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">No data for this time range</div>
+        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">
+          No data for this time range
+        </div>
       </div>
     )
   }
 
   const filters = (
     <div className="flex items-center gap-1.5">
-      <select
+      <SmallDropdown
         value={aggMode}
-        onChange={e => setAggMode(e.target.value as AggMode)}
-        className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
-      >
-        <option value="avg">Avg</option>
-        <option value="p50">P50</option>
-        <option value="p90">P90</option>
-        <option value="p95">P95</option>
-        <option value="p99">P99</option>
-        <option value="max">Max</option>
-      </select>
+        options={[
+          { value: 'avg', label: 'Avg' },
+          { value: 'p50', label: 'P50' },
+          { value: 'p90', label: 'P90' },
+          { value: 'p95', label: 'P95' },
+          { value: 'p99', label: 'P99' },
+          { value: 'max', label: 'Max' },
+        ]}
+        onChange={(v) => setAggMode(v as AggMode)}
+      />
     </div>
   )
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-end">
-        {filters}
-      </div>
+      <div className="flex items-center justify-end">{filters}</div>
       {categories.map((cat) => (
         <CategoryChart
           key={cat.key}

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -24,20 +24,27 @@ function formatBps(bps: number): string {
 }
 
 const statusColors: Record<string, string> = {
-  activated: 'text-muted-foreground',
-  provisioning: 'text-blue-600 dark:text-blue-400',
-  maintenance: 'text-amber-600 dark:text-amber-400',
-  offline: 'text-red-600 dark:text-red-400',
+  activated: 'bg-muted/60 text-muted-foreground',
+  provisioning: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  maintenance: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  offline: 'bg-red-500/10 text-red-600 dark:text-red-400',
 }
 
 export function DeviceDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<TimeRange>({ preset: '24h' })
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
-  const { data: device, isLoading, error } = useQuery({
+  const {
+    data: device,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['device', pk],
     queryFn: () => fetchDevice(pk!),
     enabled: !!pk,
@@ -45,7 +52,11 @@ export function DeviceDetailPage() {
 
   const metricsParams = useMemo(() => toDeviceMetricsParams(timeRange), [timeRange])
 
-  const { data: metrics, isLoading: metricsLoading, isFetching: metricsFetching } = useQuery({
+  const {
+    data: metrics,
+    isLoading: metricsLoading,
+    isFetching: metricsFetching,
+  } = useQuery({
     queryKey: ['deviceMetrics', pk, metricsParams],
     queryFn: () => fetchDeviceMetrics(pk!, metricsParams),
     enabled: !!pk,
@@ -67,10 +78,7 @@ export function DeviceDetailPage() {
         <div className="text-center">
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Device not found</div>
-          <Link
-            to="/dz/devices"
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
+          <Link to="/dz/devices" className="text-sm text-muted-foreground hover:text-foreground">
             Back to devices
           </Link>
         </div>
@@ -94,20 +102,27 @@ export function DeviceDetailPage() {
         </Link>
 
         {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <Server className="h-8 w-8 text-muted-foreground" />
-          <div>
-            <h1 className="text-2xl font-medium font-mono">
-              <CopyableText text={device.code} />
-            </h1>
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-muted-foreground font-mono">
-                <CopyableText text={device.pk} />
-              </span>
-              <span className={`text-sm capitalize ${statusColors[device.status] || 'text-muted-foreground'}`}>
-                {device.status}
-              </span>
+        <div className="flex flex-col sm:flex-row sm:items-end gap-2 sm:gap-5 mb-8">
+          <div className="flex items-center gap-3">
+            <Server className="hidden sm:block h-8 w-8 text-muted-foreground shrink-0" />
+            <div>
+              <h1 className="text-2xl font-medium font-mono">
+                <CopyableText text={device.code} />
+              </h1>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm text-muted-foreground font-mono">
+                  <CopyableText text={device.pk} />
+                </span>
+              </div>
             </div>
+          </div>
+          <div>
+            {' '}
+            <span
+              className={`text-xs capitalize px-2 py-0.5 rounded-full ${statusColors[device.status] || 'bg-muted/60 text-muted-foreground'}`}
+            >
+              {device.status}
+            </span>
           </div>
         </div>
       </div>
@@ -121,10 +136,11 @@ export function DeviceDetailPage() {
             <div className="text-xs text-muted-foreground">Public IP</div>
           </div>
           <div className="text-center p-3 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium">
+            <div className="text-sm sm:text-base font-medium">
               <span className="text-muted-foreground text-xs">In:</span> {formatBps(device.in_bps)}
               <span className="mx-2 text-muted-foreground">|</span>
-              <span className="text-muted-foreground text-xs">Out:</span> {formatBps(device.out_bps)}
+              <span className="text-muted-foreground text-xs">Out:</span>{' '}
+              {formatBps(device.out_bps)}
             </div>
             <div className="text-xs text-muted-foreground">Current Traffic</div>
           </div>
@@ -133,7 +149,8 @@ export function DeviceDetailPage() {
               {device.current_users} / {device.max_users} users
               {device.max_users > 0 && (
                 <span className="text-muted-foreground text-xs ml-1">
-                  ({((device.current_users / device.max_users) * 100).toFixed(0)}%)
+                  ({((device.current_users / device.max_users) * 100).toFixed(0)}
+                  %)
                 </span>
               )}
             </div>
@@ -154,7 +171,11 @@ export function DeviceDetailPage() {
             className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
             title="Refresh"
           >
-            {metricsFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {metricsFetching ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
           </button>
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
         </div>
@@ -172,9 +193,25 @@ export function DeviceDetailPage() {
         )}
         {metrics && (
           <div className="space-y-4">
-            <DeviceHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />
-            <DeviceInterfaceIssuesChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <DeviceTrafficChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+            <DeviceHealthTimeline
+              data={metrics}
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
+            <DeviceInterfaceIssuesChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <DeviceTrafficChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
           </div>
         )}
       </div>

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -1,8 +1,17 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { CheckCircle2, AlertTriangle, History, Info, ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
+import {
+  CheckCircle2,
+  AlertTriangle,
+  History,
+  Info,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from 'lucide-react'
 import { fetchBulkDeviceMetrics, fetchDeviceMetrics } from '@/lib/api'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import type { DeviceMetricsResponse } from '@/lib/api'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
@@ -56,9 +65,9 @@ interface DeviceStatusTimelinesProps {
   onTimeRangeChange?: (range: TimeRange) => void
   issueFilters?: string[]
   healthFilters?: string[]
-  devicesWithIssues?: Map<string, string[]>  // Map of device code -> issue reasons (from filter time range)
-  devicesWithHealth?: Map<string, string>    // Map of device code -> health status (from filter time range)
-  expandedDevicePk?: string                  // Device PK to auto-expand (from URL param)
+  devicesWithIssues?: Map<string, string[]> // Map of device code -> issue reasons (from filter time range)
+  devicesWithHealth?: Map<string, string> // Map of device code -> health status (from filter time range)
+  expandedDevicePk?: string // Device PK to auto-expand (from URL param)
 }
 
 interface DerivedDeviceInfo {
@@ -73,7 +82,7 @@ interface DerivedDeviceInfo {
   drainStatus: string
   isisOverload: boolean
   isisUnreachable: boolean
-  health: string  // worst health across buckets
+  health: string // worst health across buckets
 }
 
 function deriveDeviceInfo(metrics: DeviceMetricsResponse): DerivedDeviceInfo {
@@ -180,7 +189,9 @@ function DeviceInfoPopover({ deviceMetrics }: { deviceMetrics: DeviceMetricsResp
             </div>
             <div>
               <div className="text-muted-foreground">Type</div>
-              <div className="font-medium capitalize">{deviceMetrics.device_type?.replace(/_/g, ' ')}</div>
+              <div className="font-medium capitalize">
+                {deviceMetrics.device_type?.replace(/_/g, ' ')}
+              </div>
             </div>
             {(deviceMetrics.max_users ?? 0) > 0 && (
               <div>
@@ -195,9 +206,15 @@ function DeviceInfoPopover({ deviceMetrics }: { deviceMetrics: DeviceMetricsResp
   )
 }
 
-const cardClass = "rounded-lg border border-border p-4"
+const cardClass = 'rounded-lg border border-border p-4'
 
-function ExpandedDeviceCharts({ devicePk, timeRange, deviceMetrics, highlightTimeRange, onCursorTime }: {
+function ExpandedDeviceCharts({
+  devicePk,
+  timeRange,
+  deviceMetrics,
+  highlightTimeRange,
+  onCursorTime,
+}: {
   devicePk: string
   timeRange: string
   deviceMetrics: DeviceMetricsResponse
@@ -211,12 +228,14 @@ function ExpandedDeviceCharts({ devicePk, timeRange, deviceMetrics, highlightTim
     staleTime: 30_000,
   })
 
-  const hasIssues = deviceMetrics.buckets.some(b => b.traffic && (
-    b.traffic.in_errors + b.traffic.out_errors > 0 ||
-    b.traffic.in_fcs_errors > 0 ||
-    b.traffic.in_discards + b.traffic.out_discards > 0 ||
-    b.traffic.carrier_transitions > 0
-  ))
+  const hasIssues = deviceMetrics.buckets.some(
+    (b) =>
+      b.traffic &&
+      (b.traffic.in_errors + b.traffic.out_errors > 0 ||
+        b.traffic.in_fcs_errors > 0 ||
+        b.traffic.in_discards + b.traffic.out_discards > 0 ||
+        b.traffic.carrier_transitions > 0),
+  )
   if (!hasIssues) return null
 
   // Use per-interface data if available, fall back to bulk aggregate
@@ -224,7 +243,13 @@ function ExpandedDeviceCharts({ devicePk, timeRange, deviceMetrics, highlightTim
 
   return (
     <div className="px-4 pb-4 pt-2 space-y-4">
-      <DeviceInterfaceIssuesChart data={chartData} loading={isLoading} className={cardClass} highlightTimeRange={highlightTimeRange} onCursorTime={onCursorTime} />
+      <DeviceInterfaceIssuesChart
+        data={chartData}
+        loading={isLoading}
+        className={cardClass}
+        highlightTimeRange={highlightTimeRange}
+        onCursorTime={onCursorTime}
+      />
     </div>
   )
 }
@@ -237,9 +262,18 @@ interface DeviceRowProps {
   timeRange?: string
 }
 
-function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExpanded = false, timeRange = '24h' }: DeviceRowProps) {
+function DeviceRow({
+  deviceMetrics,
+  derivedInfo,
+  devicesWithIssues,
+  initiallyExpanded = false,
+  timeRange = '24h',
+}: DeviceRowProps) {
   const [expanded, setExpanded] = useState(initiallyExpanded)
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
   // Expand when initiallyExpanded prop changes to true
@@ -249,9 +283,10 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
     }
   }, [initiallyExpanded])
 
-  const issueReasons = devicesWithIssues && devicesWithIssues.size > 0
-    ? (devicesWithIssues.get(derivedInfo.code) ?? [])
-    : derivedInfo.issueReasons
+  const issueReasons =
+    devicesWithIssues && devicesWithIssues.size > 0
+      ? (devicesWithIssues.get(derivedInfo.code) ?? [])
+      : derivedInfo.issueReasons
 
   const nowMinutes = Math.floor(Date.now() / 60000)
   const recentIssues = useMemo(() => {
@@ -308,7 +343,12 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
     const cutoff = nowMinutes * 60 - 30 * 60
     let worstHealth = 'healthy'
     let isisIssue = false
-    const priority: Record<string, number> = { unhealthy: 3, degraded: 2, no_data: 1, healthy: 0 }
+    const priority: Record<string, number> = {
+      unhealthy: 3,
+      degraded: 2,
+      no_data: 1,
+      healthy: 0,
+    }
     for (const b of deviceMetrics.buckets) {
       const ts = new Date(b.ts).getTime() / 1000
       if (ts < cutoff) continue
@@ -330,28 +370,39 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
         ? 'border-l-amber-500'
         : 'border-l-transparent'
 
-  const hasExpandableContent = issueReasons.some(r =>
-    r === 'interface_errors' || r === 'fcs_errors' || r === 'discards' || r === 'carrier_transitions'
+  const hasExpandableContent = issueReasons.some(
+    (r) =>
+      r === 'interface_errors' ||
+      r === 'fcs_errors' ||
+      r === 'discards' ||
+      r === 'carrier_transitions',
   )
 
   return (
-    <div id={`device-row-${derivedInfo.pk}`} className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}>
+    <div
+      id={`device-row-${derivedInfo.pk}`}
+      className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}
+    >
       <div
         className={`px-4 py-3 transition-colors ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30' : ''}`}
         onClick={hasExpandableContent ? () => setExpanded(!expanded) : undefined}
       >
         <div className="flex items-start gap-4">
           {/* Expand/collapse indicator */}
-          <div className="flex-shrink-0 w-5 pt-0.5">
+          <div className="shrink-0 w-5 pt-0.5">
             {hasExpandableContent ? (
-              expanded ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              expanded ? (
+                <ChevronUp className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              )
             ) : (
               <div className="w-4" />
             )}
           </div>
 
           {/* Device info */}
-          <div className="flex-shrink-0 w-44">
+          <div className="shrink-0 w-44">
             <div className="flex items-center gap-1.5">
               <Link
                 to={`/dz/devices/${derivedInfo.pk}`}
@@ -364,43 +415,82 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
               <DeviceInfoPopover deviceMetrics={deviceMetrics} />
             </div>
             <div className="text-xs text-muted-foreground">
-              {derivedInfo.contributor}{derivedInfo.metro && ` \u00b7 ${derivedInfo.metro}`}
+              {derivedInfo.contributor}
+              {derivedInfo.metro && ` \u00b7 ${derivedInfo.metro}`}
             </div>
             {issueReasons.length > 0 && (
               <div className="flex flex-wrap gap-1 mt-1">
                 {issueReasons.includes('interface_errors') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('interface_errors') ? 'bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400' : dimBadgeClass}`}>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('interface_errors') ? 'bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400' : dimBadgeClass}`}
+                  >
                     Interface Errors
                   </span>
                 )}
                 {issueReasons.includes('fcs_errors') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('fcs_errors') ? '' : dimBadgeClass}`} style={isBadgeActive('fcs_errors') ? { backgroundColor: 'rgba(249, 115, 22, 0.15)', color: '#ea580c' } : undefined}>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('fcs_errors') ? '' : dimBadgeClass}`}
+                    style={
+                      isBadgeActive('fcs_errors')
+                        ? {
+                            backgroundColor: 'rgba(249, 115, 22, 0.15)',
+                            color: '#ea580c',
+                          }
+                        : undefined
+                    }
+                  >
                     FCS Errors
                   </span>
                 )}
                 {issueReasons.includes('discards') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('discards') ? 'bg-rose-500/15 text-rose-600 dark:text-rose-400' : dimBadgeClass}`}>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('discards') ? 'bg-rose-500/15 text-rose-600 dark:text-rose-400' : dimBadgeClass}`}
+                  >
                     Discards
                   </span>
                 )}
                 {issueReasons.includes('carrier_transitions') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('carrier_transitions') ? 'bg-orange-500/15 text-orange-600 dark:text-orange-400' : dimBadgeClass}`}>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('carrier_transitions') ? 'bg-orange-500/15 text-orange-600 dark:text-orange-400' : dimBadgeClass}`}
+                  >
                     Carrier Transitions
                   </span>
                 )}
                 {issueReasons.includes('drained') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('drained') ? 'bg-slate-500/15 text-slate-600 dark:text-slate-400' : dimBadgeClass}`}>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('drained') ? 'bg-slate-500/15 text-slate-600 dark:text-slate-400' : dimBadgeClass}`}
+                  >
                     Drained
                   </span>
                 )}
                 {issueReasons.includes('no_data') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('no_data') ? '' : dimBadgeClass}`} style={isBadgeActive('no_data') ? { backgroundColor: 'rgba(236, 72, 153, 0.15)', color: '#db2777' } : undefined}>No Data</span>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('no_data') ? '' : dimBadgeClass}`}
+                    style={
+                      isBadgeActive('no_data')
+                        ? {
+                            backgroundColor: 'rgba(236, 72, 153, 0.15)',
+                            color: '#db2777',
+                          }
+                        : undefined
+                    }
+                  >
+                    No Data
+                  </span>
                 )}
                 {issueReasons.includes('isis_overload') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('isis_overload') ? 'bg-red-600/15 text-red-700 dark:text-red-400' : dimBadgeClass}`}>ISIS Overload</span>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('isis_overload') ? 'bg-red-600/15 text-red-700 dark:text-red-400' : dimBadgeClass}`}
+                  >
+                    ISIS Overload
+                  </span>
                 )}
                 {issueReasons.includes('isis_unreachable') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('isis_unreachable') ? 'bg-red-800/15 text-red-800 dark:text-red-400' : dimBadgeClass}`}>ISIS Unreachable</span>
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('isis_unreachable') ? 'bg-red-800/15 text-red-800 dark:text-red-400' : dimBadgeClass}`}
+                  >
+                    ISIS Unreachable
+                  </span>
                 )}
               </div>
             )}
@@ -408,7 +498,12 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
 
           {/* Timeline */}
           <div className="flex-1 min-w-0">
-            <DeviceHealthTimeline data={deviceMetrics} hideBadges onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />
+            <DeviceHealthTimeline
+              data={deviceMetrics}
+              hideBadges
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
           </div>
         </div>
       </div>
@@ -430,7 +525,15 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
 export function DeviceStatusTimelines({
   timeRange = '24h',
   onTimeRangeChange,
-  issueFilters = ['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained', 'isis_overload', 'isis_unreachable'],
+  issueFilters = [
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+    'drained',
+    'isis_overload',
+    'isis_unreachable',
+  ],
   healthFilters = ['healthy', 'degraded', 'unhealthy', 'disabled'],
   devicesWithIssues,
   devicesWithHealth,
@@ -447,7 +550,12 @@ export function DeviceStatusTimelines({
 
   const { data, isLoading, isPlaceholderData, error } = useQuery({
     queryKey: ['bulk-device-metrics', timeRange],
-    queryFn: () => fetchBulkDeviceMetrics({ range: timeRange, include: ['status', 'traffic'], hasIssues: true }),
+    queryFn: () =>
+      fetchBulkDeviceMetrics({
+        range: timeRange,
+        include: ['status', 'traffic'],
+        hasIssues: true,
+      }),
     refetchInterval: 60_000,
     staleTime: 30_000,
     placeholderData: keepPreviousData,
@@ -456,7 +564,7 @@ export function DeviceStatusTimelines({
   // Convert the Record<string, DeviceMetricsResponse> into an array with derived info
   const devicesArray = useMemo(() => {
     if (!data?.devices) return []
-    return Object.values(data.devices).map(metrics => ({
+    return Object.values(data.devices).map((metrics) => ({
       metrics,
       derived: deriveDeviceInfo(metrics),
     }))
@@ -484,7 +592,7 @@ export function DeviceStatusTimelines({
   }
 
   // Check which issue filters are selected
-  const issueTypesSelected = issueFilters.filter(f => f !== 'no_issues')
+  const issueTypesSelected = issueFilters.filter((f) => f !== 'no_issues')
   const noIssuesSelected = issueFilters.includes('no_issues')
 
   // Filter and sort devices by recency of issues
@@ -492,17 +600,19 @@ export function DeviceStatusTimelines({
     if (devicesArray.length === 0) return []
 
     const filtered = devicesArray.filter(({ derived }) => {
-      const issueReasons = devicesWithIssues && devicesWithIssues.size > 0
-        ? (devicesWithIssues.get(derived.code) ?? [])
-        : derived.issueReasons
+      const issueReasons =
+        devicesWithIssues && devicesWithIssues.size > 0
+          ? (devicesWithIssues.get(derived.code) ?? [])
+          : derived.issueReasons
       const hasIssues = issueReasons.length > 0
 
       // Devices with only no_data or no_probes are shown based on health filter (no separate issue toggle)
-      const hasOnlyNoData = issueReasons.length > 0 && issueReasons.every(r => r === 'no_data' || r === 'no_probes')
+      const hasOnlyNoData =
+        issueReasons.length > 0 && issueReasons.every((r) => r === 'no_data' || r === 'no_probes')
       const matchesIssue = hasOnlyNoData
         ? true
         : hasIssues
-          ? issueReasons.some(reason => issueTypesSelected.includes(reason))
+          ? issueReasons.some((reason) => issueTypesSelected.includes(reason))
           : noIssuesSelected
 
       const matchesHealth = deviceMatchesHealthFilters(derived)
@@ -514,18 +624,30 @@ export function DeviceStatusTimelines({
     // 3) most recent issue timestamp, 4) total issue count, 5) alphabetical.
     const statusSeverity = (health: string): number => {
       switch (health) {
-        case 'unhealthy': return 4
-        case 'degraded': return 3
-        case 'disabled': return 2
-        case 'no_data': return 1
-        default: return 0
+        case 'unhealthy':
+          return 4
+        case 'degraded':
+          return 3
+        case 'disabled':
+          return 2
+        case 'no_data':
+          return 1
+        default:
+          return 0
       }
     }
 
     const RECENT_BUCKETS = 6
 
     return filtered.sort((a, b) => {
-      const getSortKey = (item: { metrics: DeviceMetricsResponse }): { recent: number; worst: number; latestTs: string; count: number } => {
+      const getSortKey = (item: {
+        metrics: DeviceMetricsResponse
+      }): {
+        recent: number
+        worst: number
+        latestTs: string
+        count: number
+      } => {
         const buckets = item.metrics.buckets
         if (!buckets || buckets.length === 0) return { recent: 0, worst: 0, latestTs: '', count: 0 }
         let worst = 0
@@ -556,8 +678,16 @@ export function DeviceStatusTimelines({
       if (aInfo.count !== bInfo.count) return bInfo.count - aInfo.count
       return a.derived.code.localeCompare(b.derived.code)
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [devicesArray, issueFilters, healthFilters, noIssuesSelected, issueTypesSelected, devicesWithIssues, devicesWithHealth])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    devicesArray,
+    issueFilters,
+    healthFilters,
+    noIssuesSelected,
+    issueTypesSelected,
+    devicesWithIssues,
+    devicesWithHealth,
+  ])
 
   const showSkeleton = useDelayedLoading(isLoading && !data)
 
@@ -588,39 +718,42 @@ export function DeviceStatusTimelines({
   }
 
   return (
-    <div id="device-status-history" className={`border border-border rounded-lg transition-opacity${isPlaceholderData ? ' opacity-60' : ''}`}>
-      <div className="px-4 py-2.5 bg-muted/50 border-b border-border flex items-center gap-2 rounded-t-lg">
-        {isPlaceholderData
-          ? <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
-          : <History className="h-4 w-4 text-muted-foreground" />
-        }
-        <h3 className="font-medium">
-          Device Status History
-          <span className="text-sm text-muted-foreground font-normal ml-1">
-            ({filteredDevices.length} device{filteredDevices.length !== 1 ? 's' : ''})
-          </span>
-        </h3>
-        {onTimeRangeChange && (
-          <div className="inline-flex rounded-lg border border-border bg-background/50 p-0.5 ml-auto">
-            {timeRangeOptions.map((opt) => (
-              <button
-                key={opt.value}
-                onClick={() => onTimeRangeChange(opt.value)}
-                className={`px-2.5 py-0.5 text-xs rounded-md transition-colors ${
-                  timeRange === opt.value
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
+    <div
+      id="device-status-history"
+      className={`border border-border rounded-lg transition-opacity${isPlaceholderData ? ' opacity-60' : ''}`}
+    >
+      <div className="px-4 py-2.5 bg-muted/50 border-b border-border rounded-t-lg flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-2">
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            {isPlaceholderData ? (
+              <Loader2 className="h-4 w-4 text-muted-foreground animate-spin shrink-0" />
+            ) : (
+              <History className="h-4 w-4 text-muted-foreground shrink-0" />
+            )}
+            <h3 className="font-medium">
+              Device Status History
+              <span className="hidden xss:inline text-sm text-muted-foreground font-normal ml-1">
+                ({filteredDevices.length} device
+                {filteredDevices.length !== 1 ? 's' : ''})
+              </span>
+            </h3>
           </div>
+          <div className="xss:hidden text-sm text-muted-foreground">
+            ({filteredDevices.length} device
+            {filteredDevices.length !== 1 ? 's' : ''})
+          </div>
+        </div>
+        {onTimeRangeChange && (
+          <SmallDropdown
+            value={timeRange}
+            options={timeRangeOptions}
+            onChange={(v) => onTimeRangeChange(v as TimeRange)}
+          />
         )}
       </div>
 
       {/* Legend */}
-      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 text-xs text-muted-foreground">
+      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 flex-wrap text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <div className="w-2.5 h-2.5 rounded-sm bg-green-500" />
           <span>Healthy</span>

--- a/web/src/components/dz-vs-internet-page.tsx
+++ b/web/src/components/dz-vs-internet-page.tsx
@@ -1,7 +1,19 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { Loader2, Zap, Download, ArrowRight, ChevronUp, ChevronDown, Search, X, MapPin, Filter, RefreshCw } from 'lucide-react'
+import {
+  Loader2,
+  Zap,
+  Download,
+  ArrowRight,
+  ChevronUp,
+  ChevronDown,
+  Search,
+  X,
+  MapPin,
+  Filter,
+  RefreshCw,
+} from 'lucide-react'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import { useUPlotChart } from '@/hooks/use-uplot-chart'
@@ -34,7 +46,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
   const filteredValues = useMemo(() => {
     if (!metroValues) return []
     if (!query) return metroValues
-    return metroValues.filter(v => v.toLowerCase().includes(query.toLowerCase()))
+    return metroValues.filter((v) => v.toLowerCase().includes(query.toLowerCase()))
   }, [metroValues, query])
 
   const items = isFocused ? filteredValues : []
@@ -43,38 +55,51 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
     setSelectedIndex(-1)
   }, [debouncedQuery])
 
-  const commit = useCallback((value: string) => {
-    onCommit(value)
-    setQuery('')
-    inputRef.current?.focus()
-  }, [onCommit])
+  const commit = useCallback(
+    (value: string) => {
+      onCommit(value)
+      setQuery('')
+      inputRef.current?.focus()
+    },
+    [onCommit],
+  )
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const isDropdownOpen = isFocused && items.length > 0
-    switch (e.key) {
-      case 'ArrowDown':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.min(prev + 1, items.length - 1)) }
-        break
-      case 'ArrowUp':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.max(prev - 1, -1)) }
-        break
-      case 'Enter': {
-        e.preventDefault()
-        const idx = selectedIndex >= 0 ? selectedIndex : 0
-        if (idx < items.length) commit(items[idx])
-        break
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const isDropdownOpen = isFocused && items.length > 0
+      switch (e.key) {
+        case 'ArrowDown':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1))
+          }
+          break
+        case 'ArrowUp':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.max(prev - 1, -1))
+          }
+          break
+        case 'Enter': {
+          e.preventDefault()
+          const idx = selectedIndex >= 0 ? selectedIndex : 0
+          if (idx < items.length) commit(items[idx])
+          break
+        }
+        case 'Escape':
+          e.preventDefault()
+          setQuery('')
+          inputRef.current?.blur()
+          break
       }
-      case 'Escape':
-        e.preventDefault()
-        setQuery('')
-        inputRef.current?.blur()
-        break
-    }
-  }, [items, selectedIndex, commit, isFocused])
+    },
+    [items, selectedIndex, commit, isFocused],
+  )
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setIsFocused(false)
+      if (containerRef.current && !containerRef.current.contains(e.target as Node))
+        setIsFocused(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -84,7 +109,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
 
   return (
     <div ref={containerRef} className="relative">
-      <div className="flex items-center gap-1.5 px-2 py-1 text-xs border border-border rounded-md bg-background hover:bg-muted/50 focus-within:ring-1 focus-within:ring-ring transition-colors">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted/50 focus-within:ring-1 focus-within:ring-ring transition-colors">
         <Search className="h-3 w-3 text-muted-foreground flex-shrink-0" />
         <input
           ref={inputRef}
@@ -113,7 +138,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
               onClick={() => commit(value)}
               className={cn(
                 'w-full flex items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted transition-colors',
-                index === selectedIndex && 'bg-muted'
+                index === selectedIndex && 'bg-muted',
               )}
             >
               <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
@@ -132,7 +157,10 @@ import { useDelayedLoading } from '@/hooks/use-delayed-loading'
 // Parse metro filters from URL
 function parseMetroFilters(searchParam: string): string[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
 }
 
 type SortField = 'route' | 'dz' | 'internet' | 'improvement' | 'dzJitter' | 'internetJitter'
@@ -160,7 +188,12 @@ export function DzVsInternetPage() {
   const isDark = resolvedTheme === 'dark'
 
   // Fetch latency comparison data
-  const { data: latencyData, isLoading: latencyLoading, error: latencyError, isFetching: latencyFetching } = useQuery({
+  const {
+    data: latencyData,
+    isLoading: latencyLoading,
+    error: latencyError,
+    isFetching: latencyFetching,
+  } = useQuery({
     queryKey: ['latency-comparison'],
     queryFn: fetchLatencyComparison,
     staleTime: 0,
@@ -182,63 +215,79 @@ export function DzVsInternetPage() {
   const selectedComparison = useMemo(() => {
     if (!selectedRoute || !latencyData) return null
     const [origin, target] = selectedRoute.split('-')
-    return latencyData.comparisons.find(
-      c => c.origin_metro_code === origin && c.target_metro_code === target
-    ) ?? null
+    return (
+      latencyData.comparisons.find(
+        (c) => c.origin_metro_code === origin && c.target_metro_code === target,
+      ) ?? null
+    )
   }, [selectedRoute, latencyData])
 
   // Update URL when selection changes (preserve metros filter)
-  const setSelectedComparison = useCallback((comp: LatencyComparison | null) => {
-    setSearchParams(prev => {
-      if (comp) {
-        prev.set('route', `${comp.origin_metro_code}-${comp.target_metro_code}`)
-      } else {
-        prev.delete('route')
-      }
-      return prev
-    })
-  }, [setSearchParams])
+  const setSelectedComparison = useCallback(
+    (comp: LatencyComparison | null) => {
+      setSearchParams((prev) => {
+        if (comp) {
+          prev.set('route', `${comp.origin_metro_code}-${comp.target_metro_code}`)
+        } else {
+          prev.delete('route')
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   // Remove a metro filter
-  const removeMetroFilter = useCallback((metro: string) => {
-    setSearchParams(prev => {
-      const current = parseMetroFilters(prev.get('metros') || '')
-      const newFilters = current.filter(m => m !== metro)
-      if (newFilters.length === 0) {
-        prev.delete('metros')
-      } else {
-        prev.set('metros', newFilters.join(','))
-      }
-      return prev
-    })
-  }, [setSearchParams])
+  const removeMetroFilter = useCallback(
+    (metro: string) => {
+      setSearchParams((prev) => {
+        const current = parseMetroFilters(prev.get('metros') || '')
+        const newFilters = current.filter((m) => m !== metro)
+        if (newFilters.length === 0) {
+          prev.delete('metros')
+        } else {
+          prev.set('metros', newFilters.join(','))
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   // Clear all metro filters
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       prev.delete('metros')
       return prev
     })
   }, [setSearchParams])
 
   // Add a metro filter
-  const addMetroFilter = useCallback((metro: string) => {
-    setSearchParams(prev => {
-      const current = parseMetroFilters(prev.get('metros') || '')
-      if (!current.includes(metro)) {
-        prev.set('metros', [...current, metro].join(','))
-      }
-      return prev
-    })
-  }, [setSearchParams])
+  const addMetroFilter = useCallback(
+    (metro: string) => {
+      setSearchParams((prev) => {
+        const current = parseMetroFilters(prev.get('metros') || '')
+        if (!current.includes(metro)) {
+          prev.set('metros', [...current, metro].join(','))
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   // Fetch latency history for selected comparison
   const { data: historyData, isFetching: historyFetching } = useQuery({
-    queryKey: ['latency-history', selectedComparison?.origin_metro_code, selectedComparison?.target_metro_code],
-    queryFn: () => fetchLatencyHistory(
-      selectedComparison!.origin_metro_code,
-      selectedComparison!.target_metro_code
-    ),
+    queryKey: [
+      'latency-history',
+      selectedComparison?.origin_metro_code,
+      selectedComparison?.target_metro_code,
+    ],
+    queryFn: () =>
+      fetchLatencyHistory(
+        selectedComparison!.origin_metro_code,
+        selectedComparison!.target_metro_code,
+      ),
     enabled: !!selectedComparison,
     staleTime: 0,
     placeholderData: keepPreviousData,
@@ -253,30 +302,44 @@ export function DzVsInternetPage() {
 
   const rttUPlotData = useMemo(() => {
     if (!historyData?.points || historyData.points.length === 0) return [[]] as uPlot.AlignedData
-    const ts = historyData.points.map(p => new Date(p.timestamp).getTime() / 1000)
-    const dzRtt = historyData.points.map(p => p.dz_avg_rtt_ms)
-    const inetRtt = historyData.points.map(p => p.inet_avg_rtt_ms)
+    const ts = historyData.points.map((p) => new Date(p.timestamp).getTime() / 1000)
+    const dzRtt = historyData.points.map((p) => p.dz_avg_rtt_ms)
+    const inetRtt = historyData.points.map((p) => p.inet_avg_rtt_ms)
     return [ts, dzRtt, inetRtt] as uPlot.AlignedData
   }, [historyData])
 
   const jitterUPlotData = useMemo(() => {
     if (!historyData?.points || historyData.points.length === 0) return [[]] as uPlot.AlignedData
-    const ts = historyData.points.map(p => new Date(p.timestamp).getTime() / 1000)
-    const dzJitter = historyData.points.map(p => p.dz_avg_jitter_ms)
-    const inetJitter = historyData.points.map(p => p.inet_avg_jitter_ms)
+    const ts = historyData.points.map((p) => new Date(p.timestamp).getTime() / 1000)
+    const dzJitter = historyData.points.map((p) => p.dz_avg_jitter_ms)
+    const inetJitter = historyData.points.map((p) => p.inet_avg_jitter_ms)
     return [ts, dzJitter, inetJitter] as uPlot.AlignedData
   }, [historyData])
 
-  const latencySeries = useMemo((): uPlot.Series[] => [
-    {},
-    { label: 'DZ', stroke: dzColor, width: 1.5, points: { show: false } },
-    { label: 'Internet', stroke: inetColor, width: 1.5, points: { show: false } },
-  ], [dzColor, inetColor])
+  const latencySeries = useMemo(
+    (): uPlot.Series[] => [
+      {},
+      { label: 'DZ', stroke: dzColor, width: 1.5, points: { show: false } },
+      {
+        label: 'Internet',
+        stroke: inetColor,
+        width: 1.5,
+        points: { show: false },
+      },
+    ],
+    [dzColor, inetColor],
+  )
 
-  const msAxes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map(v => `${v.toFixed(1)}ms`), size: 50 },
-  ], [])
+  const msAxes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      {
+        values: (_u: uPlot, vals: number[]) => vals.map((v) => `${v.toFixed(1)}ms`),
+        size: 50,
+      },
+    ],
+    [],
+  )
 
   useUPlotChart({
     containerRef: rttChartRef,
@@ -298,15 +361,16 @@ export function DzVsInternetPage() {
   const comparisons = useMemo(() => {
     if (!latencyData) return []
 
-    let filtered = latencyData.comparisons.filter(c => c.internet_sample_count > 0)
+    let filtered = latencyData.comparisons.filter((c) => c.internet_sample_count > 0)
 
     // Apply metro filters - show routes where origin OR target matches any filter
     if (metroFilters.length > 0) {
-      filtered = filtered.filter(c =>
-        metroFilters.some(m =>
-          c.origin_metro_code.toLowerCase() === m.toLowerCase() ||
-          c.target_metro_code.toLowerCase() === m.toLowerCase()
-        )
+      filtered = filtered.filter((c) =>
+        metroFilters.some(
+          (m) =>
+            c.origin_metro_code.toLowerCase() === m.toLowerCase() ||
+            c.target_metro_code.toLowerCase() === m.toLowerCase(),
+        ),
       )
     }
 
@@ -315,7 +379,7 @@ export function DzVsInternetPage() {
       switch (sortField) {
         case 'route':
           cmp = `${a.origin_metro_code}→${a.target_metro_code}`.localeCompare(
-            `${b.origin_metro_code}→${b.target_metro_code}`
+            `${b.origin_metro_code}→${b.target_metro_code}`,
           )
           break
         case 'dz':
@@ -340,7 +404,7 @@ export function DzVsInternetPage() {
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection(d => d === 'asc' ? 'desc' : 'asc')
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
     } else {
       setSortField(field)
       setSortDirection(field === 'improvement' ? 'desc' : 'asc')
@@ -360,8 +424,19 @@ export function DzVsInternetPage() {
   const handleExport = () => {
     if (!comparisons.length) return
 
-    const headers = ['From Metro', 'To Metro', 'DZ Avg RTT (ms)', 'DZ P95 RTT (ms)', 'DZ Jitter (ms)', 'Internet Avg RTT (ms)', 'Internet P95 RTT (ms)', 'Internet Jitter (ms)', 'RTT Improvement (%)', 'Jitter Improvement (%)']
-    const rows = comparisons.map(comp => [
+    const headers = [
+      'From Metro',
+      'To Metro',
+      'DZ Avg RTT (ms)',
+      'DZ P95 RTT (ms)',
+      'DZ Jitter (ms)',
+      'Internet Avg RTT (ms)',
+      'Internet P95 RTT (ms)',
+      'Internet Jitter (ms)',
+      'RTT Improvement (%)',
+      'Jitter Improvement (%)',
+    ]
+    const rows = comparisons.map((comp) => [
       comp.origin_metro_code,
       comp.target_metro_code,
       comp.dz_avg_rtt_ms.toFixed(1),
@@ -374,7 +449,7 @@ export function DzVsInternetPage() {
       comp.jitter_improvement_pct?.toFixed(1) ?? '-',
     ])
 
-    const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n')
+    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n')
     const blob = new Blob([csv], { type: 'text/csv' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -428,20 +503,21 @@ export function DzVsInternetPage() {
           actions={
             <button
               onClick={handleExport}
-              className="flex items-center gap-2 px-3 py-1.5 text-sm border border-border bg-background hover:bg-muted/50 rounded-md transition-colors"
+              className="flex items-center justify-center gap-2 px-3 py-1.5 text-xs border border-border bg-background hover:bg-muted/50 rounded-md transition-colors"
             >
-              <Download className="h-4 w-4" />
+              <Download className="h-3 w-3" />
               Export CSV
             </button>
           }
         />
 
         <p className="mt-3 text-sm text-muted-foreground">
-          Compares measured latency on direct DZ links against public internet latency for the same metro pairs.
+          Compares measured latency on direct DZ links against public internet latency for the same
+          metro pairs.
         </p>
 
         {/* Summary stats */}
-        <div className="flex gap-6 mt-4 text-sm">
+        <div className="flex flex-col md:flex-row md:gap-6 gap-2 mt-4 text-sm">
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Link Pairs:</span>
             <span className="font-medium">{comparisons.length}</span>
@@ -461,7 +537,7 @@ export function DzVsInternetPage() {
         </div>
 
         {/* Filter bar */}
-        <div className="flex items-center gap-2 flex-wrap mt-4">
+        <div className="flex items-center gap-2 flex-wrap mt-6">
           {/* Inline filter input */}
           <MetroInlineFilter onCommit={addMetroFilter} />
 
@@ -568,11 +644,13 @@ export function DzVsInternetPage() {
                 const rttImprovement = comp.rtt_improvement_pct ?? 0
                 const rttSaved = comp.internet_avg_rtt_ms - comp.dz_avg_rtt_ms
                 const jitterImprovement = comp.jitter_improvement_pct ?? 0
-                const hasJitter = comp.dz_avg_jitter_ms != null && comp.internet_avg_jitter_ms != null
+                const hasJitter =
+                  comp.dz_avg_jitter_ms != null && comp.internet_avg_jitter_ms != null
                 const jitterSaved = hasJitter
-                  ? (comp.internet_avg_jitter_ms! - comp.dz_avg_jitter_ms!)
+                  ? comp.internet_avg_jitter_ms! - comp.dz_avg_jitter_ms!
                   : null
-                const isSelected = selectedComparison?.origin_metro_pk === comp.origin_metro_pk &&
+                const isSelected =
+                  selectedComparison?.origin_metro_pk === comp.origin_metro_pk &&
                   selectedComparison?.target_metro_pk === comp.target_metro_pk
 
                 return (
@@ -580,7 +658,7 @@ export function DzVsInternetPage() {
                     key={`${comp.origin_metro_pk}-${comp.target_metro_pk}`}
                     className={cn(
                       'hover:bg-muted cursor-pointer transition-colors',
-                      isSelected && 'bg-muted/50'
+                      isSelected && 'bg-muted/50',
                     )}
                     onClick={() => setSelectedComparison(isSelected ? null : comp)}
                   >
@@ -600,12 +678,15 @@ export function DzVsInternetPage() {
                     </td>
                     <td className="px-4 py-3 text-right">
                       {comp.dz_avg_rtt_ms > 0 ? (
-                        <span className={cn(
-                          'inline-flex items-center px-2 py-0.5 rounded text-sm font-medium tabular-nums',
-                          getImprovementBg(rttImprovement),
-                          getImprovementColor(rttImprovement)
-                        )}>
-                          {rttImprovement > 0 ? '+' : ''}{rttImprovement.toFixed(1)}%
+                        <span
+                          className={cn(
+                            'inline-flex items-center px-2 py-0.5 rounded text-sm font-medium tabular-nums',
+                            getImprovementBg(rttImprovement),
+                            getImprovementColor(rttImprovement),
+                          )}
+                        >
+                          {rttImprovement > 0 ? '+' : ''}
+                          {rttImprovement.toFixed(1)}%
                         </span>
                       ) : (
                         <span className="text-muted-foreground">-</span>
@@ -618,19 +699,26 @@ export function DzVsInternetPage() {
                     </td>
                     {/* Jitter group */}
                     <td className="px-4 py-3 text-right tabular-nums border-l border-border">
-                      {comp.dz_avg_jitter_ms != null ? `${comp.dz_avg_jitter_ms.toFixed(2)}ms` : '-'}
+                      {comp.dz_avg_jitter_ms != null
+                        ? `${comp.dz_avg_jitter_ms.toFixed(2)}ms`
+                        : '-'}
                     </td>
                     <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">
-                      {comp.internet_avg_jitter_ms != null ? `${comp.internet_avg_jitter_ms.toFixed(2)}ms` : '-'}
+                      {comp.internet_avg_jitter_ms != null
+                        ? `${comp.internet_avg_jitter_ms.toFixed(2)}ms`
+                        : '-'}
                     </td>
                     <td className="px-4 py-3 text-right">
                       {hasJitter ? (
-                        <span className={cn(
-                          'inline-flex items-center px-2 py-0.5 rounded text-sm font-medium tabular-nums',
-                          getImprovementBg(jitterImprovement),
-                          getImprovementColor(jitterImprovement)
-                        )}>
-                          {jitterImprovement > 0 ? '+' : ''}{jitterImprovement.toFixed(1)}%
+                        <span
+                          className={cn(
+                            'inline-flex items-center px-2 py-0.5 rounded text-sm font-medium tabular-nums',
+                            getImprovementBg(jitterImprovement),
+                            getImprovementColor(jitterImprovement),
+                          )}
+                        >
+                          {jitterImprovement > 0 ? '+' : ''}
+                          {jitterImprovement.toFixed(1)}%
                         </span>
                       ) : (
                         <span className="text-muted-foreground">-</span>
@@ -650,7 +738,12 @@ export function DzVsInternetPage() {
 
         {/* Detail panel */}
         {selectedComparison && (
-          <div className="w-96 flex-shrink-0 border-l border-border p-4 bg-card overflow-y-auto">
+          <>
+            <div
+              className="fixed inset-0 z-40 bg-black/50 sm:hidden"
+              onClick={() => setSelectedComparison(null)}
+            />
+            <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[calc(100%-2rem)] max-h-[85vh] rounded-xl bg-card overflow-y-auto p-4 sm:static sm:top-auto sm:left-auto sm:translate-x-0 sm:translate-y-0 sm:w-96 sm:max-h-none sm:rounded-none sm:shrink-0 sm:border-l sm:border-border">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="font-medium flex items-center gap-2">
                   <span>{selectedComparison.origin_metro_code}</span>
@@ -667,18 +760,24 @@ export function DzVsInternetPage() {
 
               {/* DZ Latency */}
               <div className="mb-4">
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">DoubleZero</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
+                  DoubleZero
+                </div>
                 <div className="grid grid-cols-3 gap-2">
                   <div className="rounded-lg p-2 bg-muted">
                     <div className="text-[10px] text-muted-foreground mb-0.5">Avg RTT</div>
                     <div className="text-lg font-bold">
-                      {selectedComparison.dz_avg_rtt_ms > 0 ? `${selectedComparison.dz_avg_rtt_ms.toFixed(1)}ms` : '-'}
+                      {selectedComparison.dz_avg_rtt_ms > 0
+                        ? `${selectedComparison.dz_avg_rtt_ms.toFixed(1)}ms`
+                        : '-'}
                     </div>
                   </div>
                   <div className="rounded-lg p-2 bg-muted">
                     <div className="text-[10px] text-muted-foreground mb-0.5">P95 RTT</div>
                     <div className="text-lg font-bold">
-                      {selectedComparison.dz_p95_rtt_ms > 0 ? `${selectedComparison.dz_p95_rtt_ms.toFixed(1)}ms` : '-'}
+                      {selectedComparison.dz_p95_rtt_ms > 0
+                        ? `${selectedComparison.dz_p95_rtt_ms.toFixed(1)}ms`
+                        : '-'}
                     </div>
                   </div>
                   <div className="rounded-lg p-2 bg-muted">
@@ -694,15 +793,21 @@ export function DzVsInternetPage() {
 
               {/* Internet Latency */}
               <div className="mb-4">
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">Public Internet</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
+                  Public Internet
+                </div>
                 <div className="grid grid-cols-3 gap-2">
                   <div className="rounded-lg p-2 bg-muted">
                     <div className="text-[10px] text-muted-foreground mb-0.5">Avg RTT</div>
-                    <div className="text-lg font-bold">{selectedComparison.internet_avg_rtt_ms.toFixed(1)}ms</div>
+                    <div className="text-lg font-bold">
+                      {selectedComparison.internet_avg_rtt_ms.toFixed(1)}ms
+                    </div>
                   </div>
                   <div className="rounded-lg p-2 bg-muted">
                     <div className="text-[10px] text-muted-foreground mb-0.5">P95 RTT</div>
-                    <div className="text-lg font-bold">{selectedComparison.internet_p95_rtt_ms.toFixed(1)}ms</div>
+                    <div className="text-lg font-bold">
+                      {selectedComparison.internet_p95_rtt_ms.toFixed(1)}ms
+                    </div>
                   </div>
                   <div className="rounded-lg p-2 bg-muted">
                     <div className="text-[10px] text-muted-foreground mb-0.5">Jitter</div>
@@ -716,20 +821,27 @@ export function DzVsInternetPage() {
               </div>
 
               {/* Improvement */}
-              <div className={cn(
-                'rounded-lg p-3 mb-4',
-                getImprovementBg(selectedComparison.rtt_improvement_pct ?? 0)
-              )}>
+              <div
+                className={cn(
+                  'rounded-lg p-3 mb-4',
+                  getImprovementBg(selectedComparison.rtt_improvement_pct ?? 0),
+                )}
+              >
                 <div className="text-xs text-muted-foreground mb-1">DZ Advantage</div>
-                <div className={cn(
-                  'text-xl font-bold',
-                  getImprovementColor(selectedComparison.rtt_improvement_pct ?? 0)
-                )}>
+                <div
+                  className={cn(
+                    'text-xl font-bold',
+                    getImprovementColor(selectedComparison.rtt_improvement_pct ?? 0),
+                  )}
+                >
                   {(selectedComparison.rtt_improvement_pct ?? 0) > 0 ? '+' : ''}
                   {selectedComparison.rtt_improvement_pct?.toFixed(1)}%
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  {(selectedComparison.internet_avg_rtt_ms - selectedComparison.dz_avg_rtt_ms).toFixed(1)}ms saved
+                  {(
+                    selectedComparison.internet_avg_rtt_ms - selectedComparison.dz_avg_rtt_ms
+                  ).toFixed(1)}
+                  ms saved
                 </div>
               </div>
 
@@ -741,7 +853,11 @@ export function DzVsInternetPage() {
                     <Loader2 className="h-3 w-3 animate-spin" />
                   ) : (
                     <button
-                      onClick={() => queryClient.invalidateQueries({ queryKey: ['latency-history'] })}
+                      onClick={() =>
+                        queryClient.invalidateQueries({
+                          queryKey: ['latency-history'],
+                        })
+                      }
                       className="opacity-0 group-hover/chart:opacity-100 transition-opacity hover:text-foreground"
                       title="Refresh"
                     >
@@ -755,25 +871,31 @@ export function DzVsInternetPage() {
                   )}
                 </div>
                 <div style={{ minHeight: 128 }}>
-                {rttUPlotData[0].length > 0 ? (
-                  <>
-                    <div ref={rttChartRef} className="h-32" />
-                    <div className="flex justify-center gap-4 text-xs mt-1">
-                      <span className="flex items-center gap-1">
-                        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: dzColor }} />
-                        DZ
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: inetColor }} />
-                        Internet
-                      </span>
+                  {rttUPlotData[0].length > 0 ? (
+                    <>
+                      <div ref={rttChartRef} className="h-32" />
+                      <div className="flex justify-center gap-4 text-xs mt-1">
+                        <span className="flex items-center gap-1">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ backgroundColor: dzColor }}
+                          />
+                          DZ
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ backgroundColor: inetColor }}
+                          />
+                          Internet
+                        </span>
+                      </div>
+                    </>
+                  ) : !historyFetching ? (
+                    <div className="h-32 flex items-center justify-center text-xs text-muted-foreground">
+                      No history data available
                     </div>
-                  </>
-                ) : !historyFetching ? (
-                  <div className="h-32 flex items-center justify-center text-xs text-muted-foreground">
-                    No history data available
-                  </div>
-                ) : null}
+                  ) : null}
                 </div>
               </div>
 
@@ -785,7 +907,11 @@ export function DzVsInternetPage() {
                     <Loader2 className="h-3 w-3 animate-spin" />
                   ) : (
                     <button
-                      onClick={() => queryClient.invalidateQueries({ queryKey: ['latency-history'] })}
+                      onClick={() =>
+                        queryClient.invalidateQueries({
+                          queryKey: ['latency-history'],
+                        })
+                      }
                       className="opacity-0 group-hover/chart:opacity-100 transition-opacity hover:text-foreground"
                       title="Refresh"
                     >
@@ -799,38 +925,45 @@ export function DzVsInternetPage() {
                   )}
                 </div>
                 <div style={{ minHeight: 128 }}>
-                {jitterUPlotData[0].length > 0 ? (
-                  <>
-                    <div ref={jitterChartRef} className="h-32" />
-                    <div className="flex justify-center gap-4 text-xs mt-1">
-                      <span className="flex items-center gap-1">
-                        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: dzColor }} />
-                        DZ
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: inetColor }} />
-                        Internet
-                      </span>
+                  {jitterUPlotData[0].length > 0 ? (
+                    <>
+                      <div ref={jitterChartRef} className="h-32" />
+                      <div className="flex justify-center gap-4 text-xs mt-1">
+                        <span className="flex items-center gap-1">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ backgroundColor: dzColor }}
+                          />
+                          DZ
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ backgroundColor: inetColor }}
+                          />
+                          Internet
+                        </span>
+                      </div>
+                    </>
+                  ) : !historyFetching ? (
+                    <div className="h-32 flex items-center justify-center text-xs text-muted-foreground">
+                      No history data available
                     </div>
-                  </>
-                ) : !historyFetching ? (
-                  <div className="h-32 flex items-center justify-center text-xs text-muted-foreground">
-                    No history data available
-                  </div>
-                ) : null}
+                  ) : null}
                 </div>
               </div>
 
               <div className="text-xs text-muted-foreground">
-                DZ samples: {selectedComparison.dz_sample_count.toLocaleString()} •
-                Internet samples: {selectedComparison.internet_sample_count.toLocaleString()}
+                DZ samples: {selectedComparison.dz_sample_count.toLocaleString()} • Internet
+                samples: {selectedComparison.internet_sample_count.toLocaleString()}
               </div>
-          </div>
+            </div>
+          </>
         )}
       </div>
 
       {/* Legend */}
-      <div className="px-6 py-4 flex-shrink-0 flex items-center gap-6 text-xs text-muted-foreground">
+      <div className="px-6 py-4 flex-col md:flex-row flex md:items-center gap-2 lg:gap-6 text-xs text-muted-foreground">
         <span className="font-medium">Legend:</span>
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded bg-green-100 dark:bg-green-900/40 border border-green-200 dark:border-green-800" />

--- a/web/src/components/gossip-node-detail-page.tsx
+++ b/web/src/components/gossip-node-detail-page.tsx
@@ -20,13 +20,19 @@ export function GossipNodeDetailPage() {
   const { pubkey } = useParams<{ pubkey: string }>()
   const navigate = useNavigate()
 
-  const { data: node, isLoading, error } = useQuery({
+  const {
+    data: node,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['gossip-node', pubkey],
     queryFn: () => fetchGossipNode(pubkey!),
     enabled: !!pubkey,
   })
 
-  useDocumentTitle(node?.pubkey ? `${node.pubkey.slice(0, 8)}...${node.pubkey.slice(-4)}` : 'Gossip Node')
+  useDocumentTitle(
+    node?.pubkey ? `${node.pubkey.slice(0, 8)}...${node.pubkey.slice(-4)}` : 'Gossip Node',
+  )
 
   if (isLoading) {
     return (
@@ -66,14 +72,18 @@ export function GossipNodeDetailPage() {
         </button>
 
         {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <Radio className="h-8 w-8 text-muted-foreground" />
-          <div>
-            <h1 className="text-2xl font-medium font-mono">{node.pubkey.slice(0, 8)}...{node.pubkey.slice(-4)}</h1>
-            <div className="text-sm text-muted-foreground">
-              {node.city && node.country
-                ? `${node.city}, ${node.country}`
-                : node.city || node.country || 'Unknown location'}
+        <div className="flex flex-col xs:flex-row xs:items-center gap-3 mb-8">
+          <div className="flex flex-row gap-3">
+            <Radio className="h-8 w-8 text-muted-foreground" />
+            <div>
+              <h1 className="text-2xl font-medium font-mono">
+                {node.pubkey.slice(0, 8)}...{node.pubkey.slice(-4)}
+              </h1>
+              <div className="text-sm text-muted-foreground">
+                {node.city && node.country
+                  ? `${node.city}, ${node.country}`
+                  : node.city || node.country || 'Unknown location'}
+              </div>
             </div>
           </div>
           <div className="ml-4 flex items-center gap-3">
@@ -140,7 +150,10 @@ export function GossipNodeDetailPage() {
                 <div className="flex justify-between">
                   <dt className="text-sm text-muted-foreground">Vote Account</dt>
                   <dd className="text-sm">
-                    <Link to={`/solana/validators/${node.vote_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                    <Link
+                      to={`/solana/validators/${node.vote_pubkey}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                    >
                       {truncatePubkey(node.vote_pubkey)}
                     </Link>
                   </dd>
@@ -162,40 +175,60 @@ export function GossipNodeDetailPage() {
                   <dt className="text-sm text-muted-foreground">User</dt>
                   <dd className="text-sm">
                     {node.user_pk ? (
-                      <Link to={`/dz/users/${node.user_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                      <Link
+                        to={`/dz/users/${node.user_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
                         {truncatePubkey(node.user_pk)}
                       </Link>
-                    ) : '—'}
+                    ) : (
+                      '—'
+                    )}
                   </dd>
                 </div>
                 <div className="flex justify-between">
                   <dt className="text-sm text-muted-foreground">Owner</dt>
                   <dd className="text-sm">
                     {node.owner_pubkey ? (
-                      <Link to={`/dz/users?search=owner:${node.owner_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                      <Link
+                        to={`/dz/users?search=owner:${node.owner_pubkey}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
                         {truncatePubkey(node.owner_pubkey)}
                       </Link>
-                    ) : '—'}
+                    ) : (
+                      '—'
+                    )}
                   </dd>
                 </div>
                 <div className="flex justify-between">
                   <dt className="text-sm text-muted-foreground">Device</dt>
                   <dd className="text-sm">
                     {node.device_pk ? (
-                      <Link to={`/dz/devices/${node.device_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                      <Link
+                        to={`/dz/devices/${node.device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
                         {node.device_code}
                       </Link>
-                    ) : '—'}
+                    ) : (
+                      '—'
+                    )}
                   </dd>
                 </div>
                 <div className="flex justify-between">
                   <dt className="text-sm text-muted-foreground">Metro</dt>
                   <dd className="text-sm">
                     {node.metro_pk ? (
-                      <Link to={`/dz/metros/${node.metro_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                      <Link
+                        to={`/dz/metros/${node.metro_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
                         {node.metro_code}
                       </Link>
-                    ) : '—'}
+                    ) : (
+                      '—'
+                    )}
                   </dd>
                 </div>
               </dl>

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -1,7 +1,15 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useState, useMemo, useEffect } from 'react'
 import { useSearchParams, useNavigate, useLocation, Link } from 'react-router-dom'
-import { ShieldAlert, Settings, ExternalLink, Info, Download, ChevronDown, RefreshCw } from 'lucide-react'
+import {
+  ShieldAlert,
+  Settings,
+  ExternalLink,
+  Info,
+  Download,
+  ChevronDown,
+  RefreshCw,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   fetchLinkIncidents,
@@ -72,7 +80,6 @@ function formatDuration(seconds: number | undefined): string {
   if (mins > 0 && days < 7) parts.push(`${mins}m`)
   return parts.join(' ')
 }
-
 
 type IncidentScope = 'links' | 'devices'
 
@@ -153,9 +160,14 @@ function IncidentTypeBadge({ type }: { type: string }) {
       className: 'bg-rose-100 text-rose-800 dark:bg-rose-900 dark:text-rose-200',
     },
   }
-  const c = config[type] || { label: type, className: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200' }
+  const c = config[type] || {
+    label: type,
+    className: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  }
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${c.className}`}>
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${c.className}`}
+    >
       {c.label}
     </span>
   )
@@ -185,7 +197,7 @@ function IncidentSection({
         <ChevronDown
           className={cn(
             'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
-            !open && '-rotate-90'
+            !open && '-rotate-90',
           )}
         />
         <h2 className="text-sm font-semibold">{title}</h2>
@@ -194,11 +206,7 @@ function IncidentSection({
         </span>
         <span className="text-xs text-muted-foreground">{description}</span>
       </button>
-      {open && count > 0 && (
-        <div className="px-4 pb-4 overflow-hidden">
-          {children}
-        </div>
-      )}
+      {open && count > 0 && <div className="overflow-x-auto">{children}</div>}
     </div>
   )
 }
@@ -210,7 +218,6 @@ function DrainedBadge() {
     </span>
   )
 }
-
 
 function ReadinessDot({ readiness }: { readiness: string }) {
   const colors: Record<string, string> = {
@@ -227,7 +234,9 @@ function ReadinessDot({ readiness }: { readiness: string }) {
   }
   return (
     <span className="inline-flex items-center gap-1.5" title={labels[readiness] || readiness}>
-      <span className={`inline-flex rounded-full h-2.5 w-2.5 ${colors[readiness] || 'bg-gray-400'}`} />
+      <span
+        className={`inline-flex rounded-full h-2.5 w-2.5 ${colors[readiness] || 'bg-gray-400'}`}
+      />
       <span className="text-xs text-muted-foreground">{labels[readiness]}</span>
     </span>
   )
@@ -320,7 +329,9 @@ export function IncidentsPage() {
     } else {
       next.add(t)
     }
-    updateParams({ type: next.size === 0 ? undefined : Array.from(next).join(',') })
+    updateParams({
+      type: next.size === 0 ? undefined : Array.from(next).join(','),
+    })
   }
 
   const filters = useStatusFilters()
@@ -339,51 +350,86 @@ export function IncidentsPage() {
 
   const getDefaultValue = (key: string): string => {
     switch (key) {
-      case 'range': return '24h'
-      case 'threshold': return '10'
-      case 'errors_threshold': return '1'
-      case 'fcs_threshold': return '1'
-      case 'discards_threshold': return '1'
-      case 'carrier_threshold': return '1'
-      case 'min_duration': return '30'
-      case 'coalesce_gap': return '180'
-      case 'type': return ''
-      case 'view': return 'active'
-      default: return ''
+      case 'range':
+        return '24h'
+      case 'threshold':
+        return '10'
+      case 'errors_threshold':
+        return '1'
+      case 'fcs_threshold':
+        return '1'
+      case 'discards_threshold':
+        return '1'
+      case 'carrier_threshold':
+        return '1'
+      case 'min_duration':
+        return '30'
+      case 'coalesce_gap':
+        return '180'
+      case 'type':
+        return ''
+      case 'view':
+        return 'active'
+      default:
+        return ''
     }
   }
 
   const linkQuery = useQuery({
-    queryKey: ['linkIncidents', range, threshold, errorsThreshold, fcsThreshold, discardsThreshold, carrierThreshold, minDuration, coalesceGap, filterParam],
-    queryFn: () => fetchLinkIncidents({
+    queryKey: [
+      'linkIncidents',
       range,
       threshold,
-      errors_threshold: errorsThreshold,
-      fcs_threshold: fcsThreshold,
-      discards_threshold: discardsThreshold,
-      carrier_threshold: carrierThreshold,
-      min_duration: minDuration,
-      coalesce_gap: coalesceGap,
-      filter: filterParam || undefined,
-    }),
+      errorsThreshold,
+      fcsThreshold,
+      discardsThreshold,
+      carrierThreshold,
+      minDuration,
+      coalesceGap,
+      filterParam,
+    ],
+    queryFn: () =>
+      fetchLinkIncidents({
+        range,
+        threshold,
+        errors_threshold: errorsThreshold,
+        fcs_threshold: fcsThreshold,
+        discards_threshold: discardsThreshold,
+        carrier_threshold: carrierThreshold,
+        min_duration: minDuration,
+        coalesce_gap: coalesceGap,
+        filter: filterParam || undefined,
+      }),
     refetchInterval: 60000,
     placeholderData: keepPreviousData,
     enabled: scope === 'links',
   })
 
   const deviceQuery = useQuery({
-    queryKey: ['deviceIncidents', range, errorsThreshold, fcsThreshold, discardsThreshold, carrierThreshold, minDuration, coalesceGap, filterParam, showLinkInterfaces],
-    queryFn: () => fetchDeviceIncidents({
+    queryKey: [
+      'deviceIncidents',
       range,
-      errors_threshold: errorsThreshold,
-      fcs_threshold: fcsThreshold,
-      discards_threshold: discardsThreshold,
-      carrier_threshold: carrierThreshold,
-      min_duration: minDuration,
-      coalesce_gap: coalesceGap,
-      filter: filterParam || undefined,
-      link_interfaces: showLinkInterfaces || undefined,
-    }),
+      errorsThreshold,
+      fcsThreshold,
+      discardsThreshold,
+      carrierThreshold,
+      minDuration,
+      coalesceGap,
+      filterParam,
+      showLinkInterfaces,
+    ],
+    queryFn: () =>
+      fetchDeviceIncidents({
+        range,
+        errors_threshold: errorsThreshold,
+        fcs_threshold: fcsThreshold,
+        discards_threshold: discardsThreshold,
+        carrier_threshold: carrierThreshold,
+        min_duration: minDuration,
+        coalesce_gap: coalesceGap,
+        filter: filterParam || undefined,
+        link_interfaces: showLinkInterfaces || undefined,
+      }),
     refetchInterval: 60000,
     placeholderData: keepPreviousData,
     enabled: scope === 'devices',
@@ -399,9 +445,20 @@ export function IncidentsPage() {
   const deviceData = deviceQuery.data
 
   // Unfiltered summaries for the stat cards (always show all counts)
-  const allDrainedSummary = scope === 'links'
-    ? linkData?.drained_summary || { total: 0, with_incidents: 0, ready: 0, not_ready: 0 }
-    : deviceData?.drained_summary || { total: 0, with_incidents: 0, ready: 0, not_ready: 0 }
+  const allDrainedSummary =
+    scope === 'links'
+      ? linkData?.drained_summary || {
+          total: 0,
+          with_incidents: 0,
+          ready: 0,
+          not_ready: 0,
+        }
+      : deviceData?.drained_summary || {
+          total: 0,
+          with_incidents: 0,
+          ready: 0,
+          not_ready: 0,
+        }
 
   // Client-side type filtering
   const hasTypeFilter = selectedTypes.size > 0
@@ -418,21 +475,25 @@ export function IncidentsPage() {
   const drainedLinks = useMemo(() => {
     const all = linkData?.drained || []
     if (!hasTypeFilter) return all
-    return all.map(dl => ({
-      ...dl,
-      active_incidents: dl.active_incidents.filter(i => selectedTypes.has(i.incident_type)),
-      recent_incidents: dl.recent_incidents.filter(i => selectedTypes.has(i.incident_type)),
-    })).filter(dl => dl.active_incidents.length > 0 || dl.recent_incidents.length > 0)
+    return all
+      .map((dl) => ({
+        ...dl,
+        active_incidents: dl.active_incidents.filter((i) => selectedTypes.has(i.incident_type)),
+        recent_incidents: dl.recent_incidents.filter((i) => selectedTypes.has(i.incident_type)),
+      }))
+      .filter((dl) => dl.active_incidents.length > 0 || dl.recent_incidents.length > 0)
   }, [linkData?.drained, hasTypeFilter, selectedTypes])
 
   const drainedDevices = useMemo(() => {
     const all = deviceData?.drained || []
     if (!hasTypeFilter) return all
-    return all.map(dd => ({
-      ...dd,
-      active_incidents: dd.active_incidents.filter(i => selectedTypes.has(i.incident_type)),
-      recent_incidents: dd.recent_incidents.filter(i => selectedTypes.has(i.incident_type)),
-    })).filter(dd => dd.active_incidents.length > 0 || dd.recent_incidents.length > 0)
+    return all
+      .map((dd) => ({
+        ...dd,
+        active_incidents: dd.active_incidents.filter((i) => selectedTypes.has(i.incident_type)),
+        recent_incidents: dd.recent_incidents.filter((i) => selectedTypes.has(i.incident_type)),
+      }))
+      .filter((dd) => dd.active_incidents.length > 0 || dd.recent_incidents.length > 0)
   }, [deviceData?.drained, hasTypeFilter, selectedTypes])
 
   // Sort state for active view
@@ -441,7 +502,11 @@ export function IncidentsPage() {
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
 
   // Generic sort helper for incidents of either type
-  type SortableIncident = { started_at: string; is_ongoing: boolean; duration_seconds?: number }
+  type SortableIncident = {
+    started_at: string
+    is_ongoing: boolean
+    duration_seconds?: number
+  }
   const sortIncidents = <T extends SortableIncident>(items: T[]): T[] => {
     return [...items].sort((a, b) => {
       if (sortField === 'started_at') {
@@ -449,12 +514,16 @@ export function IncidentsPage() {
         const bTime = new Date(b.started_at).getTime()
         return sortDir === 'asc' ? aTime - bTime : bTime - aTime
       } else if (sortField === 'ended_at') {
-        const aEnd = a.is_ongoing ? Infinity : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
-        const bEnd = b.is_ongoing ? Infinity : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
+        const aEnd = a.is_ongoing
+          ? Infinity
+          : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
+        const bEnd = b.is_ongoing
+          ? Infinity
+          : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
         return sortDir === 'asc' ? aEnd - bEnd : bEnd - aEnd
       } else {
-        const aDur = a.is_ongoing ? Infinity : (a.duration_seconds || 0)
-        const bDur = b.is_ongoing ? Infinity : (b.duration_seconds || 0)
+        const aDur = a.is_ongoing ? Infinity : a.duration_seconds || 0
+        const bDur = b.is_ongoing ? Infinity : b.duration_seconds || 0
         return sortDir === 'asc' ? aDur - bDur : bDur - aDur
       }
     })
@@ -469,17 +538,34 @@ export function IncidentsPage() {
     return 'transient'
   }
 
-  const splitByStatus = <T extends { is_ongoing: boolean; confirmed: boolean; started_at: string; duration_seconds?: number }>(items: T[]) => {
+  const splitByStatus = <
+    T extends {
+      is_ongoing: boolean
+      confirmed: boolean
+      started_at: string
+      duration_seconds?: number
+    },
+  >(
+    items: T[],
+  ) => {
     const ongoing: T[] = []
     const detecting: T[] = []
     const resolved: T[] = []
     const transient: T[] = []
     for (const i of items) {
       switch (getStatus(i)) {
-        case 'ongoing': ongoing.push(i); break
-        case 'detecting': detecting.push(i); break
-        case 'resolved': resolved.push(i); break
-        case 'transient': transient.push(i); break
+        case 'ongoing':
+          ongoing.push(i)
+          break
+        case 'detecting':
+          detecting.push(i)
+          break
+        case 'resolved':
+          resolved.push(i)
+          break
+        case 'transient':
+          transient.push(i)
+          break
       }
     }
     return {
@@ -506,7 +592,15 @@ export function IncidentsPage() {
   const filteredByType = useMemo(() => {
     if (scope === 'links') {
       const all = linkData?.active || []
-      const byType: Record<string, number> = { packet_loss: 0, errors: 0, fcs: 0, discards: 0, carrier: 0, no_data: 0, isis_down: 0 }
+      const byType: Record<string, number> = {
+        packet_loss: 0,
+        errors: 0,
+        fcs: 0,
+        discards: 0,
+        carrier: 0,
+        no_data: 0,
+        isis_down: 0,
+      }
       let ongoing = 0
       for (const i of all) {
         byType[i.incident_type] = (byType[i.incident_type] || 0) + 1
@@ -515,7 +609,15 @@ export function IncidentsPage() {
       return { byType, ongoing }
     } else {
       const all = deviceData?.active || []
-      const byType: Record<string, number> = { errors: 0, fcs: 0, discards: 0, carrier: 0, no_data: 0, isis_overload: 0, isis_unreachable: 0 }
+      const byType: Record<string, number> = {
+        errors: 0,
+        fcs: 0,
+        discards: 0,
+        carrier: 0,
+        no_data: 0,
+        isis_overload: 0,
+        isis_unreachable: 0,
+      }
       let ongoing = 0
       for (const i of all) {
         byType[i.incident_type] = (byType[i.incident_type] || 0) + 1
@@ -548,7 +650,19 @@ export function IncidentsPage() {
     if (scope === 'devices' && showLinkInterfaces) params.set('link_interfaces', 'true')
     const base = scope === 'devices' ? '/api/incidents/devices/csv' : '/api/incidents/links/csv'
     return `${base}?${params.toString()}`
-  }, [scope, range, threshold, errorsThreshold, fcsThreshold, discardsThreshold, carrierThreshold, minDuration, coalesceGap, filterParam, showLinkInterfaces])
+  }, [
+    scope,
+    range,
+    threshold,
+    errorsThreshold,
+    fcsThreshold,
+    discardsThreshold,
+    carrierThreshold,
+    minDuration,
+    coalesceGap,
+    filterParam,
+    showLinkInterfaces,
+  ])
 
   return (
     <div className="flex-1 overflow-auto">
@@ -559,9 +673,9 @@ export function IncidentsPage() {
           actions={
             <a
               href={exportUrl}
-              className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground border border-border rounded-md hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground border border-border rounded-md hover:bg-muted transition-colors"
             >
-              <Download className="h-4 w-4" />
+              <Download className="h-3 w-3" />
               Export CSV
             </a>
           }
@@ -594,9 +708,9 @@ export function IncidentsPage() {
         </div>
 
         {/* Filters row */}
-        <div className="flex flex-wrap items-center gap-4 mb-4">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
           {/* Time range */}
-          <div className="flex items-center gap-1 bg-muted rounded-md p-1">
+          <div className="flex items-center gap-1 bg-muted rounded-md p-1 overflow-x-auto">
             {timeRanges.map((tr) => (
               <button
                 key={tr.value}
@@ -630,14 +744,19 @@ export function IncidentsPage() {
 
         {/* Settings panel */}
         {showSettings && (
-          <div className="flex flex-wrap items-center gap-6 mb-4 p-4 bg-muted/50 rounded-lg border border-border">
+          <div className="grid grid-cols-1 sm:flex sm:flex-wrap sm:items-center gap-3 sm:gap-6 mb-4 p-4 bg-muted/50 rounded-lg border border-border">
             {scope === 'links' && (
               <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground">Packet Loss:</span>
                 <input
                   type="number"
                   value={localSettings.threshold}
-                  onChange={(e) => setLocalSettings(s => ({ ...s, threshold: e.target.value }))}
+                  onChange={(e) =>
+                    setLocalSettings((s) => ({
+                      ...s,
+                      threshold: e.target.value,
+                    }))
+                  }
                   className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                   min={1}
                   max={100}
@@ -650,7 +769,12 @@ export function IncidentsPage() {
               <input
                 type="number"
                 value={localSettings.errors_threshold}
-                onChange={(e) => setLocalSettings(s => ({ ...s, errors_threshold: e.target.value }))}
+                onChange={(e) =>
+                  setLocalSettings((s) => ({
+                    ...s,
+                    errors_threshold: e.target.value,
+                  }))
+                }
                 className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                 min={1}
               />
@@ -661,7 +785,12 @@ export function IncidentsPage() {
               <input
                 type="number"
                 value={localSettings.fcs_threshold}
-                onChange={(e) => setLocalSettings(s => ({ ...s, fcs_threshold: e.target.value }))}
+                onChange={(e) =>
+                  setLocalSettings((s) => ({
+                    ...s,
+                    fcs_threshold: e.target.value,
+                  }))
+                }
                 className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                 min={1}
               />
@@ -672,7 +801,12 @@ export function IncidentsPage() {
               <input
                 type="number"
                 value={localSettings.discards_threshold}
-                onChange={(e) => setLocalSettings(s => ({ ...s, discards_threshold: e.target.value }))}
+                onChange={(e) =>
+                  setLocalSettings((s) => ({
+                    ...s,
+                    discards_threshold: e.target.value,
+                  }))
+                }
                 className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                 min={1}
               />
@@ -683,32 +817,53 @@ export function IncidentsPage() {
               <input
                 type="number"
                 value={localSettings.carrier_threshold}
-                onChange={(e) => setLocalSettings(s => ({ ...s, carrier_threshold: e.target.value }))}
+                onChange={(e) =>
+                  setLocalSettings((s) => ({
+                    ...s,
+                    carrier_threshold: e.target.value,
+                  }))
+                }
                 className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                 min={1}
               />
               <span className="text-sm text-muted-foreground">/5m</span>
             </div>
-            <div className="w-px h-6 bg-border" />
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">Min Duration:</span>
-              <input
-                type="number"
-                value={localSettings.min_duration}
-                onChange={(e) => setLocalSettings(s => ({ ...s, min_duration: e.target.value }))}
-                className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
-                min={5}
-                step={5}
-              />
-              <span className="text-sm text-muted-foreground">min</span>
-              <span className="text-xs text-muted-foreground/60">({Math.max(1, Math.floor(parseInt(localSettings.min_duration || '30') / 5))} × 5m buckets)</span>
+            <div className="flex flex-col xs:flex-row xs:items-center xs:gap-2">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Min Duration:</span>
+                <input
+                  type="number"
+                  value={localSettings.min_duration}
+                  onChange={(e) =>
+                    setLocalSettings((s) => ({
+                      ...s,
+                      min_duration: e.target.value,
+                    }))
+                  }
+                  className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
+                  min={5}
+                  step={5}
+                />
+                <span className="text-sm text-muted-foreground">min</span>
+              </div>
+              <div>
+                <span className="text-xs text-muted-foreground/60">
+                  ({Math.max(1, Math.floor(parseInt(localSettings.min_duration || '30') / 5))} × 5m
+                  buckets)
+                </span>
+              </div>
             </div>
             <div className="flex items-center gap-2">
               <span className="text-sm text-muted-foreground">Coalesce Gap:</span>
               <input
                 type="number"
                 value={localSettings.coalesce_gap}
-                onChange={(e) => setLocalSettings(s => ({ ...s, coalesce_gap: e.target.value }))}
+                onChange={(e) =>
+                  setLocalSettings((s) => ({
+                    ...s,
+                    coalesce_gap: e.target.value,
+                  }))
+                }
                 className="w-16 px-2 py-1 text-sm bg-background border border-border rounded"
                 min={0}
                 step={5}
@@ -729,12 +884,15 @@ export function IncidentsPage() {
           </div>
         )}
 
-        {isLoading ? <IncidentsContentSkeleton /> : error && !hasData ? (
+        {isLoading ? (
+          <IncidentsContentSkeleton />
+        ) : error && !hasData ? (
           <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
             <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
             <h3 className="text-lg font-medium mb-2">Unable to load incidents</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              {(error as Error).message || 'Something went wrong. The API server may be unavailable.'}
+              {(error as Error).message ||
+                'Something went wrong. The API server may be unavailable.'}
             </p>
             <button
               onClick={() => activeQuery.refetch()}
@@ -743,213 +901,275 @@ export function IncidentsPage() {
               Retry
             </button>
           </div>
-        ) : (<>
-        {/* Data freshness indicator */}
-        <div className="flex items-center gap-2 mb-4 text-xs text-muted-foreground">
-          <button
-            onClick={() => activeQuery.refetch()}
-            className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
-            title="Refresh now"
-          >
-            <RefreshCw className={cn('h-3 w-3', isFetching && 'animate-spin')} />
-            {dataUpdatedAt ? (
-              <span>Updated <RelativeTime timestamp={dataUpdatedAt} /></span>
-            ) : (
-              <span>Refreshing...</span>
-            )}
-          </button>
-          {error && (
-            <span className="text-yellow-600 dark:text-yellow-400">· Refresh failed, showing previous data</span>
-          )}
-        </div>
-        {/* Type stat cards — clickable multi-select filters */}
-        <div className={`grid gap-3 mb-6 ${scope === 'links' ? 'grid-cols-4 sm:grid-cols-7' : 'grid-cols-4 sm:grid-cols-7'}`}>
-          {([
-            ...(scope === 'links' ? [{ key: 'packet_loss', label: 'Packet Loss' }] : []),
-            { key: 'errors', label: 'Errors' },
-            { key: 'fcs', label: 'FCS Errors' },
-            { key: 'discards', label: 'Discards' },
-            { key: 'carrier', label: 'Carrier' },
-            { key: 'no_data', label: 'No Data' },
-            ...(scope === 'links' ? [{ key: 'isis_down', label: 'ISIS Down' }] : []),
-            ...(scope === 'devices' ? [
-              { key: 'isis_overload', label: 'ISIS Overload' },
-              { key: 'isis_unreachable', label: 'ISIS Unreachable' },
-            ] : []),
-          ] as { key: string; label: string }[]).map(({ key, label }) => {
-            const count = filteredByType.byType[key] || 0
-            const isSelected = selectedTypes.has(key)
-            return (
+        ) : (
+          <>
+            {/* Data freshness indicator */}
+            <div className="flex items-center gap-2 mb-4 text-xs text-muted-foreground">
               <button
-                key={key}
-                onClick={() => toggleType(key)}
-                className={`text-center p-3 rounded-lg border transition-colors ${
-                  isSelected
-                    ? 'border-primary bg-primary/5 ring-1 ring-primary'
-                    : 'border-border hover:border-muted-foreground/30'
+                onClick={() => activeQuery.refetch()}
+                className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
+                title="Refresh now"
+              >
+                <RefreshCw className={cn('h-3 w-3', isFetching && 'animate-spin')} />
+                {dataUpdatedAt ? (
+                  <span>
+                    Updated <RelativeTime timestamp={dataUpdatedAt} />
+                  </span>
+                ) : (
+                  <span>Refreshing...</span>
+                )}
+              </button>
+              {error && (
+                <span className="text-yellow-600 dark:text-yellow-400">
+                  · Refresh failed, showing previous data
+                </span>
+              )}
+            </div>
+            {/* Type stat cards — clickable multi-select filters */}
+            <div
+              className={`grid gap-3 mb-6 ${scope === 'links' ? 'grid-cols-2 xs:grid-cols-3 md:grid-cols-4 xl:grid-cols-7' : 'grid-cols-2 xs:grid-cols-3 md:grid-cols-4 xl:grid-cols-7'}`}
+            >
+              {(
+                [
+                  ...(scope === 'links' ? [{ key: 'packet_loss', label: 'Packet Loss' }] : []),
+                  { key: 'errors', label: 'Errors' },
+                  { key: 'fcs', label: 'FCS Errors' },
+                  { key: 'discards', label: 'Discards' },
+                  { key: 'carrier', label: 'Carrier' },
+                  { key: 'no_data', label: 'No Data' },
+                  ...(scope === 'links' ? [{ key: 'isis_down', label: 'ISIS Down' }] : []),
+                  ...(scope === 'devices'
+                    ? [
+                        { key: 'isis_overload', label: 'ISIS Overload' },
+                        { key: 'isis_unreachable', label: 'ISIS Unreachable' },
+                      ]
+                    : []),
+                ] as { key: string; label: string }[]
+              ).map(({ key, label }) => {
+                const count = filteredByType.byType[key] || 0
+                const isSelected = selectedTypes.has(key)
+                return (
+                  <button
+                    key={key}
+                    onClick={() => toggleType(key)}
+                    className={`text-center p-3 rounded-lg border transition-colors ${
+                      isSelected
+                        ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                        : 'border-border hover:border-muted-foreground/30'
+                    }`}
+                  >
+                    <div className="text-2xl font-medium tabular-nums tracking-tight">{count}</div>
+                    <div className="text-xs text-muted-foreground">{label}</div>
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* View tabs */}
+            <div className="flex items-center gap-1 bg-muted rounded-md p-1 w-fit mb-6">
+              <button
+                onClick={() => updateParams({ view: 'active' })}
+                className={`px-4 py-1.5 text-sm rounded transition-colors ${
+                  view === 'active'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
-                <div className="text-2xl font-medium tabular-nums tracking-tight">
-                  {count}
-                </div>
-                <div className="text-xs text-muted-foreground">{label}</div>
+                Activated
+                {filteredByType.ongoing > 0 && (
+                  <span className="ml-1.5 px-1.5 py-0.5 text-xs rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
+                    {filteredByType.ongoing}
+                  </span>
+                )}
               </button>
-            )
-          })}
-        </div>
+              <button
+                onClick={() => updateParams({ view: 'drained' })}
+                className={`px-4 py-1.5 text-sm rounded transition-colors ${
+                  view === 'drained'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Drained
+                {allDrainedSummary.total > 0 && (
+                  <span className="ml-1.5 px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground">
+                    {allDrainedSummary.total}
+                  </span>
+                )}
+              </button>
+            </div>
 
-        {/* View tabs */}
-        <div className="flex items-center gap-1 bg-muted rounded-md p-1 w-fit mb-6">
-          <button
-            onClick={() => updateParams({ view: 'active' })}
-            className={`px-4 py-1.5 text-sm rounded transition-colors ${
-              view === 'active'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Activated
-            {filteredByType.ongoing > 0 && (
-              <span className="ml-1.5 px-1.5 py-0.5 text-xs rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
-                {filteredByType.ongoing}
-              </span>
-            )}
-          </button>
-          <button
-            onClick={() => updateParams({ view: 'drained' })}
-            className={`px-4 py-1.5 text-sm rounded transition-colors ${
-              view === 'drained'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Drained
-            {allDrainedSummary.total > 0 && (
-              <span className="ml-1.5 px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground">
-                {allDrainedSummary.total}
-              </span>
-            )}
-          </button>
-        </div>
-
-        {/* Active view */}
-        {view === 'active' && (
-          <>
-            {(() => {
-              const isEmpty = scope === 'links' ? activeIncidents.length === 0 : activeDeviceIncidents.length === 0
-              if (isEmpty) {
-                return (
-                  <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
-                    <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
-                    <h3 className="text-lg font-medium mb-2">No active incidents</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {filters.length > 0 ? 'No incidents match the selected filters ' : 'No incidents '}
-                      on non-drained {scope === 'links' ? 'links' : 'devices'} in the selected time range.
-                    </p>
-                  </div>
-                )
-              }
-              const byStatus = scope === 'links' ? linkIncidentsByStatus : deviceIncidentsByStatus
-              const sections: { key: string; title: string; description: string; defaultOpen: boolean; incidents: (LinkIncident | DeviceIncident)[] }[] = [
-                { key: 'ongoing', title: 'Ongoing', description: 'Confirmed active incidents', defaultOpen: true, incidents: byStatus.ongoing },
-                { key: 'detecting', title: 'Detecting', description: 'Recently started incidents not yet confirmed', defaultOpen: true, incidents: byStatus.detecting },
-                { key: 'resolved', title: 'Resolved', description: 'Confirmed incidents that have ended', defaultOpen: true, incidents: byStatus.resolved },
-                { key: 'transient', title: 'Transient', description: 'Brief incidents that ended before being confirmed', defaultOpen: true, incidents: byStatus.transient },
-              ]
-              return (
-                <>
-                  {scope === 'devices' && (
-                    <div className="flex items-center gap-6 mb-3 justify-end">
-                      <button
-                        type="button"
-                        role="switch"
-                        aria-checked={showLinkInterfaces}
-                        onClick={() => updateParams({ link_interfaces: showLinkInterfaces ? undefined : 'true' })}
-                        className="flex items-center gap-2 text-sm text-muted-foreground"
-                      >
-                        <span
-                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                            showLinkInterfaces ? 'bg-primary' : 'bg-muted-foreground/30'
-                          }`}
-                        >
-                          <span
-                            className={`inline-block h-4 w-4 transform rounded-full bg-background shadow transition-transform ${
-                              showLinkInterfaces ? 'translate-x-4' : 'translate-x-0.5'
-                            }`}
-                          />
-                        </span>
-                        Show link interfaces
-                        <span className="relative group">
-                          <Info className="h-3.5 w-3.5 text-muted-foreground/50" />
-                          <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-popover text-popover-foreground border border-border rounded shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
-                            Include interfaces already tracked in the Links view
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                  )}
-                  <div className="flex flex-col gap-3">
-                    {sections.map(({ key, title, description, defaultOpen, incidents: sectionIncidents }) => (
-                      <IncidentSection
-                        key={key}
-                        title={title}
-                        description={description}
-                        count={sectionIncidents.length}
-                        defaultOpen={defaultOpen}
-                      >
-                        {sectionIncidents.length === 0 ? null : scope === 'links' ? (
-                          <ActiveIncidentsTable
-                            incidents={sectionIncidents as LinkIncident[]}
-                            sortField={sortField}
-                            sortDir={sortDir}
-                            toggleSort={toggleSort}
-                            coalesceGapMinutes={coalesceGap}
-                            typeFilter={selectedTypes}
-                          />
-                        ) : (
-                          <ActiveDeviceIncidentsTable
-                            incidents={sectionIncidents as DeviceIncident[]}
-                            sortField={sortField}
-                            sortDir={sortDir}
-                            toggleSort={toggleSort}
-                            typeFilter={selectedTypes}
-                          />
+            {/* Active view */}
+            {view === 'active' && (
+              <>
+                {(() => {
+                  const isEmpty =
+                    scope === 'links'
+                      ? activeIncidents.length === 0
+                      : activeDeviceIncidents.length === 0
+                  if (isEmpty) {
+                    return (
+                      <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
+                        <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
+                        <h3 className="text-lg font-medium mb-2">No active incidents</h3>
+                        <p className="text-sm text-muted-foreground">
+                          {filters.length > 0
+                            ? 'No incidents match the selected filters '
+                            : 'No incidents '}
+                          on non-drained {scope === 'links' ? 'links' : 'devices'} in the selected
+                          time range.
+                        </p>
+                      </div>
+                    )
+                  }
+                  const byStatus =
+                    scope === 'links' ? linkIncidentsByStatus : deviceIncidentsByStatus
+                  const sections: {
+                    key: string
+                    title: string
+                    description: string
+                    defaultOpen: boolean
+                    incidents: (LinkIncident | DeviceIncident)[]
+                  }[] = [
+                    {
+                      key: 'ongoing',
+                      title: 'Ongoing',
+                      description: 'Confirmed active incidents',
+                      defaultOpen: true,
+                      incidents: byStatus.ongoing,
+                    },
+                    {
+                      key: 'detecting',
+                      title: 'Detecting',
+                      description: 'Recently started incidents not yet confirmed',
+                      defaultOpen: true,
+                      incidents: byStatus.detecting,
+                    },
+                    {
+                      key: 'resolved',
+                      title: 'Resolved',
+                      description: 'Confirmed incidents that have ended',
+                      defaultOpen: true,
+                      incidents: byStatus.resolved,
+                    },
+                    {
+                      key: 'transient',
+                      title: 'Transient',
+                      description: 'Brief incidents that ended before being confirmed',
+                      defaultOpen: true,
+                      incidents: byStatus.transient,
+                    },
+                  ]
+                  return (
+                    <>
+                      {scope === 'devices' && (
+                        <div className="flex items-center gap-6 mb-3 justify-end">
+                          <button
+                            type="button"
+                            role="switch"
+                            aria-checked={showLinkInterfaces}
+                            onClick={() =>
+                              updateParams({
+                                link_interfaces: showLinkInterfaces ? undefined : 'true',
+                              })
+                            }
+                            className="flex items-center gap-2 text-sm text-muted-foreground"
+                          >
+                            <span
+                              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                                showLinkInterfaces ? 'bg-primary' : 'bg-muted-foreground/30'
+                              }`}
+                            >
+                              <span
+                                className={`inline-block h-4 w-4 transform rounded-full bg-background shadow transition-transform ${
+                                  showLinkInterfaces ? 'translate-x-4' : 'translate-x-0.5'
+                                }`}
+                              />
+                            </span>
+                            Show link interfaces
+                            <span className="relative group">
+                              <Info className="h-3.5 w-3.5 text-muted-foreground/50" />
+                              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-popover text-popover-foreground border border-border rounded shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+                                Include interfaces already tracked in the Links view
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                      )}
+                      <div className="flex flex-col gap-3">
+                        {sections.map(
+                          ({
+                            key,
+                            title,
+                            description,
+                            defaultOpen,
+                            incidents: sectionIncidents,
+                          }) => (
+                            <IncidentSection
+                              key={key}
+                              title={title}
+                              description={description}
+                              count={sectionIncidents.length}
+                              defaultOpen={defaultOpen}
+                            >
+                              {sectionIncidents.length === 0 ? null : scope === 'links' ? (
+                                <ActiveIncidentsTable
+                                  incidents={sectionIncidents as LinkIncident[]}
+                                  sortField={sortField}
+                                  sortDir={sortDir}
+                                  toggleSort={toggleSort}
+                                  coalesceGapMinutes={coalesceGap}
+                                  typeFilter={selectedTypes}
+                                />
+                              ) : (
+                                <ActiveDeviceIncidentsTable
+                                  incidents={sectionIncidents as DeviceIncident[]}
+                                  sortField={sortField}
+                                  sortDir={sortDir}
+                                  toggleSort={toggleSort}
+                                  typeFilter={selectedTypes}
+                                />
+                              )}
+                            </IncidentSection>
+                          ),
                         )}
-                      </IncidentSection>
-                    ))}
-                  </div>
-                </>
-              )
-            })()}
-          </>
-        )}
+                      </div>
+                    </>
+                  )
+                })()}
+              </>
+            )}
 
-        {/* Drained view */}
-        {view === 'drained' && (
-          <>
-            {(() => {
-              const isEmpty = scope === 'links' ? drainedLinks.length === 0 : drainedDevices.length === 0
-              const entity = scope === 'links' ? 'links' : 'devices'
-              if (isEmpty) {
-                return (
-                  <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
-                    <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
-                    <h3 className="text-lg font-medium mb-2">No drained {entity}</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {hasTypeFilter ? `No drained ${entity} have issues of the selected type(s).` : `No ${entity} are currently drained.`}
-                    </p>
-                  </div>
-                )
-              }
-              return scope === 'links' ? (
-                <DrainedLinksTable drainedLinks={drainedLinks} />
-              ) : (
-                <DrainedDevicesTable drainedDevices={drainedDevices} />
-              )
-            })()}
+            {/* Drained view */}
+            {view === 'drained' && (
+              <>
+                {(() => {
+                  const isEmpty =
+                    scope === 'links' ? drainedLinks.length === 0 : drainedDevices.length === 0
+                  const entity = scope === 'links' ? 'links' : 'devices'
+                  if (isEmpty) {
+                    return (
+                      <div className="flex flex-col items-center justify-center py-12 text-center border border-border rounded-lg">
+                        <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
+                        <h3 className="text-lg font-medium mb-2">No drained {entity}</h3>
+                        <p className="text-sm text-muted-foreground">
+                          {hasTypeFilter
+                            ? `No drained ${entity} have issues of the selected type(s).`
+                            : `No ${entity} are currently drained.`}
+                        </p>
+                      </div>
+                    )
+                  }
+                  return scope === 'links' ? (
+                    <DrainedLinksTable drainedLinks={drainedLinks} />
+                  ) : (
+                    <DrainedDevicesTable drainedDevices={drainedDevices} />
+                  )
+                })()}
+              </>
+            )}
           </>
         )}
-        </>)}
       </div>
     </div>
   )
@@ -969,7 +1189,10 @@ type GroupedLinkIncident = {
   incidents: LinkIncident[]
 }
 
-function groupIncidentsByLink(incidents: LinkIncident[], coalesceGapMinutes: number): GroupedLinkIncident[] {
+function groupIncidentsByLink(
+  incidents: LinkIncident[],
+  coalesceGapMinutes: number,
+): GroupedLinkIncident[] {
   const gapMs = coalesceGapMinutes * 60 * 1000
 
   // First group by link
@@ -999,7 +1222,9 @@ function groupIncidentsByLink(incidents: LinkIncident[], coalesceGapMinutes: num
             clusterEnd = Infinity
             break
           }
-          const end = c.ended_at ? new Date(c.ended_at).getTime() : new Date(c.started_at).getTime() + (c.duration_seconds || 0) * 1000
+          const end = c.ended_at
+            ? new Date(c.ended_at).getTime()
+            : new Date(c.started_at).getTime() + (c.duration_seconds || 0) * 1000
           if (end > clusterEnd) clusterEnd = end
         }
         if (incStart <= clusterEnd + gapMs) {
@@ -1013,10 +1238,12 @@ function groupIncidentsByLink(incidents: LinkIncident[], coalesceGapMinutes: num
     // Convert each cluster to a grouped incident
     for (const cluster of clusters) {
       const earliest = cluster.reduce((a, b) =>
-        new Date(a.started_at).getTime() < new Date(b.started_at).getTime() ? a : b
+        new Date(a.started_at).getTime() < new Date(b.started_at).getTime() ? a : b,
       )
-      const anyOngoing = cluster.some(i => i.is_ongoing)
-      const maxDuration = anyOngoing ? undefined : Math.max(...cluster.map(i => i.duration_seconds || 0))
+      const anyOngoing = cluster.some((i) => i.is_ongoing)
+      const maxDuration = anyOngoing
+        ? undefined
+        : Math.max(...cluster.map((i) => i.duration_seconds || 0))
       result.push({
         link_pk: earliest.link_pk,
         link_code: earliest.link_code,
@@ -1024,7 +1251,7 @@ function groupIncidentsByLink(incidents: LinkIncident[], coalesceGapMinutes: num
         side_a_metro: earliest.side_a_metro,
         side_z_metro: earliest.side_z_metro,
         contributor_code: earliest.contributor_code,
-        is_drained: cluster.some(i => i.is_drained),
+        is_drained: cluster.some((i) => i.is_drained),
         started_at: earliest.started_at,
         is_ongoing: anyOngoing,
         duration_seconds: maxDuration,
@@ -1060,15 +1287,17 @@ function groupIncidentsByDevice(incidents: DeviceIncident[]): GroupedDeviceIncid
   for (const incs of byDevice.values()) {
     incs.sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime())
     const earliest = incs[0]
-    const anyOngoing = incs.some(i => i.is_ongoing)
-    const maxDuration = anyOngoing ? undefined : Math.max(...incs.map(i => i.duration_seconds || 0))
+    const anyOngoing = incs.some((i) => i.is_ongoing)
+    const maxDuration = anyOngoing
+      ? undefined
+      : Math.max(...incs.map((i) => i.duration_seconds || 0))
     result.push({
       device_pk: earliest.device_pk,
       device_code: earliest.device_code,
       device_type: earliest.device_type,
       metro: earliest.metro,
       contributor_code: earliest.contributor_code,
-      is_drained: incs.some(i => i.is_drained),
+      is_drained: incs.some((i) => i.is_drained),
       started_at: earliest.started_at,
       is_ongoing: anyOngoing,
       duration_seconds: maxDuration,
@@ -1101,7 +1330,7 @@ function ActiveIncidentsTable({
     let groups = groupIncidentsByLink(incidents, coalesceGapMinutes)
     // Filter rows to those containing at least one incident of a selected type
     if (typeFilter && typeFilter.size > 0) {
-      groups = groups.filter(g => g.incidents.some(i => typeFilter.has(i.incident_type)))
+      groups = groups.filter((g) => g.incidents.some((i) => typeFilter.has(i.incident_type)))
     }
     return groups.sort((a, b) => {
       if (sortField === 'started_at') {
@@ -1109,34 +1338,47 @@ function ActiveIncidentsTable({
         const bTime = new Date(b.started_at).getTime()
         return sortDir === 'asc' ? aTime - bTime : bTime - aTime
       } else if (sortField === 'ended_at') {
-        const aEnd = a.is_ongoing ? Infinity : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
-        const bEnd = b.is_ongoing ? Infinity : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
+        const aEnd = a.is_ongoing
+          ? Infinity
+          : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
+        const bEnd = b.is_ongoing
+          ? Infinity
+          : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
         return sortDir === 'asc' ? aEnd - bEnd : bEnd - aEnd
       } else {
-        const aDur = a.is_ongoing ? Infinity : (a.duration_seconds || 0)
-        const bDur = b.is_ongoing ? Infinity : (b.duration_seconds || 0)
+        const aDur = a.is_ongoing ? Infinity : a.duration_seconds || 0
+        const bDur = b.is_ongoing ? Infinity : b.duration_seconds || 0
         return sortDir === 'asc' ? aDur - bDur : bDur - aDur
       }
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [incidents, coalesceGapMinutes, sortField, sortDir, typeFilter])
 
-  const sortIcon = (field: string) => sortField === field ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''
+  const sortIcon = (field: string) => (sortField === field ? (sortDir === 'asc' ? ' ↑' : ' ↓') : '')
 
   return (
-    <div className="overflow-hidden">
-      <table className="w-full text-sm">
+    <div>
+      <table className="min-w-full text-sm">
         <thead className="bg-muted/50">
           <tr>
-            <th className="text-left px-4 py-3 font-medium">Link</th>
-            <th className="text-left px-4 py-3 font-medium">Type</th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('started_at')}>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Link</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Type</th>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('started_at')}
+            >
               Started{sortIcon('started_at')}
             </th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('ended_at')}>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('ended_at')}
+            >
               Ended{sortIcon('ended_at')}
             </th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('duration')}>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('duration')}
+            >
               Duration{sortIcon('duration')}
             </th>
           </tr>
@@ -1150,8 +1392,10 @@ function ActiveIncidentsTable({
               for (const iface of inc.affected_interfaces || []) allInterfaces.add(iface)
               const existing = byType.get(inc.incident_type)
               if (existing) {
-                if (inc.peak_loss_pct != null) existing.peakLossPct = Math.max(existing.peakLossPct ?? 0, inc.peak_loss_pct)
-                if (inc.peak_count != null) existing.peakCount = (existing.peakCount ?? 0) + inc.peak_count
+                if (inc.peak_loss_pct != null)
+                  existing.peakLossPct = Math.max(existing.peakLossPct ?? 0, inc.peak_loss_pct)
+                if (inc.peak_count != null)
+                  existing.peakCount = (existing.peakCount ?? 0) + inc.peak_count
               } else {
                 byType.set(inc.incident_type, {
                   peakLossPct: inc.peak_loss_pct ?? undefined,
@@ -1162,7 +1406,7 @@ function ActiveIncidentsTable({
             const interfaces = Array.from(allInterfaces)
             return (
               <tr key={`${group.link_pk}-${group.started_at}`} className="hover:bg-muted/30">
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   <Link
                     to={`/dz/links/${encodeURIComponent(group.link_pk)}`}
                     state={{ backLabel: 'incidents' }}
@@ -1174,10 +1418,12 @@ function ActiveIncidentsTable({
                   <div className="text-xs text-muted-foreground">
                     {group.contributor_code} · {group.link_type}
                     <span className="mx-1">·</span>
-                    <span className="font-mono">{group.side_a_metro} &rarr; {group.side_z_metro}</span>
+                    <span className="font-mono">
+                      {group.side_a_metro} &rarr; {group.side_z_metro}
+                    </span>
                   </div>
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center gap-1.5 flex-wrap">
                     {Array.from(byType.entries()).map(([type, agg]) => (
                       <span key={type} className="inline-flex items-center gap-1">
@@ -1188,9 +1434,7 @@ function ActiveIncidentsTable({
                           </span>
                         )}
                         {agg.peakCount != null && type !== 'packet_loss' && (
-                          <span className="text-xs text-muted-foreground">
-                            ({agg.peakCount})
-                          </span>
+                          <span className="text-xs text-muted-foreground">({agg.peakCount})</span>
                         )}
                       </span>
                     ))}
@@ -1202,28 +1446,38 @@ function ActiveIncidentsTable({
                     </div>
                   )}
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   <div>{formatTimeAgo(group.started_at)}</div>
-                  <div className="text-xs text-muted-foreground">{formatTimestamp(group.started_at)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatTimestamp(group.started_at)}
+                  </div>
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   {group.is_ongoing ? (
                     <div className="text-muted-foreground">ongoing</div>
-                  ) : group.duration_seconds != null && (() => {
-                    const endedIso = new Date(new Date(group.started_at).getTime() + group.duration_seconds! * 1000).toISOString()
-                    return (
-                      <>
-                        <div>{formatTimeAgo(endedIso)}</div>
-                        <div className="text-xs text-muted-foreground">{formatTimestamp(endedIso)}</div>
-                      </>
-                    )
-                  })()}
+                  ) : (
+                    group.duration_seconds != null &&
+                    (() => {
+                      const endedIso = new Date(
+                        new Date(group.started_at).getTime() + group.duration_seconds! * 1000,
+                      ).toISOString()
+                      return (
+                        <>
+                          <div>{formatTimeAgo(endedIso)}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatTimestamp(endedIso)}
+                          </div>
+                        </>
+                      )
+                    })()
+                  )}
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   {group.is_ongoing
-                    ? formatDuration(Math.floor((renderTimestamp - new Date(group.started_at).getTime()) / 1000))
-                    : formatDuration(group.duration_seconds)
-                  }
+                    ? formatDuration(
+                        Math.floor((renderTimestamp - new Date(group.started_at).getTime()) / 1000),
+                      )
+                    : formatDuration(group.duration_seconds)}
                 </td>
               </tr>
             )
@@ -1236,17 +1490,17 @@ function ActiveIncidentsTable({
 
 function DrainedLinksTable({ drainedLinks }: { drainedLinks: DrainedLinkInfo[] }) {
   return (
-    <div className="border border-border rounded-lg overflow-hidden">
-      <table className="w-full text-sm table-fixed">
+    <div className="border border-border rounded-lg overflow-x-auto">
+      <table className="min-w-full text-sm">
         <thead className="bg-muted/50">
           <tr>
-            <th className="text-left px-4 py-3 font-medium w-[24%]">Link</th>
-            <th className="text-left px-4 py-3 font-medium w-[10%]">Route</th>
-            <th className="text-left px-4 py-3 font-medium w-[11%]">Drain Status</th>
-            <th className="text-left px-4 py-3 font-medium w-[16%]">Issues</th>
-            <th className="text-left px-4 py-3 font-medium w-[16%]">Started</th>
-            <th className="text-left px-4 py-3 font-medium w-[9%] whitespace-nowrap">Clear For</th>
-            <th className="text-left px-4 py-3 font-medium w-[14%]">Readiness</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Link</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Route</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Drain Status</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Issues</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Started</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Clear For</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Readiness</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
@@ -1262,7 +1516,9 @@ function DrainedLinksTable({ drainedLinks }: { drainedLinks: DrainedLinkInfo[] }
                   <span className="truncate">{dl.link_code}</span>
                   <ExternalLink className="h-3 w-3 shrink-0" />
                 </Link>
-                <div className="text-xs text-muted-foreground truncate">{dl.contributor_code} · {dl.link_type}</div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {dl.contributor_code} · {dl.link_type}
+                </div>
               </td>
               <td className="px-4 py-3 whitespace-nowrap">
                 <span className="font-mono">
@@ -1295,20 +1551,26 @@ function DrainedLinksTable({ drainedLinks }: { drainedLinks: DrainedLinkInfo[] }
                   const allIncidents = [...dl.active_incidents, ...dl.recent_incidents]
                   if (allIncidents.length > 0) {
                     const earliest = allIncidents.reduce((a, b) =>
-                      new Date(a.started_at) < new Date(b.started_at) ? a : b
+                      new Date(a.started_at) < new Date(b.started_at) ? a : b,
                     )
                     return (
                       <>
                         <div>{formatTimeAgo(earliest.started_at)}</div>
-                        <div className="text-xs text-muted-foreground">{formatTimestamp(earliest.started_at)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(earliest.started_at)}
+                        </div>
                       </>
                     )
                   }
                   if (dl.drained_since) {
                     return (
                       <>
-                        <div className="text-muted-foreground">{formatTimeAgo(dl.drained_since)}</div>
-                        <div className="text-xs text-muted-foreground">{formatTimestamp(dl.drained_since)}</div>
+                        <div className="text-muted-foreground">
+                          {formatTimeAgo(dl.drained_since)}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(dl.drained_since)}
+                        </div>
                       </>
                     )
                   }
@@ -1354,7 +1616,7 @@ function ActiveDeviceIncidentsTable({
   const grouped = useMemo(() => {
     let groups = groupIncidentsByDevice(incidents)
     if (typeFilter && typeFilter.size > 0) {
-      groups = groups.filter(g => g.incidents.some(i => typeFilter.has(i.incident_type)))
+      groups = groups.filter((g) => g.incidents.some((i) => typeFilter.has(i.incident_type)))
     }
     return groups.sort((a, b) => {
       if (sortField === 'started_at') {
@@ -1362,34 +1624,47 @@ function ActiveDeviceIncidentsTable({
         const bTime = new Date(b.started_at).getTime()
         return sortDir === 'asc' ? aTime - bTime : bTime - aTime
       } else if (sortField === 'ended_at') {
-        const aEnd = a.is_ongoing ? Infinity : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
-        const bEnd = b.is_ongoing ? Infinity : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
+        const aEnd = a.is_ongoing
+          ? Infinity
+          : new Date(a.started_at).getTime() + (a.duration_seconds || 0) * 1000
+        const bEnd = b.is_ongoing
+          ? Infinity
+          : new Date(b.started_at).getTime() + (b.duration_seconds || 0) * 1000
         return sortDir === 'asc' ? aEnd - bEnd : bEnd - aEnd
       } else {
-        const aDur = a.is_ongoing ? Infinity : (a.duration_seconds || 0)
-        const bDur = b.is_ongoing ? Infinity : (b.duration_seconds || 0)
+        const aDur = a.is_ongoing ? Infinity : a.duration_seconds || 0
+        const bDur = b.is_ongoing ? Infinity : b.duration_seconds || 0
         return sortDir === 'asc' ? aDur - bDur : bDur - aDur
       }
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [incidents, sortField, sortDir, typeFilter])
 
-  const sortIcon = (field: string) => sortField === field ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''
+  const sortIcon = (field: string) => (sortField === field ? (sortDir === 'asc' ? ' ↑' : ' ↓') : '')
 
   return (
-    <div className="overflow-hidden">
-      <table className="w-full text-sm">
+    <div>
+      <table className="min-w-full text-sm">
         <thead className="bg-muted/50">
           <tr>
-            <th className="text-left px-4 py-3 font-medium">Device</th>
-            <th className="text-left px-4 py-3 font-medium">Type</th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('started_at')}>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Device</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Type</th>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('started_at')}
+            >
               Started{sortIcon('started_at')}
             </th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('ended_at')}>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('ended_at')}
+            >
               Ended{sortIcon('ended_at')}
             </th>
-            <th className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground" onClick={() => toggleSort('duration')}>
+            <th
+              className="text-left px-4 py-3 font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+              onClick={() => toggleSort('duration')}
+            >
               Duration{sortIcon('duration')}
             </th>
           </tr>
@@ -1402,7 +1677,8 @@ function ActiveDeviceIncidentsTable({
               for (const iface of inc.affected_interfaces || []) allInterfaces.add(iface)
               const existing = byType.get(inc.incident_type)
               if (existing) {
-                if (inc.peak_count != null) existing.peakCount = (existing.peakCount ?? 0) + inc.peak_count
+                if (inc.peak_count != null)
+                  existing.peakCount = (existing.peakCount ?? 0) + inc.peak_count
               } else {
                 byType.set(inc.incident_type, {
                   peakCount: inc.peak_count ?? undefined,
@@ -1411,64 +1687,77 @@ function ActiveDeviceIncidentsTable({
             }
             const interfaces = Array.from(allInterfaces)
             return (
-            <tr key={group.device_pk + group.started_at} className="hover:bg-muted/30">
-              <td className="px-4 py-3">
-                <Link
-                  to={`/dz/devices/${encodeURIComponent(group.device_pk)}`}
-                  className="text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  {group.device_code}
-                  <ExternalLink className="h-3 w-3" />
-                </Link>
-                <div className="text-xs text-muted-foreground">
-                  {group.contributor_code} · {group.device_type}
-                  {group.metro && <><span className="mx-1">·</span><span className="font-mono">{group.metro}</span></>}
-                </div>
-              </td>
-              <td className="px-4 py-3">
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  {Array.from(byType.entries()).map(([type, agg]) => (
-                    <span key={type} className="inline-flex items-center gap-1">
-                      <IncidentTypeBadge type={type} />
-                      {agg.peakCount != null && (
-                        <span className="text-xs text-muted-foreground">
-                          ({agg.peakCount})
-                        </span>
-                      )}
-                    </span>
-                  ))}
-                  {group.is_drained && <DrainedBadge />}
-                </div>
-                {interfaces.length > 0 && (
-                  <div className="text-xs text-muted-foreground mt-0.5 font-mono">
-                    {interfaces.join(', ')}
+              <tr key={group.device_pk + group.started_at} className="hover:bg-muted/30">
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <Link
+                    to={`/dz/devices/${encodeURIComponent(group.device_pk)}`}
+                    className="text-primary hover:underline inline-flex items-center gap-1"
+                  >
+                    {group.device_code}
+                    <ExternalLink className="h-3 w-3" />
+                  </Link>
+                  <div className="text-xs text-muted-foreground">
+                    {group.contributor_code} · {group.device_type}
+                    {group.metro && (
+                      <>
+                        <span className="mx-1">·</span>
+                        <span className="font-mono">{group.metro}</span>
+                      </>
+                    )}
                   </div>
-                )}
-              </td>
-              <td className="px-4 py-3">
-                <div>{formatTimeAgo(group.started_at)}</div>
-                <div className="text-xs text-muted-foreground">{formatTimestamp(group.started_at)}</div>
-              </td>
-              <td className="px-4 py-3">
-                {group.is_ongoing ? (
-                  <div className="text-muted-foreground">ongoing</div>
-                ) : group.duration_seconds != null && (() => {
-                  const endedIso = new Date(new Date(group.started_at).getTime() + group.duration_seconds! * 1000).toISOString()
-                  return (
-                    <>
-                      <div>{formatTimeAgo(endedIso)}</div>
-                      <div className="text-xs text-muted-foreground">{formatTimestamp(endedIso)}</div>
-                    </>
-                  )
-                })()}
-              </td>
-              <td className="px-4 py-3">
-                {group.is_ongoing
-                  ? formatDuration(Math.floor((renderTimestamp - new Date(group.started_at).getTime()) / 1000))
-                  : formatDuration(group.duration_seconds)
-                }
-              </td>
-            </tr>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    {Array.from(byType.entries()).map(([type, agg]) => (
+                      <span key={type} className="inline-flex items-center gap-1">
+                        <IncidentTypeBadge type={type} />
+                        {agg.peakCount != null && (
+                          <span className="text-xs text-muted-foreground">({agg.peakCount})</span>
+                        )}
+                      </span>
+                    ))}
+                    {group.is_drained && <DrainedBadge />}
+                  </div>
+                  {interfaces.length > 0 && (
+                    <div className="text-xs text-muted-foreground mt-0.5 font-mono">
+                      {interfaces.join(', ')}
+                    </div>
+                  )}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <div>{formatTimeAgo(group.started_at)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatTimestamp(group.started_at)}
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  {group.is_ongoing ? (
+                    <div className="text-muted-foreground">ongoing</div>
+                  ) : (
+                    group.duration_seconds != null &&
+                    (() => {
+                      const endedIso = new Date(
+                        new Date(group.started_at).getTime() + group.duration_seconds! * 1000,
+                      ).toISOString()
+                      return (
+                        <>
+                          <div>{formatTimeAgo(endedIso)}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatTimestamp(endedIso)}
+                          </div>
+                        </>
+                      )
+                    })()
+                  )}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  {group.is_ongoing
+                    ? formatDuration(
+                        Math.floor((renderTimestamp - new Date(group.started_at).getTime()) / 1000),
+                      )
+                    : formatDuration(group.duration_seconds)}
+                </td>
+              </tr>
             )
           })}
         </tbody>
@@ -1479,17 +1768,17 @@ function ActiveDeviceIncidentsTable({
 
 function DrainedDevicesTable({ drainedDevices }: { drainedDevices: DrainedDeviceInfo[] }) {
   return (
-    <div className="border border-border rounded-lg overflow-hidden">
-      <table className="w-full text-sm table-fixed">
+    <div className="border border-border rounded-lg overflow-x-auto">
+      <table className="min-w-full text-sm">
         <thead className="bg-muted/50">
           <tr>
-            <th className="text-left px-4 py-3 font-medium w-[24%]">Device</th>
-            <th className="text-left px-4 py-3 font-medium w-[10%]">Metro</th>
-            <th className="text-left px-4 py-3 font-medium w-[11%]">Drain Status</th>
-            <th className="text-left px-4 py-3 font-medium w-[16%]">Issues</th>
-            <th className="text-left px-4 py-3 font-medium w-[16%]">Started</th>
-            <th className="text-left px-4 py-3 font-medium w-[9%] whitespace-nowrap">Clear For</th>
-            <th className="text-left px-4 py-3 font-medium w-[14%]">Readiness</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Device</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Metro</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Drain Status</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Issues</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Started</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Clear For</th>
+            <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Readiness</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
@@ -1504,7 +1793,9 @@ function DrainedDevicesTable({ drainedDevices }: { drainedDevices: DrainedDevice
                   <span className="truncate">{dd.device_code}</span>
                   <ExternalLink className="h-3 w-3 shrink-0" />
                 </Link>
-                <div className="text-xs text-muted-foreground truncate">{dd.contributor_code} · {dd.device_type}</div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {dd.contributor_code} · {dd.device_type}
+                </div>
               </td>
               <td className="px-4 py-3 whitespace-nowrap">
                 <span className="font-mono">{dd.metro}</span>
@@ -1535,20 +1826,26 @@ function DrainedDevicesTable({ drainedDevices }: { drainedDevices: DrainedDevice
                   const allIncidents = [...dd.active_incidents, ...dd.recent_incidents]
                   if (allIncidents.length > 0) {
                     const earliest = allIncidents.reduce((a, b) =>
-                      new Date(a.started_at) < new Date(b.started_at) ? a : b
+                      new Date(a.started_at) < new Date(b.started_at) ? a : b,
                     )
                     return (
                       <>
                         <div>{formatTimeAgo(earliest.started_at)}</div>
-                        <div className="text-xs text-muted-foreground">{formatTimestamp(earliest.started_at)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(earliest.started_at)}
+                        </div>
                       </>
                     )
                   }
                   if (dd.drained_since) {
                     return (
                       <>
-                        <div className="text-muted-foreground">{formatTimeAgo(dd.drained_since)}</div>
-                        <div className="text-xs text-muted-foreground">{formatTimestamp(dd.drained_since)}</div>
+                        <div className="text-muted-foreground">
+                          {formatTimeAgo(dd.drained_since)}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(dd.drained_since)}
+                        </div>
                       </>
                     )
                   }

--- a/web/src/components/ledger-page.tsx
+++ b/web/src/components/ledger-page.tsx
@@ -1,7 +1,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { BookOpen } from 'lucide-react'
 import { PageHeader } from './page-header'
-import { fetchDZLedger, fetchSolanaLedger, fetchStakeOverview, fetchValidatorPerformance, type LedgerResponse, type StakeOverview, type ValidatorPerfResponse } from '@/lib/api'
+import {
+  fetchDZLedger,
+  fetchSolanaLedger,
+  fetchStakeOverview,
+  fetchValidatorPerformance,
+  type LedgerResponse,
+  type StakeOverview,
+  type ValidatorPerfResponse,
+} from '@/lib/api'
 
 function formatDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600)
@@ -35,16 +43,28 @@ function Skeleton() {
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="rounded-lg border bg-card p-4 sm:p-5">
-      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">{title}</div>
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+        {title}
+      </div>
       {children}
     </div>
   )
 }
 
-function Metric({ label, value, sub }: { label: string; value: React.ReactNode; sub?: React.ReactNode }) {
+function Metric({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: React.ReactNode
+  sub?: React.ReactNode
+}) {
   return (
     <div className="min-w-0">
-      <div className="text-lg sm:text-2xl font-medium tabular-nums tracking-tight truncate">{value}</div>
+      <div className="text-lg sm:text-2xl font-medium tabular-nums tracking-tight truncate">
+        {value}
+      </div>
       <div className="text-xs sm:text-sm text-muted-foreground">{label}</div>
       {sub && <div className="text-xs text-muted-foreground mt-0.5">{sub}</div>}
     </div>
@@ -71,7 +91,9 @@ function EpochProgress({ data }: { data: LedgerResponse | undefined }) {
     <Card title="Epoch">
       <div className="space-y-3">
         <div className="flex items-baseline justify-between">
-          <span className="text-2xl sm:text-3xl font-medium tabular-nums">{formatNumber(data.epoch)}</span>
+          <span className="text-2xl sm:text-3xl font-medium tabular-nums">
+            {formatNumber(data.epoch)}
+          </span>
           <span className="text-sm text-muted-foreground tabular-nums">{pct.toFixed(1)}%</span>
         </div>
         <div className="h-3 rounded-full bg-muted overflow-hidden">
@@ -80,9 +102,11 @@ function EpochProgress({ data }: { data: LedgerResponse | undefined }) {
             style={{ width: `${pct}%` }}
           />
         </div>
-        <div className="flex flex-col sm:flex-row sm:justify-between gap-0.5 sm:gap-0 text-xs text-muted-foreground tabular-nums">
+        <div className="flex flex-col sm:flex-row sm:justify-between gap-2 sm:gap-0 text-xs text-muted-foreground tabular-nums">
           <span>started {started} ago</span>
-          <span>{formatCompact(data.slot_index)} / {formatCompact(data.slots_in_epoch)} slots</span>
+          <span>
+            {formatCompact(data.slot_index)} / {formatCompact(data.slots_in_epoch)} slots
+          </span>
           <span>{remaining} remaining</span>
         </div>
       </div>
@@ -94,10 +118,7 @@ function ChainState({ data }: { data: LedgerResponse | undefined }) {
   return (
     <Card title="Chain State">
       <div className="grid grid-cols-2 gap-4 sm:gap-6 md:grid-cols-4">
-        <Metric
-          label="Slot"
-          value={data ? formatCompact(data.absolute_slot) : <Skeleton />}
-        />
+        <Metric label="Slot" value={data ? formatCompact(data.absolute_slot) : <Skeleton />} />
         <Metric
           label="Block Height"
           value={data ? formatCompact(data.block_height) : <Skeleton />}
@@ -106,10 +127,7 @@ function ChainState({ data }: { data: LedgerResponse | undefined }) {
           label="Transactions"
           value={data ? formatCompact(data.transaction_count) : <Skeleton />}
         />
-        <Metric
-          label="Skip Rate"
-          value={data ? `${data.skip_rate.toFixed(2)}%` : <Skeleton />}
-        />
+        <Metric label="Skip Rate" value={data ? `${data.skip_rate.toFixed(2)}%` : <Skeleton />} />
       </div>
     </Card>
   )
@@ -136,16 +154,24 @@ function DZOnSolana({ stake }: { stake: StakeOverview | undefined }) {
         <Metric
           label="Stake Share"
           value={stake ? `${stake.stake_share_pct.toFixed(2)}%` : <Skeleton />}
-          sub={stake ? (
-            <span className="flex gap-2">
-              <span className={deltaColor()}>24h {formatDelta(stake.share_change_24h)}</span>
-              <span className={deltaColor()}>7d {formatDelta(stake.share_change_7d)}</span>
-            </span>
-          ) : undefined}
+          sub={
+            stake ? (
+              <span className="flex gap-2">
+                <span className={deltaColor()}>24h {formatDelta(stake.share_change_24h)}</span>
+                <span className={deltaColor()}>7d {formatDelta(stake.share_change_7d)}</span>
+              </span>
+            ) : undefined
+          }
         />
         <Metric
           label="DZ Stake Change (24h)"
-          value={stake ? `${stake.dz_stake_change_24h >= 0 ? '+' : ''}${formatSOL(Math.abs(stake.dz_stake_change_24h))} SOL` : <Skeleton />}
+          value={
+            stake ? (
+              `${stake.dz_stake_change_24h >= 0 ? '+' : ''}${formatSOL(Math.abs(stake.dz_stake_change_24h))} SOL`
+            ) : (
+              <Skeleton />
+            )
+          }
         />
       </div>
     </Card>
@@ -170,28 +196,48 @@ function ValidatorPerformance({ perf }: { perf: ValidatorPerfResponse | undefine
           <tbody className="tabular-nums">
             <tr className="border-t border-border/50">
               <td className="py-2.5 text-muted-foreground">Validators</td>
-              <td className="py-2.5 text-right font-medium">{dz ? formatNumber(dz.validator_count) : <Skeleton />}</td>
-              <td className="py-2.5 text-right font-medium">{nonDz ? formatNumber(nonDz.validator_count) : <Skeleton />}</td>
+              <td className="py-2.5 text-right font-medium">
+                {dz ? formatNumber(dz.validator_count) : <Skeleton />}
+              </td>
+              <td className="py-2.5 text-right font-medium">
+                {nonDz ? formatNumber(nonDz.validator_count) : <Skeleton />}
+              </td>
             </tr>
             <tr className="border-t border-border/50">
               <td className="py-2.5 text-muted-foreground">Avg Skip Rate</td>
-              <td className="py-2.5 text-right font-medium">{dz ? `${dz.avg_skip_rate.toFixed(2)}%` : <Skeleton />}</td>
-              <td className="py-2.5 text-right font-medium">{nonDz ? `${nonDz.avg_skip_rate.toFixed(2)}%` : <Skeleton />}</td>
+              <td className="py-2.5 text-right font-medium">
+                {dz ? `${dz.avg_skip_rate.toFixed(2)}%` : <Skeleton />}
+              </td>
+              <td className="py-2.5 text-right font-medium">
+                {nonDz ? `${nonDz.avg_skip_rate.toFixed(2)}%` : <Skeleton />}
+              </td>
             </tr>
             <tr className="border-t border-border/50">
               <td className="py-2.5 text-muted-foreground">Avg Vote Lag</td>
-              <td className="py-2.5 text-right font-medium">{dz ? `${dz.avg_vote_lag.toFixed(2)} slots` : <Skeleton />}</td>
-              <td className="py-2.5 text-right font-medium">{nonDz ? `${nonDz.avg_vote_lag.toFixed(2)} slots` : <Skeleton />}</td>
+              <td className="py-2.5 text-right font-medium">
+                {dz ? `${dz.avg_vote_lag.toFixed(2)} slots` : <Skeleton />}
+              </td>
+              <td className="py-2.5 text-right font-medium">
+                {nonDz ? `${nonDz.avg_vote_lag.toFixed(2)} slots` : <Skeleton />}
+              </td>
             </tr>
             <tr className="border-t border-border/50">
               <td className="py-2.5 text-muted-foreground">Delinquent</td>
-              <td className="py-2.5 text-right font-medium">{dz ? formatNumber(dz.delinquent_count) : <Skeleton />}</td>
-              <td className="py-2.5 text-right font-medium">{nonDz ? formatNumber(nonDz.delinquent_count) : <Skeleton />}</td>
+              <td className="py-2.5 text-right font-medium">
+                {dz ? formatNumber(dz.delinquent_count) : <Skeleton />}
+              </td>
+              <td className="py-2.5 text-right font-medium">
+                {nonDz ? formatNumber(nonDz.delinquent_count) : <Skeleton />}
+              </td>
             </tr>
             <tr className="border-t border-border/50">
               <td className="py-2.5 text-muted-foreground">Total Stake</td>
-              <td className="py-2.5 text-right font-medium">{dz ? `${formatSOL(dz.total_stake_sol)} SOL` : <Skeleton />}</td>
-              <td className="py-2.5 text-right font-medium">{nonDz ? `${formatSOL(nonDz.total_stake_sol)} SOL` : <Skeleton />}</td>
+              <td className="py-2.5 text-right font-medium">
+                {dz ? `${formatSOL(dz.total_stake_sol)} SOL` : <Skeleton />}
+              </td>
+              <td className="py-2.5 text-right font-medium">
+                {nonDz ? `${formatSOL(nonDz.total_stake_sol)} SOL` : <Skeleton />}
+              </td>
             </tr>
           </tbody>
         </table>
@@ -200,7 +246,13 @@ function ValidatorPerformance({ perf }: { perf: ValidatorPerfResponse | undefine
   )
 }
 
-function LedgerDashboard({ data, full = false }: { data: LedgerResponse | undefined; full?: boolean }) {
+function LedgerDashboard({
+  data,
+  full = false,
+}: {
+  data: LedgerResponse | undefined
+  full?: boolean
+}) {
   return (
     <div className="space-y-4 sm:space-y-6">
       <EpochProgress data={data} />
@@ -216,10 +268,7 @@ function LedgerDashboard({ data, full = false }: { data: LedgerResponse | undefi
                   value={data ? formatNumber(data.tps, 0) : <Skeleton />}
                   sub={data ? 'recent 10 samples' : undefined}
                 />
-                <Metric
-                  label="Node Version"
-                  value={data ? data.node_version : <Skeleton />}
-                />
+                <Metric label="Node Version" value={data ? data.node_version : <Skeleton />} />
               </div>
             </Card>
 

--- a/web/src/components/link-charts/LinkJitterChart.tsx
+++ b/web/src/components/link-charts/LinkJitterChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import uPlot from 'uplot'
 import { Loader2 } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
@@ -35,20 +36,29 @@ function getJitterValue(latency: Record<string, number>, side: 'a' | 'z', mode: 
   return (latency as Record<string, number>)[field] ?? 0
 }
 
-export function LinkJitterChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkJitterChartProps) {
+export function LinkJitterChart({
+  data,
+  className,
+  loading,
+  highlightTimeRange,
+  onCursorTime,
+}: LinkJitterChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
   const chartRef = useRef<HTMLDivElement>(null)
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
   const uPlotDataRef = useRef<uPlot.AlignedData>([[]])
-  const handleCursorIdx = useCallback((idx: number | null) => {
-    setHoveredIdx(idx)
-    if (onCursorTime) {
-      const ts = idx != null ? (uPlotDataRef.current[0] as number[])?.[idx] ?? null : null
-      onCursorTime(ts)
-    }
-  }, [onCursorTime])
+  const handleCursorIdx = useCallback(
+    (idx: number | null) => {
+      setHoveredIdx(idx)
+      if (onCursorTime) {
+        const ts = idx != null ? ((uPlotDataRef.current[0] as number[])?.[idx] ?? null) : null
+        onCursorTime(ts)
+      }
+    },
+    [onCursorTime],
+  )
   const [aggMode, setAggMode] = useState<AggMode>('avg')
 
   // Colors
@@ -58,15 +68,21 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
 
   const hasCommittedJitter = data.committed_jitter_us > 0
 
-  const scales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const scales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
-  const axes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map((v) => `${v.toFixed(1)} ms`) },
-  ], [])
+  const axes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      { values: (_u: uPlot, vals: number[]) => vals.map((v) => `${v.toFixed(1)} ms`) },
+    ],
+    [],
+  )
 
   const seriesKeys = useMemo(() => {
     const keys = ['fromA', 'fromZ']
@@ -103,9 +119,13 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
     if (hasCommittedJitter) {
       const committedMs = data.committed_jitter_us / 1000
       dataArrays.push(buckets.map(() => committedMs))
-      series.push(
-        { label: 'committed', stroke: committedColor, width: 1, dash: [4, 4], points: { show: false } },
-      )
+      series.push({
+        label: 'committed',
+        stroke: committedColor,
+        width: 1,
+        dash: [4, 4],
+        points: { show: false },
+      })
     }
 
     return {
@@ -121,7 +141,12 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
       { key: 'fromZ', color: zColor, label: 'From Z' },
     ]
     if (hasCommittedJitter) {
-      items.push({ key: 'committed', color: committedColor, label: 'Committed Jitter', dashed: true })
+      items.push({
+        key: 'committed',
+        color: committedColor,
+        label: 'Committed Jitter',
+        dashed: true,
+      })
     }
     return items
   }, [aColor, zColor, committedColor, hasCommittedJitter])
@@ -133,20 +158,25 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
 
-  const drawHooks = useMemo(() => [(u: uPlot) => {
-    const range = highlightTimeRangeRef.current
-    if (!range) return
-    const ctx = u.ctx
-    const left = u.valToPos(range.start, 'x', true)
-    const right = u.valToPos(range.end, 'x', true)
-    if (left == null || right == null) return
-    const top = u.bbox.top
-    const height = u.bbox.height
-    ctx.save()
-    ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
-    ctx.fillRect(left, top, right - left, height)
-    ctx.restore()
-  }], [])
+  const drawHooks = useMemo(
+    () => [
+      (u: uPlot) => {
+        const range = highlightTimeRangeRef.current
+        if (!range) return
+        const ctx = u.ctx
+        const left = u.valToPos(range.start, 'x', true)
+        const right = u.valToPos(range.end, 'x', true)
+        if (left == null || right == null) return
+        const top = u.bbox.top
+        const height = u.bbox.height
+        ctx.save()
+        ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
+        ctx.fillRect(left, top, right - left, height)
+        ctx.restore()
+      },
+    ],
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartRef,
@@ -175,7 +205,10 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
     if (uPlotData[0].length === 0) return map
     let defaultIdx = uPlotData[0].length - 1
     for (let j = defaultIdx; j >= 0; j--) {
-      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) { defaultIdx = j; break }
+      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) {
+        defaultIdx = j
+        break
+      }
     }
     const idx = hoveredIdx != null && hoveredIdx < uPlotData[0].length ? hoveredIdx : defaultIdx
     for (let i = 0; i < seriesKeys.length; i++) {
@@ -197,12 +230,15 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
     return map
   }, [uPlotData])
 
-  const hoveredTime = useMemo(() =>
-    formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
-    [uPlotData, hoveredIdx])
+  const hoveredTime = useMemo(
+    () =>
+      formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
+    [uPlotData, hoveredIdx],
+  )
 
-  const hasAnyData = uPlotData[0].length > 0 && uPlotData.slice(1).some(
-    (s) => (s as (number | null)[]).some((v) => v != null))
+  const hasAnyData =
+    uPlotData[0].length > 0 &&
+    uPlotData.slice(1).some((s) => (s as (number | null)[]).some((v) => v != null))
 
   if (!hasAnyData) {
     return (
@@ -210,7 +246,9 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
         <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
           <span>Jitter</span>
         </div>
-        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">No data for this time range</div>
+        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">
+          No data for this time range
+        </div>
       </div>
     )
   }
@@ -222,15 +260,11 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
           <span>Jitter</span>
           {loading && <Loader2 className="h-3 w-3 animate-spin" />}
         </div>
-        <select
+        <SmallDropdown
           value={aggMode}
-          onChange={e => setAggMode(e.target.value as AggMode)}
-          className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
-        >
-          {AGG_OPTIONS.map(o => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
+          options={AGG_OPTIONS}
+          onChange={(v) => setAggMode(v as AggMode)}
+        />
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full mb-1">
         {loading && (
@@ -238,7 +272,13 @@ export function LinkJitterChart({ data, className, loading, highlightTimeRange, 
         )}
       </div>
       <div ref={chartRef} className="h-36" />
-      <ChartLegendTable series={legendSeries} legend={legend} values={displayValues} maxValues={maxValues} hoveredTime={hoveredTime} />
+      <ChartLegendTable
+        series={legendSeries}
+        legend={legend}
+        values={displayValues}
+        maxValues={maxValues}
+        hoveredTime={hoveredTime}
+      />
     </div>
   )
 }

--- a/web/src/components/link-charts/LinkLatencyChart.tsx
+++ b/web/src/components/link-charts/LinkLatencyChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import uPlot from 'uplot'
 import { Loader2 } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
@@ -39,20 +40,29 @@ function getRttValue(latency: Record<string, number>, side: 'a' | 'z', mode: Agg
   return (latency as Record<string, number>)[field] ?? 0
 }
 
-export function LinkLatencyChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkLatencyChartProps) {
+export function LinkLatencyChart({
+  data,
+  className,
+  loading,
+  highlightTimeRange,
+  onCursorTime,
+}: LinkLatencyChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
   const chartRef = useRef<HTMLDivElement>(null)
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
   const uPlotDataRef = useRef<uPlot.AlignedData>([[]])
-  const handleCursorIdx = useCallback((idx: number | null) => {
-    setHoveredIdx(idx)
-    if (onCursorTime) {
-      const ts = idx != null ? (uPlotDataRef.current[0] as number[])?.[idx] ?? null : null
-      onCursorTime(ts)
-    }
-  }, [onCursorTime])
+  const handleCursorIdx = useCallback(
+    (idx: number | null) => {
+      setHoveredIdx(idx)
+      if (onCursorTime) {
+        const ts = idx != null ? ((uPlotDataRef.current[0] as number[])?.[idx] ?? null) : null
+        onCursorTime(ts)
+      }
+    },
+    [onCursorTime],
+  )
   const [aggMode, setAggMode] = useState<AggMode>('avg')
 
   // Colors
@@ -62,15 +72,21 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
 
   const hasCommittedRtt = data.committed_rtt_us > 0
 
-  const scales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const scales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
-  const axes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map((v) => `${v.toFixed(1)} ms`) },
-  ], [])
+  const axes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      { values: (_u: uPlot, vals: number[]) => vals.map((v) => `${v.toFixed(1)} ms`) },
+    ],
+    [],
+  )
 
   const seriesKeys = useMemo(() => {
     const keys = ['aToZ', 'zToA']
@@ -107,9 +123,13 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
     if (hasCommittedRtt) {
       const committedMs = data.committed_rtt_us / 1000
       dataArrays.push(buckets.map(() => committedMs))
-      series.push(
-        { label: 'committed', stroke: committedColor, width: 1, dash: [4, 4], points: { show: false } },
-      )
+      series.push({
+        label: 'committed',
+        stroke: committedColor,
+        width: 1,
+        dash: [4, 4],
+        points: { show: false },
+      })
     }
 
     return {
@@ -137,20 +157,25 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
 
-  const drawHooks = useMemo(() => [(u: uPlot) => {
-    const range = highlightTimeRangeRef.current
-    if (!range) return
-    const ctx = u.ctx
-    const left = u.valToPos(range.start, 'x', true)
-    const right = u.valToPos(range.end, 'x', true)
-    if (left == null || right == null) return
-    const top = u.bbox.top
-    const height = u.bbox.height
-    ctx.save()
-    ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
-    ctx.fillRect(left, top, right - left, height)
-    ctx.restore()
-  }], [])
+  const drawHooks = useMemo(
+    () => [
+      (u: uPlot) => {
+        const range = highlightTimeRangeRef.current
+        if (!range) return
+        const ctx = u.ctx
+        const left = u.valToPos(range.start, 'x', true)
+        const right = u.valToPos(range.end, 'x', true)
+        if (left == null || right == null) return
+        const top = u.bbox.top
+        const height = u.bbox.height
+        ctx.save()
+        ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
+        ctx.fillRect(left, top, right - left, height)
+        ctx.restore()
+      },
+    ],
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartRef,
@@ -179,7 +204,10 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
     if (uPlotData[0].length === 0) return map
     let defaultIdx = uPlotData[0].length - 1
     for (let j = defaultIdx; j >= 0; j--) {
-      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) { defaultIdx = j; break }
+      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) {
+        defaultIdx = j
+        break
+      }
     }
     const idx = hoveredIdx != null && hoveredIdx < uPlotData[0].length ? hoveredIdx : defaultIdx
     for (let i = 0; i < seriesKeys.length; i++) {
@@ -201,12 +229,15 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
     return map
   }, [uPlotData, seriesKeys])
 
-  const hoveredTime = useMemo(() =>
-    formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
-    [uPlotData, hoveredIdx])
+  const hoveredTime = useMemo(
+    () =>
+      formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
+    [uPlotData, hoveredIdx],
+  )
 
-  const hasAnyData = uPlotData[0].length > 0 && uPlotData.slice(1).some(
-    (s) => (s as (number | null)[]).some((v) => v != null))
+  const hasAnyData =
+    uPlotData[0].length > 0 &&
+    uPlotData.slice(1).some((s) => (s as (number | null)[]).some((v) => v != null))
 
   if (!hasAnyData) {
     return (
@@ -214,7 +245,9 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
         <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
           <span>Round-Trip Time</span>
         </div>
-        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">No data for this time range</div>
+        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">
+          No data for this time range
+        </div>
       </div>
     )
   }
@@ -226,15 +259,11 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
           <span>Round-Trip Time</span>
           {loading && <Loader2 className="h-3 w-3 animate-spin" />}
         </div>
-        <select
+        <SmallDropdown
           value={aggMode}
-          onChange={e => setAggMode(e.target.value as AggMode)}
-          className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
-        >
-          {AGG_OPTIONS.map(o => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
+          options={AGG_OPTIONS}
+          onChange={(v) => setAggMode(v as AggMode)}
+        />
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full mb-1">
         {loading && (
@@ -242,7 +271,13 @@ export function LinkLatencyChart({ data, className, loading, highlightTimeRange,
         )}
       </div>
       <div ref={chartRef} className="h-36" />
-      <ChartLegendTable series={legendSeries} legend={legend} values={displayValues} maxValues={maxValues} hoveredTime={hoveredTime} />
+      <ChartLegendTable
+        series={legendSeries}
+        legend={legend}
+        values={displayValues}
+        maxValues={maxValues}
+        hoveredTime={hoveredTime}
+      />
     </div>
   )
 }

--- a/web/src/components/link-charts/LinkTrafficChart.tsx
+++ b/web/src/components/link-charts/LinkTrafficChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useCallback, useEffect } from 'react'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import uPlot from 'uplot'
 import { Loader2 } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
@@ -36,7 +37,13 @@ function formatPps(value: number): string {
   return `${abs.toFixed(0)} pps`
 }
 
-function getTrafficValue(t: LinkMetricsTraffic, side: 'a' | 'z', dir: 'in' | 'out', agg: AggMode, metric: MetricMode): number {
+function getTrafficValue(
+  t: LinkMetricsTraffic,
+  side: 'a' | 'z',
+  dir: 'in' | 'out',
+  agg: AggMode,
+  metric: MetricMode,
+): number {
   const suffix = metric === 'bps' ? 'bps' : 'pps'
   let key: string
   if (agg === 'max') {
@@ -49,20 +56,29 @@ function getTrafficValue(t: LinkMetricsTraffic, side: 'a' | 'z', dir: 'in' | 'ou
   return (t as unknown as Record<string, number>)[key] ?? 0
 }
 
-export function LinkTrafficChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkTrafficChartProps) {
+export function LinkTrafficChart({
+  data,
+  className,
+  loading,
+  highlightTimeRange,
+  onCursorTime,
+}: LinkTrafficChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
   const chartRef = useRef<HTMLDivElement>(null)
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
   const uPlotDataRef = useRef<uPlot.AlignedData>([[]])
-  const handleCursorIdx = useCallback((idx: number | null) => {
-    setHoveredIdx(idx)
-    if (onCursorTime) {
-      const ts = idx != null ? (uPlotDataRef.current[0] as number[])?.[idx] ?? null : null
-      onCursorTime(ts)
-    }
-  }, [onCursorTime])
+  const handleCursorIdx = useCallback(
+    (idx: number | null) => {
+      setHoveredIdx(idx)
+      if (onCursorTime) {
+        const ts = idx != null ? ((uPlotDataRef.current[0] as number[])?.[idx] ?? null) : null
+        onCursorTime(ts)
+      }
+    },
+    [onCursorTime],
+  )
   const [bidir, setBidir] = useState(true)
   const [aggMode, setAggMode] = useState<AggMode>('avg')
   const [metricMode, setMetricMode] = useState<MetricMode>('bps')
@@ -75,19 +91,23 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
   const aOutColor = isDark ? '#86efac' : '#4ade80'
   const zOutColor = isDark ? '#93c5fd' : '#60a5fa'
 
-  const scales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const scales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
-  const axes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map((v) => fmt(v)) },
-  ], [fmt])
+  const axes = useMemo(
+    (): uPlot.Axis[] => [{}, { values: (_u: uPlot, vals: number[]) => vals.map((v) => fmt(v)) }],
+    [fmt],
+  )
 
-  const seriesKeys = useMemo(() =>
-    bidir ? ['aRx', 'aTx', 'zRx', 'zTx'] : ['aIn', 'aOut', 'zIn', 'zOut'],
-    [bidir])
+  const seriesKeys = useMemo(
+    () => (bidir ? ['aRx', 'aTx', 'zRx', 'zTx'] : ['aIn', 'aOut', 'zIn', 'zOut']),
+    [bidir],
+  )
 
   const { uPlotData, uPlotSeries } = useMemo(() => {
     const buckets = data.buckets.filter((b) => !b.status?.collecting)
@@ -101,9 +121,15 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
 
     if (bidir) {
       const aRx = buckets.map((b) => val(b.traffic, 'a', 'in'))
-      const aTx = buckets.map((b) => { const v = val(b.traffic, 'a', 'out'); return v ? -v : null })
+      const aTx = buckets.map((b) => {
+        const v = val(b.traffic, 'a', 'out')
+        return v ? -v : null
+      })
       const zRx = buckets.map((b) => val(b.traffic, 'z', 'in'))
-      const zTx = buckets.map((b) => { const v = val(b.traffic, 'z', 'out'); return v ? -v : null })
+      const zTx = buckets.map((b) => {
+        const v = val(b.traffic, 'z', 'out')
+        return v ? -v : null
+      })
 
       return {
         uPlotData: [timestamps, aRx, aTx, zRx, zTx] as uPlot.AlignedData,
@@ -135,21 +161,23 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
   }, [data, bidir, aggMode, metricMode, aColor, aOutColor, zColor, zOutColor])
 
   const legend = useChartLegend()
-  const legendSeries: ChartLegendSeries[] = useMemo(() =>
-    bidir
-      ? [
-          { key: 'aRx', color: aColor, label: 'Side A Rx' },
-          { key: 'aTx', color: aColor, label: 'Side A Tx', dashed: true },
-          { key: 'zRx', color: zColor, label: 'Side Z Rx' },
-          { key: 'zTx', color: zColor, label: 'Side Z Tx', dashed: true },
-        ]
-      : [
-          { key: 'aIn', color: aColor, label: 'Side A In' },
-          { key: 'aOut', color: aOutColor, label: 'Side A Out', dashed: true },
-          { key: 'zIn', color: zColor, label: 'Side Z In' },
-          { key: 'zOut', color: zOutColor, label: 'Side Z Out', dashed: true },
-        ],
-    [bidir, aColor, aOutColor, zColor, zOutColor])
+  const legendSeries: ChartLegendSeries[] = useMemo(
+    () =>
+      bidir
+        ? [
+            { key: 'aRx', color: aColor, label: 'Side A Rx' },
+            { key: 'aTx', color: aColor, label: 'Side A Tx', dashed: true },
+            { key: 'zRx', color: zColor, label: 'Side Z Rx' },
+            { key: 'zTx', color: zColor, label: 'Side Z Tx', dashed: true },
+          ]
+        : [
+            { key: 'aIn', color: aColor, label: 'Side A In' },
+            { key: 'aOut', color: aOutColor, label: 'Side A Out', dashed: true },
+            { key: 'zIn', color: zColor, label: 'Side Z In' },
+            { key: 'zOut', color: zOutColor, label: 'Side Z Out', dashed: true },
+          ],
+    [bidir, aColor, aOutColor, zColor, zOutColor],
+  )
 
   uPlotDataRef.current = uPlotData
 
@@ -158,20 +186,25 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
 
-  const drawHooks = useMemo(() => [(u: uPlot) => {
-    const range = highlightTimeRangeRef.current
-    if (!range) return
-    const ctx = u.ctx
-    const left = u.valToPos(range.start, 'x', true)
-    const right = u.valToPos(range.end, 'x', true)
-    if (left == null || right == null) return
-    const top = u.bbox.top
-    const height = u.bbox.height
-    ctx.save()
-    ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
-    ctx.fillRect(left, top, right - left, height)
-    ctx.restore()
-  }], [])
+  const drawHooks = useMemo(
+    () => [
+      (u: uPlot) => {
+        const range = highlightTimeRangeRef.current
+        if (!range) return
+        const ctx = u.ctx
+        const left = u.valToPos(range.start, 'x', true)
+        const right = u.valToPos(range.end, 'x', true)
+        if (left == null || right == null) return
+        const top = u.bbox.top
+        const height = u.bbox.height
+        ctx.save()
+        ctx.fillStyle = isDarkRef.current ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)'
+        ctx.fillRect(left, top, right - left, height)
+        ctx.restore()
+      },
+    ],
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartRef,
@@ -200,7 +233,10 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
     if (uPlotData[0].length === 0) return map
     let defaultIdx = uPlotData[0].length - 1
     for (let j = defaultIdx; j >= 0; j--) {
-      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) { defaultIdx = j; break }
+      if (seriesKeys.some((_, si) => (uPlotData[si + 1] as (number | null)[])?.[j] != null)) {
+        defaultIdx = j
+        break
+      }
     }
     const idx = hoveredIdx != null && hoveredIdx < uPlotData[0].length ? hoveredIdx : defaultIdx
     for (let i = 0; i < seriesKeys.length; i++) {
@@ -222,12 +258,15 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
     return map
   }, [uPlotData, seriesKeys, fmt])
 
-  const hoveredTime = useMemo(() =>
-    formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
-    [uPlotData, hoveredIdx])
+  const hoveredTime = useMemo(
+    () =>
+      formatHoveredTime(uPlotData[0] as ArrayLike<number>, hoveredIdx, data.bucket_seconds < 60),
+    [uPlotData, hoveredIdx],
+  )
 
-  const hasAnyData = uPlotData[0].length > 0 && uPlotData.slice(1).some(
-    (s) => (s as (number | null)[]).some((v) => v != null))
+  const hasAnyData =
+    uPlotData[0].length > 0 &&
+    uPlotData.slice(1).some((s) => (s as (number | null)[]).some((v) => v != null))
 
   if (!hasAnyData) {
     return (
@@ -235,7 +274,9 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
         <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
           <span>Traffic</span>
         </div>
-        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">No data for this time range</div>
+        <div className="text-xs text-muted-foreground/60 pt-3 pb-6 text-center">
+          No data for this time range
+        </div>
       </div>
     )
   }
@@ -248,26 +289,26 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
           {loading && <Loader2 className="h-3 w-3 animate-spin" />}
         </div>
         <div className="flex items-center gap-1.5">
-          <select
+          <SmallDropdown
             value={aggMode}
-            onChange={e => setAggMode(e.target.value as AggMode)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
-          >
-            <option value="avg">Avg</option>
-            <option value="p50">P50</option>
-            <option value="p90">P90</option>
-            <option value="p95">P95</option>
-            <option value="p99">P99</option>
-            <option value="max">Max</option>
-          </select>
-          <select
+            options={[
+              { value: 'avg', label: 'Avg' },
+              { value: 'p50', label: 'P50' },
+              { value: 'p90', label: 'P90' },
+              { value: 'p95', label: 'P95' },
+              { value: 'p99', label: 'P99' },
+              { value: 'max', label: 'Max' },
+            ]}
+            onChange={(v) => setAggMode(v as AggMode)}
+          />
+          <SmallDropdown
             value={metricMode}
-            onChange={e => setMetricMode(e.target.value as MetricMode)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-0.5 text-foreground cursor-pointer"
-          >
-            <option value="bps">bps</option>
-            <option value="pps">pps</option>
-          </select>
+            options={[
+              { value: 'bps', label: 'bps' },
+              { value: 'pps', label: 'pps' },
+            ]}
+            onChange={(v) => setMetricMode(v as MetricMode)}
+          />
           <button
             onClick={() => setBidir(!bidir)}
             className="text-[10px] text-muted-foreground hover:text-foreground border border-border rounded px-1.5 py-0.5 transition-colors"
@@ -282,7 +323,13 @@ export function LinkTrafficChart({ data, className, loading, highlightTimeRange,
         )}
       </div>
       <div ref={chartRef} className="h-36" />
-      <ChartLegendTable series={legendSeries} legend={legend} values={displayValues} maxValues={maxValues} hoveredTime={hoveredTime} />
+      <ChartLegendTable
+        series={legendSeries}
+        legend={legend}
+        values={displayValues}
+        maxValues={maxValues}
+        hoveredTime={hoveredTime}
+      />
     </div>
   )
 }

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -23,14 +23,22 @@ export function LinkDetailPage() {
   const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<TimeRange>({ preset: '24h' })
   const [bucket, setBucket] = useState<BucketSize>('auto')
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
-  const effectiveBucketLabel = bucket === 'auto'
-    ? bucketLabels[resolveAutoBucket(timeRange.preset as TimeRangePreset)]
-    : undefined
+  const effectiveBucketLabel =
+    bucket === 'auto'
+      ? bucketLabels[resolveAutoBucket(timeRange.preset as TimeRangePreset)]
+      : undefined
 
-  const { data: link, isLoading, error } = useQuery({
+  const {
+    data: link,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['link', pk],
     queryFn: () => fetchLink(pk!),
     enabled: !!pk,
@@ -38,7 +46,11 @@ export function LinkDetailPage() {
 
   const metricsParams = useMemo(() => toLinkMetricsParams(timeRange, bucket), [timeRange, bucket])
 
-  const { data: metrics, isLoading: metricsLoading, isFetching: metricsFetching } = useQuery({
+  const {
+    data: metrics,
+    isLoading: metricsLoading,
+    isFetching: metricsFetching,
+  } = useQuery({
     queryKey: ['linkMetrics', pk, metricsParams],
     queryFn: () => fetchLinkMetrics(pk!, metricsParams),
     enabled: !!pk,
@@ -60,10 +72,7 @@ export function LinkDetailPage() {
         <div className="text-center">
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Link not found</div>
-          <Link
-            to="/dz/links"
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
+          <Link to="/dz/links" className="text-sm text-muted-foreground hover:text-foreground">
             Back to links
           </Link>
         </div>
@@ -86,13 +95,15 @@ export function LinkDetailPage() {
 
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">
-          <Cable className="h-8 w-8 text-muted-foreground" />
-          <div>
-            <h1 className="text-2xl font-medium font-mono">
-              <CopyableText text={link.code} />
-            </h1>
-            <div className="text-sm text-muted-foreground font-mono">
-              <CopyableText text={link.pk} />
+          <Cable className="hidden sm:block h-8 w-8 text-muted-foreground shrink-0" />
+          <div className="min-w-0">
+            <CopyableText text={link.code} className="w-full cursor-pointer">
+              <h1 className="text-2xl font-medium font-mono break-all">{link.code}</h1>
+            </CopyableText>
+            <div className="text-sm text-muted-foreground font-mono mt-0.5">
+              <CopyableText text={link.pk} className="flex-wrap">
+                <span className="break-all">{link.pk}</span>
+              </CopyableText>
             </div>
           </div>
         </div>
@@ -112,7 +123,11 @@ export function LinkDetailPage() {
             className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
             title="Refresh"
           >
-            {metricsFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {metricsFetching ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
           </button>
           <TrafficFilters
             bucket={bucket}
@@ -135,12 +150,46 @@ export function LinkDetailPage() {
         )}
         {metrics && (
           <div className="space-y-4">
-            <LinkHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />
-            <LinkPacketLossChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkInterfaceIssuesChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkTrafficChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkLatencyChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkJitterChart data={metrics} loading={metricsFetching} className="rounded-lg border border-border p-4" highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+            <LinkHealthTimeline
+              data={metrics}
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
+            <LinkPacketLossChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkInterfaceIssuesChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkTrafficChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkLatencyChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkJitterChart
+              data={metrics}
+              loading={metricsFetching}
+              className="rounded-lg border border-border p-4"
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
           </div>
         )}
       </div>

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -1,8 +1,17 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { CheckCircle2, AlertTriangle, History, Info, ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
+import {
+  CheckCircle2,
+  AlertTriangle,
+  History,
+  Info,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from 'lucide-react'
 import { fetchBulkLinkMetrics, fetchLinkMetrics } from '@/lib/api'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import type { LinkMetricsResponse, LinkMetricsBucket } from '@/lib/api'
 import { LinkPacketLossChart as LinkPacketLossDetailChart } from '@/components/link-charts/LinkPacketLossChart'
 import { LinkInterfaceIssuesChart } from '@/components/link-charts/LinkInterfaceIssuesChart'
@@ -32,8 +41,8 @@ function LinkTimelineSkeleton() {
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="px-4 py-3 border-b border-border last:border-b-0">
           <div className="flex items-start gap-4">
-            <div className="flex-shrink-0 w-5" />
-            <div className="flex-shrink-0 w-44 space-y-1.5">
+            <div className="shrink-0 w-5" />
+            <div className="shrink-0 w-44 space-y-1.5">
               <Skeleton className="h-4 w-28" />
               <Skeleton className="h-3 w-20" />
             </div>
@@ -62,9 +71,9 @@ interface LinkStatusTimelinesProps {
   onShowDrainedChange?: (show: boolean) => void
   showProvisioning?: boolean
   onShowProvisioningChange?: (show: boolean) => void
-  linksWithIssues?: Map<string, string[]>  // Map of link code -> issue reasons (from filter time range)
-  linksWithHealth?: Map<string, string>    // Map of link code -> health status (from filter time range)
-  criticalityMap?: Map<string, 'critical' | 'important' | 'redundant'>  // Map of link code -> criticality level
+  linksWithIssues?: Map<string, string[]> // Map of link code -> issue reasons (from filter time range)
+  linksWithHealth?: Map<string, string> // Map of link code -> health status (from filter time range)
+  criticalityMap?: Map<string, 'critical' | 'important' | 'redundant'> // Map of link code -> criticality level
 }
 
 function formatBandwidth(bps: number): string {
@@ -91,7 +100,7 @@ interface DerivedLinkInfo {
   isDown: boolean
   drainStatus: string
   provisioning: boolean
-  health: string  // worst health across buckets
+  health: string // worst health across buckets
 }
 
 function deriveLinkInfo(metrics: LinkMetricsResponse): DerivedLinkInfo {
@@ -149,7 +158,13 @@ function deriveLinkInfo(metrics: LinkMetricsResponse): DerivedLinkInfo {
       if (t.side_a_in_fcs_errors + t.side_z_in_fcs_errors > 0) {
         issueReasons.add('fcs_errors')
       }
-      if (t.side_a_in_discards + t.side_a_out_discards + t.side_z_in_discards + t.side_z_out_discards > 0) {
+      if (
+        t.side_a_in_discards +
+          t.side_a_out_discards +
+          t.side_z_in_discards +
+          t.side_z_out_discards >
+        0
+      ) {
         issueReasons.add('discards')
       }
       if (t.side_a_carrier_transitions + t.side_z_carrier_transitions > 0) {
@@ -201,7 +216,13 @@ function deriveLinkInfo(metrics: LinkMetricsResponse): DerivedLinkInfo {
   }
 }
 
-function LinkInfoPopover({ linkMetrics, criticality }: { linkMetrics: LinkMetricsResponse; criticality?: 'critical' | 'important' | 'redundant' }) {
+function LinkInfoPopover({
+  linkMetrics,
+  criticality,
+}: {
+  linkMetrics: LinkMetricsResponse
+  criticality?: 'critical' | 'important' | 'redundant'
+}) {
   const [isOpen, setIsOpen] = useState(false)
 
   const criticalityInfo = {
@@ -241,7 +262,9 @@ function LinkInfoPopover({ linkMetrics, criticality }: { linkMetrics: LinkMetric
           <div className="space-y-2 text-xs">
             <div>
               <div className="text-muted-foreground">Route</div>
-              <div className="font-medium">{linkMetrics.side_a_metro} — {linkMetrics.side_z_metro}</div>
+              <div className="font-medium">
+                {linkMetrics.side_a_metro} — {linkMetrics.side_z_metro}
+              </div>
             </div>
             <div className="flex gap-4">
               <div>
@@ -258,7 +281,9 @@ function LinkInfoPopover({ linkMetrics, criticality }: { linkMetrics: LinkMetric
             {linkMetrics.committed_rtt_us > 0 && (
               <div>
                 <div className="text-muted-foreground">Committed RTT</div>
-                <div className="font-medium">{(linkMetrics.committed_rtt_us / 1000).toFixed(2)} ms</div>
+                <div className="font-medium">
+                  {(linkMetrics.committed_rtt_us / 1000).toFixed(2)} ms
+                </div>
               </div>
             )}
             {criticality && (
@@ -295,17 +320,23 @@ function addBucketIssues(b: LinkMetricsBucket, issues: Set<string>) {
   // Also check traffic data directly (for FCS errors and utilization not in reasons)
   if (b.traffic) {
     const t = b.traffic
-    if (t.side_a_in_errors + t.side_a_out_errors + t.side_z_in_errors + t.side_z_out_errors > 0) issues.add('interface_errors')
+    if (t.side_a_in_errors + t.side_a_out_errors + t.side_z_in_errors + t.side_z_out_errors > 0)
+      issues.add('interface_errors')
     if (t.side_a_in_fcs_errors + t.side_z_in_fcs_errors > 0) issues.add('fcs_errors')
-    if (t.side_a_in_discards + t.side_a_out_discards + t.side_z_in_discards + t.side_z_out_discards > 0) issues.add('discards')
-    if (t.side_a_carrier_transitions + t.side_z_carrier_transitions > 0) issues.add('carrier_transitions')
+    if (
+      t.side_a_in_discards + t.side_a_out_discards + t.side_z_in_discards + t.side_z_out_discards >
+      0
+    )
+      issues.add('discards')
+    if (t.side_a_carrier_transitions + t.side_z_carrier_transitions > 0)
+      issues.add('carrier_transitions')
     if (t.utilization_in_pct > 80 || t.utilization_out_pct > 80) issues.add('high_utilization')
   }
   if (b.status && !b.status.collecting && b.status.health === 'no_data') issues.add('no_data')
   if (b.status?.isis_down) issues.add('missing_adjacency')
 }
 
-const cardClass = "rounded-lg border border-border p-4"
+const cardClass = 'rounded-lg border border-border p-4'
 
 interface LinkRowProps {
   linkMetrics: LinkMetricsResponse
@@ -315,9 +346,18 @@ interface LinkRowProps {
   metricsTimeRange: string
 }
 
-function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, metricsTimeRange }: LinkRowProps) {
+function LinkRow({
+  linkMetrics,
+  derivedInfo,
+  linksWithIssues,
+  criticalityMap,
+  metricsTimeRange,
+}: LinkRowProps) {
   const [expanded, setExpanded] = useState(false)
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
   // Fetch full metrics (with latency) on expand for packet loss chart
@@ -367,7 +407,12 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
     const cutoff = nowMinutes * 60 - 30 * 60
     let worstHealth = 'healthy'
     let isisDown = false
-    const priority: Record<string, number> = { unhealthy: 3, degraded: 2, no_data: 1, healthy: 0 }
+    const priority: Record<string, number> = {
+      unhealthy: 3,
+      degraded: 2,
+      no_data: 1,
+      healthy: 0,
+    }
     for (const b of linkMetrics.buckets) {
       const ts = new Date(b.ts).getTime() / 1000
       if (ts < cutoff) continue
@@ -390,82 +435,217 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
         : 'border-l-transparent'
 
   // Has expandable content: packet loss or interface issues
-  const hasExpandableContent = issueReasons.some(r =>
-    r === 'packet_loss' || r === 'high_latency' || r === 'interface_errors' || r === 'fcs_errors' || r === 'discards' || r === 'carrier_transitions'
+  const hasExpandableContent = issueReasons.some(
+    (r) =>
+      r === 'packet_loss' ||
+      r === 'high_latency' ||
+      r === 'interface_errors' ||
+      r === 'fcs_errors' ||
+      r === 'discards' ||
+      r === 'carrier_transitions',
   )
 
   return (
-    <div id={`link-row-${derivedInfo.code}`} className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}>
+    <div
+      id={`link-row-${derivedInfo.code}`}
+      className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}
+    >
       <div
         className={`px-4 py-3 transition-colors ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30' : ''}`}
         onClick={hasExpandableContent ? () => setExpanded(!expanded) : undefined}
       >
-        <div className="flex items-start gap-4">
-          {/* Expand/collapse indicator */}
-          <div className="flex-shrink-0 w-5 pt-0.5">
-            {hasExpandableContent ? (
-              expanded ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <div className="w-4" />
-            )}
-          </div>
-
-          {/* Link info */}
-          <div className="flex-shrink-0 w-52 sm:w-60 lg:w-68">
-            <div className="flex items-center gap-1.5">
-              <Link to={`/dz/links/${derivedInfo.pk}`} state={{ backLabel: 'status' }} className="font-mono text-sm truncate hover:underline" title={derivedInfo.code} onClick={(e) => e.stopPropagation()}>
-                {derivedInfo.code}
-              </Link>
-              <LinkInfoPopover linkMetrics={linkMetrics} criticality={criticalityMap?.get(derivedInfo.code)} />
-            </div>
-            <div className="text-xs text-muted-foreground">
-              {derivedInfo.linkType}{derivedInfo.contributor && ` · ${derivedInfo.contributor}`} · {derivedInfo.sideAMetro} ↔ {derivedInfo.sideZMetro}
-            </div>
-            {(derivedInfo.isDown || derivedInfo.drainStatus || derivedInfo.provisioning || issueReasons.length > 0) && (
-              <div className="flex flex-wrap gap-1 mt-1">
-                {derivedInfo.isDown && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-gray-900/15 text-gray-900 dark:bg-gray-400/20 dark:text-gray-300">Down</span>
-                )}
-                {derivedInfo.drainStatus && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-gray-900/15 text-gray-900 dark:bg-gray-400/20 dark:text-gray-300">{derivedInfo.drainStatus === 'hard-drained' ? 'Hard Drained' : 'Soft Drained'}</span>
-                )}
-                {derivedInfo.provisioning && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-blue-500/15 text-blue-700 dark:bg-blue-400/20 dark:text-blue-300">Provisioning</span>
-                )}
-                {issueReasons.includes('packet_loss') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('packet_loss') ? '' : dimBadgeClass}`} style={isBadgeActive('packet_loss') ? { backgroundColor: 'rgba(168, 85, 247, 0.15)', color: '#9333ea' } : undefined}>Loss</span>
-                )}
-                {issueReasons.includes('high_latency') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('high_latency') ? '' : dimBadgeClass}`} style={isBadgeActive('high_latency') ? { backgroundColor: 'rgba(59, 130, 246, 0.15)', color: '#2563eb' } : undefined}>High Latency</span>
-                )}
-                {issueReasons.includes('high_utilization') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('high_utilization') ? '' : dimBadgeClass}`} style={isBadgeActive('high_utilization') ? { backgroundColor: 'rgba(99, 102, 241, 0.15)', color: '#4f46e5' } : undefined}>High Utilization</span>
-                )}
-                {issueReasons.includes('no_data') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('no_data') ? '' : dimBadgeClass}`} style={isBadgeActive('no_data') ? { backgroundColor: 'rgba(236, 72, 153, 0.15)', color: '#db2777' } : undefined}>No Data</span>
-                )}
-                {issueReasons.includes('interface_errors') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('interface_errors') ? '' : dimBadgeClass}`} style={isBadgeActive('interface_errors') ? { backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#dc2626' } : undefined}>Errors</span>
-                )}
-                {issueReasons.includes('fcs_errors') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('fcs_errors') ? '' : dimBadgeClass}`} style={isBadgeActive('fcs_errors') ? { backgroundColor: 'rgba(249, 115, 22, 0.15)', color: '#ea580c' } : undefined}>FCS Errors</span>
-                )}
-                {issueReasons.includes('discards') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('discards') ? '' : dimBadgeClass}`} style={isBadgeActive('discards') ? { backgroundColor: 'rgba(20, 184, 166, 0.15)', color: '#0d9488' } : undefined}>Discards</span>
-                )}
-                {issueReasons.includes('carrier_transitions') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('carrier_transitions') ? '' : dimBadgeClass}`} style={isBadgeActive('carrier_transitions') ? { backgroundColor: 'rgba(234, 179, 8, 0.15)', color: '#ca8a04' } : undefined}>Carrier Transitions</span>
-                )}
-                {issueReasons.includes('missing_adjacency') && (
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('missing_adjacency') ? 'bg-rose-600/15 text-rose-700 dark:text-rose-400' : dimBadgeClass}`}>ISIS Down</span>
-                )}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+          <div className="flex items-start justify-between gap-2">
+            {/* Link info */}
+            <div className="flex-1 min-w-0 sm:shrink-0 sm:w-52 lg:w-60">
+              <div className="flex items-center gap-1.5">
+                <LinkInfoPopover
+                  linkMetrics={linkMetrics}
+                  criticality={criticalityMap?.get(derivedInfo.code)}
+                />
+                <Link
+                  to={`/dz/links/${derivedInfo.pk}`}
+                  state={{ backLabel: 'status' }}
+                  className="font-mono text-sm truncate hover:underline"
+                  title={derivedInfo.code}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {derivedInfo.code}
+                </Link>
               </div>
-            )}
+              <div className="text-xs text-muted-foreground">
+                {derivedInfo.linkType}
+                {derivedInfo.contributor && ` · ${derivedInfo.contributor}`} ·{' '}
+                {derivedInfo.sideAMetro} ↔ {derivedInfo.sideZMetro}
+              </div>
+              {(derivedInfo.isDown ||
+                derivedInfo.drainStatus ||
+                derivedInfo.provisioning ||
+                issueReasons.length > 0) && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {derivedInfo.isDown && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-gray-900/15 text-gray-900 dark:bg-gray-400/20 dark:text-gray-300">
+                      Down
+                    </span>
+                  )}
+                  {derivedInfo.drainStatus && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-gray-900/15 text-gray-900 dark:bg-gray-400/20 dark:text-gray-300">
+                      {derivedInfo.drainStatus === 'hard-drained' ? 'Hard Drained' : 'Soft Drained'}
+                    </span>
+                  )}
+                  {derivedInfo.provisioning && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-blue-500/15 text-blue-700 dark:bg-blue-400/20 dark:text-blue-300">
+                      Provisioning
+                    </span>
+                  )}
+                  {issueReasons.includes('packet_loss') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('packet_loss') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('packet_loss')
+                          ? {
+                              backgroundColor: 'rgba(168, 85, 247, 0.15)',
+                              color: '#9333ea',
+                            }
+                          : undefined
+                      }
+                    >
+                      Loss
+                    </span>
+                  )}
+                  {issueReasons.includes('high_latency') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('high_latency') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('high_latency')
+                          ? {
+                              backgroundColor: 'rgba(59, 130, 246, 0.15)',
+                              color: '#2563eb',
+                            }
+                          : undefined
+                      }
+                    >
+                      High Latency
+                    </span>
+                  )}
+                  {issueReasons.includes('high_utilization') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('high_utilization') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('high_utilization')
+                          ? {
+                              backgroundColor: 'rgba(99, 102, 241, 0.15)',
+                              color: '#4f46e5',
+                            }
+                          : undefined
+                      }
+                    >
+                      High Utilization
+                    </span>
+                  )}
+                  {issueReasons.includes('no_data') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('no_data') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('no_data')
+                          ? {
+                              backgroundColor: 'rgba(236, 72, 153, 0.15)',
+                              color: '#db2777',
+                            }
+                          : undefined
+                      }
+                    >
+                      No Data
+                    </span>
+                  )}
+                  {issueReasons.includes('interface_errors') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('interface_errors') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('interface_errors')
+                          ? {
+                              backgroundColor: 'rgba(239, 68, 68, 0.15)',
+                              color: '#dc2626',
+                            }
+                          : undefined
+                      }
+                    >
+                      Errors
+                    </span>
+                  )}
+                  {issueReasons.includes('fcs_errors') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('fcs_errors') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('fcs_errors')
+                          ? {
+                              backgroundColor: 'rgba(249, 115, 22, 0.15)',
+                              color: '#ea580c',
+                            }
+                          : undefined
+                      }
+                    >
+                      FCS Errors
+                    </span>
+                  )}
+                  {issueReasons.includes('discards') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('discards') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('discards')
+                          ? {
+                              backgroundColor: 'rgba(20, 184, 166, 0.15)',
+                              color: '#0d9488',
+                            }
+                          : undefined
+                      }
+                    >
+                      Discards
+                    </span>
+                  )}
+                  {issueReasons.includes('carrier_transitions') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('carrier_transitions') ? '' : dimBadgeClass}`}
+                      style={
+                        isBadgeActive('carrier_transitions')
+                          ? {
+                              backgroundColor: 'rgba(234, 179, 8, 0.15)',
+                              color: '#ca8a04',
+                            }
+                          : undefined
+                      }
+                    >
+                      Carrier Transitions
+                    </span>
+                  )}
+                  {issueReasons.includes('missing_adjacency') && (
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition-all ${isBadgeActive('missing_adjacency') ? 'bg-rose-600/15 text-rose-700 dark:text-rose-400' : dimBadgeClass}`}
+                    >
+                      ISIS Down
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {hasExpandableContent ? (
+              expanded ? (
+                <ChevronUp className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+              )
+            ) : null}
           </div>
 
           {/* Timeline */}
           <div className="flex-1 min-w-0">
-            <LinkHealthTimeline data={linkMetrics} hideBadges onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />
+            <LinkHealthTimeline
+              data={linkMetrics}
+              hideBadges
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
           </div>
         </div>
       </div>
@@ -474,25 +654,64 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
       {expanded && (
         <div className="px-4 pb-4 pt-2 space-y-4">
           {/* Packet loss chart — needs latency data from per-link fetch */}
-          {fullMetrics && (() => {
-            const hasLatency = fullMetrics.buckets.some(b => b.latency && (b.latency.a_avg_rtt_us > 0 || b.latency.z_avg_rtt_us > 0))
-            const hasLoss = fullMetrics.buckets.some(b => b.latency && (b.latency.a_loss_pct > 0 || b.latency.z_loss_pct > 0))
-            return (
-              <>
-                {hasLatency && issueReasons.includes('high_latency') && <LinkLatencyChart data={fullMetrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />}
-                {hasLoss && <LinkPacketLossDetailChart data={fullMetrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />}
-              </>
-            )
-          })()}
+          {fullMetrics &&
+            (() => {
+              const hasLatency = fullMetrics.buckets.some(
+                (b) => b.latency && (b.latency.a_avg_rtt_us > 0 || b.latency.z_avg_rtt_us > 0),
+              )
+              const hasLoss = fullMetrics.buckets.some(
+                (b) => b.latency && (b.latency.a_loss_pct > 0 || b.latency.z_loss_pct > 0),
+              )
+              return (
+                <>
+                  {hasLatency && issueReasons.includes('high_latency') && (
+                    <LinkLatencyChart
+                      data={fullMetrics}
+                      loading={metricsFetching}
+                      className={cardClass}
+                      highlightTimeRange={hoveredTimeRange}
+                      onCursorTime={setChartHoveredTime}
+                    />
+                  )}
+                  {hasLoss && (
+                    <LinkPacketLossDetailChart
+                      data={fullMetrics}
+                      loading={metricsFetching}
+                      className={cardClass}
+                      highlightTimeRange={hoveredTimeRange}
+                      onCursorTime={setChartHoveredTime}
+                    />
+                  )}
+                </>
+              )
+            })()}
           {/* Interface issues chart — uses bulk data (has traffic) */}
           {(() => {
-            const hasIssues = linkMetrics.buckets.some(b => b.traffic && (
-              b.traffic.side_a_in_errors + b.traffic.side_a_out_errors + b.traffic.side_z_in_errors + b.traffic.side_z_out_errors > 0 ||
-              b.traffic.side_a_in_fcs_errors + b.traffic.side_z_in_fcs_errors > 0 ||
-              b.traffic.side_a_in_discards + b.traffic.side_a_out_discards + b.traffic.side_z_in_discards + b.traffic.side_z_out_discards > 0 ||
-              b.traffic.side_a_carrier_transitions + b.traffic.side_z_carrier_transitions > 0
-            ))
-            return hasIssues ? <LinkInterfaceIssuesChart data={linkMetrics} loading={false} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} /> : null
+            const hasIssues = linkMetrics.buckets.some(
+              (b) =>
+                b.traffic &&
+                (b.traffic.side_a_in_errors +
+                  b.traffic.side_a_out_errors +
+                  b.traffic.side_z_in_errors +
+                  b.traffic.side_z_out_errors >
+                  0 ||
+                  b.traffic.side_a_in_fcs_errors + b.traffic.side_z_in_fcs_errors > 0 ||
+                  b.traffic.side_a_in_discards +
+                    b.traffic.side_a_out_discards +
+                    b.traffic.side_z_in_discards +
+                    b.traffic.side_z_out_discards >
+                    0 ||
+                  b.traffic.side_a_carrier_transitions + b.traffic.side_z_carrier_transitions > 0),
+            )
+            return hasIssues ? (
+              <LinkInterfaceIssuesChart
+                data={linkMetrics}
+                loading={false}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
+            ) : null
           })()}
           {!fullMetrics && metricsFetching && (
             <div className="flex justify-center py-4">
@@ -508,7 +727,16 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
 export function LinkStatusTimelines({
   timeRange = '24h',
   onTimeRangeChange,
-  issueFilters = ['packet_loss', 'high_latency', 'high_utilization', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'missing_adjacency'],
+  issueFilters = [
+    'packet_loss',
+    'high_latency',
+    'high_utilization',
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+    'missing_adjacency',
+  ],
   healthFilters = ['healthy', 'degraded', 'unhealthy'],
   showDrained = false,
   onShowDrainedChange,
@@ -529,7 +757,12 @@ export function LinkStatusTimelines({
 
   const { data, isLoading, isPlaceholderData, error } = useQuery({
     queryKey: ['bulk-link-metrics', timeRange],
-    queryFn: () => fetchBulkLinkMetrics({ range: timeRange, include: ['status', 'traffic'], hasIssues: true }),
+    queryFn: () =>
+      fetchBulkLinkMetrics({
+        range: timeRange,
+        include: ['status', 'traffic'],
+        hasIssues: true,
+      }),
     refetchInterval: 60_000,
     staleTime: 30_000,
     placeholderData: keepPreviousData,
@@ -538,7 +771,7 @@ export function LinkStatusTimelines({
   // Convert the Record<string, LinkMetricsResponse> into an array with derived info
   const linksArray = useMemo(() => {
     if (!data?.links) return []
-    return Object.values(data.links).map(metrics => ({
+    return Object.values(data.links).map((metrics) => ({
       metrics,
       derived: deriveLinkInfo(metrics),
     }))
@@ -549,7 +782,7 @@ export function LinkStatusTimelines({
     if (linksWithHealth && linksWithHealth.size > 0) {
       const health = linksWithHealth.get(derived.code)
       if (health) {
-        const filterHealth = (health === 'no_data' || health === 'down') ? 'unhealthy' : health
+        const filterHealth = health === 'no_data' || health === 'down' ? 'unhealthy' : health
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return healthFilters.includes(filterHealth as any)
       }
@@ -560,11 +793,15 @@ export function LinkStatusTimelines({
     const h = derived.health
     if (h === 'healthy' && healthFilters.includes('healthy')) return true
     if (h === 'degraded' && healthFilters.includes('degraded')) return true
-    if ((h === 'unhealthy' || h === 'no_data' || h === 'down') && healthFilters.includes('unhealthy')) return true
+    if (
+      (h === 'unhealthy' || h === 'no_data' || h === 'down') &&
+      healthFilters.includes('unhealthy')
+    )
+      return true
     return false
   }
 
-  const issueTypesSelected = issueFilters.filter(f => f !== 'no_issues')
+  const issueTypesSelected = issueFilters.filter((f) => f !== 'no_issues')
   const noIssuesSelected = issueFilters.includes('no_issues')
   const noDataSelected = issueFilters.includes('no_data')
 
@@ -572,15 +809,19 @@ export function LinkStatusTimelines({
     if (linksArray.length === 0) return []
 
     const filtered = linksArray.filter(({ metrics, derived }) => {
-      const issueReasons = linksWithIssues && linksWithIssues.size > 0
-        ? (linksWithIssues.get(derived.code) ?? [])
-        : derived.issueReasons
+      const issueReasons =
+        linksWithIssues && linksWithIssues.size > 0
+          ? (linksWithIssues.get(derived.code) ?? [])
+          : derived.issueReasons
       const hasIssues = issueReasons.length > 0
 
       // When no_data filter is off, exclude links whose only issue is no_data
       if (!noDataSelected && issueReasons.length === 1 && issueReasons[0] === 'no_data') {
-        const hasNonHealthyBuckets = metrics.buckets.some(b =>
-          b.status && !b.status.collecting && (b.status.health === 'unhealthy' || b.status.health === 'degraded')
+        const hasNonHealthyBuckets = metrics.buckets.some(
+          (b) =>
+            b.status &&
+            !b.status.collecting &&
+            (b.status.health === 'unhealthy' || b.status.health === 'degraded'),
         )
         if (!hasNonHealthyBuckets) {
           return false
@@ -601,10 +842,15 @@ export function LinkStatusTimelines({
       }
 
       const matchesIssue = hasIssues
-        ? issueReasons.some(reason => issueTypesSelected.includes(reason)) ||
-          (issueReasons.length === 1 && issueReasons[0] === 'no_data' && metrics.buckets.some(b =>
-            b.status && !b.status.collecting && (b.status.health === 'unhealthy' || b.status.health === 'degraded')
-          ))
+        ? issueReasons.some((reason) => issueTypesSelected.includes(reason)) ||
+          (issueReasons.length === 1 &&
+            issueReasons[0] === 'no_data' &&
+            metrics.buckets.some(
+              (b) =>
+                b.status &&
+                !b.status.collecting &&
+                (b.status.health === 'unhealthy' || b.status.health === 'degraded'),
+            ))
         : noIssuesSelected
 
       const matchesHealth = linkMatchesHealthFilters(derived)
@@ -618,17 +864,28 @@ export function LinkStatusTimelines({
       if (isisDown) return 3
       switch (health) {
         case 'down':
-        case 'unhealthy': return 3
-        case 'degraded': return 2
-        case 'no_data': return 1
-        default: return 0
+        case 'unhealthy':
+          return 3
+        case 'degraded':
+          return 2
+        case 'no_data':
+          return 1
+        default:
+          return 0
       }
     }
 
     const RECENT_BUCKETS = 6
 
     return filtered.sort((a, b) => {
-      const getSortKey = (item: { metrics: LinkMetricsResponse }): { recent: number; worst: number; latestTs: string; count: number } => {
+      const getSortKey = (item: {
+        metrics: LinkMetricsResponse
+      }): {
+        recent: number
+        worst: number
+        latestTs: string
+        count: number
+      } => {
         const buckets = item.metrics.buckets
         if (!buckets || buckets.length === 0) return { recent: 0, worst: 0, latestTs: '', count: 0 }
         let worst = 0
@@ -660,8 +917,18 @@ export function LinkStatusTimelines({
       if (aInfo.count !== bInfo.count) return bInfo.count - aInfo.count
       return a.derived.code.localeCompare(b.derived.code)
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linksArray, issueFilters, healthFilters, noIssuesSelected, issueTypesSelected, showDrained, showProvisioning, linksWithIssues, linksWithHealth])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    linksArray,
+    issueFilters,
+    healthFilters,
+    noIssuesSelected,
+    issueTypesSelected,
+    showDrained,
+    showProvisioning,
+    linksWithIssues,
+    linksWithHealth,
+  ])
 
   const drainedCount = useMemo(() => {
     return linksArray.filter(({ derived }) => derived.drainStatus).length
@@ -700,32 +967,54 @@ export function LinkStatusTimelines({
   }
 
   return (
-    <div className={`border border-border rounded-lg transition-opacity${isPlaceholderData ? ' opacity-60' : ''}`}>
-      <div className="px-4 py-2.5 bg-muted/50 border-b border-border flex items-center gap-2 rounded-t-lg">
-        {isPlaceholderData
-          ? <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
-          : <History className="h-4 w-4 text-muted-foreground" />
-        }
-        <h3 className="font-medium">
-          Link Status History
-          <span className="text-sm text-muted-foreground font-normal ml-1">
+    <div
+      className={`border border-border rounded-lg transition-opacity${isPlaceholderData ? ' opacity-60' : ''}`}
+    >
+      <div className="px-4 py-2.5 bg-muted/50 border-b border-border justify-between rounded-t-lg flex flex-col gap-1.5 lg:flex-row lg:items-center lg:gap-2">
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            {isPlaceholderData ? (
+              <Loader2 className="h-4 w-4 text-muted-foreground animate-spin shrink-0 hidden xss:block" />
+            ) : (
+              <History className="h-4 w-4 text-muted-foreground shrink-0 hidden xss:block" />
+            )}
+            <h3 className="font-medium">
+              Link Status History
+              <span className="hidden xss:inline text-sm text-muted-foreground font-normal ml-1">
+                ({filteredLinks.length} link
+                {filteredLinks.length !== 1 ? 's' : ''})
+              </span>
+            </h3>
+          </div>
+          <div className="xss:hidden text-xs md:text-sm text-muted-foreground">
             ({filteredLinks.length} link{filteredLinks.length !== 1 ? 's' : ''})
-          </span>
-        </h3>
-        <div className="flex items-center gap-2 ml-auto">
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
           {onShowDrainedChange && (
             <button
               onClick={() => onShowDrainedChange(!showDrained)}
               className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
             >
-              <div className={`w-3 h-3 rounded-sm transition-colors ${showDrained ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}>
+              <div
+                className={`w-3 h-3 rounded-sm transition-colors ${showDrained ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}
+              >
                 {showDrained && (
                   <svg viewBox="0 0 12 12" className="w-3 h-3 text-primary-foreground">
-                    <path d="M3.5 6L5.5 8L8.5 4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                    <path
+                      d="M3.5 6L5.5 8L8.5 4"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
                   </svg>
                 )}
               </div>
-              <span className={showDrained ? 'text-foreground' : 'text-muted-foreground'}>Drained ({drainedCount})</span>
+              <span className={showDrained ? 'text-foreground' : 'text-muted-foreground'}>
+                Drained ({drainedCount})
+              </span>
             </button>
           )}
           {onShowProvisioningChange && (
@@ -733,38 +1022,39 @@ export function LinkStatusTimelines({
               onClick={() => onShowProvisioningChange(!showProvisioning)}
               className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
             >
-              <div className={`w-3 h-3 rounded-sm transition-colors ${showProvisioning ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}>
+              <div
+                className={`w-3 h-3 rounded-sm transition-colors ${showProvisioning ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}
+              >
                 {showProvisioning && (
                   <svg viewBox="0 0 12 12" className="w-3 h-3 text-primary-foreground">
-                    <path d="M3.5 6L5.5 8L8.5 4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                    <path
+                      d="M3.5 6L5.5 8L8.5 4"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
                   </svg>
                 )}
               </div>
-              <span className={showProvisioning ? 'text-foreground' : 'text-muted-foreground'}>Provisioning ({provisioningCount})</span>
+              <span className={showProvisioning ? 'text-foreground' : 'text-muted-foreground'}>
+                Provisioning ({provisioningCount})
+              </span>
             </button>
           )}
           {onTimeRangeChange && (
-            <div className="inline-flex rounded-lg border border-border bg-background/50 p-0.5">
-              {timeRangeOptions.map((opt) => (
-                <button
-                  key={opt.value}
-                  onClick={() => onTimeRangeChange(opt.value)}
-                  className={`px-2.5 py-0.5 text-xs rounded-md transition-colors ${
-                    timeRange === opt.value
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
+            <SmallDropdown
+              value={timeRange}
+              options={timeRangeOptions}
+              onChange={(v) => onTimeRangeChange(v as TimeRange)}
+            />
           )}
         </div>
       </div>
 
       {/* Legend */}
-      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 text-xs text-muted-foreground">
+      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 flex-wrap text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <div className="w-2.5 h-2.5 rounded-sm bg-green-500" />
           <span>Healthy</span>
@@ -782,7 +1072,13 @@ export function LinkStatusTimelines({
           <span>No Data</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-sm bg-muted-foreground/20 border border-muted-foreground/30" style={{ backgroundImage: 'repeating-linear-gradient(135deg, rgba(120,120,120,0.9), rgba(120,120,120,0.9) 1.5px, transparent 1.5px, transparent 3px)' }} />
+          <div
+            className="w-2.5 h-2.5 rounded-sm bg-muted-foreground/20 border border-muted-foreground/30"
+            style={{
+              backgroundImage:
+                'repeating-linear-gradient(135deg, rgba(120,120,120,0.9), rgba(120,120,120,0.9) 1.5px, transparent 1.5px, transparent 3px)',
+            }}
+          />
           <span>Drained</span>
         </div>
       </div>

--- a/web/src/components/maintenance-planner-page.tsx
+++ b/web/src/components/maintenance-planner-page.tsx
@@ -35,9 +35,9 @@ function SearchInput({
   const filteredSuggestions = useMemo(() => {
     if (!suggestions?.suggestions) return []
     if (!filterType) {
-      return suggestions.suggestions.filter(s => s.type === 'device' || s.type === 'link')
+      return suggestions.suggestions.filter((s) => s.type === 'device' || s.type === 'link')
     }
-    return suggestions.suggestions.filter(s => s.type === filterType)
+    return suggestions.suggestions.filter((s) => s.type === filterType)
   }, [suggestions, filterType])
 
   const handleSelect = (suggestion: SearchSuggestion) => {
@@ -125,9 +125,9 @@ export function MaintenancePlannerPage() {
 
   // Add an item to the maintenance list
   const handleAddItem = useCallback((item: SelectedMaintenanceItem) => {
-    setSelectedItems(prev => {
+    setSelectedItems((prev) => {
       // Check if already added
-      if (prev.some(i => i.pk === item.pk && i.type === item.type)) {
+      if (prev.some((i) => i.pk === item.pk && i.type === item.type)) {
         return prev
       }
       return [...prev, item]
@@ -138,7 +138,7 @@ export function MaintenancePlannerPage() {
 
   // Remove an item from the maintenance list
   const handleRemoveItem = useCallback((pk: string) => {
-    setSelectedItems(prev => prev.filter(i => i.pk !== pk))
+    setSelectedItems((prev) => prev.filter((i) => i.pk !== pk))
     setAnalysisResult(null)
   }, [])
 
@@ -154,8 +154,8 @@ export function MaintenancePlannerPage() {
 
     setIsAnalyzing(true)
     try {
-      const devices = selectedItems.filter(i => i.type === 'device').map(i => i.pk)
-      const links = selectedItems.filter(i => i.type === 'link').map(i => i.pk)
+      const devices = selectedItems.filter((i) => i.type === 'device').map((i) => i.pk)
+      const links = selectedItems.filter((i) => i.type === 'link').map((i) => i.pk)
       const result = await fetchWhatIfRemoval(devices, links)
       setAnalysisResult(result)
     } catch (err) {
@@ -213,8 +213,12 @@ export function MaintenancePlannerPage() {
         } else {
           const hopDiff = path.hopsAfter - path.hopsBefore
           const latencyDiffMs = ((path.metricAfter - path.metricBefore) / 1000).toFixed(2)
-          lines.push(`    Hops: ${path.hopsBefore} → ${path.hopsAfter} (${hopDiff > 0 ? '+' : ''}${hopDiff})`)
-          lines.push(`    Latency: ${latencyBeforeMs}ms → ${latencyAfterMs}ms (${Number(latencyDiffMs) > 0 ? '+' : ''}${latencyDiffMs}ms)`)
+          lines.push(
+            `    Hops: ${path.hopsBefore} → ${path.hopsAfter} (${hopDiff > 0 ? '+' : ''}${hopDiff})`,
+          )
+          lines.push(
+            `    Latency: ${latencyBeforeMs}ms → ${latencyAfterMs}ms (${Number(latencyDiffMs) > 0 ? '+' : ''}${latencyDiffMs}ms)`,
+          )
           lines.push(`    Status: ${path.status.toUpperCase()}`)
         }
         lines.push('')
@@ -227,7 +231,9 @@ export function MaintenancePlannerPage() {
     lines.push('(Items ordered from least impactful to most impactful)')
     lines.push('')
 
-    const sortedItems = [...analysisResult.items].sort((a, b) => a.affectedPathCount - b.affectedPathCount)
+    const sortedItems = [...analysisResult.items].sort(
+      (a, b) => a.affectedPathCount - b.affectedPathCount,
+    )
     for (let i = 0; i < sortedItems.length; i++) {
       const item = sortedItems[i]
       lines.push(`${i + 1}. [${item.type.toUpperCase()}] ${item.code}`)
@@ -271,7 +277,8 @@ export function MaintenancePlannerPage() {
           <h1 className="text-lg font-semibold">Maintenance Planner</h1>
         </div>
         <p className="text-sm text-muted-foreground mt-1">
-          Plan maintenance windows by selecting devices and links to take offline, then analyze the impact.
+          Plan maintenance windows by selecting devices and links to take offline, then analyze the
+          impact.
         </p>
       </div>
 
@@ -280,7 +287,7 @@ export function MaintenancePlannerPage() {
           {/* Add items section */}
           <div className="bg-card border border-border rounded-lg p-4">
             <h2 className="text-sm font-medium mb-3">Add Items to Maintenance</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Search Devices</label>
                 <SearchInput
@@ -303,9 +310,7 @@ export function MaintenancePlannerPage() {
           {/* Selected items list */}
           <div className="bg-card border border-border rounded-lg p-4">
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-sm font-medium">
-                Selected Items ({selectedItems.length})
-              </h2>
+              <h2 className="text-sm font-medium">Selected Items ({selectedItems.length})</h2>
               {selectedItems.length > 0 && (
                 <button
                   onClick={handleClearAll}
@@ -328,7 +333,7 @@ export function MaintenancePlannerPage() {
                   return (
                     <div
                       key={item.pk}
-                      className="flex items-center justify-between p-2 bg-muted rounded-md"
+                      className="flex flex-col sm:flex-row sm:items-center justify-between p-2 bg-muted rounded-md gap-2"
                     >
                       <div className="flex items-center gap-2">
                         {item.type === 'device' ? (
@@ -356,7 +361,7 @@ export function MaintenancePlannerPage() {
 
             {/* Analyze button */}
             {selectedItems.length > 0 && (
-              <div className="mt-4 flex gap-2">
+              <div className="mt-4 flex flex-col sm:flex-row gap-2">
                 <button
                   onClick={handleAnalyze}
                   disabled={isAnalyzing}
@@ -377,7 +382,7 @@ export function MaintenancePlannerPage() {
                 {analysisResult && !analysisResult.error && (
                   <button
                     onClick={handleExport}
-                    className="flex items-center gap-2 px-4 py-2 bg-muted hover:bg-muted/80 rounded-md transition-colors"
+                    className="flex items-center justify-center gap-2 px-4 py-2 bg-muted hover:bg-muted/80 rounded-md transition-colors"
                   >
                     <Download className="h-4 w-4" />
                     Export Plan
@@ -399,38 +404,62 @@ export function MaintenancePlannerPage() {
                   {/* Summary */}
                   {(() => {
                     // Compute real stats from affected paths
-                    const rerouted = analysisResult.affectedPaths?.filter(p => p.status === 'rerouted' || p.status === 'degraded') || []
-                    const disconnected = analysisResult.affectedPaths?.filter(p => p.status === 'disconnected') || []
-                    const avgHopIncrease = rerouted.length > 0
-                      ? rerouted.reduce((sum, p) => sum + (p.hopsAfter - p.hopsBefore), 0) / rerouted.length
-                      : 0
+                    const rerouted =
+                      analysisResult.affectedPaths?.filter(
+                        (p) => p.status === 'rerouted' || p.status === 'degraded',
+                      ) || []
+                    const disconnected =
+                      analysisResult.affectedPaths?.filter((p) => p.status === 'disconnected') || []
+                    const avgHopIncrease =
+                      rerouted.length > 0
+                        ? rerouted.reduce((sum, p) => sum + (p.hopsAfter - p.hopsBefore), 0) /
+                          rerouted.length
+                        : 0
                     // Convert metric (microseconds) to milliseconds
-                    const avgLatencyIncreaseMs = rerouted.length > 0
-                      ? rerouted.reduce((sum, p) => sum + (p.metricAfter - p.metricBefore), 0) / rerouted.length / 1000
-                      : 0
+                    const avgLatencyIncreaseMs =
+                      rerouted.length > 0
+                        ? rerouted.reduce((sum, p) => sum + (p.metricAfter - p.metricBefore), 0) /
+                          rerouted.length /
+                          1000
+                        : 0
 
                     return (
-                      <div className="grid grid-cols-3 gap-3 mb-6">
-                        <div className={`rounded-lg p-3 ${rerouted.length > 0 ? 'bg-yellow-100 dark:bg-yellow-900/40' : 'bg-muted'}`}>
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+                        <div
+                          className={`rounded-lg p-3 ${rerouted.length > 0 ? 'bg-yellow-100 dark:bg-yellow-900/40' : 'bg-muted'}`}
+                        >
                           <div className="text-xs text-muted-foreground mb-1">Paths Rerouted</div>
-                          <div className={`text-xl font-bold ${rerouted.length > 0 ? 'text-yellow-700 dark:text-yellow-400' : ''}`}>
+                          <div
+                            className={`text-xl font-bold ${rerouted.length > 0 ? 'text-yellow-700 dark:text-yellow-400' : ''}`}
+                          >
                             {rerouted.length}
                           </div>
                           {rerouted.length > 0 && (
                             <div className="text-xs text-muted-foreground mt-1">
-                              avg +{avgHopIncrease.toFixed(1)} hops, +{avgLatencyIncreaseMs.toFixed(2)}ms
+                              avg +{avgHopIncrease.toFixed(1)} hops, +
+                              {avgLatencyIncreaseMs.toFixed(2)}ms
                             </div>
                           )}
                         </div>
-                        <div className={`rounded-lg p-3 ${disconnected.length > 0 ? 'bg-red-100 dark:bg-red-900/40' : 'bg-muted'}`}>
-                          <div className="text-xs text-muted-foreground mb-1">Paths Disconnected</div>
-                          <div className={`text-xl font-bold ${disconnected.length > 0 ? 'text-red-700 dark:text-red-400' : ''}`}>
+                        <div
+                          className={`rounded-lg p-3 ${disconnected.length > 0 ? 'bg-red-100 dark:bg-red-900/40' : 'bg-muted'}`}
+                        >
+                          <div className="text-xs text-muted-foreground mb-1">
+                            Paths Disconnected
+                          </div>
+                          <div
+                            className={`text-xl font-bold ${disconnected.length > 0 ? 'text-red-700 dark:text-red-400' : ''}`}
+                          >
                             {disconnected.length}
                           </div>
                         </div>
-                        <div className={`rounded-lg p-3 ${analysisResult.totalDisconnected > 0 ? 'bg-red-100 dark:bg-red-900/40' : 'bg-muted'}`}>
+                        <div
+                          className={`rounded-lg p-3 ${analysisResult.totalDisconnected > 0 ? 'bg-red-100 dark:bg-red-900/40' : 'bg-muted'}`}
+                        >
                           <div className="text-xs text-muted-foreground mb-1">Devices Isolated</div>
-                          <div className={`text-xl font-bold ${analysisResult.totalDisconnected > 0 ? 'text-red-700 dark:text-red-400' : ''}`}>
+                          <div
+                            className={`text-xl font-bold ${analysisResult.totalDisconnected > 0 ? 'text-red-700 dark:text-red-400' : ''}`}
+                          >
                             {analysisResult.totalDisconnected}
                           </div>
                         </div>
@@ -439,105 +468,123 @@ export function MaintenancePlannerPage() {
                   })()}
 
                   {/* Warnings */}
-                  {analysisResult.items.some(i => i.causesPartition) && (
+                  {analysisResult.items.some((i) => i.causesPartition) && (
                     <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
                       <div className="flex items-center gap-2 text-red-700 dark:text-red-400 font-medium text-sm">
-                        <AlertTriangle className="h-4 w-4" />
+                        <AlertTriangle className="h-4 w-4 hidden sm:block" />
                         Warning: Some items will cause network partition
                       </div>
                       <ul className="mt-2 text-sm text-red-600 dark:text-red-400 space-y-1">
-                        {analysisResult.items.filter(i => i.causesPartition).map(item => (
-                          <li key={item.pk}>• {item.code}</li>
-                        ))}
+                        {analysisResult.items
+                          .filter((i) => i.causesPartition)
+                          .map((item) => (
+                            <li key={item.pk}>• {item.code}</li>
+                          ))}
                       </ul>
                     </div>
                   )}
 
                   {/* Disconnected devices */}
-                  {analysisResult.disconnectedList && analysisResult.disconnectedList.length > 0 && (
-                    <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-                      <div className="text-sm font-medium text-red-700 dark:text-red-400 mb-2">
-                        Devices That Will Lose Connectivity ({analysisResult.disconnectedList.length})
+                  {analysisResult.disconnectedList &&
+                    analysisResult.disconnectedList.length > 0 && (
+                      <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <div className="text-sm font-medium text-red-700 dark:text-red-400 mb-2">
+                          Devices That Will Lose Connectivity (
+                          {analysisResult.disconnectedList.length})
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {analysisResult.disconnectedList.map((code, idx) => (
+                            <span
+                              key={idx}
+                              className="px-2 py-1 bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 rounded text-xs font-medium"
+                            >
+                              {code}
+                            </span>
+                          ))}
+                        </div>
                       </div>
-                      <div className="flex flex-wrap gap-2">
-                        {analysisResult.disconnectedList.map((code, idx) => (
-                          <span key={idx} className="px-2 py-1 bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 rounded text-xs font-medium">
-                            {code}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
+                    )}
 
                   {/* Routing Impact - detailed path changes */}
                   {analysisResult.affectedPaths && analysisResult.affectedPaths.length > 0 && (
                     <div className="mb-4">
                       <h3 className="text-sm font-medium mb-2">Routing Impact</h3>
                       <p className="text-xs text-muted-foreground mb-3">
-                        Device pairs whose shortest path changes when maintenance targets go offline.
+                        Device pairs whose shortest path changes when maintenance targets go
+                        offline.
                       </p>
 
-                      {/* Table header */}
-                      <div className="grid grid-cols-12 gap-2 px-3 py-2 bg-muted/50 rounded-t text-xs font-medium text-muted-foreground">
-                        <div className="col-span-5">Path</div>
-                        <div className="col-span-2 text-center">Hops</div>
-                        <div className="col-span-3 text-center">Latency</div>
-                        <div className="col-span-2 text-right">Status</div>
-                      </div>
-
-                      {/* Table rows */}
-                      <div className="border border-border rounded-b divide-y divide-border">
-                        {analysisResult.affectedPaths.map((path, idx) => {
-                          const hopDiff = path.hopsAfter - path.hopsBefore
-                          // Convert metric (microseconds) to milliseconds
-                          const latencyBeforeMs = path.metricBefore / 1000
-                          const latencyAfterMs = path.metricAfter / 1000
-                          const latencyDiffMs = latencyAfterMs - latencyBeforeMs
-                          return (
-                            <div key={idx} className="grid grid-cols-12 gap-2 px-3 py-2 text-sm items-center hover:bg-muted/30">
-                              <div className="col-span-5 flex items-center gap-1 min-w-0">
-                                <span className="font-mono text-xs truncate">{path.source}</span>
-                                <span className="text-muted-foreground text-xs">→</span>
-                                <span className="font-mono text-xs truncate">{path.target}</span>
-                              </div>
-                              <div className="col-span-2 text-center text-xs">
-                                {path.hopsAfter === -1 ? (
-                                  <span className="text-red-500">{path.hopsBefore} → ✕</span>
-                                ) : (
-                                  <span>
-                                    {path.hopsBefore} → {path.hopsAfter}
-                                    <span className={`ml-1 ${hopDiff > 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-green-600'}`}>
-                                      ({hopDiff > 0 ? '+' : ''}{hopDiff})
-                                    </span>
-                                  </span>
-                                )}
-                              </div>
-                              <div className="col-span-3 text-center text-xs">
-                                {path.metricAfter === -1 ? (
-                                  <span className="text-red-500">{latencyBeforeMs.toFixed(2)}ms → ✕</span>
-                                ) : (
-                                  <span>
-                                    {latencyBeforeMs.toFixed(2)} → {latencyAfterMs.toFixed(2)}ms
-                                    <span className={`ml-1 ${latencyDiffMs > 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-green-600'}`}>
-                                      ({latencyDiffMs > 0 ? '+' : ''}{latencyDiffMs.toFixed(2)})
-                                    </span>
-                                  </span>
-                                )}
-                              </div>
-                              <div className="col-span-2 text-right">
-                                <span className={`text-xs px-2 py-0.5 rounded ${
-                                  path.status === 'disconnected'
-                                    ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
-                                    : path.status === 'degraded'
+                      <div className="overflow-x-auto rounded border border-border">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="bg-muted/50 text-muted-foreground font-medium">
+                              <th className="text-left px-3 py-2 whitespace-nowrap">Path</th>
+                              <th className="text-center px-3 py-2 whitespace-nowrap">Hops</th>
+                              <th className="text-center px-3 py-2 whitespace-nowrap">Latency</th>
+                              <th className="text-right px-3 py-2 whitespace-nowrap">Status</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-border">
+                            {analysisResult.affectedPaths.map((path, idx) => {
+                              const hopDiff = path.hopsAfter - path.hopsBefore
+                              const latencyBeforeMs = path.metricBefore / 1000
+                              const latencyAfterMs = path.metricAfter / 1000
+                              const latencyDiffMs = latencyAfterMs - latencyBeforeMs
+                              const statusClass =
+                                path.status === 'disconnected'
+                                  ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+                                  : path.status === 'degraded'
                                     ? 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
                                     : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
-                                }`}>
-                                  {path.status}
-                                </span>
-                              </div>
-                            </div>
-                          )
-                        })}
+                              return (
+                                <tr key={idx} className="hover:bg-muted/30">
+                                  <td className="px-3 py-2 whitespace-nowrap">
+                                    <span className="font-mono">{path.source}</span>
+                                    <span className="text-muted-foreground mx-1">→</span>
+                                    <span className="font-mono">{path.target}</span>
+                                  </td>
+                                  <td className="px-3 py-2 text-center whitespace-nowrap">
+                                    {path.hopsAfter === -1 ? (
+                                      <span className="text-red-500">{path.hopsBefore} → ✕</span>
+                                    ) : (
+                                      <span>
+                                        {path.hopsBefore} → {path.hopsAfter}
+                                        <span
+                                          className={`ml-1 ${hopDiff > 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-green-600'}`}
+                                        >
+                                          ({hopDiff > 0 ? '+' : ''}
+                                          {hopDiff})
+                                        </span>
+                                      </span>
+                                    )}
+                                  </td>
+                                  <td className="px-3 py-2 text-center whitespace-nowrap">
+                                    {path.metricAfter === -1 ? (
+                                      <span className="text-red-500">
+                                        {latencyBeforeMs.toFixed(2)}ms → ✕
+                                      </span>
+                                    ) : (
+                                      <span>
+                                        {latencyBeforeMs.toFixed(2)} → {latencyAfterMs.toFixed(2)}ms
+                                        <span
+                                          className={`ml-1 ${latencyDiffMs > 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-green-600'}`}
+                                        >
+                                          ({latencyDiffMs > 0 ? '+' : ''}
+                                          {latencyDiffMs.toFixed(2)})
+                                        </span>
+                                      </span>
+                                    )}
+                                  </td>
+                                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                                    <span className={`px-2 py-0.5 rounded ${statusClass}`}>
+                                      {path.status}
+                                    </span>
+                                  </td>
+                                </tr>
+                              )
+                            })}
+                          </tbody>
+                        </table>
                       </div>
                     </div>
                   )}
@@ -546,34 +593,37 @@ export function MaintenancePlannerPage() {
                   <div>
                     <h3 className="text-sm font-medium mb-2">Recommended Maintenance Order</h3>
                     <p className="text-xs text-muted-foreground mb-3">
-                      Items ordered from least impactful to most impactful. Take down items in this order to minimize disruption.
+                      Items ordered from least impactful to most impactful. Take down items in this
+                      order to minimize disruption.
                     </p>
                     <div className="space-y-2">
-                      {[...analysisResult.items].sort((a, b) => a.affectedPathCount - b.affectedPathCount).map((item, index) => (
-                        <div
-                          key={item.pk}
-                          className="flex items-center gap-3 p-3 bg-muted rounded-md"
-                        >
-                          <span className="w-6 h-6 flex items-center justify-center bg-accent text-accent-foreground rounded-full text-xs font-bold">
-                            {index + 1}
-                          </span>
-                          <div className="flex items-center gap-2 flex-1">
-                            {item.type === 'device' ? (
-                              <Server className="h-4 w-4 text-muted-foreground" />
-                            ) : (
-                              <Link2 className="h-4 w-4 text-muted-foreground" />
-                            )}
-                            <span className="font-medium">{item.code}</span>
-                            <span className="text-xs text-muted-foreground">({item.type})</span>
-                          </div>
-                          <div className="flex items-center gap-4 text-sm">
-                            <span className="text-muted-foreground">
-                              {item.affectedPathCount} paths
+                      {[...analysisResult.items]
+                        .sort((a, b) => a.affectedPathCount - b.affectedPathCount)
+                        .map((item, index) => (
+                          <div
+                            key={item.pk}
+                            className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 bg-muted rounded-md"
+                          >
+                            <span className="w-6 h-6 flex items-center justify-center bg-accent text-accent-foreground rounded-full text-xs font-bold">
+                              {index + 1}
                             </span>
-                            <ImpactBadge {...item} />
+                            <div className="flex items-center gap-2 flex-1">
+                              {item.type === 'device' ? (
+                                <Server className="h-4 w-4 text-muted-foreground" />
+                              ) : (
+                                <Link2 className="h-4 w-4 text-muted-foreground" />
+                              )}
+                              <span className="font-medium">{item.code}</span>
+                              <span className="text-xs text-muted-foreground">({item.type})</span>
+                            </div>
+                            <div className="flex items-center gap-4 text-sm">
+                              <span className="text-muted-foreground">
+                                {item.affectedPathCount} paths
+                              </span>
+                              <ImpactBadge {...item} />
+                            </div>
                           </div>
-                        </div>
-                      ))}
+                        ))}
                     </div>
                   </div>
                 </>
@@ -583,7 +633,9 @@ export function MaintenancePlannerPage() {
 
           {/* Help text */}
           <div className="text-xs text-muted-foreground">
-            <p className="mb-2"><strong>How to use:</strong></p>
+            <p className="mb-2">
+              <strong>How to use:</strong>
+            </p>
             <ol className="list-decimal list-inside space-y-1">
               <li>Search and add devices or links you plan to take offline for maintenance</li>
               <li>Click "Analyze Impact" to see how the network will be affected</li>

--- a/web/src/components/metro-connectivity-page.tsx
+++ b/web/src/components/metro-connectivity-page.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { Loader2, Network, Download, ArrowRight } from 'lucide-react'
+import { Loader2, Network, Download, ArrowRight, X } from 'lucide-react'
 import { fetchMetroConnectivity, fetchMetroPaths } from '@/lib/api'
 import type { MetroConnectivity, MetroPathsResponse } from '@/lib/api'
 import { ErrorState } from '@/components/ui/error-state'
@@ -66,9 +66,10 @@ function MatrixCell({
   const strength = getConnectivityStrength(connectivity.pathCount)
   const colors = STRENGTH_COLORS[strength]
 
-  const bwDisplay = connectivity.bottleneckBwGbps && connectivity.bottleneckBwGbps > 0
-    ? `${connectivity.bottleneckBwGbps.toFixed(0)}G`
-    : null
+  const bwDisplay =
+    connectivity.bottleneckBwGbps && connectivity.bottleneckBwGbps > 0
+      ? `${connectivity.bottleneckBwGbps.toFixed(0)}G`
+      : null
 
   return (
     <button
@@ -108,15 +109,12 @@ function ConnectivityDetail({
           <ArrowRight className="h-4 w-4 text-muted-foreground" />
           <span>{connectivity.toMetroCode}</span>
         </h3>
-        <button
-          onClick={onClose}
-          className="text-muted-foreground hover:text-foreground text-sm"
-        >
-          Close
+        <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+          <X className="h-4 w-4" />
         </button>
       </div>
 
-      <div className="grid grid-cols-4 gap-3 mb-4">
+      <div className="grid grid-cols-1 xs:grid-cols-2 gap-3 mb-4">
         <div className={`rounded-lg p-3 ${colors.bg}`}>
           <div className="text-xs text-muted-foreground mb-1">Paths</div>
           <div className={`text-xl font-bold ${colors.text}`}>{connectivity.pathCount}</div>
@@ -141,7 +139,9 @@ function ConnectivityDetail({
 
       {/* Paths breakdown */}
       <div className="mb-4">
-        <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">Available Paths</div>
+        <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
+          Available Paths
+        </div>
         {isLoadingPaths ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -153,7 +153,9 @@ function ConnectivityDetail({
               <div key={pathIdx} className="bg-muted/50 rounded-lg p-2">
                 <div className="flex items-center justify-between text-xs text-muted-foreground mb-1.5">
                   <span>Path {pathIdx + 1}</span>
-                  <span>{path.totalHops} hops • {path.latencyMs.toFixed(1)}ms</span>
+                  <span>
+                    {path.totalHops} hops • {path.latencyMs.toFixed(1)}ms
+                  </span>
                 </div>
                 <div className="flex items-center gap-1 flex-wrap text-xs">
                   {path.hops.map((hop, hopIdx) => (
@@ -180,9 +182,11 @@ function ConnectivityDetail({
 
       <div className="flex gap-2 text-sm">
         <Link
-          to={pathsData?.paths[0]?.hops[0]?.devicePK
-            ? `/topology/graph?type=device&id=${pathsData.paths[0].hops[0].devicePK}`
-            : '/topology/graph'}
+          to={
+            pathsData?.paths[0]?.hops[0]?.devicePK
+              ? `/topology/graph?type=device&id=${pathsData.paths[0].hops[0].devicePK}`
+              : '/topology/graph'
+          }
           className="text-accent hover:underline flex items-center gap-1"
         >
           View {connectivity.fromMetroCode} in Graph
@@ -200,7 +204,10 @@ function ConnectivityDetail({
 }
 
 export function MetroConnectivityPage() {
-  const [selectedCell, setSelectedCell] = useState<{ from: string; to: string } | null>(null)
+  const [selectedCell, setSelectedCell] = useState<{
+    from: string
+    to: string
+  } | null>(null)
   const queryClient = useQueryClient()
 
   const { data, isLoading, error, isFetching } = useQuery({
@@ -241,8 +248,15 @@ export function MetroConnectivityPage() {
   const handleExport = () => {
     if (!data) return
 
-    const headers = ['From Metro', 'To Metro', 'Path Count', 'Min Hops', 'Min Latency (ms)', 'Bottleneck BW (Gbps)']
-    const rows = data.connectivity.map(conn => [
+    const headers = [
+      'From Metro',
+      'To Metro',
+      'Path Count',
+      'Min Hops',
+      'Min Latency (ms)',
+      'Bottleneck BW (Gbps)',
+    ]
+    const rows = data.connectivity.map((conn) => [
       conn.fromMetroCode,
       conn.toMetroCode,
       conn.pathCount.toString(),
@@ -251,7 +265,7 @@ export function MetroConnectivityPage() {
       conn.bottleneckBwGbps && conn.bottleneckBwGbps > 0 ? conn.bottleneckBwGbps.toFixed(1) : '-',
     ])
 
-    const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n')
+    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n')
     const blob = new Blob([csv], { type: 'text/csv' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -264,13 +278,18 @@ export function MetroConnectivityPage() {
   // Summary stats
   const summary = useMemo(() => {
     if (!data) return null
-    const connections = data.connectivity.filter(c =>
-      // Dedupe by only counting fromPK < toPK
-      c.fromMetroPK < c.toMetroPK
+    const connections = data.connectivity.filter(
+      (c) =>
+        // Dedupe by only counting fromPK < toPK
+        c.fromMetroPK < c.toMetroPK,
     )
-    const strong = connections.filter(c => getConnectivityStrength(c.pathCount) === 'strong').length
-    const medium = connections.filter(c => getConnectivityStrength(c.pathCount) === 'medium').length
-    const weak = connections.filter(c => getConnectivityStrength(c.pathCount) === 'weak').length
+    const strong = connections.filter(
+      (c) => getConnectivityStrength(c.pathCount) === 'strong',
+    ).length
+    const medium = connections.filter(
+      (c) => getConnectivityStrength(c.pathCount) === 'medium',
+    ).length
+    const weak = connections.filter((c) => getConnectivityStrength(c.pathCount) === 'weak').length
     return { total: connections.length, strong, medium, weak }
   }, [data])
 
@@ -308,49 +327,58 @@ export function MetroConnectivityPage() {
     <div className="flex-1 flex flex-col bg-background overflow-hidden">
       {/* Header */}
       <div className="border-b border-border px-6 py-4">
-        <div className="flex items-center justify-between">
+        <div className="flex  sm:items-center justify-between flex-col sm:flex-row gap-2 sm:gap-0">
           <div className="flex items-center gap-3">
             <Network className="h-5 w-5 text-muted-foreground" />
             <h1 className="text-lg font-semibold">Metro Connectivity</h1>
           </div>
           <button
             onClick={handleExport}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-muted hover:bg-muted/80 rounded-md transition-colors"
+            className="flex items-center text-center justify-center gap-2 px-3 py-1.5 text-xs bg-muted hover:bg-muted/80 rounded-md transition-colors"
           >
-            <Download className="h-4 w-4" />
+            <Download className="h-3 w-3" />
             Export CSV
           </button>
         </div>
 
         <p className="mt-3 text-sm text-muted-foreground">
-          Shows routing paths and bottleneck bandwidth between each metro pair. More paths means better redundancy.
+          Shows routing paths and bottleneck bandwidth between each metro pair. More paths means
+          better redundancy.
         </p>
 
         {/* Summary stats */}
         {summary && (
-          <div className="flex gap-6 mt-4 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Metros:</span>
-              <span className="font-medium">{data.metros.length}</span>
+          <div className="flex flex-col gap-4 mt-4 text-sm">
+            <div className="flex flex-wrap gap-6">
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">Metros:</span>
+                <span className="font-medium">{data.metros.length}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">Connections:</span>
+                <span className="font-medium">{summary.total}</span>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Connections:</span>
-              <span className="font-medium">{summary.total}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded bg-green-500" />
-              <span className="text-muted-foreground">Strong (3+):</span>
-              <span className="font-medium text-green-600 dark:text-green-400">{summary.strong}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded bg-yellow-500" />
-              <span className="text-muted-foreground">Medium (2):</span>
-              <span className="font-medium text-yellow-600 dark:text-yellow-400">{summary.medium}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded bg-red-500" />
-              <span className="text-muted-foreground">Weak (1):</span>
-              <span className="font-medium text-red-600 dark:text-red-400">{summary.weak}</span>
+            <div className="flex flex-wrap gap-4">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded bg-green-500" />
+                <span className="text-muted-foreground">Strong (3+):</span>
+                <span className="font-medium text-green-600 dark:text-green-400">
+                  {summary.strong}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded bg-yellow-500" />
+                <span className="text-muted-foreground">Medium (2):</span>
+                <span className="font-medium text-yellow-600 dark:text-yellow-400">
+                  {summary.medium}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded bg-red-500" />
+                <span className="text-muted-foreground">Weak (1):</span>
+                <span className="font-medium text-red-600 dark:text-red-400">{summary.weak}</span>
+              </div>
             </div>
           </div>
         )}
@@ -372,7 +400,7 @@ export function MetroConnectivityPage() {
               <div className="bg-background sticky top-0 left-0 z-20" />
 
               {/* Column headers */}
-              {data.metros.map(metro => (
+              {data.metros.map((metro) => (
                 <div
                   key={`col-${metro.pk}`}
                   className="bg-muted px-1 py-2 text-xs font-medium text-center sticky top-0 z-10 flex items-end justify-center"
@@ -385,7 +413,7 @@ export function MetroConnectivityPage() {
               ))}
 
               {/* Rows */}
-              {data.metros.map(fromMetro => (
+              {data.metros.map((fromMetro) => (
                 <>
                   {/* Row header */}
                   <div
@@ -397,21 +425,23 @@ export function MetroConnectivityPage() {
                   </div>
 
                   {/* Cells */}
-                  {data.metros.map(toMetro => {
+                  {data.metros.map((toMetro) => {
                     const isSame = fromMetro.pk === toMetro.pk
-                    const connectivity = isSame ? null : connectivityMap.get(`${fromMetro.pk}:${toMetro.pk}`) ?? null
-                    const isSelected = selectedCell?.from === fromMetro.pk && selectedCell?.to === toMetro.pk
+                    const connectivity = isSame
+                      ? null
+                      : (connectivityMap.get(`${fromMetro.pk}:${toMetro.pk}`) ?? null)
+                    const isSelected =
+                      selectedCell?.from === fromMetro.pk && selectedCell?.to === toMetro.pk
 
                     return (
-                      <div
-                        key={`cell-${fromMetro.pk}-${toMetro.pk}`}
-                        className="bg-background"
-                      >
+                      <div key={`cell-${fromMetro.pk}-${toMetro.pk}`} className="bg-background">
                         <MatrixCell
                           connectivity={connectivity}
                           onClick={() => {
                             if (!isSame && connectivity) {
-                              setSelectedCell(isSelected ? null : { from: fromMetro.pk, to: toMetro.pk })
+                              setSelectedCell(
+                                isSelected ? null : { from: fromMetro.pk, to: toMetro.pk },
+                              )
                             }
                           }}
                           isSelected={isSelected}
@@ -426,14 +456,21 @@ export function MetroConnectivityPage() {
 
           {/* Detail panel */}
           {selectedConnectivity && (
-            <div className="w-80 flex-shrink-0">
-              <ConnectivityDetail
-                connectivity={selectedConnectivity}
-                pathsData={metroPathsData ?? null}
-                isLoadingPaths={metroPathsLoading}
-                onClose={() => setSelectedCell(null)}
+            <>
+              {/* Mobile backdrop */}
+              <div
+                className="fixed inset-0 z-40 bg-black/50 md:hidden"
+                onClick={() => setSelectedCell(null)}
               />
-            </div>
+              <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[calc(100%-2rem)] max-h-[85vh] rounded-xl overflow-y-auto md:static md:top-auto md:left-auto md:translate-x-0 md:translate-y-0 md:z-auto md:w-80 md:max-h-none md:rounded-none md:overflow-visible md:shrink-0">
+                <ConnectivityDetail
+                  connectivity={selectedConnectivity}
+                  pathsData={metroPathsData ?? null}
+                  isLoadingPaths={metroPathsLoading}
+                  onClose={() => setSelectedCell(null)}
+                />
+              </div>
+            </>
           )}
         </div>
 

--- a/web/src/components/metro-status-timelines.tsx
+++ b/web/src/components/metro-status-timelines.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { useNavigate, useLocation, Link } from 'react-router-dom'
 import { Loader2, CheckCircle2, History, Info, AlertTriangle } from 'lucide-react'
 import type { LinkHistory, CriticalLinksResponse } from '@/lib/api'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 type TimeRange = '3h' | '6h' | '12h' | '24h' | '3d' | '7d'
 type MetroHealthFilter = 'healthy' | 'degraded' | 'unhealthy'
@@ -73,7 +74,13 @@ const statusLabels: Record<string, string> = {
 // - Healthy: >= 80% of active links are working
 // - Degraded: 20-80% of active links are working
 // - Unhealthy: < 20% of active links are working
-function getMetroStatus(breakdown: { healthy: number; degraded: number; unhealthy: number; disabled: number; no_data: number }): 'healthy' | 'degraded' | 'unhealthy' {
+function getMetroStatus(breakdown: {
+  healthy: number
+  degraded: number
+  unhealthy: number
+  disabled: number
+  no_data: number
+}): 'healthy' | 'degraded' | 'unhealthy' {
   // Only count links that are actively in service (exclude disabled and no_data)
   const activeLinks = breakdown.healthy + breakdown.degraded + breakdown.unhealthy
   if (activeLinks === 0) return 'healthy'
@@ -105,21 +112,31 @@ function MetroInfoPopover({ metro }: { metro: MetroData }) {
 
   const spofStatusColor = (status: string) => {
     switch (status) {
-      case 'healthy': return 'text-green-500'
-      case 'degraded': return 'text-amber-500'
-      case 'unhealthy': return 'text-red-500'
-      case 'disabled': return 'text-gray-500'
-      default: return 'text-muted-foreground'
+      case 'healthy':
+        return 'text-green-500'
+      case 'degraded':
+        return 'text-amber-500'
+      case 'unhealthy':
+        return 'text-red-500'
+      case 'disabled':
+        return 'text-gray-500'
+      default:
+        return 'text-muted-foreground'
     }
   }
 
   const spofStatusDot = (status: string) => {
     switch (status) {
-      case 'healthy': return 'bg-green-500'
-      case 'degraded': return 'bg-amber-500'
-      case 'unhealthy': return 'bg-red-500'
-      case 'disabled': return 'bg-gray-500'
-      default: return 'bg-gray-400'
+      case 'healthy':
+        return 'bg-green-500'
+      case 'degraded':
+        return 'bg-amber-500'
+      case 'unhealthy':
+        return 'bg-red-500'
+      case 'disabled':
+        return 'bg-gray-500'
+      default:
+        return 'bg-gray-400'
     }
   }
 
@@ -164,11 +181,15 @@ function MetroInfoPopover({ metro }: { metro: MetroData }) {
             )}
             <div>
               <div className="text-muted-foreground">Current Status</div>
-              <div className={`font-medium ${
-                metro.currentHealth === 'healthy' ? 'text-green-500' :
-                metro.currentHealth === 'degraded' ? 'text-amber-500' :
-                'text-red-500'
-              }`}>
+              <div
+                className={`font-medium ${
+                  metro.currentHealth === 'healthy'
+                    ? 'text-green-500'
+                    : metro.currentHealth === 'degraded'
+                      ? 'text-amber-500'
+                      : 'text-red-500'
+                }`}
+              >
                 {metro.currentHealth.charAt(0).toUpperCase() + metro.currentHealth.slice(1)}
               </div>
             </div>
@@ -179,13 +200,7 @@ function MetroInfoPopover({ metro }: { metro: MetroData }) {
   )
 }
 
-function MetroTimeline({
-  metro,
-  bucketMinutes,
-}: {
-  metro: MetroData
-  bucketMinutes: number
-}) {
+function MetroTimeline({ metro, bucketMinutes }: { metro: MetroData; bucketMinutes: number }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
 
   return (
@@ -209,12 +224,17 @@ function MetroTimeline({
                   <div className="font-medium mb-1">
                     {formatTimeRange(bucket.hour, bucketMinutes)}
                   </div>
-                  <div className={`text-xs mb-2 ${
-                    bucket.status === 'healthy' ? 'text-green-600 dark:text-green-400' :
-                    bucket.status === 'degraded' ? 'text-amber-600 dark:text-amber-400' :
-                    bucket.status === 'unhealthy' ? 'text-red-600 dark:text-red-400' :
-                    'text-muted-foreground'
-                  }`}>
+                  <div
+                    className={`text-xs mb-2 ${
+                      bucket.status === 'healthy'
+                        ? 'text-green-600 dark:text-green-400'
+                        : bucket.status === 'degraded'
+                          ? 'text-amber-600 dark:text-amber-400'
+                          : bucket.status === 'unhealthy'
+                            ? 'text-red-600 dark:text-red-400'
+                            : 'text-muted-foreground'
+                    }`}
+                  >
                     {statusLabels[bucket.status]}
                   </div>
                   <div className="space-y-1 text-muted-foreground text-xs">
@@ -224,7 +244,10 @@ function MetroTimeline({
                           <div className="w-2 h-2 rounded-full bg-green-500" />
                           <span>Healthy</span>
                         </div>
-                        <span className="font-medium">{bucket.breakdown.healthy} {bucket.breakdown.healthy === 1 ? 'link' : 'links'}</span>
+                        <span className="font-medium">
+                          {bucket.breakdown.healthy}{' '}
+                          {bucket.breakdown.healthy === 1 ? 'link' : 'links'}
+                        </span>
                       </div>
                     )}
                     {bucket.breakdown.degraded > 0 && (
@@ -233,7 +256,10 @@ function MetroTimeline({
                           <div className="w-2 h-2 rounded-full bg-amber-500" />
                           <span>Degraded</span>
                         </div>
-                        <span className="font-medium">{bucket.breakdown.degraded} {bucket.breakdown.degraded === 1 ? 'link' : 'links'}</span>
+                        <span className="font-medium">
+                          {bucket.breakdown.degraded}{' '}
+                          {bucket.breakdown.degraded === 1 ? 'link' : 'links'}
+                        </span>
                       </div>
                     )}
                     {bucket.breakdown.unhealthy > 0 && (
@@ -242,7 +268,10 @@ function MetroTimeline({
                           <div className="w-2 h-2 rounded-full bg-red-500" />
                           <span>Unhealthy</span>
                         </div>
-                        <span className="font-medium">{bucket.breakdown.unhealthy} {bucket.breakdown.unhealthy === 1 ? 'link' : 'links'}</span>
+                        <span className="font-medium">
+                          {bucket.breakdown.unhealthy}{' '}
+                          {bucket.breakdown.unhealthy === 1 ? 'link' : 'links'}
+                        </span>
                       </div>
                     )}
                     {bucket.breakdown.disabled > 0 && (
@@ -251,7 +280,10 @@ function MetroTimeline({
                           <div className="w-2 h-2 rounded-full bg-gray-500" />
                           <span>Disabled</span>
                         </div>
-                        <span className="font-medium">{bucket.breakdown.disabled} {bucket.breakdown.disabled === 1 ? 'link' : 'links'}</span>
+                        <span className="font-medium">
+                          {bucket.breakdown.disabled}{' '}
+                          {bucket.breakdown.disabled === 1 ? 'link' : 'links'}
+                        </span>
                       </div>
                     )}
                     {bucket.breakdown.no_data > 0 && (
@@ -260,7 +292,10 @@ function MetroTimeline({
                           <div className="w-2 h-2 rounded-full border border-gray-400" />
                           <span>No Data</span>
                         </div>
-                        <span className="font-medium">{bucket.breakdown.no_data} {bucket.breakdown.no_data === 1 ? 'link' : 'links'}</span>
+                        <span className="font-medium">
+                          {bucket.breakdown.no_data}{' '}
+                          {bucket.breakdown.no_data === 1 ? 'link' : 'links'}
+                        </span>
                       </div>
                     )}
                   </div>
@@ -331,12 +366,15 @@ export function MetroStatusTimelines({
 
     const bucketCount = firstLink.hours.length
 
-    const metroMap = new Map<string, {
-      linkCount: number
-      healthyLinkCount: number
-      spofLinks: SpofLink[]
-      buckets: Map<number, { statuses: string[]; hour: string }>
-    }>()
+    const metroMap = new Map<
+      string,
+      {
+        linkCount: number
+        healthyLinkCount: number
+        spofLinks: SpofLink[]
+        buckets: Map<number, { statuses: string[]; hour: string }>
+      }
+    >()
 
     const initMetro = (code: string) => {
       if (!metroMap.has(code)) {
@@ -358,9 +396,10 @@ export function MetroStatusTimelines({
       // If last bucket is no_data (still collecting), use the previous bucket
       const lastBucket = link.hours[link.hours.length - 1]
       const prevBucket = link.hours.length > 1 ? link.hours[link.hours.length - 2] : null
-      const currentStatus = (lastBucket?.status === 'no_data' && prevBucket)
-        ? (prevBucket.status || 'healthy')
-        : (lastBucket?.status || 'healthy') as SpofLink['status']
+      const currentStatus =
+        lastBucket?.status === 'no_data' && prevBucket
+          ? prevBucket.status || 'healthy'
+          : ((lastBucket?.status || 'healthy') as SpofLink['status'])
       const isCurrentlyHealthy = currentStatus === 'healthy' || currentStatus === 'degraded'
 
       for (const metroCode of [link.side_a_metro, link.side_z_metro]) {
@@ -371,7 +410,7 @@ export function MetroStatusTimelines({
         if (isCurrentlyHealthy) metro.healthyLinkCount++
         if (isSpof) {
           // Only add if not already in the list (link touches both metros)
-          if (!metro.spofLinks.some(s => s.code === link.code)) {
+          if (!metro.spofLinks.some((s) => s.code === link.code)) {
             metro.spofLinks.push({
               code: link.code,
               pk: link.pk,
@@ -406,7 +445,12 @@ export function MetroStatusTimelines({
         // For the last bucket (most recent, still collecting), if ALL links have no_data
         // show it as no_data. Otherwise calculate from the links that do have data.
         const isLastBucket = i === bucketCount - 1
-        const totalLinks = breakdown.healthy + breakdown.degraded + breakdown.unhealthy + breakdown.disabled + breakdown.no_data
+        const totalLinks =
+          breakdown.healthy +
+          breakdown.degraded +
+          breakdown.unhealthy +
+          breakdown.disabled +
+          breakdown.no_data
         const allNoData = breakdown.no_data === totalLinks
         let bucketStatus: 'healthy' | 'degraded' | 'unhealthy' | 'no_data'
         if (isLastBucket && allNoData) {
@@ -426,7 +470,7 @@ export function MetroStatusTimelines({
       // Current health from last bucket (or previous if last is no_data)
       const lastBucket = buckets[buckets.length - 1]
       const prevBucket = buckets.length > 1 ? buckets[buckets.length - 2] : null
-      const healthBucket = (lastBucket.status === 'no_data' && prevBucket) ? prevBucket : lastBucket
+      const healthBucket = lastBucket.status === 'no_data' && prevBucket ? prevBucket : lastBucket
       let currentHealth: 'healthy' | 'degraded' | 'unhealthy' = 'healthy'
       if (healthBucket.status === 'unhealthy') {
         currentHealth = 'unhealthy'
@@ -436,8 +480,8 @@ export function MetroStatusTimelines({
 
       // Factor in SPOF status: if any SPOF is unhealthy, metro is unhealthy
       // If any SPOF is degraded, metro is at least degraded
-      const hasUnhealthySpof = data.spofLinks.some(s => s.status === 'unhealthy')
-      const hasDegradedSpof = data.spofLinks.some(s => s.status === 'degraded')
+      const hasUnhealthySpof = data.spofLinks.some((s) => s.status === 'unhealthy')
+      const hasDegradedSpof = data.spofLinks.some((s) => s.status === 'degraded')
       if (hasUnhealthySpof) {
         currentHealth = 'unhealthy'
         hasAnyIssues = true
@@ -486,7 +530,7 @@ export function MetroStatusTimelines({
 
   // Apply filters
   const filteredMetros = useMemo(() => {
-    return metroData.filter(metro => {
+    return metroData.filter((metro) => {
       // Health filter
       const matchesHealth = healthFilters.includes(metro.currentHealth)
 
@@ -494,7 +538,8 @@ export function MetroStatusTimelines({
       let matchesIssue = false
       if (issueFilters.includes('has_spof') && metro.spofLinks.length > 0) matchesIssue = true
       if (issueFilters.includes('has_issues') && metro.hasIssues) matchesIssue = true
-      if (issueFilters.includes('no_issues') && !metro.hasIssues && metro.spofLinks.length === 0) matchesIssue = true
+      if (issueFilters.includes('no_issues') && !metro.hasIssues && metro.spofLinks.length === 0)
+        matchesIssue = true
 
       return matchesHealth && matchesIssue
     })
@@ -520,9 +565,7 @@ export function MetroStatusTimelines({
       <div className="border border-border rounded-lg p-6 text-center">
         <CheckCircle2 className="h-8 w-8 text-green-500 mx-auto mb-2" />
         <div className="text-sm text-muted-foreground">
-          {metroData.length === 0
-            ? 'No metros available'
-            : 'No metros match the selected filters'}
+          {metroData.length === 0 ? 'No metros available' : 'No metros match the selected filters'}
         </div>
       </div>
     )
@@ -530,35 +573,32 @@ export function MetroStatusTimelines({
 
   return (
     <div className="border border-border rounded-lg">
-      <div className="px-4 py-2.5 bg-muted/50 border-b border-border flex items-center gap-2 rounded-t-lg">
-        <History className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">
-          Metro Status History
-          <span className="text-sm text-muted-foreground font-normal ml-1">
-            ({filteredMetros.length} metro{filteredMetros.length !== 1 ? 's' : ''})
-          </span>
-        </h3>
-        {onTimeRangeChange && (
-          <div className="inline-flex rounded-lg border border-border bg-background/50 p-0.5 ml-auto">
-            {timeRangeOptions.map((opt) => (
-              <button
-                key={opt.value}
-                onClick={() => onTimeRangeChange(opt.value)}
-                className={`px-2.5 py-0.5 text-xs rounded-md transition-colors ${
-                  timeRange === opt.value
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
+      <div className="px-4 py-2.5 bg-muted/50 border-b border-border rounded-t-lg flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-2">
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            <History className="h-4 w-4 text-muted-foreground shrink-0" />
+            <h3 className="font-medium">
+              Metro Status History
+              <span className="hidden xss:inline text-sm text-muted-foreground font-normal ml-1">
+                ({filteredMetros.length} metro{filteredMetros.length !== 1 ? 's' : ''})
+              </span>
+            </h3>
           </div>
+          <div className="xss:hidden text-sm text-muted-foreground">
+            ({filteredMetros.length} metro{filteredMetros.length !== 1 ? 's' : ''})
+          </div>
+        </div>
+        {onTimeRangeChange && (
+          <SmallDropdown
+            value={timeRange}
+            options={timeRangeOptions}
+            onChange={(v) => onTimeRangeChange(v as TimeRange)}
+          />
         )}
       </div>
 
       {/* Legend */}
-      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 text-xs text-muted-foreground">
+      <div className="px-4 py-2 border-b border-border bg-muted/30 flex items-center gap-4 flex-wrap text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <div className="w-2.5 h-2.5 rounded-sm bg-green-500" />
           <span>Healthy</span>
@@ -586,7 +626,7 @@ export function MetroStatusTimelines({
           <div key={metro.code} className="px-4 py-3 hover:bg-muted/30 transition-colors">
             <div className="flex items-start gap-4">
               {/* Metro info */}
-              <div className="flex-shrink-0 w-44">
+              <div className="shrink-0 w-44">
                 <div className="flex items-center gap-1.5">
                   <button
                     onClick={() => handleMetroClick(metro.code)}
@@ -600,29 +640,33 @@ export function MetroStatusTimelines({
                 <div className="text-xs text-muted-foreground">
                   <span className="font-mono">{metro.code}</span>
                   <span className="mx-1">·</span>
-                  <span>{metro.linkCount} {metro.linkCount === 1 ? 'link' : 'links'}</span>
+                  <span>
+                    {metro.linkCount} {metro.linkCount === 1 ? 'link' : 'links'}
+                  </span>
                 </div>
-                {metro.spofLinks.length > 0 && (() => {
-                  const hasAtRiskSpof = metro.spofLinks.some(s => s.status === 'unhealthy' || s.status === 'degraded')
-                  return (
-                    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium mt-1 inline-flex items-center gap-1 ${
-                      hasAtRiskSpof
-                        ? 'bg-red-500/20 text-red-600 dark:text-red-400'
-                        : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
-                    }`}>
-                      {hasAtRiskSpof && <AlertTriangle className="h-3 w-3" />}
-                      {metro.spofLinks.length} SPOF
-                    </span>
-                  )
-                })()}
+                {metro.spofLinks.length > 0 &&
+                  (() => {
+                    const hasAtRiskSpof = metro.spofLinks.some(
+                      (s) => s.status === 'unhealthy' || s.status === 'degraded',
+                    )
+                    return (
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded font-medium mt-1 inline-flex items-center gap-1 ${
+                          hasAtRiskSpof
+                            ? 'bg-red-500/20 text-red-600 dark:text-red-400'
+                            : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                        }`}
+                      >
+                        {hasAtRiskSpof && <AlertTriangle className="h-3 w-3" />}
+                        {metro.spofLinks.length} SPOF
+                      </span>
+                    )
+                  })()}
               </div>
 
               {/* Timeline */}
               <div className="flex-1 min-w-0">
-                <MetroTimeline
-                  metro={metro}
-                  bucketMinutes={linkHistory?.bucket_minutes || 20}
-                />
+                <MetroTimeline metro={metro} bucketMinutes={linkHistory?.bucket_minutes || 20} />
                 <div className="flex justify-between mt-1 text-[10px] text-muted-foreground">
                   <span>{timeLabels[timeRange]}</span>
                   <span>Now</span>

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -1,14 +1,33 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { Loader2, Radio, AlertCircle, ArrowLeft, ChevronUp, ChevronDown, X, Info, Search, RefreshCw } from 'lucide-react'
+import {
+  Loader2,
+  Radio,
+  AlertCircle,
+  ArrowLeft,
+  ChevronUp,
+  ChevronDown,
+  X,
+  Info,
+  Search,
+  RefreshCw,
+} from 'lucide-react'
 import uPlot from 'uplot'
 import { useUPlotChart } from '@/hooks/use-uplot-chart'
 import { useUPlotLegendSync } from '@/hooks/use-uplot-legend-sync'
 import { formatChartAxisRate, formatChartAxisPps } from '@/components/topology/utils'
-import { fetchMulticastGroup, fetchMulticastGroupMembers, fetchMulticastGroupTraffic, fetchMulticastGroupMemberCounts, fetchMulticastGroupShredStats, type MulticastMember } from '@/lib/api'
+import {
+  fetchMulticastGroup,
+  fetchMulticastGroupMembers,
+  fetchMulticastGroupTraffic,
+  fetchMulticastGroupMemberCounts,
+  fetchMulticastGroupShredStats,
+  type MulticastMember,
+} from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useChartLegend } from '@/hooks/use-chart-legend'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import { InlineFilter } from '@/components/inline-filter'
 import { Pagination } from '@/components/pagination'
 
@@ -30,8 +49,6 @@ function formatPps(pps: number): string {
 }
 
 type TrafficMetric = 'throughput' | 'packets'
-
-
 
 function formatStake(sol: number): string {
   if (sol === 0) return '—'
@@ -61,32 +78,77 @@ function leaderTimingText(member: MulticastMember): string | null {
 }
 
 const TRAFFIC_COLORS = [
-  '#7c5cbf', '#4a8fe7', '#3dad6f', '#d4854a', '#2ba3a8', '#c4a23d', '#c45fa0', '#6ba8f2',
+  '#7c5cbf',
+  '#4a8fe7',
+  '#3dad6f',
+  '#d4854a',
+  '#2ba3a8',
+  '#c4a23d',
+  '#c45fa0',
+  '#6ba8f2',
 ]
 
 const TIME_RANGES = ['1h', '3h', '6h', '12h', '24h', '3d', '7d', '14d', '30d'] as const
-const BUCKET_OPTIONS = ['auto', '10 SECOND', '30 SECOND', '1 MINUTE', '5 MINUTE', '10 MINUTE', '15 MINUTE', '30 MINUTE', '1 HOUR', '4 HOUR', '12 HOUR', '1 DAY'] as const
+const BUCKET_OPTIONS = [
+  'auto',
+  '10 SECOND',
+  '30 SECOND',
+  '1 MINUTE',
+  '5 MINUTE',
+  '10 MINUTE',
+  '15 MINUTE',
+  '30 MINUTE',
+  '1 HOUR',
+  '4 HOUR',
+  '12 HOUR',
+  '1 DAY',
+] as const
 const BUCKET_LABELS: Record<string, string> = {
-  'auto': 'Auto', '10 SECOND': '10s', '30 SECOND': '30s', '1 MINUTE': '1m', '5 MINUTE': '5m',
-  '10 MINUTE': '10m', '15 MINUTE': '15m', '30 MINUTE': '30m', '1 HOUR': '1h',
-  '4 HOUR': '4h', '12 HOUR': '12h', '1 DAY': '1d',
+  auto: 'Auto',
+  '10 SECOND': '10s',
+  '30 SECOND': '30s',
+  '1 MINUTE': '1m',
+  '5 MINUTE': '5m',
+  '10 MINUTE': '10m',
+  '15 MINUTE': '15m',
+  '30 MINUTE': '30m',
+  '1 HOUR': '1h',
+  '4 HOUR': '4h',
+  '12 HOUR': '12h',
+  '1 DAY': '1d',
 }
 function resolveAutoBucket(timeRange: string): string {
   switch (timeRange) {
-    case '1h': return '10 SECOND'
-    case '3h': return '30 SECOND'
-    case '6h': return '1 MINUTE'
-    case '12h': return '10 MINUTE'
-    case '24h': return '15 MINUTE'
-    case '3d': return '30 MINUTE'
-    case '7d': return '4 HOUR'
-    case '14d': return '12 HOUR'
-    case '30d': return '1 DAY'
-    default: return '5 MINUTE'
+    case '1h':
+      return '10 SECOND'
+    case '3h':
+      return '30 SECOND'
+    case '6h':
+      return '1 MINUTE'
+    case '12h':
+      return '10 MINUTE'
+    case '24h':
+      return '15 MINUTE'
+    case '3d':
+      return '30 MINUTE'
+    case '7d':
+      return '4 HOUR'
+    case '14d':
+      return '12 HOUR'
+    case '30d':
+      return '1 DAY'
+    default:
+      return '5 MINUTE'
   }
 }
 
-function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, onSelectMember }: {
+function MulticastTrafficChart({
+  groupCode,
+  members,
+  activeTab,
+  onHoverMember,
+  onSelectMember,
+}: {
   groupCode: string
   members: MulticastMember[]
   activeTab: 'publishers' | 'subscribers'
@@ -110,7 +172,10 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
 
   // Build a lookup from device_pk+tunnel_id to display info
   const seriesInfo = useMemo(() => {
-    const map = new Map<string, { ownerPubkey: string; nodePubkey: string; code: string; tunnelId: number; mode: string }>()
+    const map = new Map<
+      string,
+      { ownerPubkey: string; nodePubkey: string; code: string; tunnelId: number; mode: string }
+    >()
     for (const m of members) {
       if (m.tunnel_id > 0) {
         const key = `${m.device_pk}_${m.tunnel_id}`
@@ -149,20 +214,25 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
         byKey = new Map()
         timeMap.set(p.time, byKey)
       }
-      const value = metric === 'throughput'
-        ? (showPubs ? p.in_bps : p.out_bps)
-        : (showPubs ? p.in_pps : p.out_pps)
+      const value =
+        metric === 'throughput'
+          ? showPubs
+            ? p.in_bps
+            : p.out_bps
+          : showPubs
+            ? p.in_pps
+            : p.out_pps
       byKey.set(seriesKey, value)
     }
 
     const memberKeys = new Set(
-      members.filter(m => m.tunnel_id > 0).map(m => `${m.device_pk}_${m.tunnel_id}`)
+      members.filter((m) => m.tunnel_id > 0).map((m) => `${m.device_pk}_${m.tunnel_id}`),
     )
-    const keys = [...keySet].filter(k => memberKeys.has(k)).sort()
+    const keys = [...keySet].filter((k) => memberKeys.has(k)).sort()
     const sortedTimes = [...timeMap.keys()].sort()
-    const timestamps = new Float64Array(sortedTimes.map(t => new Date(t).getTime() / 1000))
-    const columns = keys.map(key =>
-      new Float64Array(sortedTimes.map(t => timeMap.get(t)?.get(key) ?? 0))
+    const timestamps = new Float64Array(sortedTimes.map((t) => new Date(t).getTime() / 1000))
+    const columns = keys.map(
+      (key) => new Float64Array(sortedTimes.map((t) => timeMap.get(t)?.get(key) ?? 0)),
     )
 
     return {
@@ -231,9 +301,8 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
   const displayValues = useMemo(() => {
     const map = new Map<string, number>()
     if (!uplotData[0] || uplotData[0].length === 0) return map
-    const idx = hoveredIdx != null && hoveredIdx < uplotData[0].length
-      ? hoveredIdx
-      : uplotData[0].length - 1
+    const idx =
+      hoveredIdx != null && hoveredIdx < uplotData[0].length ? hoveredIdx : uplotData[0].length - 1
     for (let i = 0; i < seriesKeys.length; i++) {
       map.set(seriesKeys[i], (uplotData[i + 1] as number[])?.[idx] ?? 0)
     }
@@ -246,16 +315,19 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
     setHoveredIdx(idx)
   }, [])
 
-  const handleFocusSeries = useCallback((seriesIdx: number | null) => {
-    if (seriesIdx != null && seriesIdx > 0 && seriesIdx <= seriesKeys.length) {
-      const key = seriesKeys[seriesIdx - 1]
-      focusedKeyRef.current = key
-      legend.handleMouseEnter(key)
-    } else {
-      focusedKeyRef.current = null
-      legend.handleMouseLeave()
-    }
-  }, [seriesKeys, legend])
+  const handleFocusSeries = useCallback(
+    (seriesIdx: number | null) => {
+      if (seriesIdx != null && seriesIdx > 0 && seriesIdx <= seriesKeys.length) {
+        const key = seriesKeys[seriesIdx - 1]
+        focusedKeyRef.current = key
+        legend.handleMouseEnter(key)
+      } else {
+        focusedKeyRef.current = null
+        legend.handleMouseLeave()
+      }
+    },
+    [seriesKeys, legend],
+  )
 
   const uplotSeries = useMemo((): uPlot.Series[] => {
     const s: uPlot.Series[] = [{}]
@@ -270,18 +342,26 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
     return s
   }, [seriesKeys])
 
-  const uplotAxes = useMemo((): uPlot.Axis[] => [
-    {},
-    {
-      values: (_u: uPlot, vals: number[]) =>
-        vals.map(v => metric === 'throughput' ? formatChartAxisRate(v) : formatChartAxisPps(v)),
-    },
-  ], [metric])
+  const uplotAxes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      {
+        values: (_u: uPlot, vals: number[]) =>
+          vals.map((v) =>
+            metric === 'throughput' ? formatChartAxisRate(v) : formatChartAxisPps(v),
+          ),
+      },
+    ],
+    [metric],
+  )
 
-  const chartScales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const chartScales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartContainerRef,
@@ -322,15 +402,17 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
     let keys = seriesKeys
     if (legendSearchText) {
       const needle = legendSearchText.toLowerCase()
-      keys = keys.filter(key => {
+      keys = keys.filter((key) => {
         const info = seriesInfo.get(key)
         const ownerPk = info?.ownerPubkey ?? ''
         const nodePk = info?.nodePubkey ?? ''
         const code = info?.code ?? ''
-        return ownerPk.toLowerCase().includes(needle) ||
+        return (
+          ownerPk.toLowerCase().includes(needle) ||
           nodePk.toLowerCase().includes(needle) ||
           code.toLowerCase().includes(needle) ||
           key.toLowerCase().includes(needle)
+        )
       })
     }
     const sorted = [...keys].sort((a, b) => {
@@ -349,7 +431,8 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
   }, [seriesKeys, legendSearchText, legendSortBy, legendSortDir, seriesInfo, displayValues])
 
   const legendHeight = useMemo(() => {
-    const contentHeight = LEGEND_HEADER_HEIGHT + legendFilteredKeys.length * LEGEND_ROW_HEIGHT + LEGEND_HANDLE_HEIGHT
+    const contentHeight =
+      LEGEND_HEADER_HEIGHT + legendFilteredKeys.length * LEGEND_ROW_HEIGHT + LEGEND_HANDLE_HEIGHT
     return Math.min(legendMaxHeight, contentHeight)
   }, [legendMaxHeight, legendFilteredKeys.length])
 
@@ -357,14 +440,14 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
     <div className="border border-border rounded-lg p-4 bg-card group/chart">
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            Traffic ({activeTab})
-          </h3>
+          <h3 className="text-sm font-medium text-muted-foreground">Traffic ({activeTab})</h3>
           <div className="relative group/info flex-shrink-0">
             <Info className="h-3.5 w-3.5 text-muted-foreground/50 group-hover/info:text-muted-foreground cursor-help" />
             <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1 hidden group-hover/info:block z-50 pointer-events-none">
               <div className="bg-[var(--popover)] text-[var(--popover-foreground)] border border-[var(--border)] rounded-md px-3 py-2 text-xs leading-relaxed w-64 shadow-md">
-                Traffic is measured per tunnel and does not distinguish between multicast groups. If a member publishes or subscribes on multiple groups, their traffic will look similar across each group.
+                Traffic is measured per tunnel and does not distinguish between multicast groups. If
+                a member publishes or subscribes on multiple groups, their traffic will look similar
+                across each group.
               </div>
             </div>
           </div>
@@ -372,7 +455,9 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
           ) : (
             <button
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['multicast-traffic', groupCode] })}
+              onClick={() =>
+                queryClient.invalidateQueries({ queryKey: ['multicast-traffic', groupCode] })
+              }
               className="opacity-0 group-hover/chart:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
               title="Refresh"
             >
@@ -381,32 +466,25 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
           )}
         </div>
         <div className="flex items-center gap-2">
-          <select
+          <SmallDropdown
             value={metric}
-            onChange={e => setMetric(e.target.value as TrafficMetric)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            <option value="throughput">bps</option>
-            <option value="packets">pps</option>
-          </select>
-          <select
+            options={[
+              { value: 'throughput', label: 'bps' },
+              { value: 'packets', label: 'pps' },
+            ]}
+            onChange={(v) => setMetric(v as TrafficMetric)}
+          />
+          <SmallDropdown
             value={bucket}
-            onChange={e => setBucket(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {BUCKET_OPTIONS.map(b => (
-              <option key={b} value={b}>{b === 'auto' ? `Auto (${autoBucketLabel})` : BUCKET_LABELS[b] || b}</option>
-            ))}
-          </select>
-          <select
+            displayLabel={bucket === 'auto' ? `Auto (${autoBucketLabel})` : undefined}
+            options={BUCKET_OPTIONS.map((b) => ({ value: b, label: BUCKET_LABELS[b] || b }))}
+            onChange={(v) => setBucket(v)}
+          />
+          <SmallDropdown
             value={timeRange}
-            onChange={e => setTimeRange(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {TIME_RANGES.map(r => (
-              <option key={r} value={r}>{r}</option>
-            ))}
-          </select>
+            options={TIME_RANGES.map((r) => ({ value: r, label: r }))}
+            onChange={(v) => setTimeRange(v)}
+          />
         </div>
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full mb-2">
@@ -423,13 +501,13 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
 
       {(trafficData || isFetching) && (
         <div>
-          <div
-            ref={chartContainerRef}
-            className="h-56"
-            onClick={handleChartClick}
-          />
+          <div ref={chartContainerRef} className="h-56" onClick={handleChartClick} />
           {seriesKeys.length > 0 && (
-            <div ref={legendContainerRef} className="relative mt-2" style={{ height: `${legendHeight}px` }}>
+            <div
+              ref={legendContainerRef}
+              className="relative mt-2"
+              style={{ height: `${legendHeight}px` }}
+            >
               <div className="flex flex-col h-full text-xs">
                 {/* Sticky header */}
                 <div className="flex-none px-2 pt-2">
@@ -444,13 +522,18 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                           type="text"
                           value={legendSearchText}
                           onChange={(e) => setLegendSearchText(e.target.value)}
-                          onBlur={() => { if (!legendSearchText) setLegendSearchExpanded(false) }}
+                          onBlur={() => {
+                            if (!legendSearchText) setLegendSearchExpanded(false)
+                          }}
                           placeholder="Filter by owner, node, device..."
                           className="w-full px-1.5 py-0.5 pr-6 text-xs bg-transparent border-b border-border focus:outline-none focus:border-foreground placeholder:text-muted-foreground/60"
                         />
                         {legendSearchText && (
                           <button
-                            onClick={() => { setLegendSearchText(''); legendSearchInputRef.current?.focus() }}
+                            onClick={() => {
+                              setLegendSearchText('')
+                              legendSearchInputRef.current?.focus()
+                            }}
                             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground z-10"
                             aria-label="Clear search"
                           >
@@ -460,7 +543,10 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                       </div>
                     ) : (
                       <button
-                        onClick={() => { setLegendSearchExpanded(true); setTimeout(() => legendSearchInputRef.current?.focus(), 0) }}
+                        onClick={() => {
+                          setLegendSearchExpanded(true)
+                          setTimeout(() => legendSearchInputRef.current?.focus(), 0)
+                        }}
                         className="text-muted-foreground hover:text-foreground"
                         aria-label="Search series"
                       >
@@ -483,8 +569,15 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                       <Info className="h-3 w-3 text-muted-foreground/50 group-hover:text-muted-foreground cursor-help" />
                       <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 hidden group-hover:block z-50 pointer-events-none">
                         <div className="bg-[var(--popover)] text-[var(--popover-foreground)] border border-[var(--border)] rounded-md px-2 py-1.5 text-[10px] leading-relaxed whitespace-nowrap shadow-md">
-                          <div><strong>Click</strong> — solo select</div>
-                          <div><strong>{navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click</strong> — toggle</div>
+                          <div>
+                            <strong>Click</strong> — solo select
+                          </div>
+                          <div>
+                            <strong>
+                              {navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click
+                            </strong>{' '}
+                            — toggle
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -493,19 +586,49 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                   <div className="flex items-center gap-4 px-1 mb-1">
                     <div className="w-2.5" />
                     <button
-                      onClick={() => { setLegendSortBy('name'); setLegendSortDir(legendSortBy === 'name' ? (legendSortDir === 'asc' ? 'desc' : 'asc') : 'asc') }}
+                      onClick={() => {
+                        setLegendSortBy('name')
+                        setLegendSortDir(
+                          legendSortBy === 'name'
+                            ? legendSortDir === 'asc'
+                              ? 'desc'
+                              : 'asc'
+                            : 'asc',
+                        )
+                      }}
                       className="flex-1 min-w-0 flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground font-medium"
                     >
                       Owner
-                      {legendSortBy === 'name' && (legendSortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)}
+                      {legendSortBy === 'name' &&
+                        (legendSortDir === 'asc' ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        ))}
                     </button>
-                    <div className="w-48 text-right text-xs text-muted-foreground font-medium whitespace-nowrap">DZ ID</div>
+                    <div className="w-48 text-right text-xs text-muted-foreground font-medium whitespace-nowrap">
+                      DZ ID
+                    </div>
                     <button
-                      onClick={() => { setLegendSortBy('value'); setLegendSortDir(legendSortBy === 'value' ? (legendSortDir === 'asc' ? 'desc' : 'asc') : 'desc') }}
+                      onClick={() => {
+                        setLegendSortBy('value')
+                        setLegendSortDir(
+                          legendSortBy === 'value'
+                            ? legendSortDir === 'asc'
+                              ? 'desc'
+                              : 'asc'
+                            : 'desc',
+                        )
+                      }}
                       className="w-20 flex items-center justify-end gap-0.5 text-xs text-muted-foreground hover:text-foreground font-medium"
                     >
                       Rate
-                      {legendSortBy === 'value' && (legendSortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)}
+                      {legendSortBy === 'value' &&
+                        (legendSortDir === 'asc' ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        ))}
                     </button>
                   </div>
                 </div>
@@ -517,7 +640,8 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                       const info = seriesInfo.get(key)
                       const val = displayValues.get(key)
                       const opacity = legend.getOpacity(key)
-                      const isSelected = legend.selectedSeries.size === 0 || legend.selectedSeries.has(key)
+                      const isSelected =
+                        legend.selectedSeries.size === 0 || legend.selectedSeries.has(key)
                       const ownerLabel = info?.ownerPubkey
                         ? `${info.ownerPubkey.slice(0, 4)}..${info.ownerPubkey.slice(-4)}`
                         : key.split('_')[0].slice(0, 8)
@@ -533,14 +657,28 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
                         >
                           <div
                             className="w-2.5 h-2.5 rounded-sm flex-shrink-0 transition-colors"
-                            style={{ backgroundColor: isSelected ? TRAFFIC_COLORS[i % TRAFFIC_COLORS.length] : 'var(--border)' }}
+                            style={{
+                              backgroundColor: isSelected
+                                ? TRAFFIC_COLORS[i % TRAFFIC_COLORS.length]
+                                : 'var(--border)',
+                            }}
                           />
                           <div className="flex-1 min-w-0 text-foreground truncate font-mono">
                             {ownerLabel}
-                            <span className="text-muted-foreground ml-2">{info?.code ?? key.split('_')[0].slice(0, 8)}{info?.tunnelId ? ` / ${info.tunnelId}` : ''}</span>
+                            <span className="text-muted-foreground ml-2">
+                              {info?.code ?? key.split('_')[0].slice(0, 8)}
+                              {info?.tunnelId ? ` / ${info.tunnelId}` : ''}
+                            </span>
                           </div>
-                          <div className="w-48 text-right truncate tabular-nums font-mono text-muted-foreground select-text" title={dzIdLabel}>{dzIdLabel}</div>
-                          <div className="w-20 text-right tabular-nums">{val !== undefined && opacity > 0 ? fmtValue(val) : '—'}</div>
+                          <div
+                            className="w-48 text-right truncate tabular-nums font-mono text-muted-foreground select-text"
+                            title={dzIdLabel}
+                          >
+                            {dzIdLabel}
+                          </div>
+                          <div className="w-20 text-right tabular-nums">
+                            {val !== undefined && opacity > 0 ? fmtValue(val) : '—'}
+                          </div>
                         </div>
                       )
                     })}
@@ -563,7 +701,13 @@ function MulticastTrafficChart({ groupCode, members, activeTab, onHoverMember, o
   )
 }
 
-type ShredMetric = 'unique_shreds' | 'total_packets' | 'data_shreds' | 'coding_shreds' | 'leader_slots' | 'repair_slots'
+type ShredMetric =
+  | 'unique_shreds'
+  | 'total_packets'
+  | 'data_shreds'
+  | 'coding_shreds'
+  | 'leader_slots'
+  | 'repair_slots'
 
 const SHRED_METRIC_LABELS: Record<ShredMetric, string> = {
   unique_shreds: 'Unique Shreds',
@@ -595,15 +739,25 @@ function bucketToSeconds(bucket: string): number {
   if (!match) return 60
   const n = parseInt(match[1])
   switch (match[2]) {
-    case 'SECOND': return n
-    case 'MINUTE': return n * 60
-    case 'HOUR': return n * 3600
-    case 'DAY': return n * 86400
-    default: return 60
+    case 'SECOND':
+      return n
+    case 'MINUTE':
+      return n * 60
+    case 'HOUR':
+      return n * 3600
+    case 'DAY':
+      return n * 86400
+    default:
+      return 60
   }
 }
 
-function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: {
+function ShredStatsChart({
+  groupCode,
+  members,
+  onHoverMember,
+  onSelectMember,
+}: {
   groupCode: string
   members: MulticastMember[]
   onHoverMember?: (seriesKey: string | null) => void
@@ -676,9 +830,9 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
 
     const keys = [...keySet].sort()
     const sortedTimes = [...timeMap.keys()].sort()
-    const timestamps = new Float64Array(sortedTimes.map(t => new Date(t).getTime() / 1000))
-    const columns = keys.map(key =>
-      new Float64Array(sortedTimes.map(t => timeMap.get(t)?.get(key) ?? 0))
+    const timestamps = new Float64Array(sortedTimes.map((t) => new Date(t).getTime() / 1000))
+    const columns = keys.map(
+      (key) => new Float64Array(sortedTimes.map((t) => timeMap.get(t)?.get(key) ?? 0)),
     )
 
     return {
@@ -735,9 +889,8 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
   const displayValues = useMemo(() => {
     const map = new Map<string, number>()
     if (!uplotData[0] || uplotData[0].length === 0) return map
-    const idx = hoveredIdx != null && hoveredIdx < uplotData[0].length
-      ? hoveredIdx
-      : uplotData[0].length - 1
+    const idx =
+      hoveredIdx != null && hoveredIdx < uplotData[0].length ? hoveredIdx : uplotData[0].length - 1
     for (let i = 0; i < seriesKeys.length; i++) {
       map.set(seriesKeys[i], (uplotData[i + 1] as number[])?.[idx] ?? 0)
     }
@@ -748,16 +901,19 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
     setHoveredIdx(idx)
   }, [])
 
-  const handleFocusSeries = useCallback((seriesIdx: number | null) => {
-    if (seriesIdx != null && seriesIdx > 0 && seriesIdx <= seriesKeys.length) {
-      const key = seriesKeys[seriesIdx - 1]
-      focusedKeyRef.current = key
-      legend.handleMouseEnter(key)
-    } else {
-      focusedKeyRef.current = null
-      legend.handleMouseLeave()
-    }
-  }, [seriesKeys, legend])
+  const handleFocusSeries = useCallback(
+    (seriesIdx: number | null) => {
+      if (seriesIdx != null && seriesIdx > 0 && seriesIdx <= seriesKeys.length) {
+        const key = seriesKeys[seriesIdx - 1]
+        focusedKeyRef.current = key
+        legend.handleMouseEnter(key)
+      } else {
+        focusedKeyRef.current = null
+        legend.handleMouseLeave()
+      }
+    },
+    [seriesKeys, legend],
+  )
 
   const uplotSeries = useMemo((): uPlot.Series[] => {
     const s: uPlot.Series[] = [{}]
@@ -774,17 +930,24 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
 
   const fmtValue = rateMode ? formatRate : formatCount
 
-  const uplotAxes = useMemo((): uPlot.Axis[] => [
-    {},
-    {
-      values: (_u: uPlot, vals: number[]) => vals.map(v => rateMode ? formatRate(v) : formatCount(v)),
-    },
-  ], [rateMode])
+  const uplotAxes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      {
+        values: (_u: uPlot, vals: number[]) =>
+          vals.map((v) => (rateMode ? formatRate(v) : formatCount(v))),
+      },
+    ],
+    [rateMode],
+  )
 
-  const chartScales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const chartScales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
   const { plotRef } = useUPlotChart({
     containerRef: chartContainerRef,
@@ -833,7 +996,7 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
         const memberKeySet = new Set<string>()
         for (const userPk of legend.selectedSeries) {
           const keys = userPkToMemberKeys.get(userPk)
-          if (keys) keys.forEach(k => memberKeySet.add(k))
+          if (keys) keys.forEach((k) => memberKeySet.add(k))
         }
         onSelectMember?.(memberKeySet)
       }
@@ -845,13 +1008,15 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
     let keys = seriesKeys
     if (legendSearchText) {
       const needle = legendSearchText.toLowerCase()
-      keys = keys.filter(key => {
+      keys = keys.filter((key) => {
         const info = userInfo.get(key)
         const ownerPk = info?.ownerPubkey ?? ''
         const code = info?.code ?? ''
-        return ownerPk.toLowerCase().includes(needle) ||
+        return (
+          ownerPk.toLowerCase().includes(needle) ||
           code.toLowerCase().includes(needle) ||
           key.toLowerCase().includes(needle)
+        )
       })
     }
     const sorted = [...keys].sort((a, b) => {
@@ -870,7 +1035,8 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
   }, [seriesKeys, legendSearchText, legendSortBy, legendSortDir, userInfo, displayValues])
 
   const legendHeight = useMemo(() => {
-    const contentHeight = LEGEND_HEADER_HEIGHT + legendFilteredKeys.length * LEGEND_ROW_HEIGHT + LEGEND_HANDLE_HEIGHT
+    const contentHeight =
+      LEGEND_HEADER_HEIGHT + legendFilteredKeys.length * LEGEND_ROW_HEIGHT + LEGEND_HANDLE_HEIGHT
     return Math.min(legendMaxHeight, contentHeight)
   }, [legendMaxHeight, legendFilteredKeys.length])
 
@@ -878,14 +1044,14 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
     <div className="border border-border rounded-lg p-4 bg-card group/chart">
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            Shred Stats (publishers)
-          </h3>
+          <h3 className="text-sm font-medium text-muted-foreground">Shred Stats (publishers)</h3>
           {isFetching ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
           ) : (
             <button
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['multicast-shred-stats', groupCode] })}
+              onClick={() =>
+                queryClient.invalidateQueries({ queryKey: ['multicast-shred-stats', groupCode] })
+              }
               className="opacity-0 group-hover/chart:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
               title="Refresh"
             >
@@ -894,41 +1060,33 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
           )}
         </div>
         <div className="flex items-center gap-2">
-          <select
+          <SmallDropdown
             value={metric}
-            onChange={e => setMetric(e.target.value as ShredMetric)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {(Object.keys(SHRED_METRIC_LABELS) as ShredMetric[]).map(m => (
-              <option key={m} value={m}>{SHRED_METRIC_LABELS[m]}</option>
-            ))}
-          </select>
-          <select
+            options={(Object.keys(SHRED_METRIC_LABELS) as ShredMetric[]).map((m) => ({
+              value: m,
+              label: SHRED_METRIC_LABELS[m],
+            }))}
+            onChange={(v) => setMetric(v as ShredMetric)}
+          />
+          <SmallDropdown
             value={rateMode ? 'rate' : 'total'}
-            onChange={e => setRateMode(e.target.value === 'rate')}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            <option value="rate">Rate (/s)</option>
-            <option value="total">Total</option>
-          </select>
-          <select
+            options={[
+              { value: 'rate', label: 'Rate (/s)' },
+              { value: 'total', label: 'Total' },
+            ]}
+            onChange={(v) => setRateMode(v === 'rate')}
+          />
+          <SmallDropdown
             value={bucket}
-            onChange={e => setBucket(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {BUCKET_OPTIONS.map(b => (
-              <option key={b} value={b}>{b === 'auto' ? `Auto (${autoBucketLabel})` : BUCKET_LABELS[b] || b}</option>
-            ))}
-          </select>
-          <select
+            displayLabel={bucket === 'auto' ? `Auto (${autoBucketLabel})` : undefined}
+            options={BUCKET_OPTIONS.map((b) => ({ value: b, label: BUCKET_LABELS[b] || b }))}
+            onChange={(v) => setBucket(v)}
+          />
+          <SmallDropdown
             value={timeRange}
-            onChange={e => setTimeRange(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {TIME_RANGES.map(r => (
-              <option key={r} value={r}>{r}</option>
-            ))}
-          </select>
+            options={TIME_RANGES.map((r) => ({ value: r, label: r }))}
+            onChange={(v) => setTimeRange(v)}
+          />
         </div>
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full mb-2">
@@ -945,11 +1103,7 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
 
       {(shredData || isFetching) && (
         <div>
-          <div
-            ref={chartContainerRef}
-            className="h-56"
-            onClick={handleChartClick}
-          />
+          <div ref={chartContainerRef} className="h-56" onClick={handleChartClick} />
           {seriesKeys.length > 0 && (
             <div className="relative mt-2" style={{ height: `${legendHeight}px` }}>
               <div className="flex flex-col h-full text-xs">
@@ -966,13 +1120,18 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                           type="text"
                           value={legendSearchText}
                           onChange={(e) => setLegendSearchText(e.target.value)}
-                          onBlur={() => { if (!legendSearchText) setLegendSearchExpanded(false) }}
+                          onBlur={() => {
+                            if (!legendSearchText) setLegendSearchExpanded(false)
+                          }}
                           placeholder="Filter by owner, device..."
                           className="w-full px-1.5 py-0.5 pr-6 text-xs bg-transparent border-b border-border focus:outline-none focus:border-foreground placeholder:text-muted-foreground/60"
                         />
                         {legendSearchText && (
                           <button
-                            onClick={() => { setLegendSearchText(''); legendSearchInputRef.current?.focus() }}
+                            onClick={() => {
+                              setLegendSearchText('')
+                              legendSearchInputRef.current?.focus()
+                            }}
                             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground z-10"
                             aria-label="Clear search"
                           >
@@ -982,7 +1141,10 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                       </div>
                     ) : (
                       <button
-                        onClick={() => { setLegendSearchExpanded(true); setTimeout(() => legendSearchInputRef.current?.focus(), 0) }}
+                        onClick={() => {
+                          setLegendSearchExpanded(true)
+                          setTimeout(() => legendSearchInputRef.current?.focus(), 0)
+                        }}
                         className="text-muted-foreground hover:text-foreground"
                         aria-label="Search series"
                       >
@@ -1005,8 +1167,15 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                       <Info className="h-3 w-3 text-muted-foreground/50 group-hover:text-muted-foreground cursor-help" />
                       <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 hidden group-hover:block z-50 pointer-events-none">
                         <div className="bg-[var(--popover)] text-[var(--popover-foreground)] border border-[var(--border)] rounded-md px-2 py-1.5 text-[10px] leading-relaxed whitespace-nowrap shadow-md">
-                          <div><strong>Click</strong> — solo select</div>
-                          <div><strong>{navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click</strong> — toggle</div>
+                          <div>
+                            <strong>Click</strong> — solo select
+                          </div>
+                          <div>
+                            <strong>
+                              {navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click
+                            </strong>{' '}
+                            — toggle
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1015,19 +1184,49 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                   <div className="flex items-center gap-4 px-1 mb-1">
                     <div className="w-2.5" />
                     <button
-                      onClick={() => { setLegendSortBy('name'); setLegendSortDir(legendSortBy === 'name' ? (legendSortDir === 'asc' ? 'desc' : 'asc') : 'asc') }}
+                      onClick={() => {
+                        setLegendSortBy('name')
+                        setLegendSortDir(
+                          legendSortBy === 'name'
+                            ? legendSortDir === 'asc'
+                              ? 'desc'
+                              : 'asc'
+                            : 'asc',
+                        )
+                      }}
                       className="flex-1 min-w-0 flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground font-medium"
                     >
                       Owner
-                      {legendSortBy === 'name' && (legendSortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)}
+                      {legendSortBy === 'name' &&
+                        (legendSortDir === 'asc' ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        ))}
                     </button>
-                    <div className="w-48 text-right text-xs text-muted-foreground font-medium whitespace-nowrap">DZ ID</div>
+                    <div className="w-48 text-right text-xs text-muted-foreground font-medium whitespace-nowrap">
+                      DZ ID
+                    </div>
                     <button
-                      onClick={() => { setLegendSortBy('value'); setLegendSortDir(legendSortBy === 'value' ? (legendSortDir === 'asc' ? 'desc' : 'asc') : 'desc') }}
+                      onClick={() => {
+                        setLegendSortBy('value')
+                        setLegendSortDir(
+                          legendSortBy === 'value'
+                            ? legendSortDir === 'asc'
+                              ? 'desc'
+                              : 'asc'
+                            : 'desc',
+                        )
+                      }}
                       className="w-20 flex items-center justify-end gap-0.5 text-xs text-muted-foreground hover:text-foreground font-medium"
                     >
                       Value
-                      {legendSortBy === 'value' && (legendSortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)}
+                      {legendSortBy === 'value' &&
+                        (legendSortDir === 'asc' ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        ))}
                     </button>
                   </div>
                 </div>
@@ -1039,7 +1238,8 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                       const info = userInfo.get(key)
                       const val = displayValues.get(key)
                       const opacity = legend.getOpacity(key)
-                      const isSelected = legend.selectedSeries.size === 0 || legend.selectedSeries.has(key)
+                      const isSelected =
+                        legend.selectedSeries.size === 0 || legend.selectedSeries.has(key)
                       const ownerLabel = info?.ownerPubkey
                         ? `${info.ownerPubkey.slice(0, 4)}..${info.ownerPubkey.slice(-4)}`
                         : key.slice(0, 8)
@@ -1055,14 +1255,27 @@ function ShredStatsChart({ groupCode, members, onHoverMember, onSelectMember }: 
                         >
                           <div
                             className="w-2.5 h-2.5 rounded-sm flex-shrink-0 transition-colors"
-                            style={{ backgroundColor: isSelected ? TRAFFIC_COLORS[i % TRAFFIC_COLORS.length] : 'var(--border)' }}
+                            style={{
+                              backgroundColor: isSelected
+                                ? TRAFFIC_COLORS[i % TRAFFIC_COLORS.length]
+                                : 'var(--border)',
+                            }}
                           />
                           <div className="flex-1 min-w-0 text-foreground truncate font-mono">
                             {ownerLabel}
-                            <span className="text-muted-foreground ml-2">{info?.code ?? key.slice(0, 8)}</span>
+                            <span className="text-muted-foreground ml-2">
+                              {info?.code ?? key.slice(0, 8)}
+                            </span>
                           </div>
-                          <div className="w-48 text-right truncate tabular-nums font-mono text-muted-foreground select-text" title={dzIdLabel}>{dzIdLabel}</div>
-                          <div className="w-20 text-right tabular-nums">{val !== undefined && opacity > 0 ? fmtValue(val) : '—'}</div>
+                          <div
+                            className="w-48 text-right truncate tabular-nums font-mono text-muted-foreground select-text"
+                            title={dzIdLabel}
+                          >
+                            {dzIdLabel}
+                          </div>
+                          <div className="w-20 text-right tabular-nums">
+                            {val !== undefined && opacity > 0 ? fmtValue(val) : '—'}
+                          </div>
                         </div>
                       )
                     })}
@@ -1104,29 +1317,47 @@ function MemberCountChart({ groupCode }: { groupCode: string }) {
       return { uplotData: [[]] as uPlot.AlignedData, uplotSeries: [] as uPlot.Series[] }
     }
 
-    const timestamps = countData.map(p => new Date(p.time).getTime() / 1000)
-    const pubs = countData.map(p => p.publisher_count)
-    const subs = countData.map(p => p.subscriber_count)
+    const timestamps = countData.map((p) => new Date(p.time).getTime() / 1000)
+    const pubs = countData.map((p) => p.publisher_count)
+    const subs = countData.map((p) => p.subscriber_count)
 
     return {
       uplotData: [timestamps, pubs, subs] as uPlot.AlignedData,
       uplotSeries: [
         {},
-        { label: 'Publishers', stroke: '#7c5cbf', width: 1.5, points: { show: false }, paths: steppedPaths },
-        { label: 'Subscribers', stroke: '#4a8fe7', width: 1.5, points: { show: false }, paths: steppedPaths },
+        {
+          label: 'Publishers',
+          stroke: '#7c5cbf',
+          width: 1.5,
+          points: { show: false },
+          paths: steppedPaths,
+        },
+        {
+          label: 'Subscribers',
+          stroke: '#4a8fe7',
+          width: 1.5,
+          points: { show: false },
+          paths: steppedPaths,
+        },
       ] as uPlot.Series[],
     }
   }, [countData, steppedPaths])
 
-  const chartScales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const chartScales = useMemo(
+    (): uPlot.Scales => ({
+      x: { time: true },
+      y: { auto: true },
+    }),
+    [],
+  )
 
-  const axes = useMemo((): uPlot.Axis[] => [
-    {},
-    { values: (_u: uPlot, vals: number[]) => vals.map(v => String(Math.round(v))) },
-  ], [])
+  const axes = useMemo(
+    (): uPlot.Axis[] => [
+      {},
+      { values: (_u: uPlot, vals: number[]) => vals.map((v) => String(Math.round(v))) },
+    ],
+    [],
+  )
 
   useUPlotChart({
     containerRef: chartRef,
@@ -1146,7 +1377,9 @@ function MemberCountChart({ groupCode }: { groupCode: string }) {
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
           ) : (
             <button
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['multicast-member-counts', groupCode] })}
+              onClick={() =>
+                queryClient.invalidateQueries({ queryKey: ['multicast-member-counts', groupCode] })
+              }
               className="opacity-0 group-hover/chart:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
               title="Refresh"
             >
@@ -1154,15 +1387,11 @@ function MemberCountChart({ groupCode }: { groupCode: string }) {
             </button>
           )}
         </div>
-        <select
+        <SmallDropdown
           value={timeRange}
-          onChange={e => setTimeRange(e.target.value)}
-          className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-        >
-          {TIME_RANGES.map(r => (
-            <option key={r} value={r}>{r}</option>
-          ))}
-        </select>
+          options={TIME_RANGES.map((r) => ({ value: r, label: r }))}
+          onChange={(v) => setTimeRange(v)}
+        />
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full mb-2">
         {isFetching && (
@@ -1195,7 +1424,15 @@ function MemberCountChart({ groupCode }: { groupCode: string }) {
   )
 }
 
-type MemberSortField = 'owner_pubkey' | 'node_pubkey' | 'device_code' | 'metro_name' | 'dz_ip' | 'tunnel_id' | 'stake_sol' | 'leader_schedule'
+type MemberSortField =
+  | 'owner_pubkey'
+  | 'node_pubkey'
+  | 'device_code'
+  | 'metro_name'
+  | 'dz_ip'
+  | 'tunnel_id'
+  | 'stake_sol'
+  | 'leader_schedule'
 type SortDirection = 'asc' | 'desc'
 
 const DEFAULT_PAGE_SIZE = 10
@@ -1213,7 +1450,10 @@ const memberAutocompleteFields = ['device', 'metro']
 
 function parseMemberSearchFilters(searchParam: string): string[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
 }
 
 // Base58 character class (no 0, O, I, l)
@@ -1239,7 +1479,9 @@ export function MulticastGroupDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
-  const activeTab = (searchParams.get('tab') === 'subscribers' ? 'subscribers' : 'publishers') as 'publishers' | 'subscribers'
+  const activeTab = (searchParams.get('tab') === 'subscribers' ? 'subscribers' : 'publishers') as
+    | 'publishers'
+    | 'subscribers'
   const sortField = (searchParams.get('sort') || 'stake_sol') as MemberSortField
   const sortDirection = (searchParams.get('dir') || 'desc') as SortDirection
   const page = parseInt(searchParams.get('page') || '1')
@@ -1250,45 +1492,58 @@ export function MulticastGroupDetailPage() {
   const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null)
   const [selectedSeriesKeys, setSelectedSeriesKeys] = useState<Set<string>>(new Set())
 
-  const setActiveTab = useCallback((tab: 'publishers' | 'subscribers') => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (tab === 'publishers') { p.delete('tab') } else { p.set('tab', tab) }
-      p.delete('page') // Reset to page 1
-      return p
-    })
-  }, [setSearchParams])
+  const setActiveTab = useCallback(
+    (tab: 'publishers' | 'subscribers') => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (tab === 'publishers') {
+          p.delete('tab')
+        } else {
+          p.set('tab', tab)
+        }
+        p.delete('page') // Reset to page 1
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const newParams = new URLSearchParams(prev)
-      const curSize = parseInt(newParams.get('limit') || '0')
-      const effectiveSize = PAGE_SIZE_OPTIONS.includes(curSize) ? curSize : DEFAULT_PAGE_SIZE
-      const newPage = Math.floor(newOffset / effectiveSize) + 1
-      if (newPage <= 1) {
-        newParams.delete('page')
-      } else {
-        newParams.set('page', String(newPage))
-      }
-      return newParams
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const newParams = new URLSearchParams(prev)
+        const curSize = parseInt(newParams.get('limit') || '0')
+        const effectiveSize = PAGE_SIZE_OPTIONS.includes(curSize) ? curSize : DEFAULT_PAGE_SIZE
+        const newPage = Math.floor(newOffset / effectiveSize) + 1
+        if (newPage <= 1) {
+          newParams.delete('page')
+        } else {
+          newParams.set('page', String(newPage))
+        }
+        return newParams
+      })
+    },
+    [setSearchParams],
+  )
 
-  const setPageSize = useCallback((size: number) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (size === DEFAULT_PAGE_SIZE) {
-        p.delete('limit')
-      } else {
-        p.set('limit', String(size))
-      }
-      p.delete('page') // Reset to page 1
-      return p
-    })
-  }, [setSearchParams])
+  const setPageSize = useCallback(
+    (size: number) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (size === DEFAULT_PAGE_SIZE) {
+          p.delete('limit')
+        } else {
+          p.set('limit', String(size))
+        }
+        p.delete('page') // Reset to page 1
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   const handleSort = (field: MemberSortField) => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       let newField = field
       let newDir: SortDirection = 'desc'
@@ -1315,14 +1570,16 @@ export function MulticastGroupDetailPage() {
 
   const SortIcon = ({ field }: { field: MemberSortField }) => {
     if (sortField !== field) return null
-    return sortDirection === 'asc'
-      ? <ChevronUp className="h-3 w-3" />
-      : <ChevronDown className="h-3 w-3" />
+    return sortDirection === 'asc' ? (
+      <ChevronUp className="h-3 w-3" />
+    ) : (
+      <ChevronDown className="h-3 w-3" />
+    )
   }
 
   const sortAria = (field: MemberSortField) => {
     if (sortField !== field) return 'none' as const
-    return sortDirection === 'asc' ? 'ascending' as const : 'descending' as const
+    return sortDirection === 'asc' ? ('ascending' as const) : ('descending' as const)
   }
 
   // Filter state from URL
@@ -1331,28 +1588,28 @@ export function MulticastGroupDetailPage() {
   const allFilters = liveFilter ? [...searchFilters, liveFilter] : searchFilters
 
   // Convert all filters to "field:value" params for the API
-  const filterParams = useMemo(
-    () => allFilters.map(toMemberFilterParam),
-    [allFilters]
-  )
+  const filterParams = useMemo(() => allFilters.map(toMemberFilterParam), [allFilters])
   const filterKey = filterParams.join(',')
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const newParams = new URLSearchParams(prev)
-      if (newFilters.length === 0) {
-        newParams.delete('search')
-      } else {
-        newParams.set('search', newFilters.join(','))
-      }
-      newParams.delete('page') // Reset to page 1
-      return newParams
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const newParams = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          newParams.delete('search')
+        } else {
+          newParams.set('search', newFilters.join(','))
+        }
+        newParams.delete('page') // Reset to page 1
+        return newParams
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('search')
       newParams.delete('page')
@@ -1365,7 +1622,7 @@ export function MulticastGroupDetailPage() {
   useEffect(() => {
     if (prevFilterRef.current === filterKey) return
     prevFilterRef.current = filterKey
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
@@ -1373,7 +1630,11 @@ export function MulticastGroupDetailPage() {
   }, [filterKey, setSearchParams])
 
   // Group metadata query
-  const { data: group, isLoading: groupLoading, error: groupError } = useQuery({
+  const {
+    data: group,
+    isLoading: groupLoading,
+    error: groupError,
+  } = useQuery({
     queryKey: ['multicast-group', pk],
     queryFn: () => fetchMulticastGroup(pk!),
     enabled: !!pk,
@@ -1381,17 +1642,31 @@ export function MulticastGroupDetailPage() {
   })
 
   // Members query (server-side pagination)
-  const { data: membersResponse, isLoading: membersLoading, isFetching: membersFetching } = useQuery({
-    queryKey: ['multicast-group-members', pk, activeTab, offset, pageSize, sortField, sortDirection, filterKey],
-    queryFn: () => fetchMulticastGroupMembers(
-      pk!,
-      pageSize,
+  const {
+    data: membersResponse,
+    isLoading: membersLoading,
+    isFetching: membersFetching,
+  } = useQuery({
+    queryKey: [
+      'multicast-group-members',
+      pk,
+      activeTab,
       offset,
+      pageSize,
       sortField,
       sortDirection,
-      activeTab,
-      filterParams.length > 0 ? filterParams : undefined
-    ),
+      filterKey,
+    ],
+    queryFn: () =>
+      fetchMulticastGroupMembers(
+        pk!,
+        pageSize,
+        offset,
+        sortField,
+        sortDirection,
+        activeTab,
+        filterParams.length > 0 ? filterParams : undefined,
+      ),
     enabled: !!pk,
     refetchInterval: 30000,
     placeholderData: keepPreviousData,
@@ -1407,9 +1682,9 @@ export function MulticastGroupDetailPage() {
   // Selected members not on current page — surfaced at top of table
   const surfacedMembers = useMemo(() => {
     if (selectedSeriesKeys.size === 0 || !group) return []
-    const activeKeys = new Set(activeMembers.map(m => `${m.device_pk}_${m.tunnel_id}`))
+    const activeKeys = new Set(activeMembers.map((m) => `${m.device_pk}_${m.tunnel_id}`))
     const modeFilter = activeTab === 'publishers' ? 'P' : 'S'
-    return group.members.filter(m => {
+    return group.members.filter((m) => {
       const key = `${m.device_pk}_${m.tunnel_id}`
       if (!selectedSeriesKeys.has(key)) return false
       if (activeKeys.has(key)) return false
@@ -1433,7 +1708,10 @@ export function MulticastGroupDetailPage() {
         const rowTop = row.offsetTop
         const containerScroll = container.scrollTop
         const containerHeight = container.clientHeight
-        if (rowTop < containerScroll || rowTop > containerScroll + containerHeight - row.offsetHeight) {
+        if (
+          rowTop < containerScroll ||
+          rowTop > containerScroll + containerHeight - row.offsetHeight
+        ) {
           container.scrollTo({ top: Math.max(0, rowTop - 80), behavior: 'smooth' })
         }
       })
@@ -1469,35 +1747,53 @@ export function MulticastGroupDetailPage() {
     <>
       <td className="px-4 py-3 text-sm font-mono">
         {member.owner_pubkey ? (
-          <Link to={`/dz/users/${member.user_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+          <Link
+            to={`/dz/users/${member.user_pk}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
             {member.owner_pubkey.slice(0, 4)}..{member.owner_pubkey.slice(-4)}
           </Link>
-        ) : '—'}
+        ) : (
+          '—'
+        )}
       </td>
       <td className="px-4 py-3 text-sm font-mono">
         {member.node_pubkey ? (
-          <Link to={`/solana/gossip-nodes/${member.node_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+          <Link
+            to={`/solana/gossip-nodes/${member.node_pubkey}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
             {member.node_pubkey.slice(0, 4)}..{member.node_pubkey.slice(-4)}
           </Link>
-        ) : '—'}
+        ) : (
+          '—'
+        )}
       </td>
       <td className="px-4 py-3 text-sm">
         {member.device_pk ? (
-          <Link to={`/dz/devices/${member.device_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+          <Link
+            to={`/dz/devices/${member.device_pk}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+          >
             {member.device_code || member.device_pk.slice(0, 8)}
           </Link>
-        ) : '—'}
+        ) : (
+          '—'
+        )}
       </td>
       <td className="px-4 py-3 text-sm">
         {member.metro_pk ? (
-          <Link to={`/dz/metros/${member.metro_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+          <Link
+            to={`/dz/metros/${member.metro_pk}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
             {member.metro_name || member.metro_code}
           </Link>
-        ) : '—'}
+        ) : (
+          '—'
+        )}
       </td>
-      <td className="px-4 py-3 text-sm font-mono text-muted-foreground">
-        {member.dz_ip || '—'}
-      </td>
+      <td className="px-4 py-3 text-sm font-mono text-muted-foreground">{member.dz_ip || '—'}</td>
       <td className="px-4 py-3 text-sm tabular-nums text-right text-muted-foreground font-mono">
         {member.tunnel_id > 0 ? member.tunnel_id : '—'}
       </td>
@@ -1608,49 +1904,87 @@ export function MulticastGroupDetailPage() {
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('owner_pubkey')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('owner_pubkey')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('owner_pubkey')}
+                    >
                       Owner
                       <SortIcon field="owner_pubkey" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('node_pubkey')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('node_pubkey')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('node_pubkey')}
+                    >
                       Node
                       <SortIcon field="node_pubkey" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('device_code')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('device_code')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('device_code')}
+                    >
                       Device
                       <SortIcon field="device_code" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('metro_name')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('metro_name')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('metro_name')}
+                    >
                       Metro
                       <SortIcon field="metro_name" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('dz_ip')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('dz_ip')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('dz_ip')}
+                    >
                       DZ IP
                       <SortIcon field="dz_ip" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('tunnel_id')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('tunnel_id')}>
+                  <th
+                    className="px-4 py-3 font-medium text-right"
+                    aria-sort={sortAria('tunnel_id')}
+                  >
+                    <button
+                      className="inline-flex items-center gap-1 justify-end w-full"
+                      type="button"
+                      onClick={() => handleSort('tunnel_id')}
+                    >
                       Tunnel
                       <SortIcon field="tunnel_id" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('stake_sol')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('stake_sol')}>
+                  <th
+                    className="px-4 py-3 font-medium text-right"
+                    aria-sort={sortAria('stake_sol')}
+                  >
+                    <button
+                      className="inline-flex items-center gap-1 justify-end w-full"
+                      type="button"
+                      onClick={() => handleSort('stake_sol')}
+                    >
                       Stake
                       <SortIcon field="stake_sol" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('leader_schedule')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('leader_schedule')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('leader_schedule')}
+                    >
                       Leader Schedule
                       <SortIcon field="leader_schedule" />
                     </button>
@@ -1677,15 +2011,16 @@ export function MulticastGroupDetailPage() {
                 {activeMembers.map((member) => {
                   const memberSeriesKey = `${member.device_pk}_${member.tunnel_id}`
                   const isHovered = hoveredSeriesKey === memberSeriesKey
-                  const isSelected = selectedSeriesKeys.size > 0 && selectedSeriesKeys.has(memberSeriesKey)
+                  const isSelected =
+                    selectedSeriesKeys.size > 0 && selectedSeriesKeys.has(memberSeriesKey)
                   return (
-                  <tr
-                    key={member.user_pk}
-                    ref={isSelected && surfacedMembers.length === 0 ? selectedRowRef : undefined}
-                    className={`border-b border-border last:border-b-0 hover:bg-muted transition-colors ${isSelected ? 'bg-muted border-l-2 border-l-purple-500' : isHovered ? 'bg-muted' : ''}`}
-                  >
-                    {renderMemberCells(member)}
-                  </tr>
+                    <tr
+                      key={member.user_pk}
+                      ref={isSelected && surfacedMembers.length === 0 ? selectedRowRef : undefined}
+                      className={`border-b border-border last:border-b-0 hover:bg-muted transition-colors ${isSelected ? 'bg-muted border-l-2 border-l-purple-500' : isHovered ? 'bg-muted' : ''}`}
+                    >
+                      {renderMemberCells(member)}
+                    </tr>
                   )
                 })}
                 {!membersLoading && activeMembers.length === 0 && surfacedMembers.length === 0 && (
@@ -1712,14 +2047,18 @@ export function MulticastGroupDetailPage() {
 
         <div className="space-y-6">
           {/* Shred stats chart — only for groups with shred stats */}
-          {pk && group && group.has_shred_stats && activeTab === 'publishers' && group.members.length > 0 && (
-            <ShredStatsChart
-              groupCode={pk}
-              members={group.members}
-              onHoverMember={setHoveredSeriesKey}
-              onSelectMember={setSelectedSeriesKeys}
-            />
-          )}
+          {pk &&
+            group &&
+            group.has_shred_stats &&
+            activeTab === 'publishers' &&
+            group.members.length > 0 && (
+              <ShredStatsChart
+                groupCode={pk}
+                members={group.members}
+                onHoverMember={setHoveredSeriesKey}
+                onSelectMember={setSelectedSeriesKeys}
+              />
+            )}
 
           {/* Traffic chart — uses all members (not just current page) for series labels */}
           {pk && group && group.members.length > 0 && (

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -15,8 +15,8 @@ export function PageHeader({ icon: Icon, title, count, subtitle, actions }: Page
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-      <div className="flex items-center gap-3">
-        {Icon && <Icon className="h-6 w-6 text-muted-foreground" />}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        {Icon && <Icon className="h-6 w-6 text-muted-foreground shrink-0" />}
         <h1 className="text-2xl font-medium">{title}</h1>
         {count !== undefined && <span className="text-muted-foreground">({count})</span>}
         {subtitle}

--- a/web/src/components/pagination.tsx
+++ b/web/src/components/pagination.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 interface PaginationProps {
   total: number
@@ -9,7 +10,14 @@ interface PaginationProps {
   onPageSizeChange?: (size: number) => void
 }
 
-export function Pagination({ total, limit, offset, onOffsetChange, pageSizeOptions, onPageSizeChange }: PaginationProps) {
+export function Pagination({
+  total,
+  limit,
+  offset,
+  onOffsetChange,
+  pageSizeOptions,
+  onPageSizeChange,
+}: PaginationProps) {
   const currentPage = Math.floor(offset / limit) + 1
   const totalPages = Math.ceil(total / limit)
   const startItem = offset + 1
@@ -27,19 +35,21 @@ export function Pagination({ total, limit, offset, onOffsetChange, pageSizeOptio
   if (totalPages <= 1 && !hasPageSizeSelector) return null
 
   return (
-    <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+    <div className="flex flex-col sm:flex-row items-center justify-between px-4 py-3 border-t border-border">
       <div className="flex items-center gap-3 text-sm text-muted-foreground">
-        <span>Showing {startItem.toLocaleString()} - {endItem.toLocaleString()} of {total.toLocaleString()}</span>
+        <span>
+          Showing {startItem.toLocaleString()} - {endItem.toLocaleString()} of{' '}
+          {total.toLocaleString()}
+        </span>
         {hasPageSizeSelector && (
-          <select
-            value={limit}
-            onChange={(e) => onPageSizeChange(Number(e.target.value))}
-            className="bg-background border border-border rounded px-1.5 py-0.5 text-sm text-foreground"
-          >
-            {pageSizeOptions.map(size => (
-              <option key={size} value={size}>{size} / page</option>
-            ))}
-          </select>
+          <SmallDropdown
+            value={String(limit)}
+            options={pageSizeOptions.map((size) => ({
+              value: String(size),
+              label: `${size} / page`,
+            }))}
+            onChange={(v) => onPageSizeChange(Number(v))}
+          />
         )}
       </div>
       {totalPages > 1 && (

--- a/web/src/components/path-calculator-page.tsx
+++ b/web/src/components/path-calculator-page.tsx
@@ -1,17 +1,29 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
-import { Loader2, Route, AlertCircle, ArrowRight, Search, X, Copy, Check, ExternalLink, RotateCcw } from 'lucide-react'
+import {
+  Loader2,
+  Route,
+  AlertCircle,
+  ArrowRight,
+  ArrowDown,
+  Search,
+  X,
+  Copy,
+  Check,
+  ExternalLink,
+  RotateCcw,
+} from 'lucide-react'
 import { fetchISISTopology, fetchISISPaths } from '@/lib/api'
 import type { MultiPathResponse, SinglePath } from '@/lib/api'
 
 // Path colors matching the graph view
 const PATH_COLORS = [
-  '#22c55e',  // green - primary/shortest
-  '#3b82f6',  // blue - alternate 1
-  '#a855f7',  // purple - alternate 2
-  '#f97316',  // orange - alternate 3
-  '#06b6d4',  // cyan - alternate 4
+  '#22c55e', // green - primary/shortest
+  '#3b82f6', // blue - alternate 1
+  '#a855f7', // purple - alternate 2
+  '#f97316', // orange - alternate 3
+  '#06b6d4', // cyan - alternate 4
 ]
 
 interface DeviceOption {
@@ -42,20 +54,23 @@ function DeviceSearch({
   const filteredDevices = useMemo(() => {
     const query = search.toLowerCase()
     return devices
-      .filter(d => d.pk !== excludePK)
-      .filter(d => d.code.toLowerCase().includes(query))
+      .filter((d) => d.pk !== excludePK)
+      .filter((d) => d.code.toLowerCase().includes(query))
       .slice(0, 20)
   }, [devices, search, excludePK])
 
   return (
-    <div className="flex-1">
+    <div className="flex-1 w-full">
       <label className="block text-sm font-medium text-muted-foreground mb-2">{label}</label>
       <div className="relative">
         {value ? (
           <div className="flex items-center gap-2 px-3 py-2 border border-border rounded-md bg-card">
             <span className="font-mono text-sm flex-1">{value.code}</span>
             <button
-              onClick={() => { onChange(null); setSearch('') }}
+              onClick={() => {
+                onChange(null)
+                setSearch('')
+              }}
               className="p-1 hover:bg-muted rounded"
             >
               <X className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +83,10 @@ function DeviceSearch({
               <input
                 type="text"
                 value={search}
-                onChange={(e) => { setSearch(e.target.value); setIsOpen(true) }}
+                onChange={(e) => {
+                  setSearch(e.target.value)
+                  setIsOpen(true)
+                }}
                 onFocus={() => setIsOpen(true)}
                 placeholder={placeholder}
                 className="w-full pl-9 pr-3 py-2 border border-border rounded-md bg-card text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
@@ -76,7 +94,7 @@ function DeviceSearch({
             </div>
             {isOpen && search && filteredDevices.length > 0 && (
               <div className="absolute z-50 w-full mt-1 bg-card border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
-                {filteredDevices.map(device => (
+                {filteredDevices.map((device) => (
                   <button
                     key={device.pk}
                     onClick={() => {
@@ -87,7 +105,9 @@ function DeviceSearch({
                     className="w-full px-3 py-2 text-left hover:bg-muted flex items-center justify-between"
                   >
                     <span className="font-mono text-sm">{device.code}</span>
-                    <span className="text-xs text-muted-foreground capitalize">{device.deviceType}</span>
+                    <span className="text-xs text-muted-foreground capitalize">
+                      {device.deviceType}
+                    </span>
                   </button>
                 ))}
               </div>
@@ -118,7 +138,7 @@ function PathCard({
   const [copied, setCopied] = useState(false)
 
   const copyPath = () => {
-    const pathText = path.path.map(h => h.deviceCode).join(' → ')
+    const pathText = path.path.map((h) => h.deviceCode).join(' → ')
     navigator.clipboard.writeText(pathText)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
@@ -147,7 +167,10 @@ function PathCard({
           )}
         </div>
         <button
-          onClick={(e) => { e.stopPropagation(); copyPath() }}
+          onClick={(e) => {
+            e.stopPropagation()
+            copyPath()
+          }}
           className="p-1.5 hover:bg-muted rounded-md"
           title="Copy path"
         >
@@ -159,7 +182,7 @@ function PathCard({
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-4 mb-4 text-sm">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4 text-sm">
         <div>
           <span className="text-muted-foreground">Hops:</span>{' '}
           <span className="font-medium">{path.hopCount}</span>
@@ -172,7 +195,9 @@ function PathCard({
           <>
             <div>
               <span className="text-muted-foreground">Measured:</span>{' '}
-              <span className="font-medium text-primary">{path.measuredLatencyMs.toFixed(2)}ms</span>
+              <span className="font-medium text-primary">
+                {path.measuredLatencyMs.toFixed(2)}ms
+              </span>
             </div>
             {path.totalSamples !== undefined && (
               <div>
@@ -184,35 +209,70 @@ function PathCard({
         )}
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-3">
         {path.path.map((hop, i) => (
-          <div key={hop.devicePK} className="flex items-center gap-2 text-sm">
-            <span className="w-5 text-muted-foreground">{i + 1}.</span>
-            <Link
-              to={`/dz/devices/${hop.devicePK}`}
-              onClick={(e) => e.stopPropagation()}
-              className="font-mono hover:text-primary flex items-center gap-1"
-            >
-              {hop.deviceCode}
-              <ExternalLink className="h-3 w-3 opacity-0 hover:opacity-100" />
-            </Link>
-            <div className="ml-auto flex items-center gap-2">
-              {hop.edgeMeasuredMs !== undefined && hop.edgeMeasuredMs > 0 && (
-                <span className="text-primary text-xs" title={`Measured RTT: ${hop.edgeMeasuredMs.toFixed(2)}ms (${hop.edgeSampleCount?.toLocaleString() ?? 0} samples)`}>
-                  {hop.edgeMeasuredMs.toFixed(1)}ms measured
-                </span>
-              )}
-              {hop.edgeLossPct !== undefined && hop.edgeLossPct > 0.1 && (
-                <span className={`text-xs ${hop.edgeLossPct > 1 ? 'text-red-500' : 'text-yellow-500'}`} title={`Packet loss: ${hop.edgeLossPct.toFixed(2)}%`}>
-                  {hop.edgeLossPct.toFixed(1)}% loss
-                </span>
-              )}
-              {hop.edgeMetric !== undefined && hop.edgeMetric > 0 && (
-                <span className="text-muted-foreground text-xs" title="ISIS metric (configured on router)">
-                  {(hop.edgeMetric / 1000).toFixed(1)}ms ISIS
-                </span>
-              )}
+          <div key={hop.devicePK} className="text-sm">
+            <div className="flex items-center gap-2">
+              <span className="w-5 shrink-0 text-muted-foreground">{i + 1}.</span>
+              <Link
+                to={`/dz/devices/${hop.devicePK}`}
+                onClick={(e) => e.stopPropagation()}
+                className="font-mono hover:text-primary flex items-center gap-1 min-w-0 break-all"
+              >
+                {hop.deviceCode}
+                <ExternalLink className="h-3 w-3 shrink-0 opacity-0 hover:opacity-100" />
+              </Link>
+              <div className="hidden sm:flex items-center gap-2 ml-auto shrink-0">
+                {hop.edgeMeasuredMs !== undefined && hop.edgeMeasuredMs > 0 && (
+                  <span
+                    className="text-primary text-xs"
+                    title={`Measured RTT: ${hop.edgeMeasuredMs.toFixed(2)}ms (${hop.edgeSampleCount?.toLocaleString() ?? 0} samples)`}
+                  >
+                    {hop.edgeMeasuredMs.toFixed(1)}ms meas.
+                  </span>
+                )}
+                {hop.edgeLossPct !== undefined && hop.edgeLossPct > 0.1 && (
+                  <span
+                    className={`text-xs ${hop.edgeLossPct > 1 ? 'text-red-500' : 'text-yellow-500'}`}
+                    title={`Packet loss: ${hop.edgeLossPct.toFixed(2)}%`}
+                  >
+                    {hop.edgeLossPct.toFixed(1)}% loss
+                  </span>
+                )}
+                {hop.edgeMetric !== undefined && hop.edgeMetric > 0 && (
+                  <span
+                    className="text-muted-foreground text-xs"
+                    title="ISIS metric (configured on router)"
+                  >
+                    {(hop.edgeMetric / 1000).toFixed(1)}ms ISIS
+                  </span>
+                )}
+              </div>
             </div>
+            {(hop.edgeMeasuredMs !== undefined && hop.edgeMeasuredMs > 0) ||
+            (hop.edgeLossPct !== undefined && hop.edgeLossPct > 0.1) ||
+            (hop.edgeMetric !== undefined && hop.edgeMetric > 0) ? (
+              <div className="sm:hidden flex items-center gap-2 pl-7 mt-0.5 text-xs">
+                {hop.edgeMeasuredMs !== undefined && hop.edgeMeasuredMs > 0 && (
+                  <span
+                    className="text-primary"
+                    title={`Measured RTT: ${hop.edgeMeasuredMs.toFixed(2)}ms`}
+                  >
+                    {hop.edgeMeasuredMs.toFixed(1)}ms meas.
+                  </span>
+                )}
+                {hop.edgeLossPct !== undefined && hop.edgeLossPct > 0.1 && (
+                  <span className={hop.edgeLossPct > 1 ? 'text-red-500' : 'text-yellow-500'}>
+                    {hop.edgeLossPct.toFixed(1)}% loss
+                  </span>
+                )}
+                {hop.edgeMetric !== undefined && hop.edgeMetric > 0 && (
+                  <span className="text-muted-foreground">
+                    {(hop.edgeMetric / 1000).toFixed(1)}ms ISIS
+                  </span>
+                )}
+              </div>
+            ) : null}
           </div>
         ))}
       </div>
@@ -237,12 +297,14 @@ export function PathCalculatorPage() {
   // Convert topology nodes to device options
   const devices: DeviceOption[] = useMemo(() => {
     if (!topology?.nodes) return []
-    return topology.nodes.map(n => ({
-      pk: n.data.id,
-      code: n.data.label,
-      status: n.data.status,
-      deviceType: n.data.deviceType,
-    })).sort((a, b) => a.code.localeCompare(b.code))
+    return topology.nodes
+      .map((n) => ({
+        pk: n.data.id,
+        code: n.data.label,
+        status: n.data.status,
+        deviceType: n.data.deviceType,
+      }))
+      .sort((a, b) => a.code.localeCompare(b.code))
   }, [topology])
 
   // Initialize from URL params once devices are loaded
@@ -253,11 +315,11 @@ export function PathCalculatorPage() {
     const toParam = searchParams.get('to')
 
     if (fromParam) {
-      const device = devices.find(d => d.pk === fromParam || d.code === fromParam)
+      const device = devices.find((d) => d.pk === fromParam || d.code === fromParam)
       if (device) setSourceDevice(device)
     }
     if (toParam) {
-      const device = devices.find(d => d.pk === toParam || d.code === toParam)
+      const device = devices.find((d) => d.pk === toParam || d.code === toParam)
       if (device) setTargetDevice(device)
     }
 
@@ -336,7 +398,7 @@ export function PathCalculatorPage() {
 
         {/* Device Selection */}
         <div className="bg-card border border-border rounded-lg p-6 mb-6">
-          <div className="flex items-end gap-4">
+          <div className="flex items-end gap-4 flex-col sm:flex-row">
             <DeviceSearch
               label="Source Device"
               placeholder="Search source..."
@@ -346,8 +408,9 @@ export function PathCalculatorPage() {
               excludePK={targetDevice?.pk}
             />
 
-            <div className="pb-2">
-              <ArrowRight className="h-5 w-5 text-muted-foreground" />
+            <div className="self-center sm:self-auto sm:pb-2">
+              <ArrowRight className="hidden sm:block h-5 w-5 text-muted-foreground" />
+              <ArrowDown className="block sm:hidden h-5 w-5 text-muted-foreground" />
             </div>
 
             <DeviceSearch
@@ -362,7 +425,7 @@ export function PathCalculatorPage() {
             {(sourceDevice || targetDevice) && (
               <button
                 onClick={resetSelection}
-                className="pb-2 p-2 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
+                className="hidden md:block pb-2 p-2 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
                 title="Reset selection"
               >
                 <RotateCcw className="h-5 w-5" />
@@ -371,7 +434,7 @@ export function PathCalculatorPage() {
           </div>
 
           {sourceDevice && targetDevice && (
-            <div className="mt-4 pt-4 border-t border-border">
+            <div className="mt-4 pt-4 border-t border-border flex items-center justify-between md:justify-start">
               <Link
                 to={`/topology/graph?path_source=${sourceDevice.pk}&path_target=${targetDevice.pk}`}
                 className="text-sm text-primary hover:underline flex items-center gap-1"
@@ -379,6 +442,13 @@ export function PathCalculatorPage() {
                 View in graph
                 <ExternalLink className="h-3 w-3" />
               </Link>
+              <button
+                onClick={resetSelection}
+                className="md:hidden p-2 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
+                title="Reset selection"
+              >
+                <RotateCcw className="h-5 w-5" />
+              </button>
             </div>
           )}
         </div>
@@ -429,13 +499,17 @@ export function PathCalculatorPage() {
           </div>
         )}
 
-        {sourceDevice && targetDevice && !pathsLoading && !pathsResult?.error && paths.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            <Route className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p>No paths found between these devices.</p>
-            <p className="text-sm mt-2">They may not be connected in the ISIS topology.</p>
-          </div>
-        )}
+        {sourceDevice &&
+          targetDevice &&
+          !pathsLoading &&
+          !pathsResult?.error &&
+          paths.length === 0 && (
+            <div className="text-center py-12 text-muted-foreground">
+              <Route className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>No paths found between these devices.</p>
+              <p className="text-sm mt-2">They may not be connected in the ISIS topology.</p>
+            </div>
+          )}
       </div>
     </div>
   )

--- a/web/src/components/path-latency-page.tsx
+++ b/web/src/components/path-latency-page.tsx
@@ -1,19 +1,47 @@
 import { useMemo, useCallback, useState, useRef, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router-dom'
-import { Loader2, Route, Download, ArrowRight, ChevronDown, X, Search, MapPin, Filter, Zap, Globe, TrendingUp, Activity } from 'lucide-react'
-import { fetchMetroConnectivity, fetchMetroPathLatency, fetchMetroPathDetail, fetchFieldValues } from '@/lib/api'
-import type { MetroPathLatency, MetroPathDetailResponse, MetroPathDetailHop, PathOptimizeMode } from '@/lib/api'
+import {
+  Loader2,
+  Route,
+  Download,
+  ArrowRight,
+  ChevronDown,
+  X,
+  Search,
+  MapPin,
+  Filter,
+  Zap,
+  Globe,
+  TrendingUp,
+  Activity,
+} from 'lucide-react'
+import {
+  fetchMetroConnectivity,
+  fetchMetroPathLatency,
+  fetchMetroPathDetail,
+  fetchFieldValues,
+} from '@/lib/api'
+import type {
+  MetroPathLatency,
+  MetroPathDetailResponse,
+  MetroPathDetailHop,
+  PathOptimizeMode,
+} from '@/lib/api'
 import { ErrorState } from '@/components/ui/error-state'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
 import { PageHeader } from '@/components/page-header'
 import { cn } from '@/lib/utils'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 const DEBOUNCE_MS = 150
 
 function parseMetroFilters(searchParam: string): string[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
 }
 
 function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) {
@@ -38,7 +66,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
   const filteredValues = useMemo(() => {
     if (!metroValues) return []
     if (!query) return metroValues
-    return metroValues.filter(v => v.toLowerCase().includes(query.toLowerCase()))
+    return metroValues.filter((v) => v.toLowerCase().includes(query.toLowerCase()))
   }, [metroValues, query])
 
   const items = isFocused ? filteredValues : []
@@ -47,38 +75,51 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
     setSelectedIndex(-1)
   }, [debouncedQuery])
 
-  const commit = useCallback((value: string) => {
-    onCommit(value)
-    setQuery('')
-    inputRef.current?.focus()
-  }, [onCommit])
+  const commit = useCallback(
+    (value: string) => {
+      onCommit(value)
+      setQuery('')
+      inputRef.current?.focus()
+    },
+    [onCommit],
+  )
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const isDropdownOpen = isFocused && items.length > 0
-    switch (e.key) {
-      case 'ArrowDown':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.min(prev + 1, items.length - 1)) }
-        break
-      case 'ArrowUp':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.max(prev - 1, -1)) }
-        break
-      case 'Enter': {
-        e.preventDefault()
-        const idx = selectedIndex >= 0 ? selectedIndex : 0
-        if (idx < items.length) commit(items[idx])
-        break
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const isDropdownOpen = isFocused && items.length > 0
+      switch (e.key) {
+        case 'ArrowDown':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1))
+          }
+          break
+        case 'ArrowUp':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.max(prev - 1, -1))
+          }
+          break
+        case 'Enter': {
+          e.preventDefault()
+          const idx = selectedIndex >= 0 ? selectedIndex : 0
+          if (idx < items.length) commit(items[idx])
+          break
+        }
+        case 'Escape':
+          e.preventDefault()
+          setQuery('')
+          inputRef.current?.blur()
+          break
       }
-      case 'Escape':
-        e.preventDefault()
-        setQuery('')
-        inputRef.current?.blur()
-        break
-    }
-  }, [items, selectedIndex, commit, isFocused])
+    },
+    [items, selectedIndex, commit, isFocused],
+  )
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setIsFocused(false)
+      if (containerRef.current && !containerRef.current.contains(e.target as Node))
+        setIsFocused(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -88,7 +129,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
 
   return (
     <div ref={containerRef} className="relative">
-      <div className="flex items-center gap-1.5 px-2 py-1 text-xs border border-border rounded-md bg-background hover:bg-muted/50 focus-within:ring-1 focus-within:ring-ring transition-colors">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted/50 focus-within:ring-1 focus-within:ring-ring transition-colors">
         <Search className="h-3 w-3 text-muted-foreground flex-shrink-0" />
         <input
           ref={inputRef}
@@ -98,7 +139,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
           onKeyDown={handleKeyDown}
           onFocus={() => setIsFocused(true)}
           placeholder="Filter by metro..."
-          className="w-28 bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-xs"
+          className="w-42 bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-xs"
         />
         {isLoading && <Loader2 className="h-3 w-3 text-muted-foreground animate-spin" />}
       </div>
@@ -117,7 +158,7 @@ function MetroInlineFilter({ onCommit }: { onCommit: (metro: string) => void }) 
               onClick={() => commit(value)}
               className={cn(
                 'w-full flex items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted transition-colors',
-                index === selectedIndex && 'bg-muted'
+                index === selectedIndex && 'bg-muted',
               )}
             >
               <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
@@ -193,14 +234,20 @@ function PathLatencyCell({
       className={cn(
         'w-full h-full flex flex-col items-center justify-center gap-0.5 px-1 transition-colors cursor-pointer',
         TIER_CELL[tier],
-        isSelected && 'ring-2 ring-primary ring-inset'
+        isSelected && 'ring-2 ring-primary ring-inset',
       )}
       title={`${pathLatency.fromMetroCode} → ${pathLatency.toMetroCode}: ${pathLatency.pathLatencyMs.toFixed(1)}ms (${pathLatency.hopCount} hops)${hasInternet ? ` vs Internet ${pathLatency.internetLatencyMs.toFixed(1)}ms` : ''}`}
     >
       {hasInternet && pct !== null ? (
         <>
-          <span className={cn('text-[11px] font-semibold leading-none tabular-nums', TIER_PCT_TEXT[tier])}>
-            {pct > 0 ? '+' : ''}{pct.toFixed(0)}%
+          <span
+            className={cn(
+              'text-[11px] font-semibold leading-none tabular-nums',
+              TIER_PCT_TEXT[tier],
+            )}
+          >
+            {pct > 0 ? '+' : ''}
+            {pct.toFixed(0)}%
           </span>
           <span className="text-[10px] text-muted-foreground leading-none tabular-nums">
             {pathLatency.pathLatencyMs.toFixed(0)}ms
@@ -232,13 +279,13 @@ function PathStepper({ hops }: { hops: MetroPathDetailHop[] }) {
           <div key={idx} className="flex items-stretch gap-3">
             {/* Timeline rail */}
             <div className="flex flex-col items-center w-5 flex-shrink-0">
-              <div className={cn(
-                'w-2.5 h-2.5 rounded-full flex-shrink-0 ring-2 ring-background mt-1',
-                idx === 0 ? 'bg-primary' : isLast ? 'bg-primary' : 'bg-muted-foreground/60'
-              )} />
-              {!isLast && (
-                <div className="w-px flex-1 bg-border min-h-[32px]" />
-              )}
+              <div
+                className={cn(
+                  'w-2.5 h-2.5 rounded-full flex-shrink-0 ring-2 ring-background mt-1',
+                  idx === 0 ? 'bg-primary' : isLast ? 'bg-primary' : 'bg-muted-foreground/60',
+                )}
+              />
+              {!isLast && <div className="w-px flex-1 bg-border min-h-[32px]" />}
             </div>
 
             {/* Content */}
@@ -270,7 +317,17 @@ function PathStepper({ hops }: { hops: MetroPathDetailHop[] }) {
 }
 
 // Latency comparison bar
-function LatencyBar({ label, ms, maxMs, color }: { label: string; ms: number; maxMs: number; color: string }) {
+function LatencyBar({
+  label,
+  ms,
+  maxMs,
+  color,
+}: {
+  label: string
+  ms: number
+  maxMs: number
+  color: string
+}) {
   const pct = Math.max(5, (ms / maxMs) * 100)
   return (
     <div className="space-y-1">
@@ -337,11 +394,14 @@ function PathLatencyDetail({
             <div className="flex items-center justify-between">
               <span className="text-xs text-muted-foreground">DZ vs Internet</span>
               <span className={cn('text-xl font-bold tabular-nums', TIER_PCT_TEXT[tier])}>
-                {pct > 0 ? '+' : ''}{pct.toFixed(1)}%
+                {pct > 0 ? '+' : ''}
+                {pct.toFixed(1)}%
               </span>
             </div>
             <div className={cn('text-xs mt-0.5', TIER_PCT_TEXT[tier])}>
-              {pct > 0 ? `${pct.toFixed(1)}% faster than internet` : `${Math.abs(pct).toFixed(1)}% slower than internet`}
+              {pct > 0
+                ? `${pct.toFixed(1)}% faster than internet`
+                : `${Math.abs(pct).toFixed(1)}% slower than internet`}
             </div>
           </div>
         )}
@@ -349,26 +409,45 @@ function PathLatencyDetail({
         {/* Stats grid */}
         <div className="grid grid-cols-3 gap-2 px-4 mt-3">
           <div className="bg-muted/50 rounded-lg p-2.5">
-            <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">DZ Latency</div>
-            <div className="text-lg font-bold tabular-nums">{pathLatency.pathLatencyMs.toFixed(1)}<span className="text-xs font-normal ml-0.5">ms</span></div>
+            <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+              DZ Latency
+            </div>
+            <div className="text-lg font-bold tabular-nums">
+              {pathLatency.pathLatencyMs.toFixed(1)}
+              <span className="text-xs font-normal ml-0.5">ms</span>
+            </div>
           </div>
           <div className="bg-muted/50 rounded-lg p-2.5">
-            <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Hops</div>
+            <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+              Hops
+            </div>
             <div className="text-lg font-bold tabular-nums">{pathLatency.hopCount}</div>
           </div>
           {pathLatency.bottleneckBwGbps > 0 ? (
             <div className="bg-muted/50 rounded-lg p-2.5">
-              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Bottleneck</div>
-              <div className="text-lg font-bold tabular-nums">{pathLatency.bottleneckBwGbps.toFixed(0)}<span className="text-xs font-normal ml-0.5">Gbps</span></div>
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Bottleneck
+              </div>
+              <div className="text-lg font-bold tabular-nums">
+                {pathLatency.bottleneckBwGbps.toFixed(0)}
+                <span className="text-xs font-normal ml-0.5">Gbps</span>
+              </div>
             </div>
           ) : hasInternet ? (
             <div className="bg-muted/50 rounded-lg p-2.5">
-              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Internet</div>
-              <div className="text-lg font-bold tabular-nums">{pathLatency.internetLatencyMs.toFixed(1)}<span className="text-xs font-normal ml-0.5">ms</span></div>
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Internet
+              </div>
+              <div className="text-lg font-bold tabular-nums">
+                {pathLatency.internetLatencyMs.toFixed(1)}
+                <span className="text-xs font-normal ml-0.5">ms</span>
+              </div>
             </div>
           ) : (
             <div className="bg-muted/50 rounded-lg p-2.5 opacity-40">
-              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Internet</div>
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Internet
+              </div>
               <div className="text-sm text-muted-foreground">—</div>
             </div>
           )}
@@ -377,15 +456,29 @@ function PathLatencyDetail({
         {/* Latency comparison bars */}
         {hasInternet && (
           <div className="px-4 mt-4 space-y-2.5">
-            <div className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">Latency Comparison</div>
-            <LatencyBar label="DZ Network" ms={pathLatency.pathLatencyMs} maxMs={maxMs} color="bg-blue-500" />
-            <LatencyBar label="Internet" ms={pathLatency.internetLatencyMs} maxMs={maxMs} color="bg-muted-foreground/40" />
+            <div className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">
+              Latency Comparison
+            </div>
+            <LatencyBar
+              label="DZ Network"
+              ms={pathLatency.pathLatencyMs}
+              maxMs={maxMs}
+              color="bg-blue-500"
+            />
+            <LatencyBar
+              label="Internet"
+              ms={pathLatency.internetLatencyMs}
+              maxMs={maxMs}
+              color="bg-muted-foreground/40"
+            />
           </div>
         )}
 
         {/* Path breakdown */}
         <div className="px-4 mt-4 mb-4">
-          <div className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mb-3">Path Breakdown</div>
+          <div className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mb-3">
+            Path Breakdown
+          </div>
           {isLoadingDetail ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -420,8 +513,12 @@ function SummaryCard({
         <Icon className="h-3.5 w-3.5 text-muted-foreground" />
       </div>
       <div className="min-w-0">
-        <div className="text-[10px] text-muted-foreground uppercase tracking-wider leading-none mb-1">{label}</div>
-        <div className={cn('text-base font-semibold tabular-nums leading-none', className)}>{value}</div>
+        <div className="text-[10px] text-muted-foreground uppercase tracking-wider leading-none mb-1">
+          {label}
+        </div>
+        <div className={cn('text-base font-semibold tabular-nums leading-none', className)}>
+          {value}
+        </div>
       </div>
     </div>
   )
@@ -443,31 +540,37 @@ export function PathLatencyPage() {
     return parseMetroFilters(searchParams.get('metros') || '')
   }, [searchParams])
 
-  const addMetroFilter = useCallback((metro: string) => {
-    setSearchParams(prev => {
-      const current = parseMetroFilters(prev.get('metros') || '')
-      if (!current.includes(metro)) {
-        prev.set('metros', [...current, metro].join(','))
-      }
-      return prev
-    })
-  }, [setSearchParams])
+  const addMetroFilter = useCallback(
+    (metro: string) => {
+      setSearchParams((prev) => {
+        const current = parseMetroFilters(prev.get('metros') || '')
+        if (!current.includes(metro)) {
+          prev.set('metros', [...current, metro].join(','))
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
-  const removeMetroFilter = useCallback((metro: string) => {
-    setSearchParams(prev => {
-      const current = parseMetroFilters(prev.get('metros') || '')
-      const newFilters = current.filter(m => m !== metro)
-      if (newFilters.length === 0) {
-        prev.delete('metros')
-      } else {
-        prev.set('metros', newFilters.join(','))
-      }
-      return prev
-    })
-  }, [setSearchParams])
+  const removeMetroFilter = useCallback(
+    (metro: string) => {
+      setSearchParams((prev) => {
+        const current = parseMetroFilters(prev.get('metros') || '')
+        const newFilters = current.filter((m) => m !== metro)
+        if (newFilters.length === 0) {
+          prev.delete('metros')
+        } else {
+          prev.set('metros', newFilters.join(','))
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       prev.delete('metros')
       return prev
     })
@@ -475,7 +578,12 @@ export function PathLatencyPage() {
 
   const queryClient = useQueryClient()
 
-  const { data: connectivityData, isLoading: connectivityLoading, error: connectivityError, isFetching: connectivityFetching } = useQuery({
+  const {
+    data: connectivityData,
+    isLoading: connectivityLoading,
+    error: connectivityError,
+    isFetching: connectivityFetching,
+  } = useQuery({
     queryKey: ['metro-connectivity'],
     queryFn: fetchMetroConnectivity,
     staleTime: 60000,
@@ -486,25 +594,28 @@ export function PathLatencyPage() {
     if (!fromCodeParam || !toCodeParam || !connectivityData) return null
     const fromUpper = fromCodeParam.toUpperCase()
     const toUpper = toCodeParam.toUpperCase()
-    const fromMetro = connectivityData.metros.find(m => m.code.toUpperCase() === fromUpper)
-    const toMetro = connectivityData.metros.find(m => m.code.toUpperCase() === toUpper)
+    const fromMetro = connectivityData.metros.find((m) => m.code.toUpperCase() === fromUpper)
+    const toMetro = connectivityData.metros.find((m) => m.code.toUpperCase() === toUpper)
     if (!fromMetro || !toMetro) return null
     return { from: fromMetro.pk, to: toMetro.pk }
   }, [fromCodeParam, toCodeParam, connectivityData])
 
-  const setSelectedCell = useCallback((cell: { from: string; to: string } | null, fromCode?: string, toCode?: string) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      if (cell && fromCode && toCode) {
-        next.set('from', fromCode.toUpperCase())
-        next.set('to', toCode.toUpperCase())
-      } else {
-        next.delete('from')
-        next.delete('to')
-      }
-      return next
-    })
-  }, [setSearchParams])
+  const setSelectedCell = useCallback(
+    (cell: { from: string; to: string } | null, fromCode?: string, toCode?: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (cell && fromCode && toCode) {
+          next.set('from', fromCode.toUpperCase())
+          next.set('to', toCode.toUpperCase())
+        } else {
+          next.delete('from')
+          next.delete('to')
+        }
+        return next
+      })
+    },
+    [setSearchParams],
+  )
 
   const showLoading = useDelayedLoading(connectivityLoading)
 
@@ -513,32 +624,38 @@ export function PathLatencyPage() {
   const dragStartX = useRef(0)
   const dragStartWidth = useRef(0)
 
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    isDragging.current = true
-    dragStartX.current = e.clientX
-    dragStartWidth.current = panelWidth
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      isDragging.current = true
+      dragStartX.current = e.clientX
+      dragStartWidth.current = panelWidth
 
-    const onMove = (ev: MouseEvent) => {
-      if (!isDragging.current) return
-      const delta = dragStartX.current - ev.clientX
-      const newWidth = Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, dragStartWidth.current + delta))
-      setPanelWidth(newWidth)
-    }
+      const onMove = (ev: MouseEvent) => {
+        if (!isDragging.current) return
+        const delta = dragStartX.current - ev.clientX
+        const newWidth = Math.min(
+          PANEL_MAX_WIDTH,
+          Math.max(PANEL_MIN_WIDTH, dragStartWidth.current + delta),
+        )
+        setPanelWidth(newWidth)
+      }
 
-    const onUp = () => {
-      isDragging.current = false
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
+      const onUp = () => {
+        isDragging.current = false
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
 
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
-  }, [panelWidth])
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    },
+    [panelWidth],
+  )
 
   const { data: pathLatencyData, isLoading: pathLatencyLoading } = useQuery({
     queryKey: ['metro-path-latency', optimizeMode],
@@ -561,10 +678,19 @@ export function PathLatencyPage() {
   }, [selectedCell, pathLatencyMap])
 
   const { data: pathDetailData, isLoading: pathDetailLoading } = useQuery({
-    queryKey: ['metro-path-detail', selectedPathLatency?.fromMetroCode, selectedPathLatency?.toMetroCode, optimizeMode],
+    queryKey: [
+      'metro-path-detail',
+      selectedPathLatency?.fromMetroCode,
+      selectedPathLatency?.toMetroCode,
+      optimizeMode,
+    ],
     queryFn: () => {
       if (!selectedPathLatency) return Promise.resolve(null)
-      return fetchMetroPathDetail(selectedPathLatency.fromMetroCode, selectedPathLatency.toMetroCode, optimizeMode)
+      return fetchMetroPathDetail(
+        selectedPathLatency.fromMetroCode,
+        selectedPathLatency.toMetroCode,
+        optimizeMode,
+      )
     },
     staleTime: 60000,
     enabled: selectedPathLatency !== null,
@@ -573,16 +699,24 @@ export function PathLatencyPage() {
   const metros = useMemo(() => {
     if (!connectivityData) return []
     if (metroFilters.length === 0) return connectivityData.metros
-    return connectivityData.metros.filter(m =>
-      metroFilters.some(f => m.code.toLowerCase() === f.toLowerCase())
+    return connectivityData.metros.filter((m) =>
+      metroFilters.some((f) => m.code.toLowerCase() === f.toLowerCase()),
     )
   }, [connectivityData, metroFilters])
 
   const handleExport = () => {
     if (!pathLatencyData) return
 
-    const headers = ['From Metro', 'To Metro', 'Path Latency (ms)', 'Hop Count', 'Internet Latency (ms)', 'Improvement (%)', 'Bottleneck BW (Gbps)']
-    const rows = pathLatencyData.paths.map(pl => [
+    const headers = [
+      'From Metro',
+      'To Metro',
+      'Path Latency (ms)',
+      'Hop Count',
+      'Internet Latency (ms)',
+      'Improvement (%)',
+      'Bottleneck BW (Gbps)',
+    ]
+    const rows = pathLatencyData.paths.map((pl) => [
       pl.fromMetroCode,
       pl.toMetroCode,
       pl.pathLatencyMs.toFixed(1),
@@ -592,7 +726,7 @@ export function PathLatencyPage() {
       pl.bottleneckBwGbps > 0 ? pl.bottleneckBwGbps.toFixed(1) : '-',
     ])
 
-    const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n')
+    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n')
     const blob = new Blob([csv], { type: 'text/csv' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -611,7 +745,9 @@ export function PathLatencyPage() {
   }
 
   if (connectivityError || connectivityData?.error) {
-    const errorMessage = connectivityData?.error || (connectivityError instanceof Error ? connectivityError.message : 'Unknown error')
+    const errorMessage =
+      connectivityData?.error ||
+      (connectivityError instanceof Error ? connectivityError.message : 'Unknown error')
     return (
       <div className="flex-1 flex items-center justify-center bg-background">
         <ErrorState
@@ -645,27 +781,21 @@ export function PathLatencyPage() {
           icon={Route}
           title="Path Latency"
           actions={
-            <div className="flex items-center gap-3">
-              <div className="relative">
-                <select
-                  value={optimizeMode}
-                  onChange={(e) => {
-                    const newMode = e.target.value as PathOptimizeMode
-                    setSearchParams({ optimize: newMode })
-                  }}
-                  className="appearance-none border border-border bg-background hover:bg-muted/50 rounded-md px-3 py-1.5 pr-8 text-sm cursor-pointer transition-colors"
-                >
-                  <option value="latency">Optimize: Latency</option>
-                  <option value="hops">Optimize: Hops</option>
-                  <option value="bandwidth">Optimize: Bandwidth</option>
-                </select>
-                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-              </div>
+            <div className="flex flex-col xs:flex-row xs:items-center gap-3">
+              <SmallDropdown
+                value={optimizeMode}
+                options={[
+                  { value: 'latency', label: 'Optimize: Latency' },
+                  { value: 'hops', label: 'Optimize: Hops' },
+                  { value: 'bandwidth', label: 'Optimize: Bandwidth' },
+                ]}
+                onChange={(v) => setSearchParams({ optimize: v })}
+              />
               <button
                 onClick={handleExport}
-                className="flex items-center gap-2 px-3 py-1.5 text-sm border border-border bg-background hover:bg-muted/50 rounded-md transition-colors"
+                className="flex items-center justify-center gap-2 px-3 py-1.5 text-xs border border-border bg-background hover:bg-muted/50 rounded-md transition-colors"
               >
-                <Download className="h-4 w-4" />
+                <Download className="h-3 w-3" />
                 Export CSV
               </button>
             </div>
@@ -678,14 +808,26 @@ export function PathLatencyPage() {
 
         {/* Summary cards */}
         {summary ? (
-          <div className="grid grid-cols-4 gap-2 mt-4">
-            <SummaryCard icon={Activity} label="Metro Pairs" value={summary.totalPairs.toString()} />
-            <SummaryCard icon={Globe} label="With Internet" value={summary.pairsWithInternet.toString()} />
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 mt-4">
+            <SummaryCard
+              icon={Activity}
+              label="Metro Pairs"
+              value={summary.totalPairs.toString()}
+            />
+            <SummaryCard
+              icon={Globe}
+              label="With Internet"
+              value={summary.pairsWithInternet.toString()}
+            />
             <SummaryCard
               icon={TrendingUp}
               label="Avg Improvement"
               value={`${summary.avgImprovementPct >= 0 ? '+' : ''}${summary.avgImprovementPct.toFixed(1)}%`}
-              className={summary.avgImprovementPct >= 0 ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}
+              className={
+                summary.avgImprovementPct >= 0
+                  ? 'text-green-600 dark:text-green-400'
+                  : 'text-red-600 dark:text-red-400'
+              }
             />
             <SummaryCard
               icon={Zap}
@@ -696,8 +838,11 @@ export function PathLatencyPage() {
           </div>
         ) : pathLatencyLoading ? (
           <div className="grid grid-cols-4 gap-2 mt-4">
-            {[0, 1, 2, 3].map(i => (
-              <div key={i} className="bg-card border border-border rounded-lg px-3 py-2.5 h-[56px] animate-pulse" />
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-lg px-3 py-2.5 h-[56px] animate-pulse"
+              />
             ))}
           </div>
         ) : null}
@@ -730,7 +875,7 @@ export function PathLatencyPage() {
       </div>
 
       {/* Matrix + detail panel */}
-      <div className="flex-1 flex gap-0 min-h-0 border-t border-border">
+      <div className="flex-1 flex gap-0 min-h-0 border-t border-border relative">
         {/* Scrollable matrix */}
         <div className="flex-1 overflow-auto min-w-0 p-4">
           <table className="border-separate border-spacing-0">
@@ -739,7 +884,7 @@ export function PathLatencyPage() {
                 {/* Top-left corner */}
                 <th className="relative bg-muted sticky top-0 left-0 z-30 min-w-[52px] shadow-[inset_0_0_0_1px_hsl(var(--border))] before:absolute before:-top-1 before:left-0 before:right-0 before:h-1 before:bg-muted [backface-visibility:hidden] [transform:translateZ(0)]" />
 
-                {metros.map(metro => (
+                {metros.map((metro) => (
                   <th
                     key={`col-${metro.pk}`}
                     className="relative bg-muted px-1 py-2 text-xs font-medium text-center sticky top-0 z-20 min-w-[52px] max-w-[64px] shadow-[inset_0_0_0_1px_hsl(var(--border))] before:absolute before:-top-1 before:left-0 before:right-0 before:h-1 before:bg-muted [backface-visibility:hidden] [transform:translateZ(0)]"
@@ -753,7 +898,7 @@ export function PathLatencyPage() {
               </tr>
             </thead>
             <tbody>
-              {metros.map(fromMetro => (
+              {metros.map((fromMetro) => (
                 <tr key={`row-${fromMetro.pk}`}>
                   <th
                     className="bg-muted px-2 py-1 text-[11px] font-medium text-right sticky left-0 z-10 whitespace-nowrap shadow-[inset_0_0_0_1px_hsl(var(--border))] [backface-visibility:hidden] [transform:translateZ(0)]"
@@ -762,10 +907,13 @@ export function PathLatencyPage() {
                     {fromMetro.code}
                   </th>
 
-                  {metros.map(toMetro => {
+                  {metros.map((toMetro) => {
                     const isSame = fromMetro.pk === toMetro.pk
-                    const pathLatency = isSame ? null : pathLatencyMap.get(`${fromMetro.pk}:${toMetro.pk}`) ?? null
-                    const isSelected = selectedCell?.from === fromMetro.pk && selectedCell?.to === toMetro.pk
+                    const pathLatency = isSame
+                      ? null
+                      : (pathLatencyMap.get(`${fromMetro.pk}:${toMetro.pk}`) ?? null)
+                    const isSelected =
+                      selectedCell?.from === fromMetro.pk && selectedCell?.to === toMetro.pk
 
                     return (
                       <td
@@ -779,7 +927,11 @@ export function PathLatencyPage() {
                               if (isSelected) {
                                 setSelectedCell(null)
                               } else {
-                                setSelectedCell({ from: fromMetro.pk, to: toMetro.pk }, fromMetro.code, toMetro.code)
+                                setSelectedCell(
+                                  { from: fromMetro.pk, to: toMetro.pk },
+                                  fromMetro.code,
+                                  toMetro.code,
+                                )
                               }
                             }
                           }}
@@ -797,17 +949,22 @@ export function PathLatencyPage() {
         {/* Detail panel */}
         {selectedPathLatency && selectedCell && (
           <>
-            {/* Drag handle */}
+            {/* Mobile backdrop */}
+            <div
+              className="fixed inset-0 z-40 bg-black/50 md:hidden"
+              onClick={() => setSelectedCell(null)}
+            />
+            {/* Drag handle — desktop only */}
             <div
               onMouseDown={handleResizeStart}
-              className="w-1 flex-shrink-0 cursor-col-resize bg-border hover:bg-primary/40 transition-colors group relative"
+              className="hidden md:block w-1 shrink-0 cursor-col-resize bg-border hover:bg-primary/40 transition-colors group relative"
               title="Drag to resize"
             >
               <div className="absolute inset-y-0 -left-1 -right-1" />
             </div>
             <div
-              className="flex-shrink-0 border-l border-border bg-card flex flex-col overflow-hidden"
-              style={{ width: panelWidth }}
+              className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[calc(100%-2rem)] max-h-[85vh] rounded-xl overflow-y-auto md:static md:top-auto md:left-auto md:translate-x-0 md:translate-y-0 md:z-auto md:w-auto md:max-h-none md:rounded-none md:overflow-hidden md:shrink-0 border-l border-border bg-card flex flex-col"
+              style={window.innerWidth >= 768 ? { width: panelWidth } : undefined}
             >
               <PathLatencyDetail
                 fromCode={selectedPathLatency.fromMetroCode}
@@ -823,31 +980,35 @@ export function PathLatencyPage() {
       </div>
 
       {/* Legend */}
-      <div className="px-6 py-3 border-t border-border bg-muted/20 flex-shrink-0">
-        <div className="flex items-center gap-6 text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">DZ vs Internet:</span>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-sm bg-red-100 dark:bg-red-950/60 border border-red-200 dark:border-red-900" />
-            <span>Slower (&lt;-10%)</span>
+      <div className="px-4 py-2 border-t border-border bg-muted/20 md:sticky md:bottom-0 md:z-10">
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">DZ vs Internet:</span>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm bg-red-100 dark:bg-red-950/60 border border-red-200 dark:border-red-900" />
+              <span>Slower (&lt;-10%)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900" />
+              <span>Similar (0 to -10%)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200 dark:border-emerald-900" />
+              <span>Faster (0 to +20%)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm bg-green-100 dark:bg-green-950/60 border border-green-200 dark:border-green-900" />
+              <span>Much faster (&gt;+20%)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm bg-muted/40 border border-border" />
+              <span>No internet data</span>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900" />
-            <span>Similar (0 to -10%)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-sm bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200 dark:border-emerald-900" />
-            <span>Faster (0 to +20%)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-sm bg-green-100 dark:bg-green-950/60 border border-green-200 dark:border-green-900" />
-            <span>Much faster (&gt;+20%)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-sm bg-muted/40 border border-border" />
-            <span>No internet data</span>
-          </div>
-          <div className="ml-auto text-[10px]">
-            Primary: improvement % — Secondary: latency ms
+          <div>
+            <div className="ml-auto text-[10px]">
+              Primary: improvement % — Secondary: latency ms
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/components/redundancy-report-page.tsx
+++ b/web/src/components/redundancy-report-page.tsx
@@ -1,9 +1,21 @@
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { Loader2, Shield, AlertTriangle, AlertCircle, Info, ExternalLink, ChevronDown, ChevronRight, Activity, Wifi } from 'lucide-react'
+import {
+  Loader2,
+  Shield,
+  AlertTriangle,
+  AlertCircle,
+  Info,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+  Activity,
+  Wifi,
+} from 'lucide-react'
 import { fetchRedundancyReport, fetchLinkHealth } from '@/lib/api'
 import type { RedundancyIssue, TopologyLinkHealth } from '@/lib/api'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 // Severity colors
 const SEVERITY_COLORS = {
@@ -102,23 +114,24 @@ function IssueRow({
           <Icon className={`h-4 w-4 ${severity.text}`} />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="font-medium">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <span className="font-medium break-all">
               {issue.entityType === 'link' ? (
                 <>
-                  {issue.entityCode} <span className="text-muted-foreground">↔</span> {issue.targetCode}
+                  {issue.entityCode} <span className="text-muted-foreground">↔</span>{' '}
+                  {issue.targetCode}
                 </>
               ) : (
                 issue.entityCode
               )}
             </span>
-            <span className={`text-xs px-2 py-0.5 rounded ${severity.bg} ${severity.text}`}>
+            <span
+              className={`text-xs px-2 py-0.5 rounded shrink-0 ${severity.bg} ${severity.text}`}
+            >
               {ISSUE_TYPE_LABELS[issue.type] || issue.type}
             </span>
           </div>
-          <div className="text-sm text-muted-foreground truncate">
-            {issue.description}
-          </div>
+          <div className="text-sm text-muted-foreground truncate">{issue.description}</div>
         </div>
         {isExpanded ? (
           <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
@@ -131,13 +144,17 @@ function IssueRow({
         <div className="px-3 pb-3 border-t border-border bg-muted/30">
           <div className="pt-3 space-y-3">
             <div>
-              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Impact</div>
+              <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                Impact
+              </div>
               <div className="text-sm">{issue.impact}</div>
             </div>
 
             {issue.metroCode && (
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Metro</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  Metro
+                </div>
                 <Link
                   to={`/dz/metros/${issue.metroPK}`}
                   className="text-sm hover:underline text-primary inline-flex items-center gap-1"
@@ -240,7 +257,11 @@ function DegradedLinkRow({
             <span className="inline-flex items-center gap-1">
               <Activity className="h-3 w-3" />
               P95: {formatMicroseconds(link.p95_rtt_us)}
-              {link.exceeds_commit && <span className="text-red-500">(exceeds {formatMicroseconds(committedRttUs)} commit)</span>}
+              {link.exceeds_commit && (
+                <span className="text-red-500">
+                  (exceeds {formatMicroseconds(committedRttUs)} commit)
+                </span>
+              )}
             </span>
             {link.has_packet_loss && (
               <span className="inline-flex items-center gap-1 text-red-500">
@@ -262,26 +283,36 @@ function DegradedLinkRow({
           <div className="pt-3 space-y-3">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Average RTT</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  Average RTT
+                </div>
                 <div className="text-sm font-medium">{formatMicroseconds(link.avg_rtt_us)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">P95 RTT</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  P95 RTT
+                </div>
                 <div className="text-sm font-medium">{formatMicroseconds(link.p95_rtt_us)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Committed RTT</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  Committed RTT
+                </div>
                 <div className="text-sm font-medium">{formatMicroseconds(committedRttUs)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">SLO Ratio</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  SLO Ratio
+                </div>
                 <div className="text-sm font-medium">{(link.sla_ratio * 100).toFixed(1)}%</div>
               </div>
             </div>
 
             {link.has_packet_loss && (
               <div>
-                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Packet Loss</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                  Packet Loss
+                </div>
                 <div className="text-sm font-medium text-red-500">{link.loss_pct.toFixed(2)}%</div>
               </div>
             )}
@@ -346,7 +377,7 @@ export function RedundancyReportPage() {
 
   const filteredIssues = useMemo(() => {
     if (!data?.issues) return []
-    return data.issues.filter(issue => {
+    return data.issues.filter((issue) => {
       if (filterType !== 'all' && issue.type !== filterType) return false
       if (filterSeverity !== 'all' && issue.severity !== filterSeverity) return false
       return true
@@ -354,7 +385,7 @@ export function RedundancyReportPage() {
   }, [data?.issues, filterType, filterSeverity])
 
   const toggleIssue = (issueKey: string) => {
-    setExpandedIssues(prev => {
+    setExpandedIssues((prev) => {
       const next = new Set(prev)
       if (next.has(issueKey)) {
         next.delete(issueKey)
@@ -372,12 +403,12 @@ export function RedundancyReportPage() {
   const degradedLinks = useMemo(() => {
     if (!linkHealthData?.links) return []
     return linkHealthData.links.filter(
-      link => link.sla_status === 'critical' || link.sla_status === 'warning'
+      (link) => link.sla_status === 'critical' || link.sla_status === 'warning',
     )
   }, [linkHealthData?.links])
 
   const toggleDegradedLink = (linkPk: string) => {
-    setExpandedDegradedLinks(prev => {
+    setExpandedDegradedLinks((prev) => {
       const next = new Set(prev)
       if (next.has(linkPk)) {
         next.delete(linkPk)
@@ -412,202 +443,204 @@ export function RedundancyReportPage() {
 
   return (
     <div className="h-full overflow-auto p-6">
-    <div className="max-w-5xl mx-auto">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center gap-3 mb-2">
-          <Shield className="h-6 w-6 text-primary" />
-          <h1 className="text-2xl font-semibold">Redundancy Report</h1>
-        </div>
-        <p className="text-muted-foreground">
-          Analysis of single points of failure and redundancy gaps in the network topology.
-        </p>
-      </div>
-
-      {/* Summary Cards */}
-      {summary && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <SummaryCard
-            label="Critical Issues"
-            value={summary.criticalCount}
-            color="critical"
-            icon={AlertCircle}
-          />
-          <SummaryCard
-            label="Warnings"
-            value={summary.warningCount}
-            color="warning"
-            icon={AlertTriangle}
-          />
-          <SummaryCard
-            label="Leaf Devices"
-            value={summary.leafDevices}
-            color="critical"
-            icon={AlertCircle}
-          />
-          <SummaryCard
-            label="Single-Exit Metros"
-            value={summary.singleExitMetros}
-            color="warning"
-            icon={AlertTriangle}
-          />
-        </div>
-      )}
-
-      {/* Filters */}
-      <div className="flex flex-wrap gap-4 mb-6 p-4 bg-muted/50 rounded-lg">
-        <div>
-          <label className="block text-xs text-muted-foreground uppercase tracking-wider mb-1">
-            Issue Type
-          </label>
-          <select
-            value={filterType}
-            onChange={(e) => setFilterType(e.target.value as FilterType)}
-            className="px-3 py-1.5 border border-border rounded-md bg-card text-sm"
-          >
-            <option value="all">All Types</option>
-            <option value="leaf_device">Leaf Devices</option>
-            <option value="critical_link">Critical Links</option>
-            <option value="single_exit_metro">Single-Exit Metros</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-muted-foreground uppercase tracking-wider mb-1">
-            Severity
-          </label>
-          <select
-            value={filterSeverity}
-            onChange={(e) => setFilterSeverity(e.target.value as FilterSeverity)}
-            className="px-3 py-1.5 border border-border rounded-md bg-card text-sm"
-          >
-            <option value="all">All Severities</option>
-            <option value="critical">Critical</option>
-            <option value="warning">Warning</option>
-            <option value="info">Info</option>
-          </select>
-        </div>
-        <div className="flex items-end ml-auto">
-          <span className="text-sm text-muted-foreground">
-            {filteredIssues.length} of {data?.issues?.length || 0} issues
-          </span>
-        </div>
-      </div>
-
-      {/* Issues List */}
-      <div className="space-y-3">
-        {filteredIssues.length === 0 ? (
-          <div className="text-center py-12 text-muted-foreground">
-            {data?.issues?.length === 0 ? (
-              <>
-                <Shield className="h-12 w-12 mx-auto mb-4 text-green-500" />
-                <div className="text-lg font-medium text-foreground">No redundancy issues found</div>
-                <div className="text-sm mt-1">The network topology has good redundancy.</div>
-              </>
-            ) : (
-              <>No issues match the current filters.</>
-            )}
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <Shield className="h-6 w-6 text-primary" />
+            <h1 className="text-2xl font-semibold">Redundancy Report</h1>
           </div>
-        ) : (
-          filteredIssues.map((issue, index) => {
-            const key = getIssueKey(issue, index)
-            return (
-              <IssueRow
-                key={key}
-                issue={issue}
-                isExpanded={expandedIssues.has(key)}
-                onToggle={() => toggleIssue(key)}
-              />
-            )
-          })
-        )}
-      </div>
-
-      {/* Degraded Links Section */}
-      <div className="mt-8">
-        <div className="flex items-center gap-3 mb-4">
-          <Activity className="h-5 w-5 text-primary" />
-          <h2 className="text-lg font-semibold">Latency Degradation</h2>
-          {linkHealthLoading && (
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          )}
+          <p className="text-muted-foreground">
+            Analysis of single points of failure and redundancy gaps in the network topology.
+          </p>
         </div>
 
-        {linkHealthData && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        {/* Summary Cards */}
+        {summary && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <SummaryCard
-              label="Critical Links"
-              value={linkHealthData.critical_count}
+              label="Critical Issues"
+              value={summary.criticalCount}
               color="critical"
               icon={AlertCircle}
             />
             <SummaryCard
-              label="Warning Links"
-              value={linkHealthData.warning_count}
+              label="Warnings"
+              value={summary.warningCount}
               color="warning"
               icon={AlertTriangle}
             />
             <SummaryCard
-              label="Healthy Links"
-              value={linkHealthData.healthy_count}
-              color="neutral"
-              icon={Shield}
+              label="Leaf Devices"
+              value={summary.leafDevices}
+              color="critical"
+              icon={AlertCircle}
             />
             <SummaryCard
-              label="Total Links"
-              value={linkHealthData.total_links}
-              color="neutral"
-              icon={Activity}
+              label="Single-Exit Metros"
+              value={summary.singleExitMetros}
+              color="warning"
+              icon={AlertTriangle}
             />
           </div>
         )}
 
+        {/* Filters */}
+        <div className="flex flex-wrap gap-4 mb-6 p-4 bg-muted/50 rounded-lg">
+          <div>
+            <label className="block text-xs text-muted-foreground uppercase tracking-wider mb-1">
+              Issue Type
+            </label>
+            <SmallDropdown
+              value={filterType}
+              options={[
+                { value: 'all', label: 'All Types' },
+                { value: 'leaf_device', label: 'Leaf Devices' },
+                { value: 'critical_link', label: 'Critical Links' },
+                { value: 'single_exit_metro', label: 'Single-Exit Metros' },
+              ]}
+              onChange={(v) => setFilterType(v as FilterType)}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground uppercase tracking-wider mb-1">
+              Severity
+            </label>
+            <SmallDropdown
+              value={filterSeverity}
+              options={[
+                { value: 'all', label: 'All Severities' },
+                { value: 'critical', label: 'Critical' },
+                { value: 'warning', label: 'Warning' },
+                { value: 'info', label: 'Info' },
+              ]}
+              onChange={(v) => setFilterSeverity(v as FilterSeverity)}
+            />
+          </div>
+          <div className="flex items-end ml-auto">
+            <span className="text-sm text-muted-foreground">
+              {filteredIssues.length} of {data?.issues?.length || 0} issues
+            </span>
+          </div>
+        </div>
+
+        {/* Issues List */}
         <div className="space-y-3">
-          {degradedLinks.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground bg-muted/30 rounded-lg">
-              {linkHealthLoading ? (
-                <>Loading link health data...</>
-              ) : (
+          {filteredIssues.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              {data?.issues?.length === 0 ? (
                 <>
-                  <Shield className="h-10 w-10 mx-auto mb-3 text-green-500" />
-                  <div className="text-base font-medium text-foreground">All links healthy</div>
-                  <div className="text-sm mt-1">No SLO violations detected.</div>
+                  <Shield className="h-12 w-12 mx-auto mb-4 text-green-500" />
+                  <div className="text-lg font-medium text-foreground">
+                    No redundancy issues found
+                  </div>
+                  <div className="text-sm mt-1">The network topology has good redundancy.</div>
                 </>
+              ) : (
+                <>No issues match the current filters.</>
               )}
             </div>
           ) : (
-            degradedLinks.map(link => (
-              <DegradedLinkRow
-                key={link.link_pk}
-                link={link}
-                isExpanded={expandedDegradedLinks.has(link.link_pk)}
-                onToggle={() => toggleDegradedLink(link.link_pk)}
-              />
-            ))
+            filteredIssues.map((issue, index) => {
+              const key = getIssueKey(issue, index)
+              return (
+                <IssueRow
+                  key={key}
+                  issue={issue}
+                  isExpanded={expandedIssues.has(key)}
+                  onToggle={() => toggleIssue(key)}
+                />
+              )
+            })
           )}
         </div>
-      </div>
 
-      {/* Footer links */}
-      <div className="mt-8 pt-6 border-t border-border">
-        <div className="text-sm text-muted-foreground mb-2">Related Tools</div>
-        <div className="flex gap-4">
-          <Link
-            to="/topology/graph"
-            className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-          >
-            View Topology Graph
-            <ExternalLink className="h-3 w-3" />
-          </Link>
-          <Link
-            to="/topology/map"
-            className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-          >
-            View Topology Map
-            <ExternalLink className="h-3 w-3" />
-          </Link>
+        {/* Degraded Links Section */}
+        <div className="mt-8">
+          <div className="flex items-center gap-3 mb-4">
+            <Activity className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold">Latency Degradation</h2>
+            {linkHealthLoading && (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            )}
+          </div>
+
+          {linkHealthData && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <SummaryCard
+                label="Critical Links"
+                value={linkHealthData.critical_count}
+                color="critical"
+                icon={AlertCircle}
+              />
+              <SummaryCard
+                label="Warning Links"
+                value={linkHealthData.warning_count}
+                color="warning"
+                icon={AlertTriangle}
+              />
+              <SummaryCard
+                label="Healthy Links"
+                value={linkHealthData.healthy_count}
+                color="neutral"
+                icon={Shield}
+              />
+              <SummaryCard
+                label="Total Links"
+                value={linkHealthData.total_links}
+                color="neutral"
+                icon={Activity}
+              />
+            </div>
+          )}
+
+          <div className="space-y-3">
+            {degradedLinks.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground bg-muted/30 rounded-lg">
+                {linkHealthLoading ? (
+                  <>Loading link health data...</>
+                ) : (
+                  <>
+                    <Shield className="h-10 w-10 mx-auto mb-3 text-green-500" />
+                    <div className="text-base font-medium text-foreground">All links healthy</div>
+                    <div className="text-sm mt-1">No SLO violations detected.</div>
+                  </>
+                )}
+              </div>
+            ) : (
+              degradedLinks.map((link) => (
+                <DegradedLinkRow
+                  key={link.link_pk}
+                  link={link}
+                  isExpanded={expandedDegradedLinks.has(link.link_pk)}
+                  onToggle={() => toggleDegradedLink(link.link_pk)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Footer links */}
+        <div className="mt-8 pt-6 border-t border-border">
+          <div className="text-sm text-muted-foreground mb-2">Related Tools</div>
+          <div className="flex gap-4">
+            <Link
+              to="/topology/graph"
+              className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+            >
+              View Topology Graph
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+            <Link
+              to="/topology/map"
+              className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+            >
+              View Topology Map
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
     </div>
   )
 }

--- a/web/src/components/shared/DeviceInfoContent.tsx
+++ b/web/src/components/shared/DeviceInfoContent.tsx
@@ -51,28 +51,48 @@ function formatBandwidth(bps: number): string {
 function InterfaceTypeBadges({ iface }: { iface: DeviceInterface }) {
   const badges: { label: string; className: string }[] = []
   if (iface.interface_type === 'loopback') {
-    badges.push({ label: 'loopback', className: 'bg-purple-500/15 text-purple-400' })
+    badges.push({
+      label: 'loopback',
+      className: 'bg-purple-500/15 text-purple-400',
+    })
     if (iface.loopback_type && iface.loopback_type !== 'none') {
-      badges.push({ label: iface.loopback_type, className: 'bg-purple-500/10 text-purple-400/80' })
+      badges.push({
+        label: iface.loopback_type,
+        className: 'bg-purple-500/10 text-purple-400/80',
+      })
     }
   }
   if (iface.cyoa_type && iface.cyoa_type !== 'none') {
-    badges.push({ label: iface.cyoa_type.replace(/_/g, ' '), className: 'bg-amber-500/15 text-amber-400' })
+    badges.push({
+      label: iface.cyoa_type.replace(/_/g, ' '),
+      className: 'bg-amber-500/15 text-amber-400',
+    })
   }
   if (iface.dia_type && iface.dia_type !== 'none') {
-    badges.push({ label: 'DIA', className: 'bg-orange-500/15 text-orange-400' })
+    badges.push({
+      label: 'DIA',
+      className: 'bg-orange-500/15 text-orange-400',
+    })
   }
   if (iface.routing_mode && iface.routing_mode !== 'static') {
-    badges.push({ label: iface.routing_mode.toUpperCase(), className: 'bg-blue-500/15 text-blue-400' })
+    badges.push({
+      label: iface.routing_mode.toUpperCase(),
+      className: 'bg-blue-500/15 text-blue-400',
+    })
   }
   if (iface.bandwidth && iface.bandwidth > 0) {
-    badges.push({ label: formatBandwidth(iface.bandwidth), className: 'bg-green-500/15 text-green-400' })
+    badges.push({
+      label: formatBandwidth(iface.bandwidth),
+      className: 'bg-green-500/15 text-green-400',
+    })
   }
   if (badges.length === 0) return null
   return (
-    <span className="inline-flex gap-1 ml-1.5">
+    <span className="inline-flex gap-1">
       {badges.map((b, i) => (
-        <span key={i} className={`px-1 py-0.5 rounded text-[10px] leading-none ${b.className}`}>{b.label}</span>
+        <span key={i} className={`px-1 py-0.5 rounded text-[10px] leading-none ${b.className}`}>
+          {b.label}
+        </span>
       ))}
     </span>
   )
@@ -102,10 +122,15 @@ export function DeviceInfoContent({
   hideStatusRow = false,
   hideCharts = false,
 }: DeviceInfoContentProps) {
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
-  const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>({ preset: '24h' })
+  const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>({
+    preset: '24h',
+  })
 
   const timeRange = controlledTimeRange ?? internalTimeRange
   const setTimeRange = onTimeRangeChange ?? setInternalTimeRange
@@ -118,13 +143,16 @@ export function DeviceInfoContent({
     enabled: !hideCharts,
   })
 
-  const cardClass = "rounded-lg border border-border p-4"
+  const cardClass = 'rounded-lg border border-border p-4'
   const stats = [
     { label: 'Type', value: device.deviceType },
     {
       label: 'Contributor',
       value: device.contributorPk ? (
-        <Link to={`/dz/contributors/${device.contributorPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+        <Link
+          to={`/dz/contributors/${device.contributorPk}`}
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+        >
           {device.contributorCode}
         </Link>
       ) : (
@@ -134,7 +162,10 @@ export function DeviceInfoContent({
     {
       label: 'Metro',
       value: device.metroPk ? (
-        <Link to={`/dz/metros/${device.metroPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+        <Link
+          to={`/dz/metros/${device.metroPk}`}
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+        >
           {device.metroName}
         </Link>
       ) : (
@@ -152,7 +183,7 @@ export function DeviceInfoContent({
     if (a.status === 'activated' && b.status !== 'activated') return -1
     if (a.status !== 'activated' && b.status === 'activated') return 1
     // Physical before loopback
-    const typeOrder = (t?: string) => t === 'physical' ? 0 : t === 'loopback' ? 1 : 2
+    const typeOrder = (t?: string) => (t === 'physical' ? 0 : t === 'loopback' ? 1 : 2)
     const typeA = typeOrder(a.interface_type)
     const typeB = typeOrder(b.interface_type)
     if (typeA !== typeB) return typeA - typeB
@@ -167,9 +198,7 @@ export function DeviceInfoContent({
         <div className="grid grid-cols-2 gap-2">
           {stats.map((stat, i) => (
             <div key={i} className="text-center p-2 bg-muted/30 rounded-lg">
-              <div className="text-base font-medium tabular-nums tracking-tight">
-                {stat.value}
-              </div>
+              <div className="text-base font-medium tabular-nums tracking-tight">{stat.value}</div>
               <div className="text-xs text-muted-foreground">{stat.label}</div>
             </div>
           ))}
@@ -191,9 +220,7 @@ export function DeviceInfoContent({
                     {iface.name}
                     <InterfaceTypeBadges iface={iface} />
                   </span>
-                  <span className="text-muted-foreground whitespace-nowrap">
-                    {iface.ip || '—'}
-                  </span>
+                  <span className="text-muted-foreground whitespace-nowrap">{iface.ip || '—'}</span>
                 </div>
               ))}
             </div>
@@ -210,9 +237,27 @@ export function DeviceInfoContent({
         {/* Charts from unified metrics endpoint */}
         {!hideCharts && metrics && (
           <div className="space-y-4">
-            {!hideStatusRow && <DeviceHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />}
-            <DeviceInterfaceIssuesChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <DeviceTrafficChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+            {!hideStatusRow && (
+              <DeviceHealthTimeline
+                data={metrics}
+                onBarHover={setHoveredTimeRange}
+                highlightedTime={chartHoveredTime}
+              />
+            )}
+            <DeviceInterfaceIssuesChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <DeviceTrafficChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
           </div>
         )}
       </div>
@@ -223,12 +268,10 @@ export function DeviceInfoContent({
   return (
     <div className="space-y-6">
       {/* Stats grid - responsive columns */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2">
+      <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-7 gap-2">
         {stats.map((stat, i) => (
           <div key={i} className="text-center p-3 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium tabular-nums tracking-tight">
-              {stat.value}
-            </div>
+            <div className="text-base font-medium tabular-nums tracking-tight">{stat.value}</div>
             <div className="text-xs text-muted-foreground">{stat.label}</div>
           </div>
         ))}
@@ -240,17 +283,15 @@ export function DeviceInfoContent({
           <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">
             Interfaces ({sortedInterfaces.length})
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-col gap-1.5">
             {sortedInterfaces.map((iface, i) => (
               <div
                 key={i}
-                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 bg-muted/30 rounded text-xs font-mono"
+                className="flex flex-wrap items-center gap-1.5 px-2.5 py-1.5 bg-muted/30 rounded text-xs font-mono"
                 title={`${iface.name} — ${iface.ip || 'no IP'}`}
               >
                 <span>{iface.name}</span>
-                {iface.ip && (
-                  <span className="text-muted-foreground">{iface.ip}</span>
-                )}
+                {iface.ip && <span className="text-muted-foreground">{iface.ip}</span>}
                 <InterfaceTypeBadges iface={iface} />
               </div>
             ))}
@@ -267,12 +308,29 @@ export function DeviceInfoContent({
 
       {!hideCharts && metrics && (
         <div className="space-y-4">
-          {!hideStatusRow && <DeviceHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />}
-          <DeviceInterfaceIssuesChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-          <DeviceTrafficChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+          {!hideStatusRow && (
+            <DeviceHealthTimeline
+              data={metrics}
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
+          )}
+          <DeviceInterfaceIssuesChart
+            data={metrics}
+            loading={metricsFetching}
+            className={cardClass}
+            highlightTimeRange={hoveredTimeRange}
+            onCursorTime={setChartHoveredTime}
+          />
+          <DeviceTrafficChart
+            data={metrics}
+            loading={metricsFetching}
+            className={cardClass}
+            highlightTimeRange={hoveredTimeRange}
+            onCursorTime={setChartHoveredTime}
+          />
         </div>
       )}
     </div>
   )
 }
-

--- a/web/src/components/shared/LinkInfoContent.tsx
+++ b/web/src/components/shared/LinkInfoContent.tsx
@@ -104,15 +104,27 @@ const statusColors: Record<string, string> = {
  * Shared component for displaying link information.
  * Used by both the topology panel and the link detail page.
  */
-export function LinkInfoContent({ link, compact = false, hideStatusRow = false, hideCharts = false, timeRange: controlledTimeRange, onTimeRangeChange }: LinkInfoContentProps) {
-  const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>({ preset: '24h' })
+export function LinkInfoContent({
+  link,
+  compact = false,
+  hideStatusRow = false,
+  hideCharts = false,
+  timeRange: controlledTimeRange,
+  onTimeRangeChange,
+}: LinkInfoContentProps) {
+  const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>({
+    preset: '24h',
+  })
   const timeRange = controlledTimeRange ?? internalTimeRange
   const setTimeRange = onTimeRangeChange ?? setInternalTimeRange
 
   // Check if we have directional latency data
   const hasDirectionalData = link.latencyAtoZUs > 0 || link.latencyZtoAUs > 0
 
-  const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
+  const [hoveredTimeRange, setHoveredTimeRange] = useState<{
+    start: number
+    end: number
+  } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
 
   const [bucket, setBucket] = useState<BucketSize>('auto')
@@ -125,11 +137,12 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
     enabled: !hideCharts,
   })
 
-  const effectiveBucketLabel = bucket === 'auto'
-    ? bucketLabels[resolveAutoBucket(timeRange.preset as TimeRangePreset)]
-    : undefined
+  const effectiveBucketLabel =
+    bucket === 'auto'
+      ? bucketLabels[resolveAutoBucket(timeRange.preset as TimeRangePreset)]
+      : undefined
 
-  const cardClass = "rounded-lg border border-border p-4"
+  const cardClass = 'rounded-lg border border-border p-4'
 
   // Compact mode: optimized for sidebar panels
   if (compact) {
@@ -138,7 +151,9 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         {/* Status badge for non-activated links */}
         {link.status !== 'activated' && (
           <div className="flex items-center gap-1.5">
-            <span className={`text-xs font-medium px-1.5 py-0.5 rounded bg-amber-500/15 ${statusColors[link.status] || 'text-muted-foreground'}`}>
+            <span
+              className={`text-xs font-medium px-1.5 py-0.5 rounded bg-amber-500/15 ${statusColors[link.status] || 'text-muted-foreground'}`}
+            >
               {link.status}
             </span>
           </div>
@@ -149,12 +164,17 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
           <div className="p-2 bg-muted/30 rounded-lg">
             <div className="text-xs text-muted-foreground mb-1">A-Side</div>
             <div className="text-sm font-medium">
-              <Link to={`/dz/devices/${link.sideAPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              <Link
+                to={`/dz/devices/${link.sideAPk}`}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
                 {link.sideACode}
               </Link>
             </div>
             {link.sideAIfaceName && (
-              <div className="text-xs text-muted-foreground font-mono mt-0.5">{link.sideAIfaceName}</div>
+              <div className="text-xs text-muted-foreground font-mono mt-0.5">
+                {link.sideAIfaceName}
+              </div>
             )}
             {link.sideAIP && (
               <div className="text-xs text-muted-foreground font-mono">{link.sideAIP}</div>
@@ -162,21 +182,30 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             {hasDirectionalData && (
               <div className="mt-2 pt-2 border-t border-muted/50">
                 <div className="text-xs text-muted-foreground">RTT from A</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.latencyAtoZUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.latencyAtoZUs)}
+                </div>
                 <div className="text-xs text-muted-foreground mt-1">Jitter from A</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.jitterAtoZUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.jitterAtoZUs)}
+                </div>
               </div>
             )}
           </div>
           <div className="p-2 bg-muted/30 rounded-lg">
             <div className="text-xs text-muted-foreground mb-1">Z-Side</div>
             <div className="text-sm font-medium">
-              <Link to={`/dz/devices/${link.sideZPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              <Link
+                to={`/dz/devices/${link.sideZPk}`}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
                 {link.sideZCode}
               </Link>
             </div>
             {link.sideZIfaceName && (
-              <div className="text-xs text-muted-foreground font-mono mt-0.5">{link.sideZIfaceName}</div>
+              <div className="text-xs text-muted-foreground font-mono mt-0.5">
+                {link.sideZIfaceName}
+              </div>
             )}
             {link.sideZIP && (
               <div className="text-xs text-muted-foreground font-mono">{link.sideZIP}</div>
@@ -184,9 +213,13 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             {hasDirectionalData && (
               <div className="mt-2 pt-2 border-t border-muted/50">
                 <div className="text-xs text-muted-foreground">RTT from Z</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.latencyZtoAUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.latencyZtoAUs)}
+                </div>
                 <div className="text-xs text-muted-foreground mt-1">Jitter from Z</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.jitterZtoAUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.jitterZtoAUs)}
+                </div>
               </div>
             )}
           </div>
@@ -198,7 +231,9 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             <div className="text-base font-medium tabular-nums tracking-tight">
               {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0 ? (
                 <div>
-                  <div className="line-through text-muted-foreground text-sm">{formatLatencyNs(link.committedRttNs)}</div>
+                  <div className="line-through text-muted-foreground text-sm">
+                    {formatLatencyNs(link.committedRttNs)}
+                  </div>
                   <div>{formatLatencyNs(link.isisDelayOverrideNs)}</div>
                 </div>
               ) : (
@@ -206,7 +241,9 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
               )}
             </div>
             <div className="text-xs text-muted-foreground">
-              {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0 ? 'Committed Latency (override)' : 'Committed Latency'}
+              {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0
+                ? 'Committed Latency (override)'
+                : 'Committed Latency'}
             </div>
           </div>
         )}
@@ -215,11 +252,15 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         {!hasDirectionalData && (
           <div className="grid grid-cols-2 gap-2">
             <div className="text-center p-2 bg-muted/30 rounded-lg">
-              <div className="text-base font-medium tabular-nums tracking-tight">{formatLatencyUs(link.latencyUs)}</div>
+              <div className="text-base font-medium tabular-nums tracking-tight">
+                {formatLatencyUs(link.latencyUs)}
+              </div>
               <div className="text-xs text-muted-foreground">Latency</div>
             </div>
             <div className="text-center p-2 bg-muted/30 rounded-lg">
-              <div className="text-base font-medium tabular-nums tracking-tight">{formatLatencyUs(link.jitterUs)}</div>
+              <div className="text-base font-medium tabular-nums tracking-tight">
+                {formatLatencyUs(link.jitterUs)}
+              </div>
               <div className="text-xs text-muted-foreground">Jitter</div>
             </div>
           </div>
@@ -228,25 +269,36 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         {/* Stats grid - 2 columns for sidebar */}
         <div className="grid grid-cols-2 gap-2">
           <div className="text-center p-2 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium tabular-nums tracking-tight">{formatPercent(link.lossPercent)}</div>
+            <div className="text-base font-medium tabular-nums tracking-tight">
+              {formatPercent(link.lossPercent)}
+            </div>
             <div className="text-xs text-muted-foreground">Packet Loss</div>
           </div>
           <div className="text-center p-2 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium tabular-nums tracking-tight">{formatBps(link.bandwidthBps)}</div>
+            <div className="text-base font-medium tabular-nums tracking-tight">
+              {formatBps(link.bandwidthBps)}
+            </div>
             <div className="text-xs text-muted-foreground">Bandwidth</div>
           </div>
           <div className="text-center p-2 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium tabular-nums tracking-tight">{formatBps(link.inBps)}</div>
+            <div className="text-base font-medium tabular-nums tracking-tight">
+              {formatBps(link.inBps)}
+            </div>
             <div className="text-xs text-muted-foreground">Current In</div>
           </div>
           <div className="text-center p-2 bg-muted/30 rounded-lg">
-            <div className="text-base font-medium tabular-nums tracking-tight">{formatBps(link.outBps)}</div>
+            <div className="text-base font-medium tabular-nums tracking-tight">
+              {formatBps(link.outBps)}
+            </div>
             <div className="text-xs text-muted-foreground">Current Out</div>
           </div>
           <div className="text-center p-2 bg-muted/30 rounded-lg col-span-2">
             <div className="text-base font-medium tabular-nums tracking-tight">
               {link.contributorPk ? (
-                <Link to={`/dz/contributors/${link.contributorPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                <Link
+                  to={`/dz/contributors/${link.contributorPk}`}
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
                   {link.contributorCode}
                 </Link>
               ) : (
@@ -270,12 +322,46 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         {/* Charts from unified metrics endpoint */}
         {metrics && (
           <div className="space-y-4">
-            <LinkHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />
-            <LinkPacketLossChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkInterfaceIssuesChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkTrafficChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkLatencyChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-            <LinkJitterChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+            <LinkHealthTimeline
+              data={metrics}
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
+            <LinkPacketLossChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkInterfaceIssuesChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkTrafficChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkLatencyChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
+            <LinkJitterChart
+              data={metrics}
+              loading={metricsFetching}
+              className={cardClass}
+              highlightTimeRange={hoveredTimeRange}
+              onCursorTime={setChartHoveredTime}
+            />
           </div>
         )}
       </div>
@@ -290,13 +376,20 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         <div className="p-3 bg-muted/30 rounded-lg">
           <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">A-Side</div>
           <div className="text-sm font-medium">
-            <Link to={`/dz/devices/${link.sideAPk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+            <Link
+              to={`/dz/devices/${link.sideAPk}`}
+              className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+            >
               {link.sideACode}
             </Link>
-            {link.sideAMetro && <span className="text-muted-foreground ml-1">({link.sideAMetro})</span>}
+            {link.sideAMetro && (
+              <span className="text-muted-foreground ml-1">({link.sideAMetro})</span>
+            )}
           </div>
           {link.sideAIfaceName && (
-            <div className="text-xs text-muted-foreground font-mono mt-1">{link.sideAIfaceName}</div>
+            <div className="text-xs text-muted-foreground font-mono mt-1">
+              {link.sideAIfaceName}
+            </div>
           )}
           {link.sideAIP && (
             <div className="text-xs text-muted-foreground font-mono">{link.sideAIP}</div>
@@ -305,11 +398,15 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             <div className="mt-3 pt-3 border-t border-muted/50 grid grid-cols-2 gap-2">
               <div>
                 <div className="text-xs text-muted-foreground">RTT</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.latencyAtoZUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.latencyAtoZUs)}
+                </div>
               </div>
               <div>
                 <div className="text-xs text-muted-foreground">Jitter</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.jitterAtoZUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.jitterAtoZUs)}
+                </div>
               </div>
             </div>
           )}
@@ -317,13 +414,20 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
         <div className="p-3 bg-muted/30 rounded-lg">
           <div className="text-xs text-muted-foreground uppercase tracking-wider mb-2">Z-Side</div>
           <div className="text-sm font-medium">
-            <Link to={`/dz/devices/${link.sideZPk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+            <Link
+              to={`/dz/devices/${link.sideZPk}`}
+              className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+            >
               {link.sideZCode}
             </Link>
-            {link.sideZMetro && <span className="text-muted-foreground ml-1">({link.sideZMetro})</span>}
+            {link.sideZMetro && (
+              <span className="text-muted-foreground ml-1">({link.sideZMetro})</span>
+            )}
           </div>
           {link.sideZIfaceName && (
-            <div className="text-xs text-muted-foreground font-mono mt-1">{link.sideZIfaceName}</div>
+            <div className="text-xs text-muted-foreground font-mono mt-1">
+              {link.sideZIfaceName}
+            </div>
           )}
           {link.sideZIP && (
             <div className="text-xs text-muted-foreground font-mono">{link.sideZIP}</div>
@@ -332,11 +436,15 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             <div className="mt-3 pt-3 border-t border-muted/50 grid grid-cols-2 gap-2">
               <div>
                 <div className="text-xs text-muted-foreground">RTT</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.latencyZtoAUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.latencyZtoAUs)}
+                </div>
               </div>
               <div>
                 <div className="text-xs text-muted-foreground">Jitter</div>
-                <div className="text-sm font-medium tabular-nums">{formatLatencyUs(link.jitterZtoAUs)}</div>
+                <div className="text-sm font-medium tabular-nums">
+                  {formatLatencyUs(link.jitterZtoAUs)}
+                </div>
               </div>
             </div>
           )}
@@ -344,9 +452,11 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
       </div>
 
       {/* Stats grid - responsive columns */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-2">
+      <div className="grid grid-cols-1 xss:grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-2">
         <div className="text-center p-3 bg-muted/30 rounded-lg">
-          <div className={`text-base font-medium capitalize ${statusColors[link.status] || ''}`}>{link.status}</div>
+          <div className={`text-base font-medium capitalize ${statusColors[link.status] || ''}`}>
+            {link.status}
+          </div>
           <div className="text-xs text-muted-foreground">Status</div>
         </div>
         <div className="text-center p-3 bg-muted/30 rounded-lg">
@@ -362,7 +472,9 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
           <div className="text-xs text-muted-foreground">Util In</div>
         </div>
         <div className="text-center p-3 bg-muted/30 rounded-lg">
-          <div className="text-base font-medium tabular-nums">{link.utilizationOut.toFixed(1)}%</div>
+          <div className="text-base font-medium tabular-nums">
+            {link.utilizationOut.toFixed(1)}%
+          </div>
           <div className="text-xs text-muted-foreground">Util Out</div>
         </div>
         <div className="text-center p-3 bg-muted/30 rounded-lg">
@@ -390,7 +502,9 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
             <div className="text-base font-medium tabular-nums">
               {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0 ? (
                 <div>
-                  <div className="line-through text-muted-foreground">{formatLatencyNs(link.committedRttNs)}</div>
+                  <div className="line-through text-muted-foreground">
+                    {formatLatencyNs(link.committedRttNs)}
+                  </div>
                   <div>{formatLatencyNs(link.isisDelayOverrideNs)}</div>
                 </div>
               ) : (
@@ -398,30 +512,41 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
               )}
             </div>
             <div className="text-xs text-muted-foreground">
-              {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0 ? 'Committed Latency (override)' : 'Committed Latency'}
+              {link.isisDelayOverrideNs !== undefined && link.isisDelayOverrideNs > 0
+                ? 'Committed Latency (override)'
+                : 'Committed Latency'}
             </div>
           </div>
         )}
         {!hasDirectionalData && (
           <>
             <div className="text-center p-3 bg-muted/30 rounded-lg">
-              <div className="text-base font-medium tabular-nums">{formatLatencyUs(link.latencyUs)}</div>
+              <div className="text-base font-medium tabular-nums">
+                {formatLatencyUs(link.latencyUs)}
+              </div>
               <div className="text-xs text-muted-foreground">Latency</div>
             </div>
             <div className="text-center p-3 bg-muted/30 rounded-lg">
-              <div className="text-base font-medium tabular-nums">{formatLatencyUs(link.jitterUs)}</div>
+              <div className="text-base font-medium tabular-nums">
+                {formatLatencyUs(link.jitterUs)}
+              </div>
               <div className="text-xs text-muted-foreground">Jitter</div>
             </div>
           </>
         )}
         <div className="text-center p-3 bg-muted/30 rounded-lg">
-          <div className="text-base font-medium tabular-nums">{formatPercent(link.lossPercent)}</div>
+          <div className="text-base font-medium tabular-nums">
+            {formatPercent(link.lossPercent)}
+          </div>
           <div className="text-xs text-muted-foreground">Packet Loss</div>
         </div>
         <div className="text-center p-3 bg-muted/30 rounded-lg">
           <div className="text-base font-medium">
             {link.contributorPk ? (
-              <Link to={`/dz/contributors/${link.contributorPk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              <Link
+                to={`/dz/contributors/${link.contributorPk}`}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
                 {link.contributorCode}
               </Link>
             ) : (
@@ -449,12 +574,48 @@ export function LinkInfoContent({ link, compact = false, hideStatusRow = false, 
 
           {metrics && (
             <div className="space-y-4">
-              {!hideStatusRow && <LinkHealthTimeline data={metrics} onBarHover={setHoveredTimeRange} highlightedTime={chartHoveredTime} />}
-              <LinkPacketLossChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-              <LinkInterfaceIssuesChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-              <LinkTrafficChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-              <LinkLatencyChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
-              <LinkJitterChart data={metrics} loading={metricsFetching} className={cardClass} highlightTimeRange={hoveredTimeRange} onCursorTime={setChartHoveredTime} />
+              {!hideStatusRow && (
+                <LinkHealthTimeline
+                  data={metrics}
+                  onBarHover={setHoveredTimeRange}
+                  highlightedTime={chartHoveredTime}
+                />
+              )}
+              <LinkPacketLossChart
+                data={metrics}
+                loading={metricsFetching}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
+              <LinkInterfaceIssuesChart
+                data={metrics}
+                loading={metricsFetching}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
+              <LinkTrafficChart
+                data={metrics}
+                loading={metricsFetching}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
+              <LinkLatencyChart
+                data={metrics}
+                loading={metricsFetching}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
+              <LinkJitterChart
+                data={metrics}
+                loading={metricsFetching}
+                className={cardClass}
+                highlightTimeRange={hoveredTimeRange}
+                onCursorTime={setChartHoveredTime}
+              />
             </div>
           )}
         </>

--- a/web/src/components/shreds-page.tsx
+++ b/web/src/components/shreds-page.tsx
@@ -1,7 +1,21 @@
 import { useMemo, useCallback, useState, useRef, useEffect } from 'react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useSearchParams, useNavigate, Link } from 'react-router-dom'
-import { Loader2, Puzzle, AlertCircle, ChevronDown, ChevronUp, ChevronRight, X, ExternalLink, Filter, Copy, Check, RefreshCw, Info } from 'lucide-react'
+import {
+  Loader2,
+  Puzzle,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  ChevronRight,
+  X,
+  ExternalLink,
+  Filter,
+  Copy,
+  Check,
+  RefreshCw,
+  Info,
+} from 'lucide-react'
 import {
   fetchShredClientSeats,
   fetchShredDevices,
@@ -38,17 +52,25 @@ function parseNumericFilter(input: string): NumericFilter | null {
 
 function matchesNumericFilter(value: number, filter: NumericFilter): boolean {
   switch (filter.op) {
-    case '>': return value > filter.value
-    case '>=': return value >= filter.value
-    case '<': return value < filter.value
-    case '<=': return value <= filter.value
-    case '=': return value === filter.value
+    case '>':
+      return value > filter.value
+    case '>=':
+      return value >= filter.value
+    case '<':
+      return value < filter.value
+    case '<=':
+      return value <= filter.value
+    case '=':
+      return value === filter.value
   }
 }
 
 function parseSearchFilters(searchParam: string): string[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
 }
 
 function parseFilter(filter: string, validFields: string[]): { field: string; value: string } {
@@ -67,41 +89,62 @@ function usePageState() {
   const [searchParams, setSearchParams] = useSearchParams()
   const page = parseInt(searchParams.get('page') || '1')
   const offset = (page - 1) * PAGE_SIZE
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
-      if (newPage <= 1) { p.delete('page') } else { p.set('page', String(newPage)) }
-      return p
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
+        if (newPage <= 1) {
+          p.delete('page')
+        } else {
+          p.set('page', String(newPage))
+        }
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   const sortField = searchParams.get('sort') || ''
   const sortDirection = (searchParams.get('dir') || 'desc') as SortDirection
-  const handleSort = useCallback((field: string) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (prev.get('sort') === field) { p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc') }
-      else { p.set('sort', field); p.set('dir', 'desc') }
-      return p
-    })
-  }, [setSearchParams])
+  const handleSort = useCallback(
+    (field: string) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (prev.get('sort') === field) {
+          p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc')
+        } else {
+          p.set('sort', field)
+          p.set('dir', 'desc')
+        }
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   const searchParam = searchParams.get('search') || ''
   const searchFilters = parseSearchFilters(searchParam)
   const [liveFilter, setLiveFilter] = useState('')
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (newFilters.length === 0) { p.delete('search') } else { p.set('search', newFilters.join(',')) }
-      return p
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          p.delete('search')
+        } else {
+          p.set('search', newFilters.join(','))
+        }
+        return p
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       p.delete('search')
       return p
@@ -115,7 +158,7 @@ function usePageState() {
     const key = JSON.stringify(allFilters)
     if (prevFilterRef.current === key) return
     prevFilterRef.current = key
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       p.delete('page')
       return p
@@ -123,16 +166,36 @@ function usePageState() {
   }, [allFilters, setSearchParams])
 
   return {
-    searchParams, setSearchParams,
-    offset, setOffset,
-    sortField, sortDirection, handleSort,
-    searchFilters, liveFilter, setLiveFilter, allFilters,
-    removeFilter, clearAllFilters,
+    searchParams,
+    setSearchParams,
+    offset,
+    setOffset,
+    sortField,
+    sortDirection,
+    handleSort,
+    searchFilters,
+    liveFilter,
+    setLiveFilter,
+    allFilters,
+    removeFilter,
+    clearAllFilters,
   }
 }
 
-function SortHeader({ field, label, align, currentSort, currentDir, onSort }: {
-  field: string; label: string; align?: 'right'; currentSort: string; currentDir: SortDirection; onSort: (f: string) => void
+function SortHeader({
+  field,
+  label,
+  align,
+  currentSort,
+  currentDir,
+  onSort,
+}: {
+  field: string
+  label: string
+  align?: 'right'
+  currentSort: string
+  currentDir: SortDirection
+  onSort: (f: string) => void
 }) {
   return (
     <th className={`px-4 py-3 font-medium ${align === 'right' ? 'text-right' : ''}`}>
@@ -141,16 +204,34 @@ function SortHeader({ field, label, align, currentSort, currentDir, onSort }: {
         onClick={() => onSort(field)}
       >
         {label}
-        {currentSort === field && (currentDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)}
+        {currentSort === field &&
+          (currentDir === 'asc' ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          ))}
       </button>
     </th>
   )
 }
 
-function FilterActions({ searchFilters, removeFilter, clearAllFilters, setLiveFilter, fieldPrefixes, entity, placeholder, autocompleteFields = [] }: {
-  searchFilters: string[]; removeFilter: (f: string) => void; clearAllFilters: () => void
+function FilterActions({
+  searchFilters,
+  removeFilter,
+  clearAllFilters,
+  setLiveFilter,
+  fieldPrefixes,
+  entity,
+  placeholder,
+  autocompleteFields = [],
+}: {
+  searchFilters: string[]
+  removeFilter: (f: string) => void
+  clearAllFilters: () => void
   setLiveFilter: (f: string) => void
-  fieldPrefixes: { prefix: string; description: string }[]; entity: string; placeholder: string
+  fieldPrefixes: { prefix: string; description: string }[]
+  entity: string
+  placeholder: string
   autocompleteFields?: (string | { field: string; minChars: number })[]
 }) {
   return (
@@ -166,7 +247,10 @@ function FilterActions({ searchFilters, removeFilter, clearAllFilters, setLiveFi
         </button>
       ))}
       {searchFilters.length > 1 && (
-        <button onClick={clearAllFilters} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+        <button
+          onClick={clearAllFilters}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
           Clear all
         </button>
       )}
@@ -185,7 +269,12 @@ function CopyIcon({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
   return (
     <button
-      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 2000) }}
+      onClick={(e) => {
+        e.stopPropagation()
+        navigator.clipboard.writeText(text)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
       className="inline-flex items-center justify-center h-4 w-4 text-muted-foreground opacity-0 group-hover/cell:opacity-100 hover:text-foreground transition-opacity cursor-pointer"
       title={copied ? 'Copied!' : 'Copy'}
     >
@@ -230,7 +319,7 @@ const seatFieldPrefixes = [
 
 function prepaidEpochs(seat: ShredClientSeat): number {
   if (seat.price_per_epoch_dollars <= 0 || seat.total_usdc_balance === 0) return 0
-  return Math.floor((seat.total_usdc_balance / 1e6) / seat.price_per_epoch_dollars)
+  return Math.floor(seat.total_usdc_balance / 1e6 / seat.price_per_epoch_dollars)
 }
 
 type SeatStatus = 'active' | 'expiring' | 'pending' | 'expired' | 'closed'
@@ -280,7 +369,12 @@ function useRefreshButton(refetch: () => void, isFetching: boolean, minMs = 400)
     timerRef.current = setTimeout(() => setSpinning(false), minMs)
   }, [refetch, minMs])
 
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
 
   return { spinning: spinning || isFetching, onClick }
 }
@@ -292,12 +386,21 @@ function useDebouncedFetching(isFetching: boolean, { delayMs = 300, minMs = 800 
 
   useEffect(() => {
     if (isFetching) {
-      if (hideTimerRef.current) { clearTimeout(hideTimerRef.current); hideTimerRef.current = null }
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
       if (!visible && !showTimerRef.current) {
-        showTimerRef.current = setTimeout(() => { showTimerRef.current = null; setVisible(true) }, delayMs)
+        showTimerRef.current = setTimeout(() => {
+          showTimerRef.current = null
+          setVisible(true)
+        }, delayMs)
       }
     } else {
-      if (showTimerRef.current) { clearTimeout(showTimerRef.current); showTimerRef.current = null }
+      if (showTimerRef.current) {
+        clearTimeout(showTimerRef.current)
+        showTimerRef.current = null
+      }
       if (visible) {
         hideTimerRef.current = setTimeout(() => setVisible(false), minMs)
       }
@@ -314,7 +417,9 @@ function useDebouncedFetching(isFetching: boolean, { delayMs = 300, minMs = 800 
 function SeatStatusBadge({ status }: { status: SeatStatus }) {
   const config = seatStatusConfig[status]
   return (
-    <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border whitespace-nowrap ${config.className}`}>
+    <span
+      className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border whitespace-nowrap ${config.className}`}
+    >
       {config.label}
     </span>
   )
@@ -343,19 +448,35 @@ export function ShredsSeatsPage() {
 
   // Status filter from URL (comma-separated, default: active,expiring,pending).
   const statusParam = searchParams.get('status') || 'active,expiring,pending'
-  const activeStatuses = useMemo(() => new Set(statusParam.split(',').filter(Boolean)), [statusParam])
+  const activeStatuses = useMemo(
+    () => new Set(statusParam.split(',').filter(Boolean)),
+    [statusParam],
+  )
 
-  const toggleStatus = useCallback((status: string) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      const current = new Set((prev.get('status') || 'active,expiring,pending').split(',').filter(Boolean))
-      if (current.has(status)) { current.delete(status) } else { current.add(status) }
-      const val = Array.from(current).join(',')
-      if (val === 'active,expiring,pending') { p.delete('status') } else { p.set('status', val) }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const toggleStatus = useCallback(
+    (status: string) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        const current = new Set(
+          (prev.get('status') || 'active,expiring,pending').split(',').filter(Boolean),
+        )
+        if (current.has(status)) {
+          current.delete(status)
+        } else {
+          current.add(status)
+        }
+        const val = Array.from(current).join(',')
+        if (val === 'active,expiring,pending') {
+          p.delete('status')
+        } else {
+          p.set('status', val)
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   // Filters from URL.
   const searchParam = searchParams.get('search') || ''
@@ -366,16 +487,23 @@ export function ShredsSeatsPage() {
     return searchFilters.length > 0 ? searchFilters : undefined
   }, [searchFilters])
 
-  const { data, isLoading, isFetching: rawFetching, error, refetch } = useQuery({
+  const {
+    data,
+    isLoading,
+    isFetching: rawFetching,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ['shred-client-seats', offset, sortBy, sortDir, statusParam, searchParam],
-    queryFn: () => fetchShredClientSeats({
-      limit: PAGE_SIZE,
-      offset,
-      sortBy,
-      sortDir,
-      status: statusParam,
-      filters: serverFilters,
-    }),
+    queryFn: () =>
+      fetchShredClientSeats({
+        limit: PAGE_SIZE,
+        offset,
+        sortBy,
+        sortDir,
+        status: statusParam,
+        filters: serverFilters,
+      }),
     placeholderData: keepPreviousData,
     refetchInterval: 30000,
   })
@@ -386,37 +514,58 @@ export function ShredsSeatsPage() {
   const total = data?.total ?? 0
 
   // URL state setters.
-  const handleSort = useCallback((field: string) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (prev.get('sort') === field) { p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc') }
-      else { p.set('sort', field); p.set('dir', 'desc') }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleSort = useCallback(
+    (field: string) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (prev.get('sort') === field) {
+          p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc')
+        } else {
+          p.set('sort', field)
+          p.set('dir', 'desc')
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
-      if (newPage <= 1) { p.delete('page') } else { p.set('page', String(newPage)) }
-      return p
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
+        if (newPage <= 1) {
+          p.delete('page')
+        } else {
+          p.set('page', String(newPage))
+        }
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (newFilters.length === 0) { p.delete('search') } else { p.set('search', newFilters.join(',')) }
-      p.delete('page')
-      return p
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          p.delete('search')
+        } else {
+          p.set('search', newFilters.join(','))
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       p.delete('search')
       p.delete('page')
@@ -440,29 +589,62 @@ export function ShredsSeatsPage() {
               className="text-muted-foreground hover:text-foreground transition-colors"
               title="Refresh"
             >
-              {refresh.spinning
-                ? <Loader2 className="h-4 w-4 animate-spin" />
-                : <RefreshCw className="h-4 w-4" />}
+              {refresh.spinning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
             </button>
           }
           actions={
             <FilterActions
-              searchFilters={searchFilters} removeFilter={removeFilter} clearAllFilters={clearAllFilters}
+              searchFilters={searchFilters}
+              removeFilter={removeFilter}
+              clearAllFilters={clearAllFilters}
               setLiveFilter={() => {}}
-              fieldPrefixes={seatFieldPrefixes} entity="shred-seats" placeholder="Filter seats..."
+              fieldPrefixes={seatFieldPrefixes}
+              entity="shred-seats"
+              placeholder="Filter seats..."
               autocompleteFields={['device', 'metro', 'ip', 'funder']}
             />
           }
         />
 
-        <div className="flex items-center gap-2 mb-3">
-          {([
-            { key: 'active', label: 'Active', onClass: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20', dotClass: 'bg-green-500' },
-            { key: 'expiring', label: 'Expiring', onClass: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20', dotClass: 'bg-amber-500' },
-            { key: 'pending', label: 'Pending', onClass: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20', dotClass: 'bg-blue-500' },
-            { key: 'inactive', label: 'Expired', onClass: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20', dotClass: 'bg-red-500' },
-            { key: 'closed', label: 'Closed', onClass: 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20', dotClass: 'bg-gray-500' },
-          ] as const).map(({ key, label, onClass, dotClass }) => {
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          {(
+            [
+              {
+                key: 'active',
+                label: 'Active',
+                onClass: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
+                dotClass: 'bg-green-500',
+              },
+              {
+                key: 'expiring',
+                label: 'Expiring',
+                onClass: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20',
+                dotClass: 'bg-amber-500',
+              },
+              {
+                key: 'pending',
+                label: 'Pending',
+                onClass: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
+                dotClass: 'bg-blue-500',
+              },
+              {
+                key: 'inactive',
+                label: 'Expired',
+                onClass: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20',
+                dotClass: 'bg-red-500',
+              },
+              {
+                key: 'closed',
+                label: 'Closed',
+                onClass: 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20',
+                dotClass: 'bg-gray-500',
+              },
+            ] as const
+          ).map(({ key, label, onClass, dotClass }) => {
             const on = activeStatuses.has(key)
             return (
               <button
@@ -472,7 +654,9 @@ export function ShredsSeatsPage() {
                   on ? onClass : 'bg-muted text-muted-foreground border-border opacity-50'
                 }`}
               >
-                <div className={`h-1.5 w-1.5 rounded-full ${on ? dotClass : 'bg-muted-foreground'}`} />
+                <div
+                  className={`h-1.5 w-1.5 rounded-full ${on ? dotClass : 'bg-muted-foreground'}`}
+                />
                 {label}
               </button>
             )
@@ -491,19 +675,27 @@ export function ShredsSeatsPage() {
               <span className="inline-flex items-center gap-1.5 font-medium text-green-600 dark:text-green-400">
                 <div className="h-1.5 w-1.5 rounded-full bg-green-500" /> Active
               </span>
-              <span className="text-muted-foreground">Allocated for the current epoch with 1+ epochs of prepaid balance</span>
+              <span className="text-muted-foreground">
+                Allocated for the current epoch with 1+ epochs of prepaid balance
+              </span>
               <span className="inline-flex items-center gap-1.5 font-medium text-amber-600 dark:text-amber-400">
                 <div className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Expiring
               </span>
-              <span className="text-muted-foreground">Active but less than 1 epoch of balance remaining</span>
+              <span className="text-muted-foreground">
+                Active but less than 1 epoch of balance remaining
+              </span>
               <span className="inline-flex items-center gap-1.5 font-medium text-blue-600 dark:text-blue-400">
                 <div className="h-1.5 w-1.5 rounded-full bg-blue-500" /> Pending
               </span>
-              <span className="text-muted-foreground">Funded with enough for at least 1 epoch but not yet allocated</span>
+              <span className="text-muted-foreground">
+                Funded with enough for at least 1 epoch but not yet allocated
+              </span>
               <span className="inline-flex items-center gap-1.5 font-medium text-red-600 dark:text-red-400">
                 <div className="h-1.5 w-1.5 rounded-full bg-red-500" /> Expired
               </span>
-              <span className="text-muted-foreground">Not active and insufficient balance to renew</span>
+              <span className="text-muted-foreground">
+                Not active and insufficient balance to renew
+              </span>
               <span className="inline-flex items-center gap-1.5 font-medium text-gray-500 dark:text-gray-400">
                 <div className="h-1.5 w-1.5 rounded-full bg-gray-500" /> Closed
               </span>
@@ -523,86 +715,170 @@ export function ShredsSeatsPage() {
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
                   <th className="px-4 py-3 font-medium">Seat</th>
-                  <SortHeader field="device" label="Device" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="metro" label="Metro" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="ip" label="Client IP" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
+                  <SortHeader
+                    field="device"
+                    label="Device"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="metro"
+                    label="Metro"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="ip"
+                    label="Client IP"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
                   <th className="px-4 py-3 font-medium">Status</th>
-                  <SortHeader field="tenure" label="Tenure" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="balance" label="Balance (USDC)" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="prepaid" label="Prepaid Epochs" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="last_activity" label="Last Activity" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
+                  <SortHeader
+                    field="tenure"
+                    label="Tenure"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="balance"
+                    label="Balance (USDC)"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="prepaid"
+                    label="Prepaid Epochs"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="last_activity"
+                    label="Last Activity"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
                 </tr>
               </thead>
               <tbody>
                 {items.map((seat) => {
                   const status = getSeatStatus(seat, currentSolanaEpoch)
                   return (
-                  <tr key={seat.pk} className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors" onClick={(e) => handleRowClick(e, `/dz/shreds/activity?search=seat:${seat.pk}`, navigate)}>
-                    <td className="px-4 py-3 font-mono text-xs group/cell" title={seat.pk}>
-                      <span className="inline-flex items-center gap-1">
-                        {truncatePK(seat.pk)}
-                        <CopyIcon text={seat.pk} />
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-sm whitespace-nowrap group/cell">
-                      <span className="inline-flex items-center gap-1">
-                        <Link to={`/dz/devices/${seat.device_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={seat.device_key}>
-                          {seat.device_code || truncatePK(seat.device_key)}
-                        </Link>
-                        <CopyIcon text={seat.device_code || seat.device_key} />
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-sm">
-                      {seat.metro_pk ? (
-                        <Link to={`/dz/metros/${seat.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={seat.metro_pk}>
-                          {seat.metro_code || truncatePK(seat.metro_pk)}
-                        </Link>
-                      ) : <span className="text-muted-foreground">{'\u2014'}</span>}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-mono group/cell">
-                      <span className="inline-flex items-center gap-1">
-                        {seat.user_pk ? (
-                          <Link to={`/dz/users/${seat.user_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" title={seat.user_pk}>
-                            {seat.client_ip}
+                    <tr
+                      key={seat.pk}
+                      className="border-b border-border last:border-b-0 hover:bg-muted cursor-pointer transition-colors"
+                      onClick={(e) =>
+                        handleRowClick(e, `/dz/shreds/activity?search=seat:${seat.pk}`, navigate)
+                      }
+                    >
+                      <td className="px-4 py-3 font-mono text-xs group/cell" title={seat.pk}>
+                        <span className="inline-flex items-center gap-1">
+                          {truncatePK(seat.pk)}
+                          <CopyIcon text={seat.pk} />
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm whitespace-nowrap group/cell">
+                        <span className="inline-flex items-center gap-1">
+                          <Link
+                            to={`/dz/devices/${seat.device_key}`}
+                            className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs"
+                            title={seat.device_key}
+                          >
+                            {seat.device_code || truncatePK(seat.device_key)}
                           </Link>
-                        ) : seat.client_ip}
-                        <CopyIcon text={seat.client_ip} />
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <SeatStatusBadge status={status} />
-                    </td>
-                    <td className="px-4 py-3 text-sm tabular-nums text-right">{seat.tenure_epochs}</td>
-                    <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {`$${(seat.total_usdc_balance / 1e6).toFixed(2)}`}
-                    </td>
-                    <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {prepaidEpochs(seat)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <Link
-                        to={`/dz/shreds/activity?search=seat:${seat.pk}`}
-                        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
-                      >
-                        {seat.last_activity ? new Date(seat.last_activity).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '\u2014'}
-                        <ChevronRight className="h-3 w-3" />
-                      </Link>
-                    </td>
-                  </tr>
+                          <CopyIcon text={seat.device_code || seat.device_key} />
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {seat.metro_pk ? (
+                          <Link
+                            to={`/dz/metros/${seat.metro_pk}`}
+                            className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs"
+                            title={seat.metro_pk}
+                          >
+                            {seat.metro_code || truncatePK(seat.metro_pk)}
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground">{'\u2014'}</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-mono group/cell">
+                        <span className="inline-flex items-center gap-1">
+                          {seat.user_pk ? (
+                            <Link
+                              to={`/dz/users/${seat.user_pk}`}
+                              className="text-foreground/85 hover:text-foreground hover:underline"
+                              title={seat.user_pk}
+                            >
+                              {seat.client_ip}
+                            </Link>
+                          ) : (
+                            seat.client_ip
+                          )}
+                          <CopyIcon text={seat.client_ip} />
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <SeatStatusBadge status={status} />
+                      </td>
+                      <td className="px-4 py-3 text-sm tabular-nums text-right">
+                        {seat.tenure_epochs}
+                      </td>
+                      <td className="px-4 py-3 text-sm tabular-nums text-right">
+                        {`$${(seat.total_usdc_balance / 1e6).toFixed(2)}`}
+                      </td>
+                      <td className="px-4 py-3 text-sm tabular-nums text-right">
+                        {prepaidEpochs(seat)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link
+                          to={`/dz/shreds/activity?search=seat:${seat.pk}`}
+                          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
+                        >
+                          {seat.last_activity
+                            ? new Date(seat.last_activity).toLocaleString(undefined, {
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              })
+                            : '\u2014'}
+                          <ChevronRight className="h-3 w-3" />
+                        </Link>
+                      </td>
+                    </tr>
                   )
                 })}
                 {items.length === 0 && (
-                  <tr><td colSpan={10} className="px-4 py-8 text-center text-muted-foreground">No subscribers found</td></tr>
+                  <tr>
+                    <td colSpan={10} className="px-4 py-8 text-center text-muted-foreground">
+                      No subscribers found
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>
           </div>
           {total > PAGE_SIZE && (
-            <Pagination total={total} limit={PAGE_SIZE} offset={offset} onOffsetChange={setOffset} />
+            <Pagination
+              total={total}
+              limit={PAGE_SIZE}
+              offset={offset}
+              onOffsetChange={setOffset}
+            />
           )}
         </div>
       </div>
-
     </div>
   )
 }
@@ -614,7 +890,10 @@ const deviceFieldPrefixes = [
   { prefix: 'metro:', description: 'Filter by metro code' },
   { prefix: 'price:', description: 'Filter by price/epoch (e.g., >0)' },
   { prefix: 'granted:', description: 'Filter by granted seats (e.g., >0)' },
-  { prefix: 'available:', description: 'Filter by available seats (e.g., >10)' },
+  {
+    prefix: 'available:',
+    description: 'Filter by available seats (e.g., >10)',
+  },
 ]
 
 export function ShredsDevicesPage() {
@@ -626,17 +905,27 @@ export function ShredsDevicesPage() {
   const sortDir = (searchParams.get('dir') || 'desc') as SortDirection
   const searchParam = searchParams.get('search') || ''
   const searchFilters = useMemo(() => parseSearchFilters(searchParam), [searchParam])
-  const serverFilters = useMemo(() => searchFilters.length > 0 ? searchFilters : undefined, [searchFilters])
+  const serverFilters = useMemo(
+    () => (searchFilters.length > 0 ? searchFilters : undefined),
+    [searchFilters],
+  )
 
-  const { data, isLoading, isFetching: rawFetchingDevices, error, refetch: refetchDevices } = useQuery({
+  const {
+    data,
+    isLoading,
+    isFetching: rawFetchingDevices,
+    error,
+    refetch: refetchDevices,
+  } = useQuery({
     queryKey: ['shred-devices', offset, sortBy, sortDir, searchParam],
-    queryFn: () => fetchShredDevices({
-      limit: PAGE_SIZE,
-      offset,
-      sortBy,
-      sortDir,
-      filters: serverFilters,
-    }),
+    queryFn: () =>
+      fetchShredDevices({
+        limit: PAGE_SIZE,
+        offset,
+        sortBy,
+        sortDir,
+        filters: serverFilters,
+      }),
     placeholderData: keepPreviousData,
     refetchInterval: 30000,
   })
@@ -646,37 +935,58 @@ export function ShredsDevicesPage() {
   const items = data?.items ?? []
   const total = data?.total ?? 0
 
-  const handleSort = useCallback((field: string) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (prev.get('sort') === field) { p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc') }
-      else { p.set('sort', field); p.set('dir', 'desc') }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleSort = useCallback(
+    (field: string) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (prev.get('sort') === field) {
+          p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc')
+        } else {
+          p.set('sort', field)
+          p.set('dir', 'desc')
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
-      if (newPage <= 1) { p.delete('page') } else { p.set('page', String(newPage)) }
-      return p
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
+        if (newPage <= 1) {
+          p.delete('page')
+        } else {
+          p.set('page', String(newPage))
+        }
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (newFilters.length === 0) { p.delete('search') } else { p.set('search', newFilters.join(',')) }
-      p.delete('page')
-      return p
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          p.delete('search')
+        } else {
+          p.set('search', newFilters.join(','))
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       p.delete('search')
       p.delete('page')
@@ -695,15 +1005,27 @@ export function ShredsDevicesPage() {
           title="Shred Devices"
           count={total}
           subtitle={
-            <button onClick={refreshDevices.onClick} className="text-muted-foreground hover:text-foreground transition-colors" title="Refresh">
-              {refreshDevices.spinning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            <button
+              onClick={refreshDevices.onClick}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title="Refresh"
+            >
+              {refreshDevices.spinning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
             </button>
           }
           actions={
             <FilterActions
-              searchFilters={searchFilters} removeFilter={removeFilter} clearAllFilters={clearAllFilters}
+              searchFilters={searchFilters}
+              removeFilter={removeFilter}
+              clearAllFilters={clearAllFilters}
               setLiveFilter={() => {}}
-              fieldPrefixes={deviceFieldPrefixes} entity="shred-devices" placeholder="Filter devices..."
+              fieldPrefixes={deviceFieldPrefixes}
+              entity="shred-devices"
+              placeholder="Filter devices..."
               autocompleteFields={['device', 'metro']}
             />
           }
@@ -719,46 +1041,112 @@ export function ShredsDevicesPage() {
             <table className="w-full">
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
-                  <SortHeader field="device" label="Device" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="metro" label="Metro" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="price" label="Price (USDC) / Epoch" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="granted" label="Granted" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="capacity" label="Capacity" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="available" label="Available" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
+                  <SortHeader
+                    field="device"
+                    label="Device"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="metro"
+                    label="Metro"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="price"
+                    label="Price (USDC) / Epoch"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="granted"
+                    label="Granted"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="capacity"
+                    label="Capacity"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="available"
+                    label="Available"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
                 </tr>
               </thead>
               <tbody>
                 {items.map((d) => (
-                  <tr key={d.device_key} className="border-b border-border last:border-b-0 hover:bg-muted transition-colors">
+                  <tr
+                    key={d.device_key}
+                    className="border-b border-border last:border-b-0 hover:bg-muted transition-colors"
+                  >
                     <td className="px-4 py-3 text-sm group/cell">
                       <span className="inline-flex items-center gap-1">
-                        <Link to={`/dz/devices/${d.device_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={d.device_key}>
+                        <Link
+                          to={`/dz/devices/${d.device_key}`}
+                          className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs"
+                          title={d.device_key}
+                        >
                           {d.device_code || truncatePK(d.device_key)}
                         </Link>
                         <CopyIcon text={d.device_key} />
                       </span>
                     </td>
                     <td className="px-4 py-3 text-sm">
-                      <Link to={`/dz/metros/${d.metro_exchange_key}`} className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs" title={d.metro_exchange_key}>
+                      <Link
+                        to={`/dz/metros/${d.metro_exchange_key}`}
+                        className="text-foreground/85 hover:text-foreground hover:underline font-mono text-xs"
+                        title={d.metro_exchange_key}
+                      >
                         {d.metro_code || truncatePK(d.metro_exchange_key)}
                       </Link>
                     </td>
-                    <td className="px-4 py-3 text-sm tabular-nums text-right">${d.total_price_dollars}</td>
+                    <td className="px-4 py-3 text-sm tabular-nums text-right">
+                      ${d.total_price_dollars}
+                    </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">{d.granted_seats}</td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">{d.capacity}</td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {d.available_seats > 0 ? d.available_seats : <span className="text-red-500">0</span>}
+                      {d.available_seats > 0 ? (
+                        d.available_seats
+                      ) : (
+                        <span className="text-red-500">0</span>
+                      )}
                     </td>
                   </tr>
                 ))}
                 {items.length === 0 && (
-                  <tr><td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">No devices found</td></tr>
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                      No devices found
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>
           </div>
           {total > PAGE_SIZE && (
-            <Pagination total={total} limit={PAGE_SIZE} offset={offset} onOffsetChange={setOffset} />
+            <Pagination
+              total={total}
+              limit={PAGE_SIZE}
+              offset={offset}
+              onOffsetChange={setOffset}
+            />
           )}
         </div>
       </div>
@@ -785,11 +1173,22 @@ function matchesFunderFilter(f: ShredFunder, filter: string): boolean {
   }
 
   switch (field) {
-    case 'funder': return f.funding_authority_key.toLowerCase().includes(needle)
-    case 'active': { const nf = parseNumericFilter(value); return nf ? matchesNumericFilter(f.active_seats, nf) : false }
-    case 'inactive': { const nf = parseNumericFilter(value); return nf ? matchesNumericFilter(f.inactive_seats, nf) : false }
-    case 'closed': { const nf = parseNumericFilter(value); return nf ? matchesNumericFilter(f.closed_seats, nf) : false }
-    default: return true
+    case 'funder':
+      return f.funding_authority_key.toLowerCase().includes(needle)
+    case 'active': {
+      const nf = parseNumericFilter(value)
+      return nf ? matchesNumericFilter(f.active_seats, nf) : false
+    }
+    case 'inactive': {
+      const nf = parseNumericFilter(value)
+      return nf ? matchesNumericFilter(f.inactive_seats, nf) : false
+    }
+    case 'closed': {
+      const nf = parseNumericFilter(value)
+      return nf ? matchesNumericFilter(f.closed_seats, nf) : false
+    }
+    default:
+      return true
   }
 }
 
@@ -797,7 +1196,13 @@ export function ShredsFundersPage() {
   const ps = usePageState()
   const sortField = ps.sortField || 'active'
 
-  const { data, isLoading, isFetching: rawFetchingFunders, error, refetch: refetchFunders } = useQuery({
+  const {
+    data,
+    isLoading,
+    isFetching: rawFetchingFunders,
+    error,
+    refetch: refetchFunders,
+  } = useQuery({
     queryKey: ['shred-funders'],
     queryFn: fetchShredFunders,
     refetchInterval: 30000,
@@ -813,17 +1218,27 @@ export function ShredsFundersPage() {
       const { field } = parseFilter(f, funderFilterFields)
       grouped.set(field, [...(grouped.get(field) ?? []), f])
     }
-    return data.filter(f => Array.from(grouped.values()).every(group => group.some(fl => matchesFunderFilter(f, fl))))
+    return data.filter((f) =>
+      Array.from(grouped.values()).every((group) => group.some((fl) => matchesFunderFilter(f, fl))),
+    )
   }, [data, ps.allFilters])
 
   const sorted = useMemo(() => {
     return [...filtered].sort((a, b) => {
       let cmp = 0
       switch (sortField) {
-        case 'funder': cmp = a.funding_authority_key.localeCompare(b.funding_authority_key); break
-        case 'active': cmp = a.active_seats - b.active_seats; break
-        case 'inactive': cmp = a.inactive_seats - b.inactive_seats; break
-        case 'closed': cmp = a.closed_seats - b.closed_seats; break
+        case 'funder':
+          cmp = a.funding_authority_key.localeCompare(b.funding_authority_key)
+          break
+        case 'active':
+          cmp = a.active_seats - b.active_seats
+          break
+        case 'inactive':
+          cmp = a.inactive_seats - b.inactive_seats
+          break
+        case 'closed':
+          cmp = a.closed_seats - b.closed_seats
+          break
       }
       return ps.sortDirection === 'asc' ? cmp : -cmp
     })
@@ -840,15 +1255,27 @@ export function ShredsFundersPage() {
           title="Shred Funders"
           count={sorted.length}
           subtitle={
-            <button onClick={refreshFunders.onClick} className="text-muted-foreground hover:text-foreground transition-colors" title="Refresh">
-              {refreshFunders.spinning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            <button
+              onClick={refreshFunders.onClick}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title="Refresh"
+            >
+              {refreshFunders.spinning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
             </button>
           }
           actions={
             <FilterActions
-              searchFilters={ps.searchFilters} removeFilter={ps.removeFilter} clearAllFilters={ps.clearAllFilters}
+              searchFilters={ps.searchFilters}
+              removeFilter={ps.removeFilter}
+              clearAllFilters={ps.clearAllFilters}
               setLiveFilter={ps.setLiveFilter}
-              fieldPrefixes={funderFieldPrefixes} entity="shred-funders" placeholder="Filter funders..."
+              fieldPrefixes={funderFieldPrefixes}
+              entity="shred-funders"
+              placeholder="Filter funders..."
             />
           }
         />
@@ -863,27 +1290,71 @@ export function ShredsFundersPage() {
             <table className="w-full">
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
-                  <SortHeader field="funder" label="Funder" currentSort={sortField} currentDir={ps.sortDirection} onSort={ps.handleSort} />
-                  <SortHeader field="active" label="Active Seats" align="right" currentSort={sortField} currentDir={ps.sortDirection} onSort={ps.handleSort} />
-                  <SortHeader field="inactive" label="Inactive Seats" align="right" currentSort={sortField} currentDir={ps.sortDirection} onSort={ps.handleSort} />
-                  <SortHeader field="closed" label="Closed Seats" align="right" currentSort={sortField} currentDir={ps.sortDirection} onSort={ps.handleSort} />
+                  <SortHeader
+                    field="funder"
+                    label="Funder"
+                    currentSort={sortField}
+                    currentDir={ps.sortDirection}
+                    onSort={ps.handleSort}
+                  />
+                  <SortHeader
+                    field="active"
+                    label="Active Seats"
+                    align="right"
+                    currentSort={sortField}
+                    currentDir={ps.sortDirection}
+                    onSort={ps.handleSort}
+                  />
+                  <SortHeader
+                    field="inactive"
+                    label="Inactive Seats"
+                    align="right"
+                    currentSort={sortField}
+                    currentDir={ps.sortDirection}
+                    onSort={ps.handleSort}
+                  />
+                  <SortHeader
+                    field="closed"
+                    label="Closed Seats"
+                    align="right"
+                    currentSort={sortField}
+                    currentDir={ps.sortDirection}
+                    onSort={ps.handleSort}
+                  />
                 </tr>
               </thead>
               <tbody>
                 {sorted.map((f) => (
-                  <tr key={f.funding_authority_key} className="border-b border-border last:border-b-0 hover:bg-muted transition-colors">
-                    <td className="px-4 py-3 font-mono text-xs" title={f.funding_authority_key}>{truncatePK(f.funding_authority_key)}</td>
+                  <tr
+                    key={f.funding_authority_key}
+                    className="border-b border-border last:border-b-0 hover:bg-muted transition-colors"
+                  >
+                    <td className="px-4 py-3 font-mono text-xs" title={f.funding_authority_key}>
+                      {truncatePK(f.funding_authority_key)}
+                    </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">{f.active_seats}</td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {f.inactive_seats > 0 ? f.inactive_seats : <span className="text-muted-foreground">—</span>}
+                      {f.inactive_seats > 0 ? (
+                        f.inactive_seats
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {f.closed_seats > 0 ? f.closed_seats : <span className="text-muted-foreground">—</span>}
+                      {f.closed_seats > 0 ? (
+                        f.closed_seats
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </td>
                   </tr>
                 ))}
                 {sorted.length === 0 && (
-                  <tr><td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">No funders found</td></tr>
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
+                      No funders found
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>
@@ -897,7 +1368,10 @@ export function ShredsFundersPage() {
 // --- Escrow Events Page ---
 
 const eventFieldPrefixes = [
-  { prefix: 'type:', description: 'Filter by event type (fund, close, batch_allocate, ...)' },
+  {
+    prefix: 'type:',
+    description: 'Filter by event type (fund, close, batch_allocate, ...)',
+  },
   { prefix: 'escrow:', description: 'Filter by escrow key' },
   { prefix: 'seat:', description: 'Filter by client seat key' },
   { prefix: 'signer:', description: 'Filter by transaction signer' },
@@ -907,7 +1381,13 @@ const eventFieldPrefixes = [
 
 function formatUSDC(raw: number | null): string {
   if (raw === null) return '\u2014'
-  return '$' + (raw / 1_000_000).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  return (
+    '$' +
+    (raw / 1_000_000).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  )
 }
 
 const eventTypeBadgeColors: Record<string, string> = {
@@ -994,17 +1474,32 @@ export function ShredsEscrowEventsPage() {
     return { range: timeRange }
   }, [timeRange, customStart, customEnd])
 
-  const { data, isLoading, isFetching: rawFetchingEvents, error, refetch: refetchEvents } = useQuery({
-    queryKey: ['shred-escrow-events', offset, sortBy, sortDir, timeParams, searchParam, includeInternal],
-    queryFn: () => fetchShredEscrowEvents({
-      limit: PAGE_SIZE,
+  const {
+    data,
+    isLoading,
+    isFetching: rawFetchingEvents,
+    error,
+    refetch: refetchEvents,
+  } = useQuery({
+    queryKey: [
+      'shred-escrow-events',
       offset,
       sortBy,
       sortDir,
-      ...timeParams,
-      filters: serverFilters,
+      timeParams,
+      searchParam,
       includeInternal,
-    }),
+    ],
+    queryFn: () =>
+      fetchShredEscrowEvents({
+        limit: PAGE_SIZE,
+        offset,
+        sortBy,
+        sortDir,
+        ...timeParams,
+        filters: serverFilters,
+        includeInternal,
+      }),
     placeholderData: keepPreviousData,
     refetchInterval: 30000,
   })
@@ -1015,88 +1510,121 @@ export function ShredsEscrowEventsPage() {
   const total = data?.total ?? 0
 
   // URL state setters.
-  const handleSort = useCallback((field: string) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (prev.get('sort') === field) { p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc') }
-      else { p.set('sort', field); p.set('dir', 'desc') }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleSort = useCallback(
+    (field: string) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (prev.get('sort') === field) {
+          p.set('dir', prev.get('dir') === 'asc' ? 'desc' : 'asc')
+        } else {
+          p.set('sort', field)
+          p.set('dir', 'desc')
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const handleTimeRange = useCallback((range: TimeRangePreset | 'custom') => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      p.set('range', range)
-      if (range !== 'custom') {
-        p.delete('start_time')
-        p.delete('end_time')
-      } else if (!prev.get('start_time')) {
-        // Default custom to last 7 days.
-        const now = Math.floor(Date.now() / 1000)
-        p.set('start_time', String(now - 7 * 86400))
-        p.set('end_time', String(now))
-      }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleTimeRange = useCallback(
+    (range: TimeRangePreset | 'custom') => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        p.set('range', range)
+        if (range !== 'custom') {
+          p.delete('start_time')
+          p.delete('end_time')
+        } else if (!prev.get('start_time')) {
+          // Default custom to last 7 days.
+          const now = Math.floor(Date.now() / 1000)
+          p.set('start_time', String(now - 7 * 86400))
+          p.set('end_time', String(now))
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const handleCustomStart = useCallback((value: string) => {
-    const ts = Math.floor(new Date(value).getTime() / 1000)
-    if (isNaN(ts)) return
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      p.set('start_time', String(ts))
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleCustomStart = useCallback(
+    (value: string) => {
+      const ts = Math.floor(new Date(value).getTime() / 1000)
+      if (isNaN(ts)) return
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        p.set('start_time', String(ts))
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const handleCustomEnd = useCallback((value: string) => {
-    const ts = Math.floor(new Date(value).getTime() / 1000)
-    if (isNaN(ts)) return
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      p.set('end_time', String(ts))
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleCustomEnd = useCallback(
+    (value: string) => {
+      const ts = Math.floor(new Date(value).getTime() / 1000)
+      if (isNaN(ts)) return
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        p.set('end_time', String(ts))
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
-      if (newPage <= 1) { p.delete('page') } else { p.set('page', String(newPage)) }
-      return p
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
+        if (newPage <= 1) {
+          p.delete('page')
+        } else {
+          p.set('page', String(newPage))
+        }
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (newFilters.length === 0) { p.delete('search') } else { p.set('search', newFilters.join(',')) }
-      p.delete('page')
-      return p
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          p.delete('search')
+        } else {
+          p.set('search', newFilters.join(','))
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
-  const addFilter = useCallback((filter: string) => {
-    if (searchFilters.includes(filter)) return
-    const newFilters = [...searchFilters, filter]
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      p.set('search', newFilters.join(','))
-      p.delete('page')
-      return p
-    })
-  }, [searchFilters, setSearchParams])
+  const addFilter = useCallback(
+    (filter: string) => {
+      if (searchFilters.includes(filter)) return
+      const newFilters = [...searchFilters, filter]
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        p.set('search', newFilters.join(','))
+        p.delete('page')
+        return p
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const p = new URLSearchParams(prev)
       p.delete('search')
       p.delete('page')
@@ -1104,14 +1632,21 @@ export function ShredsEscrowEventsPage() {
     })
   }, [setSearchParams])
 
-  const handleIncludeInternal = useCallback((value: boolean) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (value) { p.set('internal', 'true') } else { p.delete('internal') }
-      p.delete('page')
-      return p
-    })
-  }, [setSearchParams])
+  const handleIncludeInternal = useCallback(
+    (value: boolean) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (value) {
+          p.set('internal', 'true')
+        } else {
+          p.delete('internal')
+        }
+        p.delete('page')
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   const maxDate = new Date().toISOString().slice(0, 16)
 
@@ -1126,24 +1661,36 @@ export function ShredsEscrowEventsPage() {
           title="Shred Activity"
           count={total}
           subtitle={
-            <button onClick={refreshEvents.onClick} className="text-muted-foreground hover:text-foreground transition-colors" title="Refresh">
-              {refreshEvents.spinning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            <button
+              onClick={refreshEvents.onClick}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title="Refresh"
+            >
+              {refreshEvents.spinning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
             </button>
           }
           actions={
             <FilterActions
-              searchFilters={searchFilters} removeFilter={removeFilter} clearAllFilters={clearAllFilters}
+              searchFilters={searchFilters}
+              removeFilter={removeFilter}
+              clearAllFilters={clearAllFilters}
               setLiveFilter={() => {}}
-              fieldPrefixes={eventFieldPrefixes} entity="escrow-events" placeholder="Filter events..."
+              fieldPrefixes={eventFieldPrefixes}
+              entity="escrow-events"
+              placeholder="Filter events..."
               autocompleteFields={['type', 'seat', 'signer', 'status']}
             />
           }
         />
 
         {/* Time range selector */}
-        <div className="flex items-center gap-3 mb-4">
-          <div className="inline-flex rounded-md border border-border bg-background p-0.5">
-            {timeRangePresets.map(option => (
+        <div className="flex sm:items-center flex-col sm:flex-row gap-3 mb-4">
+          <div className="inline-flex rounded-md border border-border bg-background p-0.5 overflow-x-auto max-w-fit">
+            {timeRangePresets.map((option) => (
               <button
                 key={option.value}
                 onClick={() => handleTimeRange(option.value)}
@@ -1185,12 +1732,16 @@ export function ShredsEscrowEventsPage() {
             className="inline-flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             <span>Internal</span>
-            <div className={`relative w-7 h-4 rounded-full transition-colors ${
-              includeInternal ? 'bg-primary' : 'bg-muted-foreground/30'
-            }`}>
-              <div className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform ${
-                includeInternal ? 'translate-x-3.5' : 'translate-x-0.5'
-              }`} />
+            <div
+              className={`relative w-7 h-4 rounded-full transition-colors ${
+                includeInternal ? 'bg-primary' : 'bg-muted-foreground/30'
+              }`}
+            >
+              <div
+                className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform ${
+                  includeInternal ? 'translate-x-3.5' : 'translate-x-0.5'
+                }`}
+              />
             </div>
           </button>
         </div>
@@ -1205,25 +1756,68 @@ export function ShredsEscrowEventsPage() {
             <table className="w-full">
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
-                  <SortHeader field="time" label="Time" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="type" label="Event" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
+                  <SortHeader
+                    field="time"
+                    label="Time"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="type"
+                    label="Event"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
                   <th className="px-4 py-3 font-medium">Seat</th>
                   <th className="px-4 py-3 font-medium">Client IP</th>
                   <th className="px-4 py-3 font-medium">Signer</th>
-                  <SortHeader field="amount" label="Amount (USDC)" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="balance" label="Balance (USDC)" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
-                  <SortHeader field="epoch" label="Epoch" align="right" currentSort={sortBy} currentDir={sortDir} onSort={handleSort} />
+                  <SortHeader
+                    field="amount"
+                    label="Amount (USDC)"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="balance"
+                    label="Balance (USDC)"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    field="epoch"
+                    label="Epoch"
+                    align="right"
+                    currentSort={sortBy}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
                   <th className="px-4 py-3 font-medium">Tx</th>
                 </tr>
               </thead>
               <tbody>
                 {items.map((e) => (
-                  <tr key={`${e.tx_signature}-${e.event_type}-${e.escrow_pk}`} className="border-b border-border last:border-b-0 hover:bg-muted transition-colors">
+                  <tr
+                    key={`${e.tx_signature}-${e.event_type}-${e.escrow_pk}`}
+                    className="border-b border-border last:border-b-0 hover:bg-muted transition-colors"
+                  >
                     <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
-                      {new Date(e.event_ts).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                      {new Date(e.event_ts).toLocaleString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
                     </td>
                     <td className="px-4 py-3">
-                      <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border whitespace-nowrap ${eventTypeBadgeColors[e.event_type] || eventTypeBadgeColors.unknown}`}>
+                      <span
+                        className={`inline-flex items-center text-xs px-2 py-0.5 rounded-lg border whitespace-nowrap ${eventTypeBadgeColors[e.event_type] || eventTypeBadgeColors.unknown}`}
+                      >
                         {eventTypeLabels[e.event_type] || e.event_type}
                       </span>
                       {e.status === 'failed' && (
@@ -1240,7 +1834,7 @@ export function ShredsEscrowEventsPage() {
                         >
                           {truncatePK(e.client_seat_pk)}
                         </Link>
-                        {!searchFilters.some(f => f.startsWith('seat:')) && (
+                        {!searchFilters.some((f) => f.startsWith('seat:')) && (
                           <button
                             onClick={() => addFilter(`seat:${e.client_seat_pk}`)}
                             className="text-muted-foreground hover:text-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity p-0.5"
@@ -1259,18 +1853,34 @@ export function ShredsEscrowEventsPage() {
                     </td>
                     <td className="px-4 py-3 font-mono text-xs" title={e.signer}>
                       <span className="inline-flex items-center gap-1.5 group/cell">
-                        {e.signer ? truncatePK(e.signer) : <span className="text-muted-foreground">{'\u2014'}</span>}
+                        {e.signer ? (
+                          truncatePK(e.signer)
+                        ) : (
+                          <span className="text-muted-foreground">{'\u2014'}</span>
+                        )}
                         {e.signer && <CopyIcon text={e.signer} />}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {e.amount_usdc !== null ? formatUSDC(e.amount_usdc) : <span className="text-muted-foreground">{'\u2014'}</span>}
+                      {e.amount_usdc !== null ? (
+                        formatUSDC(e.amount_usdc)
+                      ) : (
+                        <span className="text-muted-foreground">{'\u2014'}</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {e.balance_after_usdc !== null ? formatUSDC(e.balance_after_usdc) : <span className="text-muted-foreground">{'\u2014'}</span>}
+                      {e.balance_after_usdc !== null ? (
+                        formatUSDC(e.balance_after_usdc)
+                      ) : (
+                        <span className="text-muted-foreground">{'\u2014'}</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right">
-                      {e.epoch !== null ? e.epoch : <span className="text-muted-foreground">{'\u2014'}</span>}
+                      {e.epoch !== null ? (
+                        e.epoch
+                      ) : (
+                        <span className="text-muted-foreground">{'\u2014'}</span>
+                      )}
                     </td>
                     <td className="px-4 py-3">
                       <a
@@ -1287,7 +1897,11 @@ export function ShredsEscrowEventsPage() {
                   </tr>
                 ))}
                 {items.length === 0 && (
-                  <tr><td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">No activity found</td></tr>
+                  <tr>
+                    <td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">
+                      No activity found
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -55,7 +55,8 @@ export function Sidebar() {
   const isIncidentsRoute = location.pathname.startsWith('/incidents')
   const isChatRoute = location.pathname.startsWith('/chat')
   const isChatSessions = location.pathname === '/chat/sessions'
-  const isTopologyRoute = location.pathname === '/topology' || location.pathname.startsWith('/topology/')
+  const isTopologyRoute =
+    location.pathname === '/topology' || location.pathname.startsWith('/topology/')
   const isPerformanceRoute = location.pathname.startsWith('/performance')
   const isTrafficRoute = location.pathname.startsWith('/traffic')
   const isDZRoute = location.pathname.startsWith('/dz/')
@@ -69,7 +70,11 @@ export function Sidebar() {
   const isTopologyRedundancy = location.pathname === '/topology/redundancy'
   const isTopologyMetroConnectivity = location.pathname === '/topology/metro-connectivity'
   const isTopologyMaintenance = location.pathname === '/topology/maintenance'
-  const isTopologyTool = isTopologyPathCalculator || isTopologyRedundancy || isTopologyMetroConnectivity || isTopologyMaintenance
+  const isTopologyTool =
+    isTopologyPathCalculator ||
+    isTopologyRedundancy ||
+    isTopologyMetroConnectivity ||
+    isTopologyMaintenance
 
   // Performance sub-routes
   const isPerformanceDzVsInternet = location.pathname === '/performance/dz-vs-internet'
@@ -98,6 +103,10 @@ export function Sidebar() {
   const isGossipNodesRoute = location.pathname.startsWith('/solana/gossip-nodes')
   const isSolanaOverviewRoute = location.pathname === '/solana/overview'
 
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== 'undefined' && window.innerWidth < 1024,
+  )
+
   const [isCollapsed, setIsCollapsed] = useState(() => {
     const userPref = localStorage.getItem('sidebar-user-collapsed')
     if (userPref !== null) return userPref === 'true'
@@ -107,6 +116,12 @@ export function Sidebar() {
     const saved = localStorage.getItem('sidebar-user-collapsed')
     return saved !== null ? saved === 'true' : null
   })
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 1024)
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
 
   // Auto-collapse/expand based on screen size and user preference
   useEffect(() => {
@@ -137,271 +152,123 @@ export function Sidebar() {
     localStorage.setItem('sidebar-collapsed', String(isCollapsed))
   }, [isCollapsed])
 
+  useEffect(() => {
+    if (isMobile) {
+      setIsCollapsed(true)
+    }
+  }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleSetCollapsed = (collapsed: boolean) => {
     setIsCollapsed(collapsed)
-    setUserCollapsed(collapsed)
-    localStorage.setItem('sidebar-user-collapsed', String(collapsed))
+    if (!isMobile) {
+      setUserCollapsed(collapsed)
+      localStorage.setItem('sidebar-user-collapsed', String(collapsed))
+    }
   }
 
   // Active state classes for nav items
-  const navItemClass = (isActive: boolean) => cn(
-    'w-full flex items-center gap-2 px-3 py-1.5 text-sm rounded-r transition-colors border-l-2',
-    isActive
-      ? 'border-accent bg-[var(--sidebar-active)] text-foreground font-medium'
-      : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]'
-  )
+  const navItemClass = (isActive: boolean) =>
+    cn(
+      'w-full flex items-center gap-2 px-3 py-1.5 text-sm rounded-r transition-colors border-l-2',
+      isActive
+        ? 'border-accent bg-[var(--sidebar-active)] text-foreground font-medium'
+        : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]',
+    )
 
   // Expanded parent nav item (e.g., "Topology" when on /topology/*) — subtle, no background
   const navItemExpandedClass = cn(
     'w-full flex items-center gap-2 px-3 py-1.5 text-sm rounded-r transition-colors border-l-2',
-    'border-transparent text-foreground font-medium hover:bg-[var(--sidebar-active)]'
+    'border-transparent text-foreground font-medium hover:bg-[var(--sidebar-active)]',
   )
 
   // Sub-nav item class (indented, with optional deeper nesting)
-  const subNavItemClass = (isActive: boolean, nested?: boolean) => cn(
-    'w-full flex items-center gap-2 pr-3 py-1.5 text-sm rounded-r transition-colors border-l-2',
-    nested ? 'pl-12' : 'pl-8',
-    isActive
-      ? 'border-accent bg-[var(--sidebar-active)] text-foreground font-medium'
-      : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]'
-  )
+  const subNavItemClass = (isActive: boolean, nested?: boolean) =>
+    cn(
+      'w-full flex items-center gap-2 pr-3 py-1.5 text-sm rounded-r transition-colors border-l-2',
+      nested ? 'pl-12' : 'pl-8',
+      isActive
+        ? 'border-accent bg-[var(--sidebar-active)] text-foreground font-medium'
+        : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]',
+    )
 
-  const collapsedIconClass = (isActive: boolean) => cn(
-    'p-2 rounded transition-colors',
-    isActive
-      ? 'bg-[oklch(25%_.04_250)] text-white hover:bg-[oklch(30%_.05_250)]'
-      : 'text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]'
-  )
+  const collapsedIconClass = (isActive: boolean) =>
+    cn(
+      'p-2 rounded transition-colors',
+      isActive
+        ? 'bg-[oklch(25%_.04_250)] text-white hover:bg-[oklch(30%_.05_250)]'
+        : 'text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]',
+    )
 
   // ─── Collapsed sidebar ───────────────────────────────────────────────
   if (isCollapsed) {
     return (
-      <div className="w-12 border-r bg-[var(--sidebar)] flex flex-col items-center relative z-10">
-        {/* Logo icon - matches expanded header height */}
-        <div className="w-full h-12 flex items-center justify-center border-b border-border/50 shrink-0">
-          <button
-            onClick={() => handleSetCollapsed(false)}
-            className="group relative"
-            title="Expand sidebar"
-          >
-            <img src={resolvedTheme === 'dark' ? '/logoDarkSm.svg' : '/logoLightSm.svg'} alt="Data" className="h-6 group-hover:opacity-0 transition-opacity" />
-            <PanelLeftOpen className="h-5 w-5 absolute inset-0 m-auto opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground" />
-          </button>
-        </div>
-
-        <div className="flex-1 flex flex-col items-center gap-1 pt-4 overflow-y-auto min-h-0">
-          {/* Search */}
-          <button
-            onClick={() => window.dispatchEvent(new CustomEvent('open-search'))}
-            className="p-2 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]"
-            title="Search (⌘K)"
-          >
-            <Search className="h-4 w-4" />
-          </button>
-
-          {/* Main nav */}
-          <Link to="/status" className={collapsedIconClass(isStatusRoute)} title="Status">
-            <Activity className="h-4 w-4" />
-          </Link>
-          <Link to="/topology/map" className={collapsedIconClass(isTopologyRoute)} title="Topology">
-            <Globe className="h-4 w-4" />
-          </Link>
-          <Link to="/traffic/overview" className={collapsedIconClass(isTrafficRoute)} title="Traffic">
-            <Network className="h-4 w-4" />
-          </Link>
-          <Link to="/performance/dz-vs-internet" className={collapsedIconClass(isPerformanceRoute)} title="Performance">
-            <Gauge className="h-4 w-4" />
-          </Link>
-          <Link to="/incidents/links" className={collapsedIconClass(isIncidentsRoute)} title="Incidents">
-            <ShieldAlert className="h-4 w-4" />
-          </Link>
-          <button
-            onClick={(e) => {
-              if (e.metaKey || e.ctrlKey) {
-                window.open('/chat', '_blank')
-              } else if (location.pathname === '/chat') {
-                window.dispatchEvent(new CustomEvent('refresh-chat-suggestions'))
-              } else {
-                navigate('/chat')
-              }
-            }}
-            className={collapsedIconClass(isChatRoute)}
-            title="Chat"
-          >
-            <MessageSquare className="h-4 w-4" />
-          </button>
-          {/* Divider */}
-          <div className="w-6 border-t border-border/50 my-2" />
-
-          {/* Entity sections */}
-          <Link to="/dz/devices" className={collapsedIconClass(isDZRoute)} title="DoubleZero">
-            <Server className="h-4 w-4" />
-          </Link>
-          {hasSolana && (
-            <Link to="/solana/validators" className={collapsedIconClass(isSolanaRoute)} title="Solana">
-              <Landmark className="h-4 w-4" />
-            </Link>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex flex-col items-center gap-1 mb-3 shrink-0">
-          {updateAvailable && (
+      <>
+        {isMobile && <div className="w-12 shrink-0" />}
+        <div
+          className={
+            isMobile
+              ? 'fixed inset-y-0 left-0 z-50 w-12 border-r bg-(--sidebar) flex flex-col items-center'
+              : 'w-12 border-r bg-(--sidebar) flex flex-col items-center relative z-10'
+          }
+        >
+          {/* Logo icon - matches expanded header height */}
+          <div className="w-full h-12 flex items-center justify-center border-b border-border/50 shrink-0">
             <button
-              onClick={reload}
-              className="p-2 text-blue-500 hover:text-blue-400 transition-colors animate-pulse"
-              title="Click to reload and get the latest version"
+              onClick={() => handleSetCollapsed(false)}
+              className="group relative"
+              title="Expand sidebar"
             >
-              <ArrowUpCircle className="h-4 w-4" />
+              <img
+                src={resolvedTheme === 'dark' ? '/logoDarkSm.svg' : '/logoLightSm.svg'}
+                alt="Data"
+                className="h-6 group-hover:opacity-0 transition-opacity"
+              />
+              <PanelLeftOpen className="h-5 w-5 absolute inset-0 m-auto opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground" />
             </button>
-          )}
-          <button
-            onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-            className="p-2 text-muted-foreground hover:text-foreground transition-colors"
-            title={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
-          >
-            {resolvedTheme === 'dark' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
-          </button>
-          <UserPopover collapsed />
-          <button
-            onClick={() => handleSetCollapsed(false)}
-            className="p-2 text-muted-foreground hover:text-foreground transition-colors"
-            title="Expand sidebar"
-          >
-            <PanelLeftOpen className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-    )
-  }
+          </div>
 
-  // ─── Expanded sidebar ────────────────────────────────────────────────
-  return (
-    <div className="w-64 border-r bg-[var(--sidebar)] flex flex-col relative z-10">
-      {/* Header with logo and collapse */}
-      <div className="px-3 h-12 flex items-center justify-between border-b border-border/50 shrink-0">
-        <Link
-          to="/"
-          className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer"
-        >
-          <img src={resolvedTheme === 'dark' ? '/logoDark.svg' : '/logoLight.svg'} alt="DoubleZero" className="h-6" />
-          <span className="wordmark text-lg">Data</span>
-        </Link>
-        <button
-          onClick={() => handleSetCollapsed(true)}
-          className="p-1 text-muted-foreground hover:text-foreground transition-colors"
-          title="Collapse sidebar"
-        >
-          <PanelLeftClose className="h-4 w-4 translate-y-0.5" />
-        </button>
-      </div>
+          <div className="flex-1 flex flex-col items-center gap-1 pt-4 overflow-y-auto min-h-0">
+            {/* Search */}
+            <button
+              onClick={() => window.dispatchEvent(new CustomEvent('open-search'))}
+              className="p-2 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]"
+              title="Search (⌘K)"
+            >
+              <Search className="h-4 w-4" />
+            </button>
 
-      {/* Scrollable content area */}
-      <div className="flex-1 flex flex-col overflow-y-auto min-h-0">
-        {/* Main nav - no section label */}
-        <div className="px-3 pt-4">
-          <div className="space-y-1">
-            <Link to="/status" className={navItemClass(isStatusRoute)}>
+            {/* Main nav */}
+            <Link to="/status" className={collapsedIconClass(isStatusRoute)} title="Status">
               <Activity className="h-4 w-4" />
-              Status
             </Link>
-
-            {/* Topology with inline sub-items */}
-            <Link to="/topology/map" className={isTopologyRoute ? navItemExpandedClass : navItemClass(false)}>
+            <Link
+              to="/topology/map"
+              className={collapsedIconClass(isTopologyRoute)}
+              title="Topology"
+            >
               <Globe className="h-4 w-4" />
-              Topology
             </Link>
-            {isTopologyRoute && (
-              <>
-                <Link to="/topology/map" className={subNavItemClass(isTopologyMap)}>
-                  <Map className="h-4 w-4" />
-                  Map
-                </Link>
-                <Link to="/topology/globe" className={subNavItemClass(isTopologyGlobe)}>
-                  <Globe className="h-4 w-4" />
-                  Globe
-                </Link>
-                {hasNeo4j && (
-                  <>
-                    <Link to="/topology/graph" className={subNavItemClass(isTopologyGraph)}>
-                      <Network className="h-4 w-4" />
-                      Graph
-                    </Link>
-                    <Link to="/topology/path-calculator" className={subNavItemClass(isTopologyTool)}>
-                      <Wrench className="h-4 w-4" />
-                      Tools
-                    </Link>
-                    {isTopologyTool && (
-                      <>
-                        <Link to="/topology/path-calculator" className={subNavItemClass(isTopologyPathCalculator, true)}>
-                          <Route className="h-4 w-4" />
-                          Path Calculator
-                        </Link>
-                        <Link to="/topology/redundancy" className={subNavItemClass(isTopologyRedundancy, true)}>
-                          <Shield className="h-4 w-4" />
-                          Redundancy
-                        </Link>
-                        <Link to="/topology/metro-connectivity" className={subNavItemClass(isTopologyMetroConnectivity, true)}>
-                          <Network className="h-4 w-4" />
-                          Metro Connectivity
-                        </Link>
-                        <Link to="/topology/maintenance" className={subNavItemClass(isTopologyMaintenance, true)}>
-                          <Wrench className="h-4 w-4" />
-                          Maintenance
-                        </Link>
-                      </>
-                    )}
-                  </>
-                )}
-              </>
-            )}
-
-            {/* Traffic with inline sub-items */}
-            <Link to="/traffic/overview" className={isTrafficRoute ? navItemExpandedClass : navItemClass(false)}>
+            <Link
+              to="/traffic/overview"
+              className={collapsedIconClass(isTrafficRoute)}
+              title="Traffic"
+            >
               <Network className="h-4 w-4" />
-              Traffic
             </Link>
-            {isTrafficRoute && (
-              <>
-                <Link to="/traffic/overview" className={subNavItemClass(isTrafficDashboard)}>
-                  <BarChart3 className="h-4 w-4" />
-                  Overview
-                </Link>
-                <Link to="/traffic/interfaces" className={subNavItemClass(isTrafficInterfaces)}>
-                  <Network className="h-4 w-4" />
-                  Interfaces
-                </Link>
-              </>
-            )}
-
-            {/* Performance with inline sub-items */}
-            <Link to="/performance/dz-vs-internet" className={isPerformanceRoute ? navItemExpandedClass : navItemClass(false)}>
+            <Link
+              to="/performance/dz-vs-internet"
+              className={collapsedIconClass(isPerformanceRoute)}
+              title="Performance"
+            >
               <Gauge className="h-4 w-4" />
-              Performance
             </Link>
-            {isPerformanceRoute && (
-              <>
-                <Link to="/performance/dz-vs-internet" className={subNavItemClass(isPerformanceDzVsInternet)}>
-                  <Zap className="h-4 w-4" />
-                  DZ vs Internet
-                </Link>
-                <Link to="/performance/link-latency" className={subNavItemClass(isPerformanceLinkLatency)}>
-                  <ArrowRightLeft className="h-4 w-4" />
-                  Link Latency
-                </Link>
-                {hasNeo4j && (
-                  <Link to="/performance/path-latency" className={subNavItemClass(isPerformancePathLatency)}>
-                    <Route className="h-4 w-4" />
-                    Path Latency
-                  </Link>
-                )}
-              </>
-            )}
-            <Link to="/incidents/links" className={navItemClass(isIncidentsRoute)}>
+            <Link
+              to="/incidents/links"
+              className={collapsedIconClass(isIncidentsRoute)}
+              title="Incidents"
+            >
               <ShieldAlert className="h-4 w-4" />
-              Incidents
             </Link>
-            {/* Chat with inline sub-items */}
             <button
               onClick={(e) => {
                 if (e.metaKey || e.ctrlKey) {
@@ -412,172 +279,433 @@ export function Sidebar() {
                   navigate('/chat')
                 }
               }}
-              className={isChatRoute ? navItemExpandedClass : navItemClass(false)}
+              className={collapsedIconClass(isChatRoute)}
+              title="Chat"
             >
               <MessageSquare className="h-4 w-4" />
-              Chat
             </button>
-            {isChatRoute && (
-              <>
-                <button
-                  onClick={(e) => {
-                    if (e.metaKey || e.ctrlKey) {
-                      window.open('/chat', '_blank')
-                    } else {
-                      navigate('/chat')
-                    }
-                  }}
-                  className={subNavItemClass(!isChatSessions && (location.pathname === '/chat' || !!location.pathname.match(/^\/chat\/[^/]+$/)))}
-                >
-                  New chat
-                </button>
-                <Link to="/chat/sessions" className={subNavItemClass(isChatSessions)}>
-                  History
-                </Link>
-              </>
-            )}
+            {/* Divider */}
+            <div className="w-6 border-t border-border/50 my-2" />
 
-            <button
-              onClick={() => window.dispatchEvent(new CustomEvent('open-search'))}
-              className="w-full flex items-center gap-2 px-3 py-1.5 text-sm rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]"
-            >
-              <Search className="h-4 w-4" />
-              <span className="flex-1 text-left">Search</span>
-              <kbd className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">⌘K</kbd>
-            </button>
-          </div>
-        </div>
-
-        {/* DoubleZero section - always visible */}
-        <div className="px-3 pt-4">
-          <div className="px-3 mb-2">
-            <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">DoubleZero</span>
-          </div>
-          <div className="space-y-1">
-            <Link to="/dz/devices" className={navItemClass(isDevicesRoute)}>
+            {/* Entity sections */}
+            <Link to="/dz/devices" className={collapsedIconClass(isDZRoute)} title="DoubleZero">
               <Server className="h-4 w-4" />
-              Devices
             </Link>
-            <Link to="/dz/links" className={navItemClass(isLinksRoute)}>
-              <Link2 className="h-4 w-4" />
-              Links
-            </Link>
-            <Link to="/dz/metros" className={navItemClass(isMetrosRoute)}>
-              <MapPin className="h-4 w-4" />
-              Metros
-            </Link>
-            <Link to="/dz/contributors" className={navItemClass(isContributorsRoute)}>
-              <Building2 className="h-4 w-4" />
-              Contributors
-            </Link>
-            <Link to="/dz/tenants" className={navItemClass(isTenantsRoute)}>
-              <Layers className="h-4 w-4" />
-              Tenants
-            </Link>
-            <Link to="/dz/users" className={navItemClass(isUsersRoute)}>
-              <Users className="h-4 w-4" />
-              Users
-            </Link>
-            <Link to="/dz/multicast-groups" className={navItemClass(isMulticastGroupsRoute)}>
-              <Radio className="h-4 w-4" />
-              Multicast
-            </Link>
-            <Link to="/dz/publisher-check" className={navItemClass(isPublisherCheckRoute)}>
-              <ShieldCheck className="h-4 w-4" />
-              Publisher Check
-            </Link>
-            <Link to="/dz/shreds/subscribers" className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}>
-              <Puzzle className="h-4 w-4" />
-              Shreds
-            </Link>
-            {isShredsRoute && (
-              <>
-                <Link to="/dz/shreds/subscribers" className={subNavItemClass(isShredsSeatsRoute)}>
-                  Subscribers
-                </Link>
-                <Link to="/dz/shreds/devices" className={subNavItemClass(isShredsDevicesRoute)}>
-                  Devices
-                </Link>
-                <Link to="/dz/shreds/activity" className={subNavItemClass(isShredsEscrowEventsRoute)}>
-                  Activity
-                </Link>
-                {isInternalUser && (
-                  <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
-                    Scoreboard
-                  </Link>
-                )}
-              </>
+            {hasSolana && (
+              <Link
+                to="/solana/validators"
+                className={collapsedIconClass(isSolanaRoute)}
+                title="Solana"
+              >
+                <Landmark className="h-4 w-4" />
+              </Link>
             )}
           </div>
+
+          {/* Footer */}
+          <div className="flex flex-col items-center gap-1 mb-3 shrink-0">
+            {updateAvailable && (
+              <button
+                onClick={reload}
+                className="p-2 text-blue-500 hover:text-blue-400 transition-colors animate-pulse"
+                title="Click to reload and get the latest version"
+              >
+                <ArrowUpCircle className="h-4 w-4" />
+              </button>
+            )}
+            <button
+              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+              title={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
+            >
+              {resolvedTheme === 'dark' ? (
+                <Moon className="h-4 w-4" />
+              ) : (
+                <Sun className="h-4 w-4" />
+              )}
+            </button>
+            <UserPopover collapsed />
+            <button
+              onClick={() => handleSetCollapsed(false)}
+              className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+              title="Expand sidebar"
+            >
+              <PanelLeftOpen className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  // ─── Expanded sidebar ────────────────────────────────────────────────
+  return (
+    <>
+      {isMobile && <div className="w-12 shrink-0" />}
+      {isMobile && (
+        <div className="fixed inset-0 z-40 bg-black/50" onClick={() => handleSetCollapsed(true)} />
+      )}
+      <div
+        className={
+          isMobile
+            ? 'fixed inset-y-0 left-0 z-50 w-64 border-r bg-(--sidebar) flex flex-col'
+            : 'w-64 border-r bg-(--sidebar) flex flex-col relative z-10'
+        }
+      >
+        {/* Header with logo and collapse */}
+        <div className="px-3 h-12 flex items-center justify-between border-b border-border/50 shrink-0">
+          <Link
+            to="/"
+            className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            <img
+              src={resolvedTheme === 'dark' ? '/logoDark.svg' : '/logoLight.svg'}
+              alt="DoubleZero"
+              className="h-6"
+            />
+            <span className="wordmark text-lg">Data</span>
+          </Link>
+          <button
+            onClick={() => handleSetCollapsed(true)}
+            className="p-1 text-muted-foreground hover:text-foreground transition-colors"
+            title="Collapse sidebar"
+          >
+            <PanelLeftClose className="h-4 w-4 translate-y-0.5" />
+          </button>
         </div>
 
-        {/* Solana section - always visible when feature-gated */}
-        {hasSolana && (
+        {/* Scrollable content area */}
+        <div className="flex-1 flex flex-col overflow-y-auto min-h-0">
+          {/* Main nav - no section label */}
+          <div className="px-3 pt-4">
+            <div className="space-y-1">
+              <Link to="/status" className={navItemClass(isStatusRoute)}>
+                <Activity className="h-4 w-4" />
+                Status
+              </Link>
+
+              {/* Topology with inline sub-items */}
+              <Link
+                to="/topology/map"
+                className={isTopologyRoute ? navItemExpandedClass : navItemClass(false)}
+              >
+                <Globe className="h-4 w-4" />
+                Topology
+              </Link>
+              {isTopologyRoute && (
+                <>
+                  <Link to="/topology/map" className={subNavItemClass(isTopologyMap)}>
+                    <Map className="h-4 w-4" />
+                    Map
+                  </Link>
+                  <Link to="/topology/globe" className={subNavItemClass(isTopologyGlobe)}>
+                    <Globe className="h-4 w-4" />
+                    Globe
+                  </Link>
+                  {hasNeo4j && (
+                    <>
+                      <Link to="/topology/graph" className={subNavItemClass(isTopologyGraph)}>
+                        <Network className="h-4 w-4" />
+                        Graph
+                      </Link>
+                      <Link
+                        to="/topology/path-calculator"
+                        className={subNavItemClass(isTopologyTool)}
+                      >
+                        <Wrench className="h-4 w-4" />
+                        Tools
+                      </Link>
+                      {isTopologyTool && (
+                        <>
+                          <Link
+                            to="/topology/path-calculator"
+                            className={subNavItemClass(isTopologyPathCalculator, true)}
+                          >
+                            <Route className="h-4 w-4" />
+                            Path Calculator
+                          </Link>
+                          <Link
+                            to="/topology/redundancy"
+                            className={subNavItemClass(isTopologyRedundancy, true)}
+                          >
+                            <Shield className="h-4 w-4" />
+                            Redundancy
+                          </Link>
+                          <Link
+                            to="/topology/metro-connectivity"
+                            className={subNavItemClass(isTopologyMetroConnectivity, true)}
+                          >
+                            <Network className="h-4 w-4" />
+                            Metro Connectivity
+                          </Link>
+                          <Link
+                            to="/topology/maintenance"
+                            className={subNavItemClass(isTopologyMaintenance, true)}
+                          >
+                            <Wrench className="h-4 w-4" />
+                            Maintenance
+                          </Link>
+                        </>
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+
+              {/* Traffic with inline sub-items */}
+              <Link
+                to="/traffic/overview"
+                className={isTrafficRoute ? navItemExpandedClass : navItemClass(false)}
+              >
+                <Network className="h-4 w-4" />
+                Traffic
+              </Link>
+              {isTrafficRoute && (
+                <>
+                  <Link to="/traffic/overview" className={subNavItemClass(isTrafficDashboard)}>
+                    <BarChart3 className="h-4 w-4" />
+                    Overview
+                  </Link>
+                  <Link to="/traffic/interfaces" className={subNavItemClass(isTrafficInterfaces)}>
+                    <Network className="h-4 w-4" />
+                    Interfaces
+                  </Link>
+                </>
+              )}
+
+              {/* Performance with inline sub-items */}
+              <Link
+                to="/performance/dz-vs-internet"
+                className={isPerformanceRoute ? navItemExpandedClass : navItemClass(false)}
+              >
+                <Gauge className="h-4 w-4" />
+                Performance
+              </Link>
+              {isPerformanceRoute && (
+                <>
+                  <Link
+                    to="/performance/dz-vs-internet"
+                    className={subNavItemClass(isPerformanceDzVsInternet)}
+                  >
+                    <Zap className="h-4 w-4" />
+                    DZ vs Internet
+                  </Link>
+                  <Link
+                    to="/performance/link-latency"
+                    className={subNavItemClass(isPerformanceLinkLatency)}
+                  >
+                    <ArrowRightLeft className="h-4 w-4" />
+                    Link Latency
+                  </Link>
+                  {hasNeo4j && (
+                    <Link
+                      to="/performance/path-latency"
+                      className={subNavItemClass(isPerformancePathLatency)}
+                    >
+                      <Route className="h-4 w-4" />
+                      Path Latency
+                    </Link>
+                  )}
+                </>
+              )}
+              <Link to="/incidents/links" className={navItemClass(isIncidentsRoute)}>
+                <ShieldAlert className="h-4 w-4" />
+                Incidents
+              </Link>
+              {/* Chat with inline sub-items */}
+              <button
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) {
+                    window.open('/chat', '_blank')
+                  } else if (location.pathname === '/chat') {
+                    window.dispatchEvent(new CustomEvent('refresh-chat-suggestions'))
+                  } else {
+                    navigate('/chat')
+                  }
+                }}
+                className={isChatRoute ? navItemExpandedClass : navItemClass(false)}
+              >
+                <MessageSquare className="h-4 w-4" />
+                Chat
+              </button>
+              {isChatRoute && (
+                <>
+                  <button
+                    onClick={(e) => {
+                      if (e.metaKey || e.ctrlKey) {
+                        window.open('/chat', '_blank')
+                      } else {
+                        navigate('/chat')
+                      }
+                    }}
+                    className={subNavItemClass(
+                      !isChatSessions &&
+                        (location.pathname === '/chat' ||
+                          !!location.pathname.match(/^\/chat\/[^/]+$/)),
+                    )}
+                  >
+                    New chat
+                  </button>
+                  <Link to="/chat/sessions" className={subNavItemClass(isChatSessions)}>
+                    History
+                  </Link>
+                </>
+              )}
+
+              <button
+                onClick={() => window.dispatchEvent(new CustomEvent('open-search'))}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-sm rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-[var(--sidebar-active)]"
+              >
+                <Search className="h-4 w-4" />
+                <span className="flex-1 text-left">Search</span>
+                <kbd className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                  ⌘K
+                </kbd>
+              </button>
+            </div>
+          </div>
+
+          {/* DoubleZero section - always visible */}
           <div className="px-3 pt-4">
             <div className="px-3 mb-2">
-              <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">Solana</span>
+              <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">
+                DoubleZero
+              </span>
             </div>
             <div className="space-y-1">
-              <Link to="/solana/overview" className={navItemClass(isSolanaOverviewRoute)}>
-                <BookOpen className="h-4 w-4" />
-                Overview
+              <Link to="/dz/devices" className={navItemClass(isDevicesRoute)}>
+                <Server className="h-4 w-4" />
+                Devices
               </Link>
-              <Link to="/solana/validators" className={navItemClass(isValidatorsRoute)}>
-                <Landmark className="h-4 w-4" />
-                Validators
+              <Link to="/dz/links" className={navItemClass(isLinksRoute)}>
+                <Link2 className="h-4 w-4" />
+                Links
               </Link>
-              <Link to="/solana/gossip-nodes" className={navItemClass(isGossipNodesRoute)}>
+              <Link to="/dz/metros" className={navItemClass(isMetrosRoute)}>
+                <MapPin className="h-4 w-4" />
+                Metros
+              </Link>
+              <Link to="/dz/contributors" className={navItemClass(isContributorsRoute)}>
+                <Building2 className="h-4 w-4" />
+                Contributors
+              </Link>
+              <Link to="/dz/tenants" className={navItemClass(isTenantsRoute)}>
+                <Layers className="h-4 w-4" />
+                Tenants
+              </Link>
+              <Link to="/dz/users" className={navItemClass(isUsersRoute)}>
+                <Users className="h-4 w-4" />
+                Users
+              </Link>
+              <Link to="/dz/multicast-groups" className={navItemClass(isMulticastGroupsRoute)}>
                 <Radio className="h-4 w-4" />
-                Gossip Nodes
+                Multicast
               </Link>
+              <Link to="/dz/publisher-check" className={navItemClass(isPublisherCheckRoute)}>
+                <ShieldCheck className="h-4 w-4" />
+                Publisher Check
+              </Link>
+              <Link
+                to="/dz/shreds/subscribers"
+                className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}
+              >
+                <Puzzle className="h-4 w-4" />
+                Shreds
+              </Link>
+              {isShredsRoute && (
+                <>
+                  <Link to="/dz/shreds/subscribers" className={subNavItemClass(isShredsSeatsRoute)}>
+                    Subscribers
+                  </Link>
+                  <Link to="/dz/shreds/devices" className={subNavItemClass(isShredsDevicesRoute)}>
+                    Devices
+                  </Link>
+                  <Link
+                    to="/dz/shreds/activity"
+                    className={subNavItemClass(isShredsEscrowEventsRoute)}
+                  >
+                    Activity
+                  </Link>
+                  {isInternalUser && (
+                    <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
+                      Scoreboard
+                    </Link>
+                  )}
+                </>
+              )}
             </div>
           </div>
-        )}
 
-        {/* Spacer */}
-        <div className="flex-1" />
-      </div>
+          {/* Solana section - always visible when feature-gated */}
+          {hasSolana && (
+            <div className="px-3 pt-4">
+              <div className="px-3 mb-2">
+                <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">
+                  Solana
+                </span>
+              </div>
+              <div className="space-y-1">
+                <Link to="/solana/overview" className={navItemClass(isSolanaOverviewRoute)}>
+                  <BookOpen className="h-4 w-4" />
+                  Overview
+                </Link>
+                <Link to="/solana/validators" className={navItemClass(isValidatorsRoute)}>
+                  <Landmark className="h-4 w-4" />
+                  Validators
+                </Link>
+                <Link to="/solana/gossip-nodes" className={navItemClass(isGossipNodesRoute)}>
+                  <Radio className="h-4 w-4" />
+                  Gossip Nodes
+                </Link>
+              </div>
+            </div>
+          )}
 
-      {/* Footer */}
-      <div className="px-3 py-3 border-t border-border/50 space-y-2 shrink-0">
-        {updateAvailable && (
-          <button
-            onClick={reload}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-blue-500 hover:text-blue-400 bg-blue-500/10 hover:bg-blue-500/20 rounded transition-colors"
-            title="Click to reload and get the latest version"
-          >
-            <ArrowUpCircle className="h-4 w-4" />
-            Update available
-          </button>
-        )}
-        <UserPopover />
-        <div className="flex rounded-lg border border-border overflow-hidden bg-card">
-          <button
-            onClick={() => setTheme('light')}
-            className={cn(
-              'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs transition-colors',
-              resolvedTheme === 'light'
-                ? 'bg-muted text-foreground font-medium'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-            )}
-          >
-            <Sun className="h-3.5 w-3.5" />
-            Light
-          </button>
-          <button
-            onClick={() => setTheme('dark')}
-            className={cn(
-              'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs border-l border-border transition-colors',
-              resolvedTheme === 'dark'
-                ? 'bg-muted text-foreground font-medium'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-            )}
-          >
-            <Moon className="h-3.5 w-3.5" />
-            Dark
-          </button>
+          {/* Spacer */}
+          <div className="flex-1" />
+        </div>
+
+        {/* Footer */}
+        <div className="px-3 py-3 border-t border-border/50 space-y-2 shrink-0">
+          {updateAvailable && (
+            <button
+              onClick={reload}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-blue-500 hover:text-blue-400 bg-blue-500/10 hover:bg-blue-500/20 rounded transition-colors"
+              title="Click to reload and get the latest version"
+            >
+              <ArrowUpCircle className="h-4 w-4" />
+              Update available
+            </button>
+          )}
+          <UserPopover />
+          <div className="flex rounded-lg border border-border overflow-hidden bg-card">
+            <button
+              onClick={() => setTheme('light')}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs transition-colors',
+                resolvedTheme === 'light'
+                  ? 'bg-muted text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              )}
+            >
+              <Sun className="h-3.5 w-3.5" />
+              Light
+            </button>
+            <button
+              onClick={() => setTheme('dark')}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs border-l border-border transition-colors',
+                resolvedTheme === 'dark'
+                  ? 'bg-muted text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              )}
+            >
+              <Moon className="h-3.5 w-3.5" />
+              Dark
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/web/src/components/stat-card.tsx
+++ b/web/src/components/stat-card.tsx
@@ -44,7 +44,7 @@ function useAnimatedNumber(target: number | undefined, duration = 500) {
 function formatValue(
   value: number | undefined,
   format: 'number' | 'stake' | 'bandwidth' | 'percent',
-  decimals?: number
+  decimals?: number,
 ): string {
   if (value === undefined) return '—'
 
@@ -77,7 +77,9 @@ function formatValue(
       return `${value.toFixed(decimals ?? 1)}%`
     case 'number':
     default:
-      return value.toLocaleString('en-US', { maximumFractionDigits: decimals ?? 0 })
+      return value.toLocaleString('en-US', {
+        maximumFractionDigits: decimals ?? 0,
+      })
   }
 }
 
@@ -105,7 +107,7 @@ export function StatCard({ label, value, format, decimals, delta, href }: StatCa
 
   const content = (
     <>
-      <div className="text-4xl font-medium tabular-nums tracking-tight mb-1">
+      <div className="text-2xl lg:text-3xl font-medium tabular-nums tracking-tight mb-1 ">
         {isLoading ? (
           showSkeleton ? (
             <span className="inline-block h-10 w-16 rounded bg-muted animate-pulse" />
@@ -116,7 +118,9 @@ export function StatCard({ label, value, format, decimals, delta, href }: StatCa
           <span className="inline-flex items-baseline gap-2">
             {formatValue(animatedValue, format, decimals)}
             {showDelta && (
-              <span className={`text-sm font-normal ${delta > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              <span
+                className={`text-sm font-normal ${delta > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+              >
                 {formatDelta(delta)}
               </span>
             )}
@@ -129,11 +133,18 @@ export function StatCard({ label, value, format, decimals, delta, href }: StatCa
 
   if (href) {
     return (
-      <Link to={href} className="text-center block transition-opacity hover:opacity-70">
+      <Link
+        to={href}
+        className="text-center block rounded-[0.3rem] bg-muted/50 hover:bg-muted transition-colors p-2 lg:p-4"
+      >
         {content}
       </Link>
     )
   }
 
-  return <div className="text-center">{content}</div>
+  return (
+    <div className="text-center rounded-[0.3rem] bg-muted/50 hover:bg-muted transition-colors p-2 lg:p-4">
+      {content}
+    </div>
+  )
 }

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -1,8 +1,8 @@
-import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { useState, useEffect, useMemo } from 'react'
-import { useDocumentTitle } from '@/hooks/use-document-title'
-import { useDelayedLoading } from '@/hooks/use-delayed-loading'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useState, useEffect, useMemo } from "react";
+import { useDocumentTitle } from "@/hooks/use-document-title";
+import { useDelayedLoading } from "@/hooks/use-delayed-loading";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   CheckCircle2,
   AlertTriangle,
@@ -13,7 +13,7 @@ import {
   ChevronUp,
   Info,
   WifiOff,
-} from 'lucide-react'
+} from "lucide-react";
 import {
   fetchStatus,
   fetchLinkHistory,
@@ -32,51 +32,58 @@ import {
   type DeviceUtilization,
   type CriticalLinksResponse,
   type LinkIssue,
-} from '@/lib/api'
-import { StatusFilters, useStatusFilters, type StatusFilter } from '@/components/status-search-bar'
-import { StatCard } from '@/components/stat-card'
-import { LinkStatusTimelines } from '@/components/link-status-timelines'
-import { DeviceStatusTimelines } from '@/components/device-status-timelines'
+  type LinkHistoryResponse,
+} from "@/lib/api";
+import {
+  StatusFilters,
+  useStatusFilters,
+  type StatusFilter,
+} from "@/components/status-search-bar";
+import { StatCard } from "@/components/stat-card";
+import { LinkStatusTimelines } from "@/components/link-status-timelines";
+import { DeviceStatusTimelines } from "@/components/device-status-timelines";
 import {
   MetroStatusTimelines,
   type MetroHealthFilter,
   type MetroIssueFilter,
-} from '@/components/metro-status-timelines'
+} from "@/components/metro-status-timelines";
 
-type TimeRange = '3h' | '6h' | '12h' | '24h' | '3d' | '7d'
+type TimeRange = "3h" | "6h" | "12h" | "24h" | "3d" | "7d";
 type IssueFilter =
-  | 'packet_loss'
-  | 'high_latency'
-  | 'no_data'
-  | 'missing_adjacency'
-  | 'interface_errors'
-  | 'fcs_errors'
-  | 'discards'
-  | 'carrier_transitions'
-  | 'high_utilization'
-  | 'no_issues'
+  | "packet_loss"
+  | "high_latency"
+  | "no_data"
+  | "missing_adjacency"
+  | "interface_errors"
+  | "fcs_errors"
+  | "discards"
+  | "carrier_transitions"
+  | "high_utilization"
+  | "no_issues";
 type DeviceIssueFilter =
-  | 'interface_errors'
-  | 'fcs_errors'
-  | 'discards'
-  | 'carrier_transitions'
-  | 'drained'
-  | 'isis_overload'
-  | 'isis_unreachable'
-  | 'no_issues'
-type HealthFilter = 'healthy' | 'degraded' | 'unhealthy' | 'disabled'
+  | "interface_errors"
+  | "fcs_errors"
+  | "discards"
+  | "carrier_transitions"
+  | "drained"
+  | "isis_overload"
+  | "isis_unreachable"
+  | "no_issues";
+type HealthFilter = "healthy" | "degraded" | "unhealthy" | "disabled";
 
 const timeRangeLabels: Record<TimeRange, string> = {
-  '3h': 'Last 3 hours',
-  '6h': 'Last 6 hours',
-  '12h': 'Last 12 hours',
-  '24h': 'Last 24 hours',
-  '3d': 'Last 3 days',
-  '7d': 'Last 7 days',
-}
+  "3h": "Last 3 hours",
+  "6h": "Last 6 hours",
+  "12h": "Last 12 hours",
+  "24h": "Last 24 hours",
+  "3d": "Last 3 days",
+  "7d": "Last 7 days",
+};
 
 function Skeleton({ className }: { className?: string }) {
-  return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
+  return (
+    <div className={`animate-pulse bg-muted rounded ${className || ""}`} />
+  );
 }
 
 function StatusPageSkeleton() {
@@ -101,218 +108,254 @@ function StatusPageSkeleton() {
         <Skeleton className="h-[300px] rounded-lg" />
       </div>
     </div>
-  )
+  );
 }
 
 interface IssueCounts {
-  packet_loss: number
-  high_latency: number
-  high_utilization: number
-  no_data: number
-  missing_adjacency: number
-  interface_errors: number
-  fcs_errors: number
-  discards: number
-  carrier_transitions: number
-  no_issues: number
-  total: number
+  packet_loss: number;
+  high_latency: number;
+  high_utilization: number;
+  no_data: number;
+  missing_adjacency: number;
+  interface_errors: number;
+  fcs_errors: number;
+  discards: number;
+  carrier_transitions: number;
+  no_issues: number;
+  total: number;
 }
 
 function formatTimeAgo(isoString: string): string {
-  const date = new Date(isoString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffSecs = Math.floor(diffMs / 1000)
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
 
-  if (diffSecs < 60) return `${diffSecs}s ago`
-  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m ago`
-  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}h ago`
-  return `${Math.floor(diffSecs / 86400)}d ago`
+  if (diffSecs < 60) return `${diffSecs}s ago`;
+  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m ago`;
+  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}h ago`;
+  return `${Math.floor(diffSecs / 86400)}d ago`;
 }
 
 // Filter out devices with only minor/transient interface issues (low error counts).
 // Groups issues by device, sums totals, and keeps only devices exceeding thresholds.
-const DEVICE_ISSUE_MIN_ERRORS = 100
-const DEVICE_ISSUE_MIN_DISCARDS = 100
-const DEVICE_ISSUE_MIN_CARRIER = 5
+const DEVICE_ISSUE_MIN_ERRORS = 100;
+const DEVICE_ISSUE_MIN_DISCARDS = 100;
+const DEVICE_ISSUE_MIN_CARRIER = 5;
 
-function filterSignificantDeviceIssues(issues: InterfaceIssue[]): InterfaceIssue[] {
+function filterSignificantDeviceIssues(
+  issues: InterfaceIssue[],
+): InterfaceIssue[] {
   // Group by device and compute totals
-  const deviceTotals = new Map<string, { errors: number; discards: number; carrier: number }>()
+  const deviceTotals = new Map<
+    string,
+    { errors: number; discards: number; carrier: number }
+  >();
   for (const i of issues) {
     const prev = deviceTotals.get(i.device_pk) ?? {
       errors: 0,
       discards: 0,
       carrier: 0,
-    }
-    prev.errors += i.in_errors + i.out_errors + i.in_fcs_errors
-    prev.discards += i.in_discards + i.out_discards
-    prev.carrier += i.carrier_transitions
-    deviceTotals.set(i.device_pk, prev)
+    };
+    prev.errors += i.in_errors + i.out_errors + i.in_fcs_errors;
+    prev.discards += i.in_discards + i.out_discards;
+    prev.carrier += i.carrier_transitions;
+    deviceTotals.set(i.device_pk, prev);
   }
 
   // Keep only devices that exceed at least one threshold
-  const significantDevices = new Set<string>()
+  const significantDevices = new Set<string>();
   for (const [pk, totals] of deviceTotals) {
     if (
       totals.errors >= DEVICE_ISSUE_MIN_ERRORS ||
       totals.discards >= DEVICE_ISSUE_MIN_DISCARDS ||
       totals.carrier >= DEVICE_ISSUE_MIN_CARRIER
     ) {
-      significantDevices.add(pk)
+      significantDevices.add(pk);
     }
   }
 
-  return issues.filter((i) => significantDevices.has(i.device_pk))
+  return issues.filter((i) => significantDevices.has(i.device_pk));
 }
 
 function getStatusReasons(status: StatusResponse): string[] {
-  const reasons: string[] = []
+  const reasons: string[] = [];
 
   if (status.links.down > 0) {
-    reasons.push(`${status.links.down} link${status.links.down > 1 ? 's' : ''} down`)
+    reasons.push(
+      `${status.links.down} link${status.links.down > 1 ? "s" : ""} down`,
+    );
   }
   if (status.links.unhealthy > 0) {
     reasons.push(
-      `${status.links.unhealthy} link${status.links.unhealthy > 1 ? 's' : ''} with critical issues`,
-    )
+      `${status.links.unhealthy} link${status.links.unhealthy > 1 ? "s" : ""} with critical issues`,
+    );
   }
   if (status.links.degraded > 0) {
     reasons.push(
-      `${status.links.degraded} link${status.links.degraded > 1 ? 's' : ''} with degraded performance`,
-    )
+      `${status.links.degraded} link${status.links.degraded > 1 ? "s" : ""} with degraded performance`,
+    );
   }
 
   // Count telemetry stopped issues
-  const noDataCount = (status.links.issues || []).filter((i) => i.issue === 'no_data').length
+  const noDataCount = (status.links.issues || []).filter(
+    (i) => i.issue === "no_data",
+  ).length;
   if (noDataCount > 0) {
-    reasons.push(`${noDataCount} link${noDataCount > 1 ? 's' : ''} with telemetry stopped`)
+    reasons.push(
+      `${noDataCount} link${noDataCount > 1 ? "s" : ""} with telemetry stopped`,
+    );
   }
 
   // Count missing ISIS adjacency issues
   const missingAdjCount = (status.links.issues || []).filter(
-    (i) => i.issue === 'missing_adjacency',
-  ).length
+    (i) => i.issue === "missing_adjacency",
+  ).length;
   if (missingAdjCount > 0) {
-    reasons.push(`${missingAdjCount} link${missingAdjCount > 1 ? 's' : ''} with ISIS down`)
+    reasons.push(
+      `${missingAdjCount} link${missingAdjCount > 1 ? "s" : ""} with ISIS down`,
+    );
   }
 
   // Count ISIS device issues
-  const isisDeviceCount = (status.alerts?.isis_devices || []).length
+  const isisDeviceCount = (status.alerts?.isis_devices || []).length;
   if (isisDeviceCount > 0) {
-    const overloadCount = status.alerts.isis_devices.filter((d) => d.issue === 'overload').length
+    const overloadCount = status.alerts.isis_devices.filter(
+      (d) => d.issue === "overload",
+    ).length;
     const unreachableCount = status.alerts.isis_devices.filter(
-      (d) => d.issue === 'unreachable',
-    ).length
-    const parts: string[] = []
-    if (unreachableCount > 0) parts.push(`${unreachableCount} unreachable`)
-    if (overloadCount > 0) parts.push(`${overloadCount} overloaded`)
+      (d) => d.issue === "unreachable",
+    ).length;
+    const parts: string[] = [];
+    if (unreachableCount > 0) parts.push(`${unreachableCount} unreachable`);
+    if (overloadCount > 0) parts.push(`${overloadCount} overloaded`);
     reasons.push(
-      `${isisDeviceCount} device${isisDeviceCount > 1 ? 's' : ''} with ISIS issues (${parts.join(', ')})`,
-    )
+      `${isisDeviceCount} device${isisDeviceCount > 1 ? "s" : ""} with ISIS issues (${parts.join(", ")})`,
+    );
   }
 
   // Count devices with significant interface issues (exclude minor/transient)
-  const significantDeviceIssues = filterSignificantDeviceIssues(status.interfaces?.issues || [])
-  const devicesWithIssues = new Set(significantDeviceIssues.map((i) => i.device_pk)).size
+  const significantDeviceIssues = filterSignificantDeviceIssues(
+    status.interfaces?.issues || [],
+  );
+  const devicesWithIssues = new Set(
+    significantDeviceIssues.map((i) => i.device_pk),
+  ).size;
   if (devicesWithIssues > 0) {
     reasons.push(
-      `${devicesWithIssues} device${devicesWithIssues > 1 ? 's' : ''} with interface issues`,
-    )
+      `${devicesWithIssues} device${devicesWithIssues > 1 ? "s" : ""} with interface issues`,
+    );
   }
 
   const nonActivatedDevices = Object.entries(status.network.devices_by_status)
-    .filter(([s]) => s !== 'activated')
-    .reduce((sum, [, count]) => sum + count, 0)
+    .filter(([s]) => s !== "activated")
+    .reduce((sum, [, count]) => sum + count, 0);
   const nonActivatedLinks = Object.entries(status.network.links_by_status)
-    .filter(([s]) => s === 'soft-drained' || s === 'hard-drained')
-    .reduce((sum, [, count]) => sum + count, 0)
+    .filter(([s]) => s === "soft-drained" || s === "hard-drained")
+    .reduce((sum, [, count]) => sum + count, 0);
 
   if (nonActivatedDevices > 0) {
-    reasons.push(`${nonActivatedDevices} device${nonActivatedDevices > 1 ? 's' : ''} not activated`)
+    reasons.push(
+      `${nonActivatedDevices} device${nonActivatedDevices > 1 ? "s" : ""} not activated`,
+    );
   }
   if (nonActivatedLinks > 0) {
-    reasons.push(`${nonActivatedLinks} Drained Link${nonActivatedLinks > 1 ? 's' : ''}`)
+    reasons.push(
+      `${nonActivatedLinks} Drained Link${nonActivatedLinks > 1 ? "s" : ""}`,
+    );
   }
 
-  return reasons
+  return reasons;
 }
 
 function formatRelativeTime(timestamp: string): string {
-  const now = Date.now()
-  const then = new Date(timestamp).getTime()
-  const seconds = Math.floor((now - then) / 1000)
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const seconds = Math.floor((now - then) / 1000);
 
-  if (seconds < 10) return 'just now'
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  return `${hours}h ago`
+  if (seconds < 10) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
 }
 
-type IssueSeverity = 'down' | 'critical' | 'degraded' | 'no_data'
+type IssueSeverity = "down" | "critical" | "degraded" | "no_data";
 
 function classifyIssueSeverity(issue: LinkIssue): IssueSeverity {
-  if (issue.is_down) return 'down'
-  if (issue.issue === 'missing_adjacency') return 'down'
-  if (issue.issue === 'packet_loss') {
-    if (issue.value >= 95) return 'down'
-    if (issue.value >= 10) return 'critical'
-    return 'degraded'
-  } else if (issue.issue === 'no_data') {
-    return 'no_data'
+  if (issue.is_down) return "down";
+  if (issue.issue === "missing_adjacency") return "down";
+  if (issue.issue === "packet_loss") {
+    if (issue.value >= 95) return "down";
+    if (issue.value >= 10) return "critical";
+    return "degraded";
+  } else if (issue.issue === "no_data") {
+    return "no_data";
   } else {
     // high_latency
-    if (issue.value >= 50) return 'critical'
-    return 'degraded'
+    if (issue.value >= 50) return "critical";
+    return "degraded";
   }
 }
 
 function formatDuration(since: string): string {
-  if (!since) return ''
-  const start = new Date(since).getTime()
-  const now = Date.now()
-  const diffMs = Math.max(0, now - start)
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
+  if (!since) return "";
+  const start = new Date(since).getTime();
+  const now = Date.now();
+  const diffMs = Math.max(0, now - start);
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
 
   if (diffDays > 0) {
-    const remainingHours = diffHours % 24
-    return remainingHours > 0 ? `${diffDays}d ${remainingHours}h` : `${diffDays}d`
+    const remainingHours = diffHours % 24;
+    return remainingHours > 0
+      ? `${diffDays}d ${remainingHours}h`
+      : `${diffDays}d`;
   }
   if (diffHours > 0) {
-    const remainingMins = diffMins % 60
-    return remainingMins > 0 ? `${diffHours}h ${remainingMins}m` : `${diffHours}h`
+    const remainingMins = diffMins % 60;
+    return remainingMins > 0
+      ? `${diffHours}h ${remainingMins}m`
+      : `${diffHours}h`;
   }
-  return `${diffMins}m`
+  return `${diffMins}m`;
 }
 
 function drainIncidentLabel(incidentType: string): string {
   const labels: Record<string, string> = {
-    packet_loss: 'Packet Loss',
-    isis_down: 'ISIS Down',
-    fcs: 'FCS Errors',
-    errors: 'Interface Errors',
-    discards: 'Discards',
-    carrier: 'Carrier Events',
-    no_data: 'No Data',
-  }
-  return labels[incidentType] ?? incidentType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    packet_loss: "Packet Loss",
+    isis_down: "ISIS Down",
+    fcs: "FCS Errors",
+    errors: "Interface Errors",
+    discards: "Discards",
+    carrier: "Carrier Events",
+    no_data: "No Data",
+  };
+  return (
+    labels[incidentType] ??
+    incidentType.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  );
 }
 
 function drainIncidentColor(incidentType: string): string {
   const colors: Record<string, string> = {
-    packet_loss: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    isis_down:   'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    fcs:         'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    errors:      'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    discards:    'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-    carrier:     'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-    no_data:     'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  }
-  return colors[incidentType] ?? 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+    packet_loss: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    isis_down: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    fcs: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    errors: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    discards:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+    carrier:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+    no_data:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  };
+  return (
+    colors[incidentType] ??
+    "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+  );
 }
 
 function IssueDetails({
@@ -326,21 +369,21 @@ function IssueDetails({
   onNonActivatedDeviceClick,
   onDeviceIssueClick,
 }: {
-  issues: LinkIssue[]
-  nonActivatedLinks: NonActivatedLink[]
-  deviceIssues: InterfaceIssue[]
-  nonActivatedDevices: NonActivatedDevice[]
-  isisDeviceIssues: ISISDeviceIssue[]
-  onIssueClick: (linkCode: string) => void
-  onNonActivatedClick: (linkCode: string) => void
-  onNonActivatedDeviceClick: (deviceCode: string) => void
-  onDeviceIssueClick: (devicePk: string) => void
+  issues: LinkIssue[];
+  nonActivatedLinks: NonActivatedLink[];
+  deviceIssues: InterfaceIssue[];
+  nonActivatedDevices: NonActivatedDevice[];
+  isisDeviceIssues: ISISDeviceIssue[];
+  onIssueClick: (linkCode: string) => void;
+  onNonActivatedClick: (linkCode: string) => void;
+  onNonActivatedDeviceClick: (deviceCode: string) => void;
+  onDeviceIssueClick: (devicePk: string) => void;
 }) {
   const grouped = issues.reduce(
     (acc, issue) => {
-      const severity = classifyIssueSeverity(issue)
-      acc[severity].push(issue)
-      return acc
+      const severity = classifyIssueSeverity(issue);
+      acc[severity].push(issue);
+      return acc;
     },
     {
       down: [] as LinkIssue[],
@@ -348,44 +391,44 @@ function IssueDetails({
       degraded: [] as LinkIssue[],
       no_data: [] as LinkIssue[],
     },
-  )
+  );
 
   const sections: {
-    key: IssueSeverity
-    label: string
-    icon: typeof XCircle
-    iconColor: string
-    valueColor: string
+    key: IssueSeverity;
+    label: string;
+    icon: typeof XCircle;
+    iconColor: string;
+    valueColor: string;
   }[] = [
     {
-      key: 'down',
-      label: 'Links Down',
+      key: "down",
+      label: "Links Down",
       icon: XCircle,
-      iconColor: 'text-red-500',
-      valueColor: 'text-red-600 dark:text-red-400',
+      iconColor: "text-red-500",
+      valueColor: "text-red-600 dark:text-red-400",
     },
     {
-      key: 'critical',
-      label: 'Critical Issues',
+      key: "critical",
+      label: "Critical Issues",
       icon: XCircle,
-      iconColor: 'text-red-500',
-      valueColor: 'text-red-500',
+      iconColor: "text-red-500",
+      valueColor: "text-red-500",
     },
     {
-      key: 'degraded',
-      label: 'Degraded Performance',
+      key: "degraded",
+      label: "Degraded Performance",
       icon: AlertTriangle,
-      iconColor: 'text-orange-500',
-      valueColor: 'text-orange-500',
+      iconColor: "text-orange-500",
+      valueColor: "text-orange-500",
     },
     {
-      key: 'no_data',
-      label: 'Telemetry Stopped',
+      key: "no_data",
+      label: "Telemetry Stopped",
       icon: WifiOff,
-      iconColor: 'text-amber-500',
-      valueColor: 'text-amber-500',
+      iconColor: "text-amber-500",
+      valueColor: "text-amber-500",
     },
-  ]
+  ];
 
   // Group device issues by device
   const deviceIssuesByDevice = deviceIssues.reduce(
@@ -397,50 +440,56 @@ function IssueDetails({
           contributor: issue.contributor,
           metro: issue.metro,
           issues: [],
-        }
+        };
       }
-      acc[issue.device_pk].issues.push(issue)
-      return acc
+      acc[issue.device_pk].issues.push(issue);
+      return acc;
     },
     {} as Record<
       string,
       {
-        device_code: string
-        device_type: string
-        contributor: string
-        metro: string
-        issues: InterfaceIssue[]
+        device_code: string;
+        device_type: string;
+        contributor: string;
+        metro: string;
+        issues: InterfaceIssue[];
       }
     >,
-  )
+  );
 
   return (
     <div className="border-t border-border px-3 lg:px-6 py-4 space-y-4">
-      <div className="text-xs text-muted-foreground">Showing issues from the last hour</div>
+      <div className="text-xs text-muted-foreground">
+        Showing issues from the last hour
+      </div>
       {sections.map(({ key, label, icon: Icon, iconColor, valueColor }) => {
-        const sectionIssues = grouped[key]
-        if (sectionIssues.length === 0) return null
+        const sectionIssues = grouped[key];
+        if (sectionIssues.length === 0) return null;
 
         // Group issues by link code so the same link appears once with all its issues
-        const byLink = new Map<string, LinkIssue[]>()
+        const byLink = new Map<string, LinkIssue[]>();
         for (const issue of sectionIssues) {
-          const existing = byLink.get(issue.code) || []
-          existing.push(issue)
-          byLink.set(issue.code, existing)
+          const existing = byLink.get(issue.code) || [];
+          existing.push(issue);
+          byLink.set(issue.code, existing);
         }
 
         return (
           <div key={key}>
-            <div className="text-sm font-medium text-muted-foreground mb-2">{label}</div>
+            <div className="text-sm font-medium text-muted-foreground mb-2">
+              {label}
+            </div>
             <div className="space-y-2">
               {[...byLink.entries()].map(([code, linkIssues]) => {
-                const first = linkIssues[0]
+                const first = linkIssues[0];
                 // Use the most recent "since" across all issues for this link
                 const mostRecentSince = linkIssues.reduce((latest, i) => {
-                  if (!i.since) return latest
-                  if (!latest) return i.since
-                  return new Date(i.since) > new Date(latest) ? i.since : latest
-                }, '' as string)
+                  if (!i.since) return latest;
+                  if (!latest) return i.since;
+                  return new Date(i.since) > new Date(latest)
+                    ? i.since
+                    : latest;
+                }, "" as string);
                 return (
                   <button
                     key={code}
@@ -454,14 +503,15 @@ function IssueDetails({
                         {code}
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        {first.side_a_metro} → {first.side_z_metro} · {first.link_type}
+                        {first.side_a_metro} → {first.side_z_metro} ·{" "}
+                        {first.link_type}
                         {first.contributor && ` · ${first.contributor}`}
                         {mostRecentSince && (
                           <span
                             className="text-muted-foreground font-normal"
                             title={new Date(mostRecentSince).toLocaleString()}
                           >
-                            {' '}
+                            {" "}
                             · for {formatDuration(mostRecentSince)}
                           </span>
                         )}
@@ -473,30 +523,41 @@ function IssueDetails({
                       <div>
                         <div className="font-medium text-sm">{code}</div>
                         <div className="text-xs text-muted-foreground">
-                          {first.side_a_metro} → {first.side_z_metro} · {first.link_type}
+                          {first.side_a_metro} → {first.side_z_metro} ·{" "}
+                          {first.link_type}
                           {first.contributor && ` · ${first.contributor}`}
                         </div>
                       </div>
                     </div>
                     <div className="hidden md:block text-right">
                       {(() => {
-                        const hasISISDown = linkIssues.some((i) => i.issue === 'missing_adjacency')
+                        const hasISISDown = linkIssues.some(
+                          (i) => i.issue === "missing_adjacency",
+                        );
                         return linkIssues.map((issue, idx) => (
                           <div key={idx}>
-                            {issue.issue === 'missing_adjacency' && (
-                              <div className={`text-sm font-medium ${valueColor}`}>ISIS down</div>
+                            {issue.issue === "missing_adjacency" && (
+                              <div
+                                className={`text-sm font-medium ${valueColor}`}
+                              >
+                                ISIS down
+                              </div>
                             )}
-                            {issue.issue !== 'no_data' &&
-                              issue.issue !== 'missing_adjacency' &&
-                              !(hasISISDown && issue.issue === 'packet_loss') && (
-                                <div className={`text-sm font-medium ${valueColor}`}>
-                                  {issue.issue === 'packet_loss'
+                            {issue.issue !== "no_data" &&
+                              issue.issue !== "missing_adjacency" &&
+                              !(
+                                hasISISDown && issue.issue === "packet_loss"
+                              ) && (
+                                <div
+                                  className={`text-sm font-medium ${valueColor}`}
+                                >
+                                  {issue.issue === "packet_loss"
                                     ? `${issue.value.toFixed(1)}% loss`
                                     : `${issue.value.toFixed(0)}% over SLO`}
                                 </div>
                               )}
                           </div>
-                        ))
+                        ));
                       })()}
                       {mostRecentSince && (
                         <div
@@ -508,11 +569,11 @@ function IssueDetails({
                       )}
                     </div>
                   </button>
-                )
+                );
               })}
             </div>
           </div>
-        )
+        );
       })}
       {Object.keys(deviceIssuesByDevice).length > 0 && (
         <div>
@@ -526,22 +587,30 @@ function IssueDetails({
                 (acc, i) => ({
                   errors: acc.errors + i.in_errors + i.out_errors,
                   discards: acc.discards + i.in_discards + i.out_discards,
-                  carrierTransitions: acc.carrierTransitions + i.carrier_transitions,
+                  carrierTransitions:
+                    acc.carrierTransitions + i.carrier_transitions,
                 }),
                 { errors: 0, discards: 0, carrierTransitions: 0 },
-              )
+              );
               // Find the most recent last_seen among all interfaces
               const lastSeen = device.issues.reduce((latest, i) => {
-                if (!i.last_seen) return latest
-                if (!latest) return i.last_seen
-                return new Date(i.last_seen) > new Date(latest) ? i.last_seen : latest
-              }, '' as string)
-              const detailParts: string[] = []
-              if (totals.errors > 0) detailParts.push(`${totals.errors.toLocaleString()} errors`)
+                if (!i.last_seen) return latest;
+                if (!latest) return i.last_seen;
+                return new Date(i.last_seen) > new Date(latest)
+                  ? i.last_seen
+                  : latest;
+              }, "" as string);
+              const detailParts: string[] = [];
+              if (totals.errors > 0)
+                detailParts.push(`${totals.errors.toLocaleString()} errors`);
               if (totals.discards > 0)
-                detailParts.push(`${totals.discards.toLocaleString()} discards`)
+                detailParts.push(
+                  `${totals.discards.toLocaleString()} discards`,
+                );
               if (totals.carrierTransitions > 0)
-                detailParts.push(`${totals.carrierTransitions} carrier transitions`)
+                detailParts.push(
+                  `${totals.carrierTransitions} carrier transitions`,
+                );
 
               return (
                 <button
@@ -552,7 +621,9 @@ function IssueDetails({
                   <div className="flex items-center gap-3">
                     <Cpu className="h-4 w-4 text-amber-500" />
                     <div>
-                      <div className="font-medium text-sm">{device.device_code}</div>
+                      <div className="font-medium text-sm">
+                        {device.device_code}
+                      </div>
                       <div className="text-xs text-muted-foreground">
                         {device.metro} · {device.device_type}
                         {device.contributor && ` · ${device.contributor}`}
@@ -561,27 +632,29 @@ function IssueDetails({
                   </div>
                   <div className="text-right">
                     <div className="text-sm font-medium text-amber-500">
-                      {detailParts.join(', ')}
+                      {detailParts.join(", ")}
                     </div>
                     <div className="text-xs text-muted-foreground">
                       {device.issues.length} interface
-                      {device.issues.length > 1 ? 's' : ''}
+                      {device.issues.length > 1 ? "s" : ""}
                       {lastSeen && (
                         <span title={new Date(lastSeen).toLocaleString()}>
-                          {' · '}last seen {formatDuration(lastSeen)} ago
+                          {" · "}last seen {formatDuration(lastSeen)} ago
                         </span>
                       )}
                     </div>
                   </div>
                 </button>
-              )
+              );
             })}
           </div>
         </div>
       )}
       {isisDeviceIssues.length > 0 && (
         <div>
-          <div className="text-sm font-medium text-muted-foreground mb-2">ISIS Device Issues</div>
+          <div className="text-sm font-medium text-muted-foreground mb-2">
+            ISIS Device Issues
+          </div>
           <div className="space-y-2">
             {isisDeviceIssues.map((device, idx) => (
               <button
@@ -595,13 +668,15 @@ function IssueDetails({
                     <div className="font-medium text-sm">{device.code}</div>
                     <div className="text-xs text-muted-foreground">
                       {device.metro && `${device.metro} · `}
-                      {device.device_type || 'ISIS device'}
+                      {device.device_type || "ISIS device"}
                     </div>
                   </div>
                 </div>
                 <div className="text-right">
                   <div className="text-sm font-medium text-red-500 capitalize">
-                    {device.issue === 'unreachable' ? 'Node Unreachable' : 'Overloaded'}
+                    {device.issue === "unreachable"
+                      ? "Node Unreachable"
+                      : "Overloaded"}
                   </div>
                   {device.since && (
                     <div
@@ -619,7 +694,9 @@ function IssueDetails({
       )}
       {nonActivatedLinks.length > 0 && (
         <div>
-          <div className="text-sm font-medium text-muted-foreground mb-2">Drained Links</div>
+          <div className="text-sm font-medium text-muted-foreground mb-2">
+            Drained Links
+          </div>
           <div className="space-y-2">
             {nonActivatedLinks.map((link, idx) => (
               <button
@@ -639,11 +716,11 @@ function IssueDetails({
                     <span className="hidden xs:inline"> · </span>
                     <span className="block xs:inline">
                       <span className="capitalize text-slate-600 dark:text-slate-400 font-bold">
-                        {link.status.replace(/-/g, ' ')}
+                        {link.status.replace(/-/g, " ")}
                       </span>
                       {link.since && (
                         <span className="text-muted-foreground font-normal">
-                          {' '}
+                          {" "}
                           · for {formatDuration(link.since)}
                         </span>
                       )}
@@ -656,11 +733,13 @@ function IssueDetails({
                   <div className="flex flex-col items-start">
                     <div className="font-medium text-sm">{link.code}</div>
                     <div className="text-xs text-muted-foreground">
-                      {link.side_a_metro} → {link.side_z_metro} · {link.link_type}
+                      {link.side_a_metro} → {link.side_z_metro} ·{" "}
+                      {link.link_type}
                     </div>
-                    {link.status !== 'provisioning' && (
+                    {link.status !== "provisioning" && (
                       <div className="flex flex-wrap gap-1 mt-1">
-                        {link.active_incident_types && link.active_incident_types.length > 0 ? (
+                        {link.active_incident_types &&
+                        link.active_incident_types.length > 0 ? (
                           link.active_incident_types.map((t) => (
                             <span
                               key={t}
@@ -680,7 +759,7 @@ function IssueDetails({
                 </div>
                 <div className="hidden md:block text-right">
                   <div className="text-sm font-medium text-slate-600 dark:text-slate-400 capitalize">
-                    {link.status.replace(/-/g, ' ')}
+                    {link.status.replace(/-/g, " ")}
                   </div>
                   {link.since && (
                     <div
@@ -698,7 +777,9 @@ function IssueDetails({
       )}
       {nonActivatedDevices.length > 0 && (
         <div>
-          <div className="text-sm font-medium text-muted-foreground mb-2">Devices Not Active</div>
+          <div className="text-sm font-medium text-muted-foreground mb-2">
+            Devices Not Active
+          </div>
           <div className="space-y-2">
             {nonActivatedDevices.map((device, idx) => (
               <button
@@ -717,7 +798,7 @@ function IssueDetails({
                 </div>
                 <div className="text-right">
                   <div className="text-sm font-medium text-slate-600 dark:text-slate-400 capitalize">
-                    {device.status.replace(/-/g, ' ')}
+                    {device.status.replace(/-/g, " ")}
                   </div>
                   {device.since && (
                     <div
@@ -734,154 +815,167 @@ function IssueDetails({
         </div>
       )}
     </div>
-  )
+  );
 }
 
 function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
-  const status = statusData.status
-  const reasons = getStatusReasons(statusData)
-  const [, forceUpdate] = useState(0)
-  const [expanded, setExpanded] = useState(false)
-  const navigate = useNavigate()
-  const location = useLocation()
+  const status = statusData.status;
+  const reasons = getStatusReasons(statusData);
+  const [, forceUpdate] = useState(0);
+  const [expanded, setExpanded] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
-    const interval = setInterval(() => forceUpdate((n) => n + 1), 10000)
-    return () => clearInterval(interval)
-  }, [])
+    const interval = setInterval(() => forceUpdate((n) => n + 1), 10000);
+    return () => clearInterval(interval);
+  }, []);
 
   const flashHighlight = (el: Element) => {
-    el.classList.remove('scroll-highlight')
+    el.classList.remove("scroll-highlight");
     // Force reflow so re-adding the class restarts the animation
-    void (el as HTMLElement).offsetWidth
-    el.classList.add('scroll-highlight')
-  }
+    void (el as HTMLElement).offsetWidth;
+    el.classList.add("scroll-highlight");
+  };
 
-  const scrollAndHighlight = (id: string, block: ScrollLogicalPosition = 'start') => {
-    const el = document.getElementById(id)
+  const scrollAndHighlight = (
+    id: string,
+    block: ScrollLogicalPosition = "start",
+  ) => {
+    const el = document.getElementById(id);
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block })
-      flashHighlight(el)
+      el.scrollIntoView({ behavior: "smooth", block });
+      flashHighlight(el);
     }
-    return el
-  }
+    return el;
+  };
 
   const scrollToLinkHistory = (linkCode: string) => {
     const scrollToLink = () => {
-      const el = scrollAndHighlight(`link-row-${linkCode}`, 'center')
+      const el = scrollAndHighlight(`link-row-${linkCode}`, "center");
       if (!el) {
-        scrollAndHighlight('link-status-history')
+        scrollAndHighlight("link-status-history");
       }
-    }
+    };
     // If not on links tab, navigate there first
-    if (!location.pathname.includes('/status/links')) {
-      navigate('/status/links')
+    if (!location.pathname.includes("/status/links")) {
+      navigate("/status/links");
       // Wait for navigation then scroll
-      setTimeout(scrollToLink, 100)
+      setTimeout(scrollToLink, 100);
     } else {
-      scrollToLink()
+      scrollToLink();
     }
-  }
+  };
   const scrollToDisabledLinks = (linkCode: string) => {
     const scrollToLink = () => {
-      const el = scrollAndHighlight(`disabled-link-${linkCode}`, 'center')
+      const el = scrollAndHighlight(`disabled-link-${linkCode}`, "center");
       if (!el) {
-        scrollAndHighlight('disabled-links')
+        scrollAndHighlight("disabled-links");
       }
-    }
-    if (!location.pathname.includes('/status/links')) {
-      navigate('/status/links')
-      setTimeout(scrollToLink, 100)
+    };
+    if (!location.pathname.includes("/status/links")) {
+      navigate("/status/links");
+      setTimeout(scrollToLink, 100);
     } else {
-      scrollToLink()
+      scrollToLink();
     }
-  }
+  };
   const scrollToDisabledDevices = (deviceCode: string) => {
     const scrollToDevice = () => {
-      const el = scrollAndHighlight(`disabled-device-${deviceCode}`, 'center')
+      const el = scrollAndHighlight(`disabled-device-${deviceCode}`, "center");
       if (!el) {
-        scrollAndHighlight('disabled-devices')
+        scrollAndHighlight("disabled-devices");
       }
-    }
-    if (!location.pathname.includes('/status/devices')) {
-      navigate('/status/devices')
-      setTimeout(scrollToDevice, 100)
+    };
+    if (!location.pathname.includes("/status/devices")) {
+      navigate("/status/devices");
+      setTimeout(scrollToDevice, 100);
     } else {
-      scrollToDevice()
+      scrollToDevice();
     }
-  }
+  };
   const scrollToDeviceHistory = (devicePk: string) => {
     const scrollToDevice = () => {
-      const el = scrollAndHighlight(`device-row-${devicePk}`, 'center')
+      const el = scrollAndHighlight(`device-row-${devicePk}`, "center");
       if (!el) {
-        scrollAndHighlight('device-status-history')
+        scrollAndHighlight("device-status-history");
       }
-    }
-    if (!location.pathname.includes('/status/devices')) {
-      navigate('/status/devices', { state: { expandDevice: devicePk } })
-      setTimeout(scrollToDevice, 200)
+    };
+    if (!location.pathname.includes("/status/devices")) {
+      navigate("/status/devices", { state: { expandDevice: devicePk } });
+      setTimeout(scrollToDevice, 200);
     } else {
       navigate(location.pathname + location.search, {
         state: { expandDevice: devicePk },
         replace: true,
-      })
-      setTimeout(scrollToDevice, 50)
+      });
+      setTimeout(scrollToDevice, 50);
     }
-  }
+  };
 
   const config = {
     healthy: {
       icon: CheckCircle2,
-      label: 'All Systems Operational',
-      className: 'text-green-700 dark:text-green-400',
-      borderClassName: 'border-l-green-500',
+      label: "All Systems Operational",
+      className: "text-green-700 dark:text-green-400",
+      borderClassName: "border-l-green-500",
     },
     degraded: {
       icon: AlertTriangle,
-      label: 'Some Issues Detected',
-      className: 'text-orange-600 dark:text-orange-400',
-      borderClassName: 'border-l-orange-500',
+      label: "Some Issues Detected",
+      className: "text-orange-600 dark:text-orange-400",
+      borderClassName: "border-l-orange-500",
     },
     unhealthy: {
       icon: XCircle,
-      label: 'System Issues Detected',
-      className: 'text-red-700 dark:text-red-400',
-      borderClassName: 'border-l-red-500',
+      label: "System Issues Detected",
+      className: "text-red-700 dark:text-red-400",
+      borderClassName: "border-l-red-500",
     },
-  }
+  };
 
-  const { icon: Icon, label, className, borderClassName } = config[status]
+  const { icon: Icon, label, className, borderClassName } = config[status];
 
   // Check if there are issues to show (filter out minor/transient device interface issues)
-  const linkIssues = statusData.links.issues || []
+  const linkIssues = statusData.links.issues || [];
   const nonActivatedLinks = (statusData.alerts?.links || []).filter(
-    (l) => l.status !== 'provisioning',
-  )
-  const deviceIssues = filterSignificantDeviceIssues(statusData.interfaces?.issues || [])
-  const nonActivatedDevices = statusData.alerts?.devices || []
+    (l) => l.status !== "provisioning",
+  );
+  const deviceIssues = filterSignificantDeviceIssues(
+    statusData.interfaces?.issues || [],
+  );
+  const nonActivatedDevices = statusData.alerts?.devices || [];
   const hasExpandableContent =
     linkIssues.length > 0 ||
     nonActivatedLinks.length > 0 ||
     deviceIssues.length > 0 ||
-    nonActivatedDevices.length > 0
+    nonActivatedDevices.length > 0;
 
   return (
-    <div className={`rounded-lg bg-card border border-border border-l-4 ${borderClassName}`}>
+    <div
+      className={`rounded-lg bg-card border border-border border-l-4 ${borderClassName}`}
+    >
       <div
-        className={`flex flex-col md:flex-row md:items-center gap-2 md:gap-3 px-3 lg:px-6 py-4 ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`}
-        onClick={hasExpandableContent ? () => setExpanded(!expanded) : undefined}
+        className={`flex flex-col md:flex-row md:items-center gap-2 md:gap-3 px-3 lg:px-6 py-4 ${hasExpandableContent ? "cursor-pointer hover:bg-muted/30 transition-colors" : ""}`}
+        onClick={
+          hasExpandableContent ? () => setExpanded(!expanded) : undefined
+        }
       >
         {/* Desktop: icon standalone */}
         <Icon className={`hidden md:block size-8 shrink-0 ${className}`} />
         <div className="flex-1 flex flex-col gap-1 md:gap-0">
           {/* Mobile: icon left of title */}
           <div className="flex items-center gap-1 md:block">
-            <Icon className={`hidden xs:block md:hidden size-5.5 shrink-0 ${className}`} />
-            <div className={`text-base xs:text-lg font-medium ${className}`}>{label}</div>
+            <Icon
+              className={`hidden xs:block md:hidden size-5.5 shrink-0 ${className}`}
+            />
+            <div className={`text-base xs:text-lg font-medium ${className}`}>
+              {label}
+            </div>
           </div>
           {reasons.length > 0 && (
             <div className="text-sm text-muted-foreground md:mt-0 mt-0">
-              {reasons.slice(0, 2).join(' · ')}
+              {reasons.slice(0, 2).join(" · ")}
             </div>
           )}
         </div>
@@ -891,7 +985,11 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
           </div>
           {hasExpandableContent && (
             <div className="text-muted-foreground">
-              {expanded ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+              {expanded ? (
+                <ChevronUp className="h-5 w-5" />
+              ) : (
+                <ChevronDown className="h-5 w-5" />
+              )}
             </div>
           )}
         </div>
@@ -910,48 +1008,52 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
         />
       )}
     </div>
-  )
+  );
 }
 
-function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros' }) {
-  const navigate = useNavigate()
-  const location = useLocation()
+function TabNavigation({
+  activeTab,
+}: {
+  activeTab: "links" | "devices" | "metros";
+}) {
+  const navigate = useNavigate();
+  const location = useLocation();
 
   // Preserve query params when switching tabs
   const navigateWithParams = (path: string) => {
-    navigate(path + location.search)
-  }
+    navigate(path + location.search);
+  };
 
   return (
     <div className="mb-4">
       <div className="flex items-center justify-between border-b border-border">
         <div className="flex gap-1">
           <button
-            onClick={() => navigateWithParams('/status/links')}
+            onClick={() => navigateWithParams("/status/links")}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              activeTab === 'links'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
+              activeTab === "links"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
           >
             Links
           </button>
           <button
-            onClick={() => navigateWithParams('/status/devices')}
+            onClick={() => navigateWithParams("/status/devices")}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              activeTab === 'devices'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
+              activeTab === "devices"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
           >
             Devices
           </button>
           <button
-            onClick={() => navigateWithParams('/status/metros')}
+            onClick={() => navigateWithParams("/status/metros")}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              activeTab === 'metros'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
+              activeTab === "metros"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
           >
             Metros
@@ -961,35 +1063,35 @@ function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros
       </div>
       <StatusFilters className="pt-4 sm:hidden" />
     </div>
-  )
+  );
 }
 
 interface HealthIssueBreakdown {
-  packet_loss: number
-  high_latency: number
-  no_data: number
-  missing_adjacency: number
-  interface_errors: number
-  fcs_errors: number
-  discards: number
-  carrier_transitions: number
-  high_utilization: number
+  packet_loss: number;
+  high_latency: number;
+  no_data: number;
+  missing_adjacency: number;
+  interface_errors: number;
+  fcs_errors: number;
+  discards: number;
+  carrier_transitions: number;
+  high_utilization: number;
 }
 
 interface DeviceIssueBreakdown {
-  interface_errors: number
-  fcs_errors: number
-  discards: number
-  carrier_transitions: number
-  drained: number
-  isis_overload: number
-  isis_unreachable: number
+  interface_errors: number;
+  fcs_errors: number;
+  discards: number;
+  carrier_transitions: number;
+  drained: number;
+  isis_overload: number;
+  isis_unreachable: number;
 }
 
 interface IssueHealthBreakdown {
-  healthy: number
-  degraded: number
-  unhealthy: number
+  healthy: number;
+  degraded: number;
+  unhealthy: number;
 }
 
 function HealthFilterItem({
@@ -1003,75 +1105,78 @@ function HealthFilterItem({
   deviceIssueBreakdown,
   healthBreakdown,
 }: {
-  color: string
-  label: string
-  count: number
-  description: string
-  selected: boolean
-  onClick: () => void
-  issueBreakdown?: HealthIssueBreakdown
-  deviceIssueBreakdown?: DeviceIssueBreakdown
-  healthBreakdown?: IssueHealthBreakdown
+  color: string;
+  label: string;
+  count: number;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+  issueBreakdown?: HealthIssueBreakdown;
+  deviceIssueBreakdown?: DeviceIssueBreakdown;
+  healthBreakdown?: IssueHealthBreakdown;
 }) {
-  const [showTooltip, setShowTooltip] = useState(false)
+  const [showTooltip, setShowTooltip] = useState(false);
 
   const issueLabels: {
-    key: keyof HealthIssueBreakdown
-    label: string
-    color: string
+    key: keyof HealthIssueBreakdown;
+    label: string;
+    color: string;
   }[] = [
-    { key: 'packet_loss', label: 'Packet Loss', color: 'bg-purple-500' },
-    { key: 'high_latency', label: 'High Latency', color: 'bg-blue-500' },
+    { key: "packet_loss", label: "Packet Loss", color: "bg-purple-500" },
+    { key: "high_latency", label: "High Latency", color: "bg-blue-500" },
     {
-      key: 'high_utilization',
-      label: 'High Utilization',
-      color: 'bg-indigo-500',
+      key: "high_utilization",
+      label: "High Utilization",
+      color: "bg-indigo-500",
     },
     {
-      key: 'carrier_transitions',
-      label: 'Carrier Transitions',
-      color: 'bg-yellow-500',
+      key: "carrier_transitions",
+      label: "Carrier Transitions",
+      color: "bg-yellow-500",
     },
-    { key: 'discards', label: 'Discards', color: 'bg-teal-500' },
-    { key: 'interface_errors', label: 'Errors', color: 'bg-red-500' },
-    { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-500' },
-    { key: 'no_data', label: 'No Data', color: 'bg-pink-500' },
-    { key: 'missing_adjacency', label: 'ISIS Down', color: 'bg-rose-600' },
-  ]
+    { key: "discards", label: "Discards", color: "bg-teal-500" },
+    { key: "interface_errors", label: "Errors", color: "bg-red-500" },
+    { key: "fcs_errors", label: "FCS Errors", color: "bg-orange-500" },
+    { key: "no_data", label: "No Data", color: "bg-pink-500" },
+    { key: "missing_adjacency", label: "ISIS Down", color: "bg-rose-600" },
+  ];
 
   const deviceIssueLabels: {
-    key: keyof DeviceIssueBreakdown
-    label: string
-    color: string
+    key: keyof DeviceIssueBreakdown;
+    label: string;
+    color: string;
   }[] = [
     {
-      key: 'interface_errors',
-      label: 'Interface Errors',
-      color: 'bg-fuchsia-500',
+      key: "interface_errors",
+      label: "Interface Errors",
+      color: "bg-fuchsia-500",
     },
-    { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600' },
-    { key: 'discards', label: 'Discards', color: 'bg-rose-500' },
+    { key: "fcs_errors", label: "FCS Errors", color: "bg-orange-600" },
+    { key: "discards", label: "Discards", color: "bg-rose-500" },
     {
-      key: 'carrier_transitions',
-      label: 'Carrier Transitions',
-      color: 'bg-orange-500',
+      key: "carrier_transitions",
+      label: "Carrier Transitions",
+      color: "bg-orange-500",
     },
-  ]
+  ];
 
   const healthLabels: {
-    key: keyof IssueHealthBreakdown
-    label: string
-    color: string
+    key: keyof IssueHealthBreakdown;
+    label: string;
+    color: string;
   }[] = [
-    { key: 'healthy', label: 'Healthy', color: 'bg-green-500' },
-    { key: 'degraded', label: 'Degraded', color: 'bg-amber-500' },
-    { key: 'unhealthy', label: 'Unhealthy', color: 'bg-red-500' },
-  ]
+    { key: "healthy", label: "Healthy", color: "bg-green-500" },
+    { key: "degraded", label: "Degraded", color: "bg-amber-500" },
+    { key: "unhealthy", label: "Unhealthy", color: "bg-red-500" },
+  ];
 
-  const hasIssues = issueBreakdown && Object.values(issueBreakdown).some((v) => v > 0)
+  const hasIssues =
+    issueBreakdown && Object.values(issueBreakdown).some((v) => v > 0);
   const hasDeviceIssues =
-    deviceIssueBreakdown && Object.values(deviceIssueBreakdown).some((v) => v > 0)
-  const hasHealth = healthBreakdown && Object.values(healthBreakdown).some((v) => v > 0)
+    deviceIssueBreakdown &&
+    Object.values(deviceIssueBreakdown).some((v) => v > 0);
+  const hasHealth =
+    healthBreakdown && Object.values(healthBreakdown).some((v) => v > 0);
 
   return (
     <button
@@ -1084,10 +1189,10 @@ function HealthFilterItem({
         onMouseLeave={() => setShowTooltip(false)}
       >
         <div
-          className={`h-2.5 w-2.5 rounded-full ${color} transition-opacity ${!selected ? 'opacity-25' : ''}`}
+          className={`h-2.5 w-2.5 rounded-full ${color} transition-opacity ${!selected ? "opacity-25" : ""}`}
         />
         <span
-          className={`transition-colors ${selected ? 'text-foreground' : 'text-muted-foreground/50'}`}
+          className={`transition-colors ${selected ? "text-foreground" : "text-muted-foreground/50"}`}
         >
           {label}
         </span>
@@ -1097,51 +1202,66 @@ function HealthFilterItem({
             {hasIssues && (
               <div className="mt-2 pt-2 border-t border-border space-y-1">
                 {issueLabels.map(({ key, label, color }) => {
-                  const issueCount = issueBreakdown[key]
-                  if (issueCount === 0) return null
+                  const issueCount = issueBreakdown[key];
+                  if (issueCount === 0) return null;
                   return (
-                    <div key={key} className="flex items-center justify-between">
+                    <div
+                      key={key}
+                      className="flex items-center justify-between"
+                    >
                       <div className="flex items-center gap-1.5">
                         <div className={`h-2 w-2 rounded-full ${color}`} />
                         <span className="text-muted-foreground">{label}</span>
                       </div>
-                      <span className="font-medium tabular-nums">{issueCount}</span>
+                      <span className="font-medium tabular-nums">
+                        {issueCount}
+                      </span>
                     </div>
-                  )
+                  );
                 })}
               </div>
             )}
             {hasDeviceIssues && (
               <div className="mt-2 pt-2 border-t border-border space-y-1">
                 {deviceIssueLabels.map(({ key, label, color }) => {
-                  const issueCount = deviceIssueBreakdown[key]
-                  if (issueCount === 0) return null
+                  const issueCount = deviceIssueBreakdown[key];
+                  if (issueCount === 0) return null;
                   return (
-                    <div key={key} className="flex items-center justify-between">
+                    <div
+                      key={key}
+                      className="flex items-center justify-between"
+                    >
                       <div className="flex items-center gap-1.5">
                         <div className={`h-2 w-2 rounded-full ${color}`} />
                         <span className="text-muted-foreground">{label}</span>
                       </div>
-                      <span className="font-medium tabular-nums">{issueCount}</span>
+                      <span className="font-medium tabular-nums">
+                        {issueCount}
+                      </span>
                     </div>
-                  )
+                  );
                 })}
               </div>
             )}
             {hasHealth && (
               <div className="mt-2 pt-2 border-t border-border space-y-1">
                 {healthLabels.map(({ key, label, color }) => {
-                  const healthCount = healthBreakdown[key]
-                  if (healthCount === 0) return null
+                  const healthCount = healthBreakdown[key];
+                  if (healthCount === 0) return null;
                   return (
-                    <div key={key} className="flex items-center justify-between">
+                    <div
+                      key={key}
+                      className="flex items-center justify-between"
+                    >
                       <div className="flex items-center gap-1.5">
                         <div className={`h-2 w-2 rounded-full ${color}`} />
                         <span className="text-muted-foreground">{label}</span>
                       </div>
-                      <span className="font-medium tabular-nums">{healthCount}</span>
+                      <span className="font-medium tabular-nums">
+                        {healthCount}
+                      </span>
                     </div>
-                  )
+                  );
                 })}
               </div>
             )}
@@ -1149,31 +1269,31 @@ function HealthFilterItem({
         )}
       </div>
       <span
-        className={`font-medium tabular-nums transition-colors ${!selected ? 'text-muted-foreground/50' : ''}`}
+        className={`font-medium tabular-nums transition-colors ${!selected ? "text-muted-foreground/50" : ""}`}
       >
         {count}
       </span>
     </button>
-  )
+  );
 }
 
 interface IssuesByHealth {
-  healthy: HealthIssueBreakdown
-  degraded: HealthIssueBreakdown
-  unhealthy: HealthIssueBreakdown
+  healthy: HealthIssueBreakdown;
+  degraded: HealthIssueBreakdown;
+  unhealthy: HealthIssueBreakdown;
 }
 
 interface HealthByIssue {
-  packet_loss: IssueHealthBreakdown
-  high_latency: IssueHealthBreakdown
-  no_data: IssueHealthBreakdown
-  missing_adjacency: IssueHealthBreakdown
-  interface_errors: IssueHealthBreakdown
-  fcs_errors: IssueHealthBreakdown
-  discards: IssueHealthBreakdown
-  carrier_transitions: IssueHealthBreakdown
-  high_utilization: IssueHealthBreakdown
-  no_issues: IssueHealthBreakdown
+  packet_loss: IssueHealthBreakdown;
+  high_latency: IssueHealthBreakdown;
+  no_data: IssueHealthBreakdown;
+  missing_adjacency: IssueHealthBreakdown;
+  interface_errors: IssueHealthBreakdown;
+  fcs_errors: IssueHealthBreakdown;
+  discards: IssueHealthBreakdown;
+  carrier_transitions: IssueHealthBreakdown;
+  high_utilization: IssueHealthBreakdown;
+  no_issues: IssueHealthBreakdown;
 }
 
 function LinkHealthFilterCard({
@@ -1184,31 +1304,34 @@ function LinkHealthFilterCard({
   timeRange,
 }: {
   links: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    total: number
-  }
-  selected: HealthFilter[]
-  onChange: (filters: HealthFilter[]) => void
-  issuesByHealth?: IssuesByHealth
-  timeRange: TimeRange
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    total: number;
+  };
+  selected: HealthFilter[];
+  onChange: (filters: HealthFilter[]) => void;
+  issuesByHealth?: IssuesByHealth;
+  timeRange: TimeRange;
 }) {
   const toggleFilter = (filter: HealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === 3
+  const allSelected = selected.length === 3;
 
-  const healthyPct = links.total > 0 ? (links.healthy / links.total) * 100 : 100
-  const degradedPct = links.total > 0 ? (links.degraded / links.total) * 100 : 0
-  const unhealthyPct = links.total > 0 ? (links.unhealthy / links.total) * 100 : 0
+  const healthyPct =
+    links.total > 0 ? (links.healthy / links.total) * 100 : 100;
+  const degradedPct =
+    links.total > 0 ? (links.degraded / links.total) * 100 : 0;
+  const unhealthyPct =
+    links.total > 0 ? (links.unhealthy / links.total) * 100 : 0;
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -1220,10 +1343,10 @@ function LinkHealthFilterCard({
             ({timeRangeLabels[timeRange]})
           </span>
           <button
-            onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            onClick={() => onChange(["healthy", "degraded", "unhealthy"])}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -1233,27 +1356,27 @@ function LinkHealthFilterCard({
 
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
-          onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          onClick={() => onChange(["healthy", "degraded", "unhealthy"])}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {healthyPct > 0 && (
             <div
-              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              className={`bg-green-500 h-full transition-all ${!selected.includes("healthy") ? "opacity-30" : ""}`}
               style={{ width: `${healthyPct}%` }}
             />
           )}
           {degradedPct > 0 && (
             <div
-              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              className={`bg-amber-500 h-full transition-all ${!selected.includes("degraded") ? "opacity-30" : ""}`}
               style={{ width: `${degradedPct}%` }}
             />
           )}
           {unhealthyPct > 0 && (
             <div
-              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              className={`bg-red-500 h-full transition-all ${!selected.includes("unhealthy") ? "opacity-30" : ""}`}
               style={{ width: `${unhealthyPct}%` }}
             />
           )}
@@ -1266,8 +1389,8 @@ function LinkHealthFilterCard({
           label="Healthy"
           count={links.healthy}
           description="No active issues detected."
-          selected={selected.includes('healthy')}
-          onClick={() => toggleFilter('healthy')}
+          selected={selected.includes("healthy")}
+          onClick={() => toggleFilter("healthy")}
           issueBreakdown={issuesByHealth?.healthy}
         />
         <HealthFilterItem
@@ -1275,8 +1398,8 @@ function LinkHealthFilterCard({
           label="Degraded"
           count={links.degraded}
           description="Moderate packet loss (1% - 10%), or latency SLO breach."
-          selected={selected.includes('degraded')}
-          onClick={() => toggleFilter('degraded')}
+          selected={selected.includes("degraded")}
+          onClick={() => toggleFilter("degraded")}
           issueBreakdown={issuesByHealth?.degraded}
         />
         <HealthFilterItem
@@ -1284,13 +1407,13 @@ function LinkHealthFilterCard({
           label="Unhealthy"
           count={links.unhealthy}
           description="Severe packet loss (>= 10%), or missing telemetry (link dark)."
-          selected={selected.includes('unhealthy')}
-          onClick={() => toggleFilter('unhealthy')}
+          selected={selected.includes("unhealthy")}
+          onClick={() => toggleFilter("unhealthy")}
           issueBreakdown={issuesByHealth?.unhealthy}
         />
       </div>
     </div>
-  )
+  );
 }
 
 function LinkIssuesFilterCard({
@@ -1300,126 +1423,127 @@ function LinkIssuesFilterCard({
   healthByIssue,
   timeRange,
 }: {
-  counts: IssueCounts
-  selected: IssueFilter[]
-  onChange: (filters: IssueFilter[]) => void
-  healthByIssue?: HealthByIssue
-  timeRange: TimeRange
+  counts: IssueCounts;
+  selected: IssueFilter[];
+  onChange: (filters: IssueFilter[]) => void;
+  healthByIssue?: HealthByIssue;
+  timeRange: TimeRange;
 }) {
   const allFilters: IssueFilter[] = [
-    'packet_loss',
-    'high_latency',
-    'high_utilization',
-    'no_data',
-    'missing_adjacency',
-    'interface_errors',
-    'fcs_errors',
-    'discards',
-    'carrier_transitions',
-    'no_issues',
-  ]
+    "packet_loss",
+    "high_latency",
+    "high_utilization",
+    "no_data",
+    "missing_adjacency",
+    "interface_errors",
+    "fcs_errors",
+    "discards",
+    "carrier_transitions",
+    "no_issues",
+  ];
 
   const toggleFilter = (filter: IssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === allFilters.length
+  const allSelected = selected.length === allFilters.length;
 
   const itemDefs: {
-    filter: IssueFilter
-    label: string
-    color: string
-    description: string
+    filter: IssueFilter;
+    label: string;
+    color: string;
+    description: string;
   }[] = [
     {
-      filter: 'packet_loss',
-      label: 'Packet Loss',
-      color: 'bg-purple-500',
-      description: 'Link experiencing measurable packet loss (>= 1%).',
+      filter: "packet_loss",
+      label: "Packet Loss",
+      color: "bg-purple-500",
+      description: "Link experiencing measurable packet loss (>= 1%).",
     },
     {
-      filter: 'high_latency',
-      label: 'High Latency',
-      color: 'bg-blue-500',
-      description: 'Link latency exceeds committed RTT.',
+      filter: "high_latency",
+      label: "High Latency",
+      color: "bg-blue-500",
+      description: "Link latency exceeds committed RTT.",
     },
     {
-      filter: 'high_utilization',
-      label: 'High Utilization',
-      color: 'bg-indigo-500',
-      description: 'Link utilization exceeds 80%.',
+      filter: "high_utilization",
+      label: "High Utilization",
+      color: "bg-indigo-500",
+      description: "Link utilization exceeds 80%.",
     },
     {
-      filter: 'carrier_transitions',
-      label: 'Carrier Transitions',
-      color: 'bg-yellow-500',
-      description: 'Carrier transitions (interface up/down) on link endpoints.',
+      filter: "carrier_transitions",
+      label: "Carrier Transitions",
+      color: "bg-yellow-500",
+      description: "Carrier transitions (interface up/down) on link endpoints.",
     },
     {
-      filter: 'discards',
-      label: 'Discards',
-      color: 'bg-teal-500',
-      description: 'Interface discards detected on link endpoints.',
+      filter: "discards",
+      label: "Discards",
+      color: "bg-teal-500",
+      description: "Interface discards detected on link endpoints.",
     },
     {
-      filter: 'interface_errors',
-      label: 'Errors',
-      color: 'bg-red-500',
-      description: 'Interface errors detected on link endpoints.',
+      filter: "interface_errors",
+      label: "Errors",
+      color: "bg-red-500",
+      description: "Interface errors detected on link endpoints.",
     },
     {
-      filter: 'fcs_errors',
-      label: 'FCS Errors',
-      color: 'bg-orange-500',
-      description: 'FCS (Frame Check Sequence) errors detected on link endpoints.',
+      filter: "fcs_errors",
+      label: "FCS Errors",
+      color: "bg-orange-500",
+      description:
+        "FCS (Frame Check Sequence) errors detected on link endpoints.",
     },
     {
-      filter: 'no_data',
-      label: 'No Data',
-      color: 'bg-pink-500',
-      description: 'No telemetry received for this link.',
+      filter: "no_data",
+      label: "No Data",
+      color: "bg-pink-500",
+      description: "No telemetry received for this link.",
     },
     {
-      filter: 'missing_adjacency',
-      label: 'ISIS Down',
-      color: 'bg-rose-600',
-      description: 'Activated link with no ISIS adjacency detected.',
+      filter: "missing_adjacency",
+      label: "ISIS Down",
+      color: "bg-rose-600",
+      description: "Activated link with no ISIS adjacency detected.",
     },
     {
-      filter: 'no_issues',
-      label: 'No Issues',
-      color: 'bg-cyan-500',
-      description: 'Link with no detected issues in the time range.',
+      filter: "no_issues",
+      label: "No Issues",
+      color: "bg-cyan-500",
+      description: "Link with no detected issues in the time range.",
     },
-  ]
+  ];
 
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(false);
 
   // Sort items by count (highest first), alphabetically if same, with no_issues always last
   const items = [...itemDefs].sort((a, b) => {
-    if (a.filter === 'no_issues') return 1
-    if (b.filter === 'no_issues') return -1
-    const countDiff = (counts[b.filter] ?? 0) - (counts[a.filter] ?? 0)
-    if (countDiff !== 0) return countDiff
-    return a.label.localeCompare(b.label)
-  })
+    if (a.filter === "no_issues") return 1;
+    if (b.filter === "no_issues") return -1;
+    const countDiff = (counts[b.filter] ?? 0) - (counts[a.filter] ?? 0);
+    if (countDiff !== 0) return countDiff;
+    return a.label.localeCompare(b.label);
+  });
 
   // Collapse if more than 4 items
-  const shouldCollapse = items.length > 4
-  const visibleItems = shouldCollapse && !expanded ? items.slice(0, 4) : items
+  const shouldCollapse = items.length > 4;
+  const visibleItems = shouldCollapse && !expanded ? items.slice(0, 4) : items;
 
-  const grandTotal = counts.total + counts.no_issues || 1
-  const packetLossPct = (counts.packet_loss / grandTotal) * 100
-  const highLatencyPct = (counts.high_latency / grandTotal) * 100
-  const noDataPct = (counts.no_data / grandTotal) * 100
-  const missingAdjPct = (counts.missing_adjacency / grandTotal) * 100
-  const noIssuesPct = (counts.no_issues / grandTotal) * 100
+  const grandTotal = counts.total + counts.no_issues || 1;
+  const packetLossPct = (counts.packet_loss / grandTotal) * 100;
+  const highLatencyPct = (counts.high_latency / grandTotal) * 100;
+  const noDataPct = (counts.no_data / grandTotal) * 100;
+  const missingAdjPct = (counts.missing_adjacency / grandTotal) * 100;
+  const noIssuesPct = (counts.no_issues / grandTotal) * 100;
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -1432,9 +1556,9 @@ function LinkIssuesFilterCard({
           </span>
           <button
             onClick={() => onChange(allFilters)}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -1445,38 +1569,38 @@ function LinkIssuesFilterCard({
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {noIssuesPct > 0 && (
             <div
-              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes("no_issues") ? "opacity-30" : ""}`}
               style={{ width: `${noIssuesPct}%` }}
             />
           )}
           {packetLossPct > 0 && (
             <div
-              className={`bg-purple-500 h-full transition-all ${!selected.includes('packet_loss') ? 'opacity-30' : ''}`}
+              className={`bg-purple-500 h-full transition-all ${!selected.includes("packet_loss") ? "opacity-30" : ""}`}
               style={{ width: `${packetLossPct}%` }}
             />
           )}
           {highLatencyPct > 0 && (
             <div
-              className={`bg-blue-500 h-full transition-all ${!selected.includes('high_latency') ? 'opacity-30' : ''}`}
+              className={`bg-blue-500 h-full transition-all ${!selected.includes("high_latency") ? "opacity-30" : ""}`}
               style={{ width: `${highLatencyPct}%` }}
             />
           )}
           {noDataPct > 0 && (
             <div
-              className={`bg-pink-500 h-full transition-all ${!selected.includes('no_data') ? 'opacity-30' : ''}`}
+              className={`bg-pink-500 h-full transition-all ${!selected.includes("no_data") ? "opacity-30" : ""}`}
               style={{ width: `${noDataPct}%` }}
             />
           )}
           {missingAdjPct > 0 && (
             <div
-              className={`bg-rose-600 h-full transition-all ${!selected.includes('missing_adjacency') ? 'opacity-30' : ''}`}
+              className={`bg-rose-600 h-full transition-all ${!selected.includes("missing_adjacency") ? "opacity-30" : ""}`}
               style={{ width: `${missingAdjPct}%` }}
             />
           )}
@@ -1501,37 +1625,49 @@ function LinkIssuesFilterCard({
             onClick={() => setExpanded(!expanded)}
             className="w-full flex justify-center pt-1 text-muted-foreground hover:text-foreground transition-colors"
           >
-            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
           </button>
         )}
       </div>
     </div>
-  )
+  );
 }
 
 function formatBandwidth(bps: number): string {
   if (bps >= 1e9) {
-    return `${(bps / 1e9).toFixed(1)} Gbps`
+    return `${(bps / 1e9).toFixed(1)} Gbps`;
   } else if (bps >= 1e6) {
-    return `${(bps / 1e6).toFixed(1)} Mbps`
+    return `${(bps / 1e6).toFixed(1)} Mbps`;
   } else if (bps >= 1e3) {
-    return `${(bps / 1e3).toFixed(1)} Kbps`
+    return `${(bps / 1e3).toFixed(1)} Kbps`;
   }
-  return `${bps.toFixed(0)} bps`
+  return `${bps.toFixed(0)} bps`;
 }
 
-function TopLinkUtilization({ links }: { links: StatusResponse['links']['top_util_links'] }) {
+function TopLinkUtilization({
+  links,
+}: {
+  links: StatusResponse["links"]["top_util_links"];
+}) {
   if (!links || links.length === 0) {
     return (
       <div className="border border-border rounded-lg p-4">
         <div className="flex items-center gap-2 mb-3">
           <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
           <h3 className="font-medium">Max Link Utilization</h3>
-          <span className="text-xs text-muted-foreground ml-auto">p95 - Last 24h</span>
+          <span className="text-xs text-muted-foreground ml-auto">
+            p95 - Last 24h
+          </span>
         </div>
-        <div className="text-sm text-muted-foreground">No link data available</div>
+        <div className="text-sm text-muted-foreground">
+          No link data available
+        </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -1544,33 +1680,41 @@ function TopLinkUtilization({ links }: { links: StatusResponse['links']['top_uti
             p95 - Last 24h
           </span>
         </div>
-        <span className="text-xs text-muted-foreground sm:hidden">p95 - Last 24h</span>
+        <span className="text-xs text-muted-foreground sm:hidden">
+          p95 - Last 24h
+        </span>
       </div>
       <div className="space-y-2">
         {links.slice(0, 5).map((link) => {
-          const maxUtil = Math.max(link.utilization_in, link.utilization_out)
-          const peakBps = Math.max(link.in_bps, link.out_bps)
+          const maxUtil = Math.max(link.utilization_in, link.utilization_out);
+          const peakBps = Math.max(link.in_bps, link.out_bps);
           return (
-            <div key={link.pk} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+            <div
+              key={link.pk}
+              className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3"
+            >
               {/* Mobile layout */}
               <div className="sm:hidden flex flex-col gap-1">
                 <div className="flex items-center justify-between gap-2">
                   <Link
                     to={`/dz/links/${link.pk}`}
-                    state={{ backLabel: 'status' }}
+                    state={{ backLabel: "status" }}
                     className="font-mono text-xs truncate hover:underline"
                     title={link.code}
                   >
                     {link.code}
                   </Link>
-                  <span className="text-xs tabular-nums shrink-0">{maxUtil.toFixed(0)}%</span>
+                  <span className="text-xs tabular-nums shrink-0">
+                    {maxUtil.toFixed(0)}%
+                  </span>
                 </div>
                 <div className="text-[10px] text-muted-foreground">
-                  {link.side_a_metro} - {link.side_z_metro} · {formatBandwidth(peakBps)}
+                  {link.side_a_metro} - {link.side_z_metro} ·{" "}
+                  {formatBandwidth(peakBps)}
                 </div>
                 <div className="h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
-                    className={`h-full rounded-full ${maxUtil >= 90 ? 'bg-red-500' : maxUtil >= 70 ? 'bg-amber-500' : 'bg-green-500'}`}
+                    className={`h-full rounded-full ${maxUtil >= 90 ? "bg-red-500" : maxUtil >= 70 ? "bg-amber-500" : "bg-green-500"}`}
                     style={{ width: `${Math.min(maxUtil, 100)}%` }}
                   />
                 </div>
@@ -1579,7 +1723,7 @@ function TopLinkUtilization({ links }: { links: StatusResponse['links']['top_uti
               <div className="hidden sm:flex flex-1 min-w-0 flex-col">
                 <Link
                   to={`/dz/links/${link.pk}`}
-                  state={{ backLabel: 'status' }}
+                  state={{ backLabel: "status" }}
                   className="font-mono text-xs truncate hover:underline"
                   title={link.code}
                 >
@@ -1595,21 +1739,27 @@ function TopLinkUtilization({ links }: { links: StatusResponse['links']['top_uti
               <div className="hidden sm:flex w-20 items-center gap-2">
                 <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
-                    className={`h-full rounded-full ${maxUtil >= 90 ? 'bg-red-500' : maxUtil >= 70 ? 'bg-amber-500' : 'bg-green-500'}`}
+                    className={`h-full rounded-full ${maxUtil >= 90 ? "bg-red-500" : maxUtil >= 70 ? "bg-amber-500" : "bg-green-500"}`}
                     style={{ width: `${Math.min(maxUtil, 100)}%` }}
                   />
                 </div>
-                <span className="text-xs tabular-nums w-8 text-right">{maxUtil.toFixed(0)}%</span>
+                <span className="text-xs tabular-nums w-8 text-right">
+                  {maxUtil.toFixed(0)}%
+                </span>
               </div>
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }
 
-function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device_util'] }) {
+function TopDeviceUtilization({
+  devices,
+}: {
+  devices: StatusResponse["top_device_util"];
+}) {
   if (!devices || devices.length === 0) {
     return (
       <div className="border border-border rounded-lg p-4">
@@ -1618,9 +1768,11 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
           <h3 className="font-medium">Top Device Utilization</h3>
           <span className="text-xs text-muted-foreground ml-auto">Current</span>
         </div>
-        <div className="text-sm text-muted-foreground">No device data available</div>
+        <div className="text-sm text-muted-foreground">
+          No device data available
+        </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -1629,13 +1781,18 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
         <div className="flex items-center gap-2">
           <Cpu className="h-4 w-4 text-muted-foreground shrink-0" />
           <h3 className="font-medium">Top Device Utilization</h3>
-          <span className="text-xs text-muted-foreground ml-auto hidden sm:block">Current</span>
+          <span className="text-xs text-muted-foreground ml-auto hidden sm:block">
+            Current
+          </span>
         </div>
         <span className="text-xs text-muted-foreground sm:hidden">Current</span>
       </div>
       <div className="space-y-2">
         {devices.slice(0, 5).map((device) => (
-          <div key={device.pk} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+          <div
+            key={device.pk}
+            className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3"
+          >
             {/* Mobile layout */}
             <div className="sm:hidden flex flex-col gap-1">
               <div className="flex items-center justify-between gap-2">
@@ -1651,12 +1808,12 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
                 </span>
               </div>
               <div className="text-[10px] text-muted-foreground">
-                {device.current_users}/{device.max_users} users • {device.metro} •{' '}
-                {device.contributor}
+                {device.current_users}/{device.max_users} users • {device.metro}{" "}
+                • {device.contributor}
               </div>
               <div className="h-1.5 bg-muted rounded-full overflow-hidden">
                 <div
-                  className={`h-full rounded-full ${device.utilization >= 80 ? 'bg-amber-500' : 'bg-green-500'}`}
+                  className={`h-full rounded-full ${device.utilization >= 80 ? "bg-amber-500" : "bg-green-500"}`}
                   style={{ width: `${Math.min(device.utilization, 100)}%` }}
                 />
               </div>
@@ -1671,14 +1828,14 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
                 {device.code}
               </Link>
               <div className="text-[10px] text-muted-foreground">
-                {device.current_users}/{device.max_users} users • {device.metro} •{' '}
-                {device.contributor}
+                {device.current_users}/{device.max_users} users • {device.metro}{" "}
+                • {device.contributor}
               </div>
             </div>
             <div className="hidden sm:flex w-24 items-center gap-2">
               <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
                 <div
-                  className={`h-full rounded-full ${device.utilization >= 80 ? 'bg-amber-500' : 'bg-green-500'}`}
+                  className={`h-full rounded-full ${device.utilization >= 80 ? "bg-amber-500" : "bg-green-500"}`}
                   style={{ width: `${Math.min(device.utilization, 100)}%` }}
                 />
               </div>
@@ -1690,35 +1847,35 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
         ))}
       </div>
     </div>
-  )
+  );
 }
 
 interface DisabledLinkRow {
-  pk: string
-  code: string
-  link_type: string
-  side_a_metro: string
-  side_z_metro: string
-  reason: string
+  pk: string;
+  code: string;
+  link_type: string;
+  side_a_metro: string;
+  side_z_metro: string;
+  reason: string;
 }
 
 function DisabledLinksTable({
   drainedLinks,
   packetLossLinks,
 }: {
-  drainedLinks: NonActivatedLink[] | null
-  packetLossLinks: DisabledLinkRow[]
+  drainedLinks: NonActivatedLink[] | null;
+  packetLossLinks: DisabledLinkRow[];
 }) {
   const allLinks = useMemo(() => {
-    const linkMap = new Map<string, DisabledLinkRow>()
+    const linkMap = new Map<string, DisabledLinkRow>();
 
     for (const link of drainedLinks || []) {
       const reason =
-        link.status === 'provisioning'
-          ? 'provisioning'
-          : link.status === 'hard-drained'
-            ? 'hard drained'
-            : 'soft drained'
+        link.status === "provisioning"
+          ? "provisioning"
+          : link.status === "hard-drained"
+            ? "hard drained"
+            : "soft drained";
       linkMap.set(link.code, {
         pk: link.pk,
         code: link.code,
@@ -1726,30 +1883,33 @@ function DisabledLinksTable({
         side_a_metro: link.side_a_metro,
         side_z_metro: link.side_z_metro,
         reason,
-      })
+      });
     }
 
     for (const link of packetLossLinks) {
       if (!linkMap.has(link.code)) {
-        linkMap.set(link.code, link)
+        linkMap.set(link.code, link);
       }
     }
 
-    return Array.from(linkMap.values())
-  }, [drainedLinks, packetLossLinks])
+    return Array.from(linkMap.values());
+  }, [drainedLinks, packetLossLinks]);
 
-  if (allLinks.length === 0) return null
+  if (allLinks.length === 0) return null;
 
   const reasonColors: Record<string, string> = {
-    provisioning: 'text-blue-600 dark:text-blue-400',
-    'soft drained': 'text-amber-600 dark:text-amber-400',
-    'hard drained': 'text-orange-600 dark:text-orange-400',
-    'isis delay override': 'text-amber-600 dark:text-amber-400',
-    'extended packet loss': 'text-red-600 dark:text-red-400',
-  }
+    provisioning: "text-blue-600 dark:text-blue-400",
+    "soft drained": "text-amber-600 dark:text-amber-400",
+    "hard drained": "text-orange-600 dark:text-orange-400",
+    "isis delay override": "text-amber-600 dark:text-amber-400",
+    "extended packet loss": "text-red-600 dark:text-red-400",
+  };
 
   return (
-    <div id="disabled-links" className="border border-border rounded-lg overflow-hidden">
+    <div
+      id="disabled-links"
+      className="border border-border rounded-lg overflow-hidden"
+    >
       <div className="px-4 py-3 bg-muted/50 border-b border-border flex items-center gap-2">
         <AlertTriangle className="h-4 w-4 text-muted-foreground" />
         <h3 className="font-medium">Disabled Links</h3>
@@ -1774,18 +1934,20 @@ function DisabledLinksTable({
                 <td className="px-4 py-2.5 whitespace-nowrap">
                   <Link
                     to={`/dz/links/${link.pk}`}
-                    state={{ backLabel: 'status' }}
+                    state={{ backLabel: "status" }}
                     className="font-mono text-sm hover:underline"
                   >
                     {link.code}
                   </Link>
-                  <span className="text-xs text-muted-foreground ml-2">{link.link_type}</span>
+                  <span className="text-xs text-muted-foreground ml-2">
+                    {link.link_type}
+                  </span>
                 </td>
                 <td className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">
                   {link.side_a_metro} - {link.side_z_metro}
                 </td>
                 <td
-                  className={`px-4 py-2.5 text-sm capitalize whitespace-nowrap ${reasonColors[link.reason] || ''}`}
+                  className={`px-4 py-2.5 text-sm capitalize whitespace-nowrap ${reasonColors[link.reason] || ""}`}
                 >
                   {link.reason}
                 </td>
@@ -1795,27 +1957,30 @@ function DisabledLinksTable({
         </table>
       </div>
     </div>
-  )
+  );
 }
 
 function DisabledDevicesTable({
   devices,
 }: {
-  devices: StatusResponse['alerts']['devices'] | null
+  devices: StatusResponse["alerts"]["devices"] | null;
 }) {
-  if (!devices || devices.length === 0) return null
+  if (!devices || devices.length === 0) return null;
 
   const statusColors: Record<string, string> = {
-    'soft-drained': 'text-amber-600 dark:text-amber-400',
-    'hard-drained': 'text-amber-600 dark:text-amber-400',
-    suspended: 'text-red-600 dark:text-red-400',
-    pending: 'text-amber-600 dark:text-amber-400',
-    deleted: 'text-gray-400',
-    rejected: 'text-red-400',
-  }
+    "soft-drained": "text-amber-600 dark:text-amber-400",
+    "hard-drained": "text-amber-600 dark:text-amber-400",
+    suspended: "text-red-600 dark:text-red-400",
+    pending: "text-amber-600 dark:text-amber-400",
+    deleted: "text-gray-400",
+    rejected: "text-red-400",
+  };
 
   return (
-    <div id="disabled-devices" className="border border-border rounded-lg overflow-hidden">
+    <div
+      id="disabled-devices"
+      className="border border-border rounded-lg overflow-hidden"
+    >
       <div className="px-4 py-3 bg-muted/50 border-b border-border flex items-center gap-2">
         <AlertTriangle className="h-4 w-4 text-muted-foreground" />
         <h3 className="font-medium">Disabled Devices</h3>
@@ -1845,13 +2010,17 @@ function DisabledDevicesTable({
                   >
                     {device.code}
                   </Link>
-                  <span className="text-xs text-muted-foreground ml-2">{device.device_type}</span>
+                  <span className="text-xs text-muted-foreground ml-2">
+                    {device.device_type}
+                  </span>
                 </td>
-                <td className="px-4 py-2.5 text-sm text-muted-foreground">{device.metro}</td>
+                <td className="px-4 py-2.5 text-sm text-muted-foreground">
+                  {device.metro}
+                </td>
                 <td
-                  className={`px-4 py-2.5 text-sm capitalize ${statusColors[device.status] || ''}`}
+                  className={`px-4 py-2.5 text-sm capitalize ${statusColors[device.status] || ""}`}
                 >
-                  {device.status.replace('-', ' ')}
+                  {device.status.replace("-", " ")}
                 </td>
                 <td className="px-4 py-2.5 text-sm tabular-nums text-right text-muted-foreground">
                   {formatTimeAgo(device.since)}
@@ -1862,7 +2031,7 @@ function DisabledDevicesTable({
         </table>
       </div>
     </div>
-  )
+  );
 }
 
 function InterfaceIssuesTable({
@@ -1871,19 +2040,19 @@ function InterfaceIssuesTable({
   onTimeRangeChange,
   isLoading,
 }: {
-  issues: InterfaceIssue[] | null
-  timeRange: TimeRange
-  onTimeRangeChange: (range: TimeRange) => void
-  isLoading?: boolean
+  issues: InterfaceIssue[] | null;
+  timeRange: TimeRange;
+  onTimeRangeChange: (range: TimeRange) => void;
+  isLoading?: boolean;
 }) {
   const timeRangeOptions: { value: TimeRange; label: string }[] = [
-    { value: '3h', label: '3h' },
-    { value: '6h', label: '6h' },
-    { value: '12h', label: '12h' },
-    { value: '24h', label: '24h' },
-    { value: '3d', label: '3d' },
-    { value: '7d', label: '7d' },
-  ]
+    { value: "3h", label: "3h" },
+    { value: "6h", label: "6h" },
+    { value: "12h", label: "12h" },
+    { value: "24h", label: "24h" },
+    { value: "3d", label: "3d" },
+    { value: "7d", label: "7d" },
+  ];
 
   if (isLoading) {
     return (
@@ -1896,7 +2065,7 @@ function InterfaceIssuesTable({
           Loading interface issues...
         </div>
       </div>
-    )
+    );
   }
 
   if (!issues || issues.length === 0) {
@@ -1912,8 +2081,8 @@ function InterfaceIssuesTable({
                 onClick={() => onTimeRangeChange(opt.value)}
                 className={`px-2.5 py-0.5 text-xs rounded-md transition-colors ${
                   timeRange === opt.value
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                 }`}
               >
                 {opt.label}
@@ -1925,7 +2094,7 @@ function InterfaceIssuesTable({
           No interface issues in the selected time range
         </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -1940,8 +2109,8 @@ function InterfaceIssuesTable({
               onClick={() => onTimeRangeChange(opt.value)}
               className={`px-2.5 py-0.5 text-xs rounded-md transition-colors ${
                 timeRange === opt.value
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
               }`}
             >
               {opt.label}
@@ -1959,15 +2128,17 @@ function InterfaceIssuesTable({
               <th className="px-4 py-2 font-medium text-right">Errors</th>
               <th className="px-4 py-2 font-medium text-right">FCS Errors</th>
               <th className="px-4 py-2 font-medium text-right">Discards</th>
-              <th className="px-4 py-2 font-medium text-right">Carrier Transitions</th>
+              <th className="px-4 py-2 font-medium text-right">
+                Carrier Transitions
+              </th>
               <th className="px-4 py-2 font-medium text-right">First Seen</th>
               <th className="px-4 py-2 font-medium text-right">Last Seen</th>
             </tr>
           </thead>
           <tbody>
             {issues.map((issue, idx) => {
-              const totalErrors = issue.in_errors + issue.out_errors
-              const totalDiscards = issue.in_discards + issue.out_discards
+              const totalErrors = issue.in_errors + issue.out_errors;
+              const totalDiscards = issue.in_discards + issue.out_discards;
               return (
                 <tr
                   key={`${issue.device_code}-${issue.interface_name}-${idx}`}
@@ -1989,17 +2160,17 @@ function InterfaceIssuesTable({
                     {issue.interface_type && (
                       <span
                         className={`ml-1.5 px-1 py-0.5 rounded text-[10px] leading-none ${
-                          issue.interface_type === 'loopback'
-                            ? 'bg-purple-500/15 text-purple-400'
-                            : 'bg-muted text-muted-foreground'
+                          issue.interface_type === "loopback"
+                            ? "bg-purple-500/15 text-purple-400"
+                            : "bg-muted text-muted-foreground"
                         }`}
                       >
                         {issue.interface_type}
                       </span>
                     )}
-                    {issue.cyoa_type && issue.cyoa_type !== 'none' && (
+                    {issue.cyoa_type && issue.cyoa_type !== "none" && (
                       <span className="ml-1 px-1 py-0.5 rounded text-[10px] leading-none bg-amber-500/15 text-amber-400">
-                        {issue.cyoa_type.replace(/_/g, ' ')}
+                        {issue.cyoa_type.replace(/_/g, " ")}
                       </span>
                     )}
                   </td>
@@ -2008,7 +2179,7 @@ function InterfaceIssuesTable({
                       <div>
                         <Link
                           to={`/dz/links/${issue.link_pk}`}
-                          state={{ backLabel: 'status' }}
+                          state={{ backLabel: "status" }}
                           className="font-mono hover:underline"
                         >
                           {issue.link_code}
@@ -2022,64 +2193,66 @@ function InterfaceIssuesTable({
                     )}
                   </td>
                   <td
-                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalErrors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalErrors > 0 ? "text-red-600 dark:text-red-400" : ""}`}
                   >
-                    {totalErrors > 0 ? totalErrors.toLocaleString() : '-'}
+                    {totalErrors > 0 ? totalErrors.toLocaleString() : "-"}
                   </td>
                   <td
-                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.in_fcs_errors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.in_fcs_errors > 0 ? "text-red-600 dark:text-red-400" : ""}`}
                   >
-                    {issue.in_fcs_errors > 0 ? issue.in_fcs_errors.toLocaleString() : '-'}
+                    {issue.in_fcs_errors > 0
+                      ? issue.in_fcs_errors.toLocaleString()
+                      : "-"}
                   </td>
                   <td
-                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalDiscards > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalDiscards > 0 ? "text-amber-600 dark:text-amber-400" : ""}`}
                   >
-                    {totalDiscards > 0 ? totalDiscards.toLocaleString() : '-'}
+                    {totalDiscards > 0 ? totalDiscards.toLocaleString() : "-"}
                   </td>
                   <td
-                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.carrier_transitions > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.carrier_transitions > 0 ? "text-amber-600 dark:text-amber-400" : ""}`}
                   >
                     {issue.carrier_transitions > 0
                       ? issue.carrier_transitions.toLocaleString()
-                      : '-'}
+                      : "-"}
                   </td>
                   <td className="px-4 py-2.5 text-sm tabular-nums text-right text-muted-foreground">
-                    {issue.first_seen ? formatTimeAgo(issue.first_seen) : '-'}
+                    {issue.first_seen ? formatTimeAgo(issue.first_seen) : "-"}
                   </td>
                   <td className="px-4 py-2.5 text-sm tabular-nums text-right text-muted-foreground">
-                    {issue.last_seen ? formatTimeAgo(issue.last_seen) : '-'}
+                    {issue.last_seen ? formatTimeAgo(issue.last_seen) : "-"}
                   </td>
                 </tr>
-              )
+              );
             })}
           </tbody>
         </table>
       </div>
     </div>
-  )
+  );
 }
 
 function useBucketCount() {
-  const [buckets, setBuckets] = useState(72)
+  const [buckets, setBuckets] = useState(72);
 
   useEffect(() => {
     const updateBuckets = () => {
-      const width = window.innerWidth
+      const width = window.innerWidth;
       if (width < 640) {
-        setBuckets(24)
+        setBuckets(24);
       } else if (width < 1024) {
-        setBuckets(48)
+        setBuckets(48);
       } else {
-        setBuckets(72)
+        setBuckets(72);
       }
-    }
+    };
 
-    updateBuckets()
-    window.addEventListener('resize', updateBuckets)
-    return () => window.removeEventListener('resize', updateBuckets)
-  }, [])
+    updateBuckets();
+    window.addEventListener("resize", updateBuckets);
+    return () => window.removeEventListener("resize", updateBuckets);
+  }, []);
 
-  return buckets
+  return buckets;
 }
 
 // Links tab content
@@ -2089,82 +2262,82 @@ function LinksContent({
   linkHistory,
   criticalLinks,
 }: {
-  status: StatusResponse
-  linkHistory: any
-  criticalLinks: CriticalLinksResponse | undefined
+  status: StatusResponse;
+  linkHistory: LinkHistoryResponse | undefined;
+  criticalLinks: CriticalLinksResponse | undefined;
 }) {
-  const [timeRange, setTimeRange] = useState<TimeRange>('24h')
+  const [timeRange, setTimeRange] = useState<TimeRange>("24h");
   const [issueFilters, setIssueFilters] = useState<IssueFilter[]>([
-    'packet_loss',
-    'high_latency',
-    'high_utilization',
-    'missing_adjacency',
-    'interface_errors',
-    'fcs_errors',
-    'discards',
-    'carrier_transitions',
-  ])
+    "packet_loss",
+    "high_latency",
+    "high_utilization",
+    "missing_adjacency",
+    "interface_errors",
+    "fcs_errors",
+    "discards",
+    "carrier_transitions",
+  ]);
   const [healthFilters, setHealthFilters] = useState<HealthFilter[]>([
-    'healthy',
-    'degraded',
-    'unhealthy',
-  ])
-  const [showDrained, setShowDrained] = useState(false)
-  const [showProvisioning, setShowProvisioning] = useState(false)
+    "healthy",
+    "degraded",
+    "unhealthy",
+  ]);
+  const [showDrained, setShowDrained] = useState(false);
+  const [showProvisioning, setShowProvisioning] = useState(false);
 
   // Get search filters from URL
-  const searchFilters = useStatusFilters()
+  const searchFilters = useStatusFilters();
 
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h':
-        return 36
-      case '6h':
-        return 36
-      case '12h':
-        return 48
-      case '24h':
-        return 72
-      case '3d':
-        return 72
-      case '7d':
-        return 84
+      case "3h":
+        return 36;
+      case "6h":
+        return 36;
+      case "12h":
+        return 48;
+      case "24h":
+        return 72;
+      case "3d":
+        return 72;
+      case "7d":
+        return 84;
       default:
-        return 72
+        return 72;
     }
-  })()
+  })();
 
   // Fetch link history for the selected time range (used for both display and health/issue counts)
   const { data: linkHistoryData } = useQuery({
-    queryKey: ['link-history', timeRange, buckets],
+    queryKey: ["link-history", timeRange, buckets],
     queryFn: () => fetchLinkHistory(timeRange, buckets),
     refetchInterval: 60_000,
-    staleTime: timeRange === '24h' ? 30_000 : 0,
+    staleTime: timeRange === "24h" ? 30_000 : 0,
     placeholderData: keepPreviousData,
-  })
+  });
 
   // Apply search filters to link history
   const filteredLinkHistory = useMemo(() => {
     if (!linkHistoryData?.links || searchFilters.length === 0) {
-      return linkHistoryData
+      return linkHistoryData;
     }
     return {
       ...linkHistoryData,
       links: linkHistoryData.links.filter((link: LinkHistory) =>
         linkMatchesSearchFilters(link, searchFilters),
       ),
-    }
-  }, [linkHistoryData, searchFilters])
+    };
+  }, [linkHistoryData, searchFilters]);
 
   // Helper to get the effective health status from a link's hours
   // Returns the worst status seen in the time range
   // Excludes the latest bucket if it's no_data (likely still being collected)
   const getEffectiveHealth = (link: LinkHistory): string => {
     // Down is highest priority — link is currently unreachable
-    if (link.is_down) return 'down'
+    if (link.is_down) return "down";
 
-    if (!link.hours || link.hours.length === 0) return 'healthy'
+    if (!link.hours || link.hours.length === 0) return "healthy";
 
     // Priority from worst to best (lower index = worse)
     const statusPriority: Record<string, number> = {
@@ -2172,57 +2345,64 @@ function LinksContent({
       no_data: 1,
       degraded: 2,
       healthy: 3,
-    }
+    };
 
-    let worstStatus = 'healthy'
-    let worstPriority = statusPriority['healthy']
+    let worstStatus = "healthy";
+    let worstPriority = statusPriority["healthy"];
 
     // Check if we should skip the last bucket (if it's no_data, it's likely still being collected)
-    const lastBucket = link.hours[link.hours.length - 1]
-    const skipLastBucket = lastBucket?.status === 'no_data' && link.hours.length > 1
-    const bucketsToCheck = skipLastBucket ? link.hours.slice(0, -1) : link.hours
+    const lastBucket = link.hours[link.hours.length - 1];
+    const skipLastBucket =
+      lastBucket?.status === "no_data" && link.hours.length > 1;
+    const bucketsToCheck = skipLastBucket
+      ? link.hours.slice(0, -1)
+      : link.hours;
 
     for (const bucket of bucketsToCheck) {
-      const status = bucket.status || 'healthy'
-      const priority = statusPriority[status] ?? 4
+      const status = bucket.status || "healthy";
+      const priority = statusPriority[status] ?? 4;
       if (priority < worstPriority) {
-        worstPriority = priority
-        worstStatus = status
+        worstPriority = priority;
+        worstStatus = status;
       }
     }
 
-    return worstStatus
-  }
+    return worstStatus;
+  };
 
   // Filter out drained/provisioning links when toggles are off, so counts reflect visibility
   const visibleLinks = useMemo(() => {
-    if (!filteredLinkHistory?.links) return []
+    if (!filteredLinkHistory?.links) return [];
     return filteredLinkHistory.links.filter((link: LinkHistory) => {
-      if (link.drain_status && !showDrained) return false
-      if (link.provisioning && !showProvisioning) return false
-      return true
-    })
-  }, [filteredLinkHistory, showDrained, showProvisioning])
+      if (link.drain_status && !showDrained) return false;
+      if (link.provisioning && !showProvisioning) return false;
+      return true;
+    });
+  }, [filteredLinkHistory, showDrained, showProvisioning]);
 
   // Calculate health counts from link history (based on most recent bucket status)
   const healthCounts = useMemo(() => {
     if (visibleLinks.length === 0) {
-      return { healthy: 0, degraded: 0, unhealthy: 0, total: 0 }
+      return { healthy: 0, degraded: 0, unhealthy: 0, total: 0 };
     }
 
-    const counts = { healthy: 0, degraded: 0, unhealthy: 0, total: 0 }
+    const counts = { healthy: 0, degraded: 0, unhealthy: 0, total: 0 };
 
     for (const link of visibleLinks) {
-      counts.total++
-      const status = getEffectiveHealth(link)
-      if (status === 'healthy') counts.healthy++
-      else if (status === 'degraded') counts.degraded++
-      else if (status === 'down' || status === 'unhealthy' || status === 'no_data')
-        counts.unhealthy++ // down, no_data map to unhealthy
+      counts.total++;
+      const status = getEffectiveHealth(link);
+      if (status === "healthy") counts.healthy++;
+      else if (status === "degraded") counts.degraded++;
+      else if (
+        status === "down" ||
+        status === "unhealthy" ||
+        status === "no_data"
+      )
+        counts.unhealthy++; // down, no_data map to unhealthy
     }
 
-    return counts
-  }, [visibleLinks])
+    return counts;
+  }, [visibleLinks]);
 
   // Calculate issue breakdown per health category
   const issuesByHealth = useMemo((): IssuesByHealth => {
@@ -2236,37 +2416,41 @@ function LinksContent({
       fcs_errors: 0,
       discards: 0,
       carrier_transitions: 0,
-    })
+    });
 
     const result: IssuesByHealth = {
       healthy: emptyBreakdown(),
       degraded: emptyBreakdown(),
       unhealthy: emptyBreakdown(),
-    }
+    };
 
-    if (visibleLinks.length === 0) return result
+    if (visibleLinks.length === 0) return result;
 
     for (const link of visibleLinks) {
-      const rawHealth = getEffectiveHealth(link)
+      const rawHealth = getEffectiveHealth(link);
       // Map no_data and down to unhealthy for categorization
-      const health = rawHealth === 'no_data' || rawHealth === 'down' ? 'unhealthy' : rawHealth
-      if (!(health in result)) continue
+      const health =
+        rawHealth === "no_data" || rawHealth === "down"
+          ? "unhealthy"
+          : rawHealth;
+      if (!(health in result)) continue;
 
-      const breakdown = result[health as keyof IssuesByHealth]
-      const issues = link.issue_reasons ?? []
+      const breakdown = result[health as keyof IssuesByHealth];
+      const issues = link.issue_reasons ?? [];
 
-      if (issues.includes('packet_loss')) breakdown.packet_loss++
-      if (issues.includes('high_latency')) breakdown.high_latency++
-      if (issues.includes('high_utilization')) breakdown.high_utilization++
-      if (issues.includes('no_data')) breakdown.no_data++
-      if (issues.includes('interface_errors')) breakdown.interface_errors++
-      if (issues.includes('fcs_errors')) breakdown.fcs_errors++
-      if (issues.includes('discards')) breakdown.discards++
-      if (issues.includes('carrier_transitions')) breakdown.carrier_transitions++
+      if (issues.includes("packet_loss")) breakdown.packet_loss++;
+      if (issues.includes("high_latency")) breakdown.high_latency++;
+      if (issues.includes("high_utilization")) breakdown.high_utilization++;
+      if (issues.includes("no_data")) breakdown.no_data++;
+      if (issues.includes("interface_errors")) breakdown.interface_errors++;
+      if (issues.includes("fcs_errors")) breakdown.fcs_errors++;
+      if (issues.includes("discards")) breakdown.discards++;
+      if (issues.includes("carrier_transitions"))
+        breakdown.carrier_transitions++;
     }
 
-    return result
-  }, [visibleLinks])
+    return result;
+  }, [visibleLinks]);
 
   // Calculate health breakdown per issue type
   const healthByIssue = useMemo((): HealthByIssue => {
@@ -2274,7 +2458,7 @@ function LinksContent({
       healthy: 0,
       degraded: 0,
       unhealthy: 0,
-    })
+    });
 
     const result: HealthByIssue = {
       packet_loss: emptyBreakdown(),
@@ -2287,35 +2471,41 @@ function LinksContent({
       discards: emptyBreakdown(),
       carrier_transitions: emptyBreakdown(),
       no_issues: emptyBreakdown(),
-    }
+    };
 
-    if (visibleLinks.length === 0) return result
+    if (visibleLinks.length === 0) return result;
 
     for (const link of visibleLinks) {
-      const rawHealth = getEffectiveHealth(link)
+      const rawHealth = getEffectiveHealth(link);
       // Map no_data and down to unhealthy for categorization
       const health = (
-        rawHealth === 'no_data' || rawHealth === 'down' ? 'unhealthy' : rawHealth
-      ) as keyof IssueHealthBreakdown
-      const issues = link.issue_reasons ?? []
+        rawHealth === "no_data" || rawHealth === "down"
+          ? "unhealthy"
+          : rawHealth
+      ) as keyof IssueHealthBreakdown;
+      const issues = link.issue_reasons ?? [];
 
       if (issues.length === 0) {
-        result.no_issues[health]++
+        result.no_issues[health]++;
       } else {
-        if (issues.includes('packet_loss')) result.packet_loss[health]++
-        if (issues.includes('high_latency')) result.high_latency[health]++
-        if (issues.includes('high_utilization')) result.high_utilization[health]++
-        if (issues.includes('no_data')) result.no_data[health]++
-        if (issues.includes('missing_adjacency')) result.missing_adjacency[health]++
-        if (issues.includes('interface_errors')) result.interface_errors[health]++
-        if (issues.includes('fcs_errors')) result.fcs_errors[health]++
-        if (issues.includes('discards')) result.discards[health]++
-        if (issues.includes('carrier_transitions')) result.carrier_transitions[health]++
+        if (issues.includes("packet_loss")) result.packet_loss[health]++;
+        if (issues.includes("high_latency")) result.high_latency[health]++;
+        if (issues.includes("high_utilization"))
+          result.high_utilization[health]++;
+        if (issues.includes("no_data")) result.no_data[health]++;
+        if (issues.includes("missing_adjacency"))
+          result.missing_adjacency[health]++;
+        if (issues.includes("interface_errors"))
+          result.interface_errors[health]++;
+        if (issues.includes("fcs_errors")) result.fcs_errors[health]++;
+        if (issues.includes("discards")) result.discards[health]++;
+        if (issues.includes("carrier_transitions"))
+          result.carrier_transitions[health]++;
       }
     }
 
-    return result
-  }, [visibleLinks])
+    return result;
+  }, [visibleLinks]);
 
   // Issue counts from filter time range
   const issueCounts = useMemo((): IssueCounts => {
@@ -2332,7 +2522,7 @@ function LinksContent({
         carrier_transitions: 0,
         no_issues: 0,
         total: 0,
-      }
+      };
     }
 
     const counts = {
@@ -2347,104 +2537,118 @@ function LinksContent({
       carrier_transitions: 0,
       no_issues: 0,
       total: 0,
-    }
-    const seenLinks = new Set<string>()
+    };
+    const seenLinks = new Set<string>();
 
     for (const link of visibleLinks) {
-      if (link.issue_reasons?.includes('packet_loss')) counts.packet_loss++
-      if (link.issue_reasons?.includes('high_latency')) counts.high_latency++
-      if (link.issue_reasons?.includes('high_utilization')) counts.high_utilization++
-      if (link.issue_reasons?.includes('no_data')) counts.no_data++
-      if (link.issue_reasons?.includes('missing_adjacency')) counts.missing_adjacency++
-      if (link.issue_reasons?.includes('interface_errors')) counts.interface_errors++
-      if (link.issue_reasons?.includes('fcs_errors')) counts.fcs_errors++
-      if (link.issue_reasons?.includes('discards')) counts.discards++
-      if (link.issue_reasons?.includes('carrier_transitions')) counts.carrier_transitions++
+      if (link.issue_reasons?.includes("packet_loss")) counts.packet_loss++;
+      if (link.issue_reasons?.includes("high_latency")) counts.high_latency++;
+      if (link.issue_reasons?.includes("high_utilization"))
+        counts.high_utilization++;
+      if (link.issue_reasons?.includes("no_data")) counts.no_data++;
+      if (link.issue_reasons?.includes("missing_adjacency"))
+        counts.missing_adjacency++;
+      if (link.issue_reasons?.includes("interface_errors"))
+        counts.interface_errors++;
+      if (link.issue_reasons?.includes("fcs_errors")) counts.fcs_errors++;
+      if (link.issue_reasons?.includes("discards")) counts.discards++;
+      if (link.issue_reasons?.includes("carrier_transitions"))
+        counts.carrier_transitions++;
       if (link.issue_reasons?.length > 0 && !seenLinks.has(link.code)) {
-        counts.total++
-        seenLinks.add(link.code)
+        counts.total++;
+        seenLinks.add(link.code);
       }
     }
 
-    const totalLinks = healthCounts.total || 0
-    counts.no_issues = Math.max(0, totalLinks - counts.total)
+    const totalLinks = healthCounts.total || 0;
+    counts.no_issues = Math.max(0, totalLinks - counts.total);
 
-    return counts
-  }, [visibleLinks, healthCounts])
+    return counts;
+  }, [visibleLinks, healthCounts]);
 
   // Get set of link codes with issues in the filter time range (for filtering history table)
   const linksWithIssues = useMemo(() => {
-    if (!filteredLinkHistory?.links) return new Map<string, string[]>()
-    const map = new Map<string, string[]>()
+    if (!filteredLinkHistory?.links) return new Map<string, string[]>();
+    const map = new Map<string, string[]>();
     for (const link of filteredLinkHistory.links) {
       if (link.issue_reasons?.length > 0) {
-        map.set(link.code, link.issue_reasons)
+        map.set(link.code, link.issue_reasons);
       }
     }
-    return map
-  }, [filteredLinkHistory])
+    return map;
+  }, [filteredLinkHistory]);
 
   // Get health status for each link from the filter time range (for filtering history table)
   const linksWithHealth = useMemo(() => {
-    if (!filteredLinkHistory?.links) return new Map<string, string>()
-    const map = new Map<string, string>()
+    if (!filteredLinkHistory?.links) return new Map<string, string>();
+    const map = new Map<string, string>();
     for (const link of filteredLinkHistory.links) {
-      map.set(link.code, getEffectiveHealth(link))
+      map.set(link.code, getEffectiveHealth(link));
     }
-    return map
-  }, [filteredLinkHistory])
+    return map;
+  }, [filteredLinkHistory]);
 
   // Build criticality map from critical links data
   // Maps link code -> criticality by matching device codes
   const criticalityMap = useMemo(() => {
-    const map = new Map<string, 'critical' | 'important' | 'redundant'>()
-    if (!criticalLinks?.links || !filteredLinkHistory?.links) return map
+    const map = new Map<string, "critical" | "important" | "redundant">();
+    if (!criticalLinks?.links || !filteredLinkHistory?.links) return map;
 
     // Build a map from device pair -> criticality
-    const devicePairMap = new Map<string, 'critical' | 'important' | 'redundant'>()
+    const devicePairMap = new Map<
+      string,
+      "critical" | "important" | "redundant"
+    >();
     for (const critLink of criticalLinks.links) {
       // Create keys for both directions
-      const key1 = `${critLink.sourceCode}::${critLink.targetCode}`
-      const key2 = `${critLink.targetCode}::${critLink.sourceCode}`
-      devicePairMap.set(key1, critLink.criticality)
-      devicePairMap.set(key2, critLink.criticality)
+      const key1 = `${critLink.sourceCode}::${critLink.targetCode}`;
+      const key2 = `${critLink.targetCode}::${critLink.sourceCode}`;
+      devicePairMap.set(key1, critLink.criticality);
+      devicePairMap.set(key2, critLink.criticality);
     }
 
     // Match link history entries to criticality by device codes
     for (const link of filteredLinkHistory.links) {
       if (link.side_a_device && link.side_z_device) {
-        const key = `${link.side_a_device}::${link.side_z_device}`
-        const criticality = devicePairMap.get(key)
+        const key = `${link.side_a_device}::${link.side_z_device}`;
+        const criticality = devicePairMap.get(key);
         if (criticality) {
-          map.set(link.code, criticality)
+          map.set(link.code, criticality);
         }
       }
     }
 
-    return map
-  }, [criticalLinks, filteredLinkHistory])
+    return map;
+  }, [criticalLinks, filteredLinkHistory]);
 
   const packetLossDisabledLinks = useMemo((): DisabledLinkRow[] => {
-    if (!linkHistory?.links || !status) return []
+    if (!linkHistory?.links || !status) return [];
 
     const drainedCodes = new Set(
       (status.alerts?.links || [])
-        .filter((l) => l.status === 'soft-drained' || l.status === 'hard-drained')
+        .filter(
+          (l) => l.status === "soft-drained" || l.status === "hard-drained",
+        )
         .map((l) => l.code),
-    )
+    );
 
-    const bucketsFor2Hours = Math.ceil(120 / (linkHistory.bucket_minutes || 20))
+    const bucketsFor2Hours = Math.ceil(
+      120 / (linkHistory.bucket_minutes || 20),
+    );
 
-    const isCurrentlyDisabledByPacketLoss = (hours: { status: string }[]): boolean => {
-      if (!hours || hours.length < bucketsFor2Hours) return false
-      const recentBuckets = hours.slice(-bucketsFor2Hours)
-      return recentBuckets.every((h) => h.status === 'disabled')
-    }
+    const isCurrentlyDisabledByPacketLoss = (
+      hours: { status: string }[],
+    ): boolean => {
+      if (!hours || hours.length < bucketsFor2Hours) return false;
+      const recentBuckets = hours.slice(-bucketsFor2Hours);
+      return recentBuckets.every((h) => h.status === "disabled");
+    };
 
     return linkHistory.links
       .filter(
         (link: LinkHistory) =>
-          !drainedCodes.has(link.code) && isCurrentlyDisabledByPacketLoss(link.hours),
+          !drainedCodes.has(link.code) &&
+          isCurrentlyDisabledByPacketLoss(link.hours),
       )
       .map((link: LinkHistory) => ({
         pk: link.pk,
@@ -2452,9 +2656,9 @@ function LinksContent({
         link_type: link.link_type,
         side_a_metro: link.side_a_metro,
         side_z_metro: link.side_z_metro,
-        reason: 'extended packet loss',
-      }))
-  }, [linkHistory, status])
+        reason: "extended packet loss",
+      }));
+  }, [linkHistory, status]);
 
   return (
     <>
@@ -2503,117 +2707,120 @@ function LinksContent({
 
       {/* Methodology link */}
       <div className="text-center text-sm text-muted-foreground pb-4">
-        <Link to="/status/methodology" className="hover:text-foreground hover:underline">
+        <Link
+          to="/status/methodology"
+          className="hover:text-foreground hover:underline"
+        >
           How is status calculated?
         </Link>
       </div>
     </>
-  )
+  );
 }
 
 // Device issue counts interface
 interface DeviceIssueCounts {
-  interface_errors: number
-  fcs_errors: number
-  discards: number
-  carrier_transitions: number
-  drained: number
-  isis_overload: number
-  isis_unreachable: number
-  no_issues: number
-  total: number
+  interface_errors: number;
+  fcs_errors: number;
+  discards: number;
+  carrier_transitions: number;
+  drained: number;
+  isis_overload: number;
+  isis_unreachable: number;
+  no_issues: number;
+  total: number;
 }
 
 // Device issues breakdown per health category
 interface DeviceIssuesByHealth {
   healthy: {
-    interface_errors: number
-    fcs_errors: number
-    discards: number
-    carrier_transitions: number
-    drained: number
-    isis_overload: number
-    isis_unreachable: number
-  }
+    interface_errors: number;
+    fcs_errors: number;
+    discards: number;
+    carrier_transitions: number;
+    drained: number;
+    isis_overload: number;
+    isis_unreachable: number;
+  };
   degraded: {
-    interface_errors: number
-    fcs_errors: number
-    discards: number
-    carrier_transitions: number
-    drained: number
-    isis_overload: number
-    isis_unreachable: number
-  }
+    interface_errors: number;
+    fcs_errors: number;
+    discards: number;
+    carrier_transitions: number;
+    drained: number;
+    isis_overload: number;
+    isis_unreachable: number;
+  };
   unhealthy: {
-    interface_errors: number
-    fcs_errors: number
-    discards: number
-    carrier_transitions: number
-    drained: number
-    isis_overload: number
-    isis_unreachable: number
-  }
+    interface_errors: number;
+    fcs_errors: number;
+    discards: number;
+    carrier_transitions: number;
+    drained: number;
+    isis_overload: number;
+    isis_unreachable: number;
+  };
   disabled: {
-    interface_errors: number
-    fcs_errors: number
-    discards: number
-    carrier_transitions: number
-    drained: number
-    isis_overload: number
-    isis_unreachable: number
-  }
+    interface_errors: number;
+    fcs_errors: number;
+    discards: number;
+    carrier_transitions: number;
+    drained: number;
+    isis_overload: number;
+    isis_unreachable: number;
+  };
 }
 
 // Device health breakdown per issue type
 interface DeviceHealthByIssue {
   interface_errors: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   fcs_errors: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   discards: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   carrier_transitions: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   drained: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   isis_overload: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   isis_unreachable: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
   no_issues: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-  }
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+  };
 }
 
 function DeviceHealthFilterCard({
@@ -2624,33 +2831,37 @@ function DeviceHealthFilterCard({
   timeRange,
 }: {
   devices: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    disabled: number
-    total: number
-  }
-  selected: HealthFilter[]
-  onChange: (filters: HealthFilter[]) => void
-  issuesByHealth?: DeviceIssuesByHealth
-  timeRange: TimeRange
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    disabled: number;
+    total: number;
+  };
+  selected: HealthFilter[];
+  onChange: (filters: HealthFilter[]) => void;
+  issuesByHealth?: DeviceIssuesByHealth;
+  timeRange: TimeRange;
 }) {
   const toggleFilter = (filter: HealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === 4
+  const allSelected = selected.length === 4;
 
-  const healthyPct = devices.total > 0 ? (devices.healthy / devices.total) * 100 : 100
-  const degradedPct = devices.total > 0 ? (devices.degraded / devices.total) * 100 : 0
-  const unhealthyPct = devices.total > 0 ? (devices.unhealthy / devices.total) * 100 : 0
-  const disabledPct = devices.total > 0 ? ((devices.disabled || 0) / devices.total) * 100 : 0
+  const healthyPct =
+    devices.total > 0 ? (devices.healthy / devices.total) * 100 : 100;
+  const degradedPct =
+    devices.total > 0 ? (devices.degraded / devices.total) * 100 : 0;
+  const unhealthyPct =
+    devices.total > 0 ? (devices.unhealthy / devices.total) * 100 : 0;
+  const disabledPct =
+    devices.total > 0 ? ((devices.disabled || 0) / devices.total) * 100 : 0;
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -2662,10 +2873,12 @@ function DeviceHealthFilterCard({
             ({timeRangeLabels[timeRange]})
           </span>
           <button
-            onClick={() => onChange(['healthy', 'degraded', 'unhealthy', 'disabled'])}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            onClick={() =>
+              onChange(["healthy", "degraded", "unhealthy", "disabled"])
+            }
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -2675,33 +2888,35 @@ function DeviceHealthFilterCard({
 
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
-          onClick={() => onChange(['healthy', 'degraded', 'unhealthy', 'disabled'])}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          onClick={() =>
+            onChange(["healthy", "degraded", "unhealthy", "disabled"])
+          }
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {healthyPct > 0 && (
             <div
-              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              className={`bg-green-500 h-full transition-all ${!selected.includes("healthy") ? "opacity-30" : ""}`}
               style={{ width: `${healthyPct}%` }}
             />
           )}
           {degradedPct > 0 && (
             <div
-              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              className={`bg-amber-500 h-full transition-all ${!selected.includes("degraded") ? "opacity-30" : ""}`}
               style={{ width: `${degradedPct}%` }}
             />
           )}
           {unhealthyPct > 0 && (
             <div
-              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              className={`bg-red-500 h-full transition-all ${!selected.includes("unhealthy") ? "opacity-30" : ""}`}
               style={{ width: `${unhealthyPct}%` }}
             />
           )}
           {disabledPct > 0 && (
             <div
-              className={`bg-gray-500 dark:bg-gray-700 h-full transition-all ${!selected.includes('disabled') ? 'opacity-30' : ''}`}
+              className={`bg-gray-500 dark:bg-gray-700 h-full transition-all ${!selected.includes("disabled") ? "opacity-30" : ""}`}
               style={{ width: `${disabledPct}%` }}
             />
           )}
@@ -2714,8 +2929,8 @@ function DeviceHealthFilterCard({
           label="Healthy"
           count={devices.healthy}
           description="No errors, discards, or carrier transitions."
-          selected={selected.includes('healthy')}
-          onClick={() => toggleFilter('healthy')}
+          selected={selected.includes("healthy")}
+          onClick={() => toggleFilter("healthy")}
           deviceIssueBreakdown={issuesByHealth?.healthy}
         />
         <HealthFilterItem
@@ -2723,8 +2938,8 @@ function DeviceHealthFilterCard({
           label="Degraded"
           count={devices.degraded}
           description="1-99 errors, discards, or carrier transitions per bucket."
-          selected={selected.includes('degraded')}
-          onClick={() => toggleFilter('degraded')}
+          selected={selected.includes("degraded")}
+          onClick={() => toggleFilter("degraded")}
           deviceIssueBreakdown={issuesByHealth?.degraded}
         />
         <HealthFilterItem
@@ -2732,8 +2947,8 @@ function DeviceHealthFilterCard({
           label="Unhealthy"
           count={devices.unhealthy}
           description="100+ errors, discards, or carrier transitions per bucket."
-          selected={selected.includes('unhealthy')}
-          onClick={() => toggleFilter('unhealthy')}
+          selected={selected.includes("unhealthy")}
+          onClick={() => toggleFilter("unhealthy")}
           deviceIssueBreakdown={issuesByHealth?.unhealthy}
         />
         <HealthFilterItem
@@ -2741,13 +2956,13 @@ function DeviceHealthFilterCard({
           label="Disabled"
           count={devices.disabled || 0}
           description="Device is drained or suspended."
-          selected={selected.includes('disabled')}
-          onClick={() => toggleFilter('disabled')}
+          selected={selected.includes("disabled")}
+          onClick={() => toggleFilter("disabled")}
           deviceIssueBreakdown={issuesByHealth?.disabled}
         />
       </div>
     </div>
-  )
+  );
 }
 
 function DeviceIssuesFilterCard({
@@ -2757,100 +2972,100 @@ function DeviceIssuesFilterCard({
   healthByIssue,
   timeRange,
 }: {
-  counts: DeviceIssueCounts
-  selected: DeviceIssueFilter[]
-  onChange: (filters: DeviceIssueFilter[]) => void
-  healthByIssue?: DeviceHealthByIssue
-  timeRange: TimeRange
+  counts: DeviceIssueCounts;
+  selected: DeviceIssueFilter[];
+  onChange: (filters: DeviceIssueFilter[]) => void;
+  healthByIssue?: DeviceHealthByIssue;
+  timeRange: TimeRange;
 }) {
   const allFilters: DeviceIssueFilter[] = [
-    'interface_errors',
-    'fcs_errors',
-    'discards',
-    'carrier_transitions',
-    'drained',
-    'isis_overload',
-    'isis_unreachable',
-    'no_issues',
-  ]
+    "interface_errors",
+    "fcs_errors",
+    "discards",
+    "carrier_transitions",
+    "drained",
+    "isis_overload",
+    "isis_unreachable",
+    "no_issues",
+  ];
 
   const toggleFilter = (filter: DeviceIssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === allFilters.length
+  const allSelected = selected.length === allFilters.length;
 
-  const grandTotal = counts.total + counts.no_issues || 1
-  const interfaceErrorsPct = (counts.interface_errors / grandTotal) * 100
-  const fcsErrorsPct = (counts.fcs_errors / grandTotal) * 100
-  const discardsPct = (counts.discards / grandTotal) * 100
-  const carrierTransitionsPct = (counts.carrier_transitions / grandTotal) * 100
-  const drainedPct = (counts.drained / grandTotal) * 100
-  const isisOverloadPct = (counts.isis_overload / grandTotal) * 100
-  const isisUnreachablePct = (counts.isis_unreachable / grandTotal) * 100
-  const noIssuesPct = (counts.no_issues / grandTotal) * 100
+  const grandTotal = counts.total + counts.no_issues || 1;
+  const interfaceErrorsPct = (counts.interface_errors / grandTotal) * 100;
+  const fcsErrorsPct = (counts.fcs_errors / grandTotal) * 100;
+  const discardsPct = (counts.discards / grandTotal) * 100;
+  const carrierTransitionsPct = (counts.carrier_transitions / grandTotal) * 100;
+  const drainedPct = (counts.drained / grandTotal) * 100;
+  const isisOverloadPct = (counts.isis_overload / grandTotal) * 100;
+  const isisUnreachablePct = (counts.isis_unreachable / grandTotal) * 100;
+  const noIssuesPct = (counts.no_issues / grandTotal) * 100;
 
   const items: {
-    filter: DeviceIssueFilter
-    label: string
-    color: string
-    description: string
+    filter: DeviceIssueFilter;
+    label: string;
+    color: string;
+    description: string;
   }[] = [
     {
-      filter: 'interface_errors',
-      label: 'Interface Errors',
-      color: 'bg-fuchsia-500',
-      description: 'Device experiencing interface errors.',
+      filter: "interface_errors",
+      label: "Interface Errors",
+      color: "bg-fuchsia-500",
+      description: "Device experiencing interface errors.",
     },
     {
-      filter: 'fcs_errors',
-      label: 'FCS Errors',
-      color: 'bg-orange-600',
-      description: 'Device experiencing FCS (Frame Check Sequence) errors.',
+      filter: "fcs_errors",
+      label: "FCS Errors",
+      color: "bg-orange-600",
+      description: "Device experiencing FCS (Frame Check Sequence) errors.",
     },
     {
-      filter: 'discards',
-      label: 'Discards',
-      color: 'bg-rose-500',
-      description: 'Device experiencing interface discards.',
+      filter: "discards",
+      label: "Discards",
+      color: "bg-rose-500",
+      description: "Device experiencing interface discards.",
     },
     {
-      filter: 'carrier_transitions',
-      label: 'Carrier Transitions',
-      color: 'bg-orange-500',
-      description: 'Device experiencing carrier state changes (link up/down).',
+      filter: "carrier_transitions",
+      label: "Carrier Transitions",
+      color: "bg-orange-500",
+      description: "Device experiencing carrier state changes (link up/down).",
     },
     {
-      filter: 'drained',
-      label: 'Drained',
-      color: 'bg-slate-500 dark:bg-slate-600',
-      description: 'Device is soft-drained, hard-drained, or suspended.',
+      filter: "drained",
+      label: "Drained",
+      color: "bg-slate-500 dark:bg-slate-600",
+      description: "Device is soft-drained, hard-drained, or suspended.",
     },
     {
-      filter: 'isis_overload',
-      label: 'ISIS Overload',
-      color: 'bg-red-600',
-      description: 'Device is in ISIS overload state.',
+      filter: "isis_overload",
+      label: "ISIS Overload",
+      color: "bg-red-600",
+      description: "Device is in ISIS overload state.",
     },
     {
-      filter: 'isis_unreachable',
-      label: 'ISIS Unreachable',
-      color: 'bg-red-800',
-      description: 'Device is unreachable in the ISIS topology.',
+      filter: "isis_unreachable",
+      label: "ISIS Unreachable",
+      color: "bg-red-800",
+      description: "Device is unreachable in the ISIS topology.",
     },
     {
-      filter: 'no_issues',
-      label: 'No Issues',
-      color: 'bg-cyan-500',
-      description: 'Device with no detected issues in the time range.',
+      filter: "no_issues",
+      label: "No Issues",
+      color: "bg-cyan-500",
+      description: "Device with no detected issues in the time range.",
     },
-  ]
+  ];
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -2863,9 +3078,9 @@ function DeviceIssuesFilterCard({
           </span>
           <button
             onClick={() => onChange(allFilters)}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -2876,56 +3091,56 @@ function DeviceIssuesFilterCard({
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {noIssuesPct > 0 && (
             <div
-              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes("no_issues") ? "opacity-30" : ""}`}
               style={{ width: `${noIssuesPct}%` }}
             />
           )}
           {interfaceErrorsPct > 0 && (
             <div
-              className={`bg-fuchsia-500 h-full transition-all ${!selected.includes('interface_errors') ? 'opacity-30' : ''}`}
+              className={`bg-fuchsia-500 h-full transition-all ${!selected.includes("interface_errors") ? "opacity-30" : ""}`}
               style={{ width: `${interfaceErrorsPct}%` }}
             />
           )}
           {fcsErrorsPct > 0 && (
             <div
-              className={`bg-orange-600 h-full transition-all ${!selected.includes('fcs_errors') ? 'opacity-30' : ''}`}
+              className={`bg-orange-600 h-full transition-all ${!selected.includes("fcs_errors") ? "opacity-30" : ""}`}
               style={{ width: `${fcsErrorsPct}%` }}
             />
           )}
           {discardsPct > 0 && (
             <div
-              className={`bg-rose-500 h-full transition-all ${!selected.includes('discards') ? 'opacity-30' : ''}`}
+              className={`bg-rose-500 h-full transition-all ${!selected.includes("discards") ? "opacity-30" : ""}`}
               style={{ width: `${discardsPct}%` }}
             />
           )}
           {carrierTransitionsPct > 0 && (
             <div
-              className={`bg-orange-500 h-full transition-all ${!selected.includes('carrier_transitions') ? 'opacity-30' : ''}`}
+              className={`bg-orange-500 h-full transition-all ${!selected.includes("carrier_transitions") ? "opacity-30" : ""}`}
               style={{ width: `${carrierTransitionsPct}%` }}
             />
           )}
           {drainedPct > 0 && (
             <div
-              className={`bg-slate-500 dark:bg-slate-600 h-full transition-all ${!selected.includes('drained') ? 'opacity-30' : ''}`}
+              className={`bg-slate-500 dark:bg-slate-600 h-full transition-all ${!selected.includes("drained") ? "opacity-30" : ""}`}
               style={{ width: `${drainedPct}%` }}
             />
           )}
           {isisOverloadPct > 0 && (
             <div
-              className={`bg-red-600 h-full transition-all ${!selected.includes('isis_overload') ? 'opacity-30' : ''}`}
+              className={`bg-red-600 h-full transition-all ${!selected.includes("isis_overload") ? "opacity-30" : ""}`}
               style={{ width: `${isisOverloadPct}%` }}
             />
           )}
           {isisUnreachablePct > 0 && (
             <div
-              className={`bg-red-800 h-full transition-all ${!selected.includes('isis_unreachable') ? 'opacity-30' : ''}`}
+              className={`bg-red-800 h-full transition-all ${!selected.includes("isis_unreachable") ? "opacity-30" : ""}`}
               style={{ width: `${isisUnreachablePct}%` }}
             />
           )}
@@ -2947,18 +3162,20 @@ function DeviceIssuesFilterCard({
         ))}
       </div>
     </div>
-  )
+  );
 }
 
 // Group filters by type: AND across types, OR within same type
-function groupFiltersByType(filters: StatusFilter[]): Map<string, StatusFilter[]> {
-  const grouped = new Map<string, StatusFilter[]>()
+function groupFiltersByType(
+  filters: StatusFilter[],
+): Map<string, StatusFilter[]> {
+  const grouped = new Map<string, StatusFilter[]>();
   for (const filter of filters) {
-    const existing = grouped.get(filter.type) || []
-    existing.push(filter)
-    grouped.set(filter.type, existing)
+    const existing = grouped.get(filter.type) || [];
+    existing.push(filter);
+    grouped.set(filter.type, existing);
   }
-  return grouped
+  return grouped;
 }
 
 // Generic filter matcher: AND across filter types, OR within same type
@@ -2966,25 +3183,30 @@ function matchesGroupedFilters(
   filters: StatusFilter[],
   matchSingle: (filter: StatusFilter) => boolean,
 ): boolean {
-  if (filters.length === 0) return true
-  const grouped = groupFiltersByType(filters)
-  return Array.from(grouped.values()).every((group) => group.some(matchSingle))
+  if (filters.length === 0) return true;
+  const grouped = groupFiltersByType(filters);
+  return Array.from(grouped.values()).every((group) => group.some(matchSingle));
 }
 
 // Helper to check if a device matches search filters
-function deviceMatchesSearchFilters(device: DeviceHistory, filters: StatusFilter[]): boolean {
+function deviceMatchesSearchFilters(
+  device: DeviceHistory,
+  filters: StatusFilter[],
+): boolean {
   return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
-      case 'device':
-        return device.code.toLowerCase().includes(filter.value.toLowerCase())
-      case 'metro':
-        return device.metro?.toLowerCase() === filter.value.toLowerCase()
-      case 'contributor':
-        return device.contributor?.toLowerCase().includes(filter.value.toLowerCase())
+      case "device":
+        return device.code.toLowerCase().includes(filter.value.toLowerCase());
+      case "metro":
+        return device.metro?.toLowerCase() === filter.value.toLowerCase();
+      case "contributor":
+        return device.contributor
+          ?.toLowerCase()
+          .includes(filter.value.toLowerCase());
       default:
-        return false
+        return false;
     }
-  })
+  });
 }
 
 // Helper to check if an interface issue matches search filters
@@ -2994,62 +3216,87 @@ function interfaceIssueMatchesSearchFilters(
 ): boolean {
   return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
-      case 'device':
-        return issue.device_code.toLowerCase().includes(filter.value.toLowerCase())
-      case 'metro':
-        return issue.metro?.toLowerCase() === filter.value.toLowerCase()
-      case 'contributor':
-        return issue.contributor?.toLowerCase().includes(filter.value.toLowerCase())
-      case 'link':
-        return issue.link_code?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
+      case "device":
+        return issue.device_code
+          .toLowerCase()
+          .includes(filter.value.toLowerCase());
+      case "metro":
+        return issue.metro?.toLowerCase() === filter.value.toLowerCase();
+      case "contributor":
+        return issue.contributor
+          ?.toLowerCase()
+          .includes(filter.value.toLowerCase());
+      case "link":
+        return (
+          issue.link_code?.toLowerCase().includes(filter.value.toLowerCase()) ??
+          false
+        );
       default:
-        return false
+        return false;
     }
-  })
+  });
 }
 
 // Helper to check if a link matches search filters
-function linkMatchesSearchFilters(link: LinkHistory, filters: StatusFilter[]): boolean {
+function linkMatchesSearchFilters(
+  link: LinkHistory,
+  filters: StatusFilter[],
+): boolean {
   return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
-      case 'link':
-        return link.code.toLowerCase().includes(filter.value.toLowerCase())
-      case 'device':
+      case "link":
+        return link.code.toLowerCase().includes(filter.value.toLowerCase());
+      case "device":
         return (
-          link.side_a_device?.toLowerCase().includes(filter.value.toLowerCase()) ||
-          link.side_z_device?.toLowerCase().includes(filter.value.toLowerCase()) ||
+          link.side_a_device
+            ?.toLowerCase()
+            .includes(filter.value.toLowerCase()) ||
+          link.side_z_device
+            ?.toLowerCase()
+            .includes(filter.value.toLowerCase()) ||
           false
-        )
-      case 'metro':
+        );
+      case "metro":
         return (
           link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
           link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
-        )
-      case 'contributor':
-        return link.contributor?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
+        );
+      case "contributor":
+        return (
+          link.contributor
+            ?.toLowerCase()
+            .includes(filter.value.toLowerCase()) ?? false
+        );
       default:
-        return false
+        return false;
     }
-  })
+  });
 }
 
 // Helper to check if a link metric (for utilization) matches search filters
-function linkMetricMatchesSearchFilters(link: LinkMetric, filters: StatusFilter[]): boolean {
+function linkMetricMatchesSearchFilters(
+  link: LinkMetric,
+  filters: StatusFilter[],
+): boolean {
   return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
-      case 'link':
-        return link.code.toLowerCase().includes(filter.value.toLowerCase())
-      case 'metro':
+      case "link":
+        return link.code.toLowerCase().includes(filter.value.toLowerCase());
+      case "metro":
         return (
           link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
           link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
-        )
-      case 'contributor':
-        return link.contributor?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
+        );
+      case "contributor":
+        return (
+          link.contributor
+            ?.toLowerCase()
+            .includes(filter.value.toLowerCase()) ?? false
+        );
       default:
-        return false
+        return false;
     }
-  })
+  });
 }
 
 // Helper to check if a device utilization matches search filters
@@ -3059,107 +3306,113 @@ function deviceUtilMatchesSearchFilters(
 ): boolean {
   return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
-      case 'device':
-        return device.code.toLowerCase().includes(filter.value.toLowerCase())
-      case 'metro':
-        return device.metro?.toLowerCase() === filter.value.toLowerCase()
-      case 'contributor':
-        return device.contributor?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
+      case "device":
+        return device.code.toLowerCase().includes(filter.value.toLowerCase());
+      case "metro":
+        return device.metro?.toLowerCase() === filter.value.toLowerCase();
+      case "contributor":
+        return (
+          device.contributor
+            ?.toLowerCase()
+            .includes(filter.value.toLowerCase()) ?? false
+        );
       default:
-        return false
+        return false;
     }
-  })
+  });
 }
 
 // Devices tab content
 function DevicesContent({ status }: { status: StatusResponse }) {
-  const [timeRange, setTimeRange] = useState<TimeRange>('24h')
+  const [timeRange, setTimeRange] = useState<TimeRange>("24h");
   const [issueFilters, setIssueFilters] = useState<DeviceIssueFilter[]>([
-    'interface_errors',
-    'fcs_errors',
-    'discards',
-    'carrier_transitions',
-    'drained',
-    'isis_overload',
-    'isis_unreachable',
-  ])
+    "interface_errors",
+    "fcs_errors",
+    "discards",
+    "carrier_transitions",
+    "drained",
+    "isis_overload",
+    "isis_unreachable",
+  ]);
   const [healthFilters, setHealthFilters] = useState<HealthFilter[]>([
-    'healthy',
-    'degraded',
-    'unhealthy',
-    'disabled',
-  ])
-  const location = useLocation()
+    "healthy",
+    "degraded",
+    "unhealthy",
+    "disabled",
+  ]);
+  const location = useLocation();
 
   // Get expanded device from navigation state
-  const expandedDevicePk = (location.state as { expandDevice?: string } | null)?.expandDevice
+  const expandedDevicePk = (location.state as { expandDevice?: string } | null)
+    ?.expandDevice;
 
   // Get search filters from URL
-  const searchFilters = useStatusFilters()
+  const searchFilters = useStatusFilters();
 
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h':
-        return 36
-      case '6h':
-        return 36
-      case '12h':
-        return 48
-      case '24h':
-        return 72
-      case '3d':
-        return 72
-      case '7d':
-        return 84
+      case "3h":
+        return 36;
+      case "6h":
+        return 36;
+      case "12h":
+        return 48;
+      case "24h":
+        return 72;
+      case "3d":
+        return 72;
+      case "7d":
+        return 84;
       default:
-        return 72
+        return 72;
     }
-  })()
+  })();
 
   // Fetch device history for the selected time range (used for both display and health/issue counts)
   const { data: deviceHistoryData } = useQuery({
-    queryKey: ['device-history', timeRange, buckets],
+    queryKey: ["device-history", timeRange, buckets],
     queryFn: () => fetchDeviceHistory(timeRange, buckets),
     refetchInterval: 60_000,
-    staleTime: timeRange === '24h' ? 30_000 : 0,
+    staleTime: timeRange === "24h" ? 30_000 : 0,
     placeholderData: keepPreviousData,
-  })
+  });
 
   // Fetch interface issues for the selected time range
-  const { data: interfaceIssuesData, isLoading: interfaceIssuesLoading } = useQuery({
-    queryKey: ['interface-issues', timeRange],
-    queryFn: () => fetchInterfaceIssues(timeRange),
-    refetchInterval: 60_000,
-    staleTime: timeRange === '24h' ? 30_000 : 0,
-  })
+  const { data: interfaceIssuesData, isLoading: interfaceIssuesLoading } =
+    useQuery({
+      queryKey: ["interface-issues", timeRange],
+      queryFn: () => fetchInterfaceIssues(timeRange),
+      refetchInterval: 60_000,
+      staleTime: timeRange === "24h" ? 30_000 : 0,
+    });
 
   // Apply search filters to device history
   const filteredDeviceHistory = useMemo(() => {
     if (!deviceHistoryData?.devices || searchFilters.length === 0) {
-      return deviceHistoryData
+      return deviceHistoryData;
     }
     return {
       ...deviceHistoryData,
       devices: deviceHistoryData.devices.filter((d) =>
         deviceMatchesSearchFilters(d, searchFilters),
       ),
-    }
-  }, [deviceHistoryData, searchFilters])
+    };
+  }, [deviceHistoryData, searchFilters]);
 
   // Apply search filters to interface issues
   const filteredInterfaceIssues = useMemo(() => {
     if (!interfaceIssuesData?.issues || searchFilters.length === 0) {
-      return interfaceIssuesData?.issues ?? null
+      return interfaceIssuesData?.issues ?? null;
     }
     return interfaceIssuesData.issues.filter((i) =>
       interfaceIssueMatchesSearchFilters(i, searchFilters),
-    )
-  }, [interfaceIssuesData, searchFilters])
+    );
+  }, [interfaceIssuesData, searchFilters]);
 
   // Helper to get the effective health status from a device's hours
   const getEffectiveHealth = (device: DeviceHistory): string => {
-    if (!device.hours || device.hours.length === 0) return 'healthy'
+    if (!device.hours || device.hours.length === 0) return "healthy";
 
     const statusPriority: Record<string, number> = {
       unhealthy: 0,
@@ -3167,32 +3420,35 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       disabled: 2,
       degraded: 3,
       healthy: 4,
-    }
+    };
 
-    let worstStatus = 'healthy'
-    let worstPriority = statusPriority['healthy']
+    let worstStatus = "healthy";
+    let worstPriority = statusPriority["healthy"];
 
     // Skip the last bucket if it's no_data (still being collected)
-    const lastBucket = device.hours[device.hours.length - 1]
-    const skipLastBucket = lastBucket?.status === 'no_data' && device.hours.length > 1
-    const bucketsToCheck = skipLastBucket ? device.hours.slice(0, -1) : device.hours
+    const lastBucket = device.hours[device.hours.length - 1];
+    const skipLastBucket =
+      lastBucket?.status === "no_data" && device.hours.length > 1;
+    const bucketsToCheck = skipLastBucket
+      ? device.hours.slice(0, -1)
+      : device.hours;
 
     for (const bucket of bucketsToCheck) {
-      const status = bucket.status || 'healthy'
-      const priority = statusPriority[status] ?? 4
+      const status = bucket.status || "healthy";
+      const priority = statusPriority[status] ?? 4;
       if (priority < worstPriority) {
-        worstPriority = priority
-        worstStatus = status
+        worstPriority = priority;
+        worstStatus = status;
       }
     }
 
-    return worstStatus
-  }
+    return worstStatus;
+  };
 
   // Calculate health counts from device history
   const healthCounts = useMemo(() => {
     if (!filteredDeviceHistory?.devices) {
-      return { healthy: 0, degraded: 0, unhealthy: 0, disabled: 0, total: 0 }
+      return { healthy: 0, degraded: 0, unhealthy: 0, disabled: 0, total: 0 };
     }
 
     const counts = {
@@ -3201,19 +3457,20 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       unhealthy: 0,
       disabled: 0,
       total: 0,
-    }
+    };
 
     for (const device of filteredDeviceHistory.devices) {
-      counts.total++
-      const status = getEffectiveHealth(device)
-      if (status === 'healthy') counts.healthy++
-      else if (status === 'degraded') counts.degraded++
-      else if (status === 'unhealthy' || status === 'no_data') counts.unhealthy++
-      else if (status === 'disabled') counts.disabled++
+      counts.total++;
+      const status = getEffectiveHealth(device);
+      if (status === "healthy") counts.healthy++;
+      else if (status === "degraded") counts.degraded++;
+      else if (status === "unhealthy" || status === "no_data")
+        counts.unhealthy++;
+      else if (status === "disabled") counts.disabled++;
     }
 
-    return counts
-  }, [filteredDeviceHistory])
+    return counts;
+  }, [filteredDeviceHistory]);
 
   // Calculate issue breakdown per health category
   const issuesByHealth = useMemo((): DeviceIssuesByHealth => {
@@ -3225,36 +3482,37 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       drained: 0,
       isis_overload: 0,
       isis_unreachable: 0,
-    })
+    });
 
     const result: DeviceIssuesByHealth = {
       healthy: emptyBreakdown(),
       degraded: emptyBreakdown(),
       unhealthy: emptyBreakdown(),
       disabled: emptyBreakdown(),
-    }
+    };
 
-    if (!filteredDeviceHistory?.devices) return result
+    if (!filteredDeviceHistory?.devices) return result;
 
     for (const device of filteredDeviceHistory.devices) {
-      const rawHealth = getEffectiveHealth(device)
-      const health = rawHealth === 'no_data' ? 'unhealthy' : rawHealth
-      if (!(health in result)) continue
+      const rawHealth = getEffectiveHealth(device);
+      const health = rawHealth === "no_data" ? "unhealthy" : rawHealth;
+      if (!(health in result)) continue;
 
-      const breakdown = result[health as keyof DeviceIssuesByHealth]
-      const issues = device.issue_reasons ?? []
+      const breakdown = result[health as keyof DeviceIssuesByHealth];
+      const issues = device.issue_reasons ?? [];
 
-      if (issues.includes('interface_errors')) breakdown.interface_errors++
-      if (issues.includes('fcs_errors')) breakdown.fcs_errors++
-      if (issues.includes('discards')) breakdown.discards++
-      if (issues.includes('carrier_transitions')) breakdown.carrier_transitions++
-      if (issues.includes('drained')) breakdown.drained++
-      if (issues.includes('isis_overload')) breakdown.isis_overload++
-      if (issues.includes('isis_unreachable')) breakdown.isis_unreachable++
+      if (issues.includes("interface_errors")) breakdown.interface_errors++;
+      if (issues.includes("fcs_errors")) breakdown.fcs_errors++;
+      if (issues.includes("discards")) breakdown.discards++;
+      if (issues.includes("carrier_transitions"))
+        breakdown.carrier_transitions++;
+      if (issues.includes("drained")) breakdown.drained++;
+      if (issues.includes("isis_overload")) breakdown.isis_overload++;
+      if (issues.includes("isis_unreachable")) breakdown.isis_unreachable++;
     }
 
-    return result
-  }, [filteredDeviceHistory])
+    return result;
+  }, [filteredDeviceHistory]);
 
   // Calculate health breakdown per issue type
   const healthByIssue = useMemo((): DeviceHealthByIssue => {
@@ -3263,7 +3521,7 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       degraded: 0,
       unhealthy: 0,
       disabled: 0,
-    })
+    });
 
     const result: DeviceHealthByIssue = {
       interface_errors: emptyBreakdown(),
@@ -3274,32 +3532,35 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       isis_overload: emptyBreakdown(),
       isis_unreachable: emptyBreakdown(),
       no_issues: emptyBreakdown(),
-    }
+    };
 
-    if (!filteredDeviceHistory?.devices) return result
+    if (!filteredDeviceHistory?.devices) return result;
 
     for (const device of filteredDeviceHistory.devices) {
-      const rawHealth = getEffectiveHealth(device)
+      const rawHealth = getEffectiveHealth(device);
       const health = (
-        rawHealth === 'no_data' ? 'unhealthy' : rawHealth
-      ) as keyof IssueHealthBreakdown
-      const issues = device.issue_reasons ?? []
+        rawHealth === "no_data" ? "unhealthy" : rawHealth
+      ) as keyof IssueHealthBreakdown;
+      const issues = device.issue_reasons ?? [];
 
       if (issues.length === 0) {
-        result.no_issues[health]++
+        result.no_issues[health]++;
       } else {
-        if (issues.includes('interface_errors')) result.interface_errors[health]++
-        if (issues.includes('fcs_errors')) result.fcs_errors[health]++
-        if (issues.includes('discards')) result.discards[health]++
-        if (issues.includes('carrier_transitions')) result.carrier_transitions[health]++
-        if (issues.includes('drained')) result.drained[health]++
-        if (issues.includes('isis_overload')) result.isis_overload[health]++
-        if (issues.includes('isis_unreachable')) result.isis_unreachable[health]++
+        if (issues.includes("interface_errors"))
+          result.interface_errors[health]++;
+        if (issues.includes("fcs_errors")) result.fcs_errors[health]++;
+        if (issues.includes("discards")) result.discards[health]++;
+        if (issues.includes("carrier_transitions"))
+          result.carrier_transitions[health]++;
+        if (issues.includes("drained")) result.drained[health]++;
+        if (issues.includes("isis_overload")) result.isis_overload[health]++;
+        if (issues.includes("isis_unreachable"))
+          result.isis_unreachable[health]++;
       }
     }
 
-    return result
-  }, [filteredDeviceHistory])
+    return result;
+  }, [filteredDeviceHistory]);
 
   // Issue counts from filter time range
   const issueCounts = useMemo((): DeviceIssueCounts => {
@@ -3314,7 +3575,7 @@ function DevicesContent({ status }: { status: StatusResponse }) {
         isis_unreachable: 0,
         no_issues: 0,
         total: 0,
-      }
+      };
     }
 
     const counts = {
@@ -3327,50 +3588,54 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       isis_unreachable: 0,
       no_issues: 0,
       total: 0,
-    }
-    const seenDevices = new Set<string>()
+    };
+    const seenDevices = new Set<string>();
 
     for (const device of filteredDeviceHistory.devices) {
-      if (device.issue_reasons?.includes('interface_errors')) counts.interface_errors++
-      if (device.issue_reasons?.includes('fcs_errors')) counts.fcs_errors++
-      if (device.issue_reasons?.includes('discards')) counts.discards++
-      if (device.issue_reasons?.includes('carrier_transitions')) counts.carrier_transitions++
-      if (device.issue_reasons?.includes('drained')) counts.drained++
-      if (device.issue_reasons?.includes('isis_overload')) counts.isis_overload++
-      if (device.issue_reasons?.includes('isis_unreachable')) counts.isis_unreachable++
+      if (device.issue_reasons?.includes("interface_errors"))
+        counts.interface_errors++;
+      if (device.issue_reasons?.includes("fcs_errors")) counts.fcs_errors++;
+      if (device.issue_reasons?.includes("discards")) counts.discards++;
+      if (device.issue_reasons?.includes("carrier_transitions"))
+        counts.carrier_transitions++;
+      if (device.issue_reasons?.includes("drained")) counts.drained++;
+      if (device.issue_reasons?.includes("isis_overload"))
+        counts.isis_overload++;
+      if (device.issue_reasons?.includes("isis_unreachable"))
+        counts.isis_unreachable++;
       if (device.issue_reasons?.length > 0 && !seenDevices.has(device.code)) {
-        counts.total++
-        seenDevices.add(device.code)
+        counts.total++;
+        seenDevices.add(device.code);
       }
     }
 
-    const totalDevices = healthCounts.total || 0
-    counts.no_issues = Math.max(0, totalDevices - counts.total)
+    const totalDevices = healthCounts.total || 0;
+    counts.no_issues = Math.max(0, totalDevices - counts.total);
 
-    return counts
-  }, [filteredDeviceHistory, healthCounts])
+    return counts;
+  }, [filteredDeviceHistory, healthCounts]);
 
   // Get set of device codes with issues in the filter time range
   const devicesWithIssues = useMemo(() => {
-    if (!filteredDeviceHistory?.devices) return new Map<string, string[]>()
-    const map = new Map<string, string[]>()
+    if (!filteredDeviceHistory?.devices) return new Map<string, string[]>();
+    const map = new Map<string, string[]>();
     for (const device of filteredDeviceHistory.devices) {
       if (device.issue_reasons?.length > 0) {
-        map.set(device.code, device.issue_reasons)
+        map.set(device.code, device.issue_reasons);
       }
     }
-    return map
-  }, [filteredDeviceHistory])
+    return map;
+  }, [filteredDeviceHistory]);
 
   // Get health status for each device from the filter time range
   const devicesWithHealth = useMemo(() => {
-    if (!filteredDeviceHistory?.devices) return new Map<string, string>()
-    const map = new Map<string, string>()
+    if (!filteredDeviceHistory?.devices) return new Map<string, string>();
+    const map = new Map<string, string>();
     for (const device of filteredDeviceHistory.devices) {
-      map.set(device.code, getEffectiveHealth(device))
+      map.set(device.code, getEffectiveHealth(device));
     }
-    return map
-  }, [filteredDeviceHistory])
+    return map;
+  }, [filteredDeviceHistory]);
 
   return (
     <>
@@ -3422,12 +3687,15 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
       {/* Methodology link */}
       <div className="text-center text-sm text-muted-foreground pb-4">
-        <Link to="/status/methodology" className="hover:text-foreground hover:underline">
+        <Link
+          to="/status/methodology"
+          className="hover:text-foreground hover:underline"
+        >
           How is status calculated?
         </Link>
       </div>
     </>
-  )
+  );
 }
 
 // Metro health filter card
@@ -3438,30 +3706,33 @@ function MetroHealthFilterCard({
   timeRange,
 }: {
   metros: {
-    healthy: number
-    degraded: number
-    unhealthy: number
-    total: number
-  }
-  selected: MetroHealthFilter[]
-  onChange: (filters: MetroHealthFilter[]) => void
-  timeRange: TimeRange
+    healthy: number;
+    degraded: number;
+    unhealthy: number;
+    total: number;
+  };
+  selected: MetroHealthFilter[];
+  onChange: (filters: MetroHealthFilter[]) => void;
+  timeRange: TimeRange;
 }) {
   const toggleFilter = (filter: MetroHealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === 3
+  const allSelected = selected.length === 3;
 
-  const healthyPct = metros.total > 0 ? (metros.healthy / metros.total) * 100 : 100
-  const degradedPct = metros.total > 0 ? (metros.degraded / metros.total) * 100 : 0
-  const unhealthyPct = metros.total > 0 ? (metros.unhealthy / metros.total) * 100 : 0
+  const healthyPct =
+    metros.total > 0 ? (metros.healthy / metros.total) * 100 : 100;
+  const degradedPct =
+    metros.total > 0 ? (metros.degraded / metros.total) * 100 : 0;
+  const unhealthyPct =
+    metros.total > 0 ? (metros.unhealthy / metros.total) * 100 : 0;
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -3473,10 +3744,10 @@ function MetroHealthFilterCard({
             ({timeRangeLabels[timeRange]})
           </span>
           <button
-            onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            onClick={() => onChange(["healthy", "degraded", "unhealthy"])}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -3486,27 +3757,27 @@ function MetroHealthFilterCard({
 
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
-          onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          onClick={() => onChange(["healthy", "degraded", "unhealthy"])}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {healthyPct > 0 && (
             <div
-              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              className={`bg-green-500 h-full transition-all ${!selected.includes("healthy") ? "opacity-30" : ""}`}
               style={{ width: `${healthyPct}%` }}
             />
           )}
           {degradedPct > 0 && (
             <div
-              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              className={`bg-amber-500 h-full transition-all ${!selected.includes("degraded") ? "opacity-30" : ""}`}
               style={{ width: `${degradedPct}%` }}
             />
           )}
           {unhealthyPct > 0 && (
             <div
-              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              className={`bg-red-500 h-full transition-all ${!selected.includes("unhealthy") ? "opacity-30" : ""}`}
               style={{ width: `${unhealthyPct}%` }}
             />
           )}
@@ -3519,28 +3790,28 @@ function MetroHealthFilterCard({
           label="Operational"
           count={metros.healthy}
           description="All links operational, no issues detected."
-          selected={selected.includes('healthy')}
-          onClick={() => toggleFilter('healthy')}
+          selected={selected.includes("healthy")}
+          onClick={() => toggleFilter("healthy")}
         />
         <HealthFilterItem
           color="bg-amber-500"
           label="Some Issues"
           count={metros.degraded}
           description="Some links down but metro still connected."
-          selected={selected.includes('degraded')}
-          onClick={() => toggleFilter('degraded')}
+          selected={selected.includes("degraded")}
+          onClick={() => toggleFilter("degraded")}
         />
         <HealthFilterItem
           color="bg-red-500"
           label="Significant Issues"
           count={metros.unhealthy}
           description="Most links down, major connectivity impact."
-          selected={selected.includes('unhealthy')}
-          onClick={() => toggleFilter('unhealthy')}
+          selected={selected.includes("unhealthy")}
+          onClick={() => toggleFilter("unhealthy")}
         />
       </div>
     </div>
-  )
+  );
 }
 
 // Metro issues filter card
@@ -3551,33 +3822,37 @@ function MetroIssuesFilterCard({
   timeRange,
 }: {
   counts: {
-    has_issues: number
-    has_spof: number
-    no_issues: number
-    total: number
-  }
-  selected: MetroIssueFilter[]
-  onChange: (filters: MetroIssueFilter[]) => void
-  timeRange: TimeRange
+    has_issues: number;
+    has_spof: number;
+    no_issues: number;
+    total: number;
+  };
+  selected: MetroIssueFilter[];
+  onChange: (filters: MetroIssueFilter[]) => void;
+  timeRange: TimeRange;
 }) {
-  const allFilters: MetroIssueFilter[] = ['has_issues', 'has_spof', 'no_issues']
+  const allFilters: MetroIssueFilter[] = [
+    "has_issues",
+    "has_spof",
+    "no_issues",
+  ];
 
   const toggleFilter = (filter: MetroIssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter((f) => f !== filter))
+        onChange(selected.filter((f) => f !== filter));
       }
     } else {
-      onChange([...selected, filter])
+      onChange([...selected, filter]);
     }
-  }
+  };
 
-  const allSelected = selected.length === allFilters.length
+  const allSelected = selected.length === allFilters.length;
 
-  const grandTotal = counts.total || 1
-  const hasIssuesPct = (counts.has_issues / grandTotal) * 100
-  const hasSpofPct = (counts.has_spof / grandTotal) * 100
-  const noIssuesPct = (counts.no_issues / grandTotal) * 100
+  const grandTotal = counts.total || 1;
+  const hasIssuesPct = (counts.has_issues / grandTotal) * 100;
+  const hasSpofPct = (counts.has_spof / grandTotal) * 100;
+  const noIssuesPct = (counts.no_issues / grandTotal) * 100;
 
   return (
     <div className="border border-border rounded-lg p-4">
@@ -3590,9 +3865,9 @@ function MetroIssuesFilterCard({
           </span>
           <button
             onClick={() => onChange(allFilters)}
-            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
           >
-            {allSelected ? 'All selected' : 'Select all'}
+            {allSelected ? "All selected" : "Select all"}
           </button>
         </div>
         <span className="sm:hidden text-xs text-muted-foreground">
@@ -3603,26 +3878,26 @@ function MetroIssuesFilterCard({
       <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? "text-muted-foreground" : "text-primary hover:underline"}`}
         >
-          {allSelected ? 'All selected' : 'Select all'}
+          {allSelected ? "All selected" : "Select all"}
         </button>
         <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
           {noIssuesPct > 0 && (
             <div
-              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes("no_issues") ? "opacity-30" : ""}`}
               style={{ width: `${noIssuesPct}%` }}
             />
           )}
           {hasIssuesPct > 0 && (
             <div
-              className={`bg-purple-500 h-full transition-all ${!selected.includes('has_issues') ? 'opacity-30' : ''}`}
+              className={`bg-purple-500 h-full transition-all ${!selected.includes("has_issues") ? "opacity-30" : ""}`}
               style={{ width: `${hasIssuesPct}%` }}
             />
           )}
           {hasSpofPct > 0 && (
             <div
-              className={`bg-red-500 h-full transition-all ${!selected.includes('has_spof') ? 'opacity-30' : ''}`}
+              className={`bg-red-500 h-full transition-all ${!selected.includes("has_spof") ? "opacity-30" : ""}`}
               style={{ width: `${hasSpofPct}%` }}
             />
           )}
@@ -3635,28 +3910,28 @@ function MetroIssuesFilterCard({
           label="Has Issues"
           count={counts.has_issues}
           description="Metro has links with health issues in the time range."
-          selected={selected.includes('has_issues')}
-          onClick={() => toggleFilter('has_issues')}
+          selected={selected.includes("has_issues")}
+          onClick={() => toggleFilter("has_issues")}
         />
         <HealthFilterItem
           color="bg-red-500"
           label="Has SPOF"
           count={counts.has_spof}
           description="Metro has single points of failure (critical links)."
-          selected={selected.includes('has_spof')}
-          onClick={() => toggleFilter('has_spof')}
+          selected={selected.includes("has_spof")}
+          onClick={() => toggleFilter("has_spof")}
         />
         <HealthFilterItem
           color="bg-cyan-500"
           label="No Issues"
           count={counts.no_issues}
           description="Metro with no issues and no critical links."
-          selected={selected.includes('no_issues')}
-          onClick={() => toggleFilter('no_issues')}
+          selected={selected.includes("no_issues")}
+          onClick={() => toggleFilter("no_issues")}
         />
       </div>
     </div>
-  )
+  );
 }
 
 // Metros tab content
@@ -3665,65 +3940,65 @@ function MetrosContent({
   criticalLinksLoading,
   metroNames,
 }: {
-  criticalLinks: CriticalLinksResponse | undefined
-  criticalLinksLoading: boolean
-  metroNames: Map<string, string>
+  criticalLinks: CriticalLinksResponse | undefined;
+  criticalLinksLoading: boolean;
+  metroNames: Map<string, string>;
 }) {
-  const [timeRange, setTimeRange] = useState<TimeRange>('24h')
+  const [timeRange, setTimeRange] = useState<TimeRange>("24h");
   const [healthFilters, setHealthFilters] = useState<MetroHealthFilter[]>([
-    'healthy',
-    'degraded',
-    'unhealthy',
-  ])
+    "healthy",
+    "degraded",
+    "unhealthy",
+  ]);
   const [issueFilters, setIssueFilters] = useState<MetroIssueFilter[]>([
-    'has_issues',
-    'has_spof',
-    'no_issues',
-  ])
+    "has_issues",
+    "has_spof",
+    "no_issues",
+  ]);
 
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h':
-        return 36
-      case '6h':
-        return 36
-      case '12h':
-        return 48
-      case '24h':
-        return 72
-      case '3d':
-        return 72
-      case '7d':
-        return 84
+      case "3h":
+        return 36;
+      case "6h":
+        return 36;
+      case "12h":
+        return 48;
+      case "24h":
+        return 72;
+      case "3d":
+        return 72;
+      case "7d":
+        return 84;
       default:
-        return 72
+        return 72;
     }
-  })()
+  })();
 
   // Fetch link history for the selected time range
   const { data: linkHistory } = useQuery({
-    queryKey: ['link-history', timeRange, buckets],
+    queryKey: ["link-history", timeRange, buckets],
     queryFn: () => fetchLinkHistory(timeRange, buckets),
     refetchInterval: 60_000,
-    staleTime: timeRange === '24h' ? 30_000 : 0,
+    staleTime: timeRange === "24h" ? 30_000 : 0,
     placeholderData: keepPreviousData,
-  })
+  });
 
-  const isLoading = !linkHistory || criticalLinksLoading
+  const isLoading = !linkHistory || criticalLinksLoading;
 
   // Build critical link set
   const criticalLinkSet = useMemo(() => {
-    if (!criticalLinks?.links) return new Set<string>()
-    const linkSet = new Set<string>()
+    if (!criticalLinks?.links) return new Set<string>();
+    const linkSet = new Set<string>();
     for (const link of criticalLinks.links) {
-      if (link.criticality === 'critical') {
-        linkSet.add(`${link.sourceCode}--${link.targetCode}`)
-        linkSet.add(`${link.targetCode}--${link.sourceCode}`)
+      if (link.criticality === "critical") {
+        linkSet.add(`${link.sourceCode}--${link.targetCode}`);
+        linkSet.add(`${link.targetCode}--${link.sourceCode}`);
       }
     }
-    return linkSet
-  }, [criticalLinks])
+    return linkSet;
+  }, [criticalLinks]);
 
   // Calculate metro counts for filter cards using proportional logic
   // Metro health is based on % of working links, not worst-case single link
@@ -3732,48 +4007,50 @@ function MetrosContent({
       return {
         health: { healthy: 0, degraded: 0, unhealthy: 0, total: 0 },
         issues: { has_issues: 0, has_spof: 0, no_issues: 0, total: 0 },
-      }
+      };
     }
 
     // Track link counts per metro for current status (last bucket)
     const metroMap = new Map<
       string,
       {
-        workingLinks: number // healthy or degraded
-        downLinks: number // unhealthy, disabled, no_data
-        totalLinks: number
-        hasIssues: boolean // had any non-healthy status in time range
-        hasSpof: boolean
+        workingLinks: number; // healthy or degraded
+        downLinks: number; // unhealthy, disabled, no_data
+        totalLinks: number;
+        hasIssues: boolean; // had any non-healthy status in time range
+        hasSpof: boolean;
       }
-    >()
+    >();
 
     for (const link of linkHistory.links) {
-      if (!link.hours || link.hours.length === 0) continue
+      if (!link.hours || link.hours.length === 0) continue;
 
-      const deviceKey = `${link.side_a_device}--${link.side_z_device}`
-      const isSpof = criticalLinkSet.has(deviceKey)
+      const deviceKey = `${link.side_a_device}--${link.side_z_device}`;
+      const isSpof = criticalLinkSet.has(deviceKey);
 
       // Get current status from last bucket
       // If last bucket is no_data (still collecting), use the previous bucket
-      const lastBucket = link.hours[link.hours.length - 1]
-      const prevBucket = link.hours.length > 1 ? link.hours[link.hours.length - 2] : null
+      const lastBucket = link.hours[link.hours.length - 1];
+      const prevBucket =
+        link.hours.length > 1 ? link.hours[link.hours.length - 2] : null;
       const currentStatus =
-        lastBucket?.status === 'no_data' && prevBucket
-          ? prevBucket.status || 'healthy'
-          : lastBucket?.status || 'healthy'
-      const isWorking = currentStatus === 'healthy' || currentStatus === 'degraded'
+        lastBucket?.status === "no_data" && prevBucket
+          ? prevBucket.status || "healthy"
+          : lastBucket?.status || "healthy";
+      const isWorking =
+        currentStatus === "healthy" || currentStatus === "degraded";
 
       // Check if link had any issues in time range (no_data is also an issue)
       const hadIssues = link.hours.some(
         (h: { status: string }) =>
-          h.status === 'unhealthy' ||
-          h.status === 'degraded' ||
-          h.status === 'disabled' ||
-          h.status === 'no_data',
-      )
+          h.status === "unhealthy" ||
+          h.status === "degraded" ||
+          h.status === "disabled" ||
+          h.status === "no_data",
+      );
 
       for (const metroCode of [link.side_a_metro, link.side_z_metro]) {
-        if (!metroCode) continue
+        if (!metroCode) continue;
         if (!metroMap.has(metroCode)) {
           metroMap.set(metroCode, {
             workingLinks: 0,
@@ -3781,37 +4058,38 @@ function MetrosContent({
             totalLinks: 0,
             hasIssues: false,
             hasSpof: false,
-          })
+          });
         }
-        const metro = metroMap.get(metroCode)!
-        metro.totalLinks++
-        if (isWorking) metro.workingLinks++
-        else metro.downLinks++
-        if (hadIssues) metro.hasIssues = true
-        if (isSpof) metro.hasSpof = true
+        const metro = metroMap.get(metroCode)!;
+        metro.totalLinks++;
+        if (isWorking) metro.workingLinks++;
+        else metro.downLinks++;
+        if (hadIssues) metro.hasIssues = true;
+        if (isSpof) metro.hasSpof = true;
       }
     }
 
-    const health = { healthy: 0, degraded: 0, unhealthy: 0, total: 0 }
-    const issues = { has_issues: 0, has_spof: 0, no_issues: 0, total: 0 }
+    const health = { healthy: 0, degraded: 0, unhealthy: 0, total: 0 };
+    const issues = { has_issues: 0, has_spof: 0, no_issues: 0, total: 0 };
 
     for (const [, data] of metroMap) {
-      health.total++
-      issues.total++
+      health.total++;
+      issues.total++;
 
       // Proportional health: >= 80% working = healthy, 20-80% = degraded, < 20% = unhealthy
-      const workingPct = data.totalLinks > 0 ? (data.workingLinks / data.totalLinks) * 100 : 100
-      if (workingPct >= 80) health.healthy++
-      else if (workingPct >= 20) health.degraded++
-      else health.unhealthy++
+      const workingPct =
+        data.totalLinks > 0 ? (data.workingLinks / data.totalLinks) * 100 : 100;
+      if (workingPct >= 80) health.healthy++;
+      else if (workingPct >= 20) health.degraded++;
+      else health.unhealthy++;
 
-      if (data.hasSpof) issues.has_spof++
-      if (data.hasIssues) issues.has_issues++
-      if (!data.hasIssues && !data.hasSpof) issues.no_issues++
+      if (data.hasSpof) issues.has_spof++;
+      if (data.hasIssues) issues.has_issues++;
+      if (!data.hasIssues && !data.hasSpof) issues.no_issues++;
     }
 
-    return { health, issues }
-  }, [linkHistory, criticalLinkSet])
+    return { health, issues };
+  }, [linkHistory, criticalLinkSet]);
 
   return (
     <>
@@ -3847,106 +4125,109 @@ function MetrosContent({
 
       {/* Methodology link */}
       <div className="text-center text-sm text-muted-foreground pb-4">
-        <Link to="/status/methodology" className="hover:text-foreground hover:underline">
+        <Link
+          to="/status/methodology"
+          className="hover:text-foreground hover:underline"
+        >
           How is status calculated?
         </Link>
       </div>
     </>
-  )
+  );
 }
 
 export function StatusPage() {
-  useDocumentTitle('Status')
-  const location = useLocation()
-  const navigate = useNavigate()
-  const buckets = useBucketCount()
+  useDocumentTitle("Status");
+  const location = useLocation();
+  const navigate = useNavigate();
+  const buckets = useBucketCount();
 
   // Determine active tab from URL
-  const activeTab = location.pathname.includes('/devices')
-    ? 'devices'
-    : location.pathname.includes('/metros')
-      ? 'metros'
-      : 'links'
+  const activeTab = location.pathname.includes("/devices")
+    ? "devices"
+    : location.pathname.includes("/metros")
+      ? "metros"
+      : "links";
 
   // Redirect /status to /status/links (preserving query params)
   useEffect(() => {
-    if (location.pathname === '/status') {
-      navigate('/status/links' + location.search, { replace: true })
+    if (location.pathname === "/status") {
+      navigate("/status/links" + location.search, { replace: true });
     }
-  }, [location.pathname, location.search, navigate])
+  }, [location.pathname, location.search, navigate]);
 
   const {
     data: status,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['status'],
+    queryKey: ["status"],
     queryFn: fetchStatus,
     refetchInterval: 30_000,
     staleTime: 15_000,
-  })
+  });
 
   const { data: linkHistory } = useQuery({
-    queryKey: ['link-history', '24h', buckets],
-    queryFn: () => fetchLinkHistory('24h', buckets),
+    queryKey: ["link-history", "24h", buckets],
+    queryFn: () => fetchLinkHistory("24h", buckets),
     refetchInterval: 60_000,
     staleTime: 30_000,
-  })
+  });
 
   const { data: criticalLinks, isLoading: criticalLinksLoading } = useQuery({
-    queryKey: ['critical-links'],
+    queryKey: ["critical-links"],
     queryFn: fetchCriticalLinks,
     staleTime: 5 * 60_000, // 5 minutes - topology changes less frequently
-  })
+  });
 
   const { data: metrosData } = useQuery({
-    queryKey: ['metros'],
+    queryKey: ["metros"],
     queryFn: () => fetchMetros(500, 0), // Fetch all metros
     staleTime: 5 * 60_000,
-  })
+  });
 
   // Build metro code -> name lookup
   const metroNames = useMemo(() => {
-    const map = new Map<string, string>()
+    const map = new Map<string, string>();
     if (metrosData?.items) {
       for (const metro of metrosData.items) {
-        map.set(metro.code, metro.name)
+        map.set(metro.code, metro.name);
       }
     }
-    return map
-  }, [metrosData])
+    return map;
+  }, [metrosData]);
 
-  const showSkeleton = useDelayedLoading(isLoading)
+  const showSkeleton = useDelayedLoading(isLoading);
 
   // Get search filters for filtering utilization data
-  const searchFilters = useStatusFilters()
+  const searchFilters = useStatusFilters();
 
   // Filter top link utilization by search filters
   const filteredTopLinks = useMemo(() => {
     if (!status?.links?.top_util_links || searchFilters.length === 0) {
-      return status?.links?.top_util_links ?? []
+      return status?.links?.top_util_links ?? [];
     }
     return status.links.top_util_links.filter((link) =>
       linkMetricMatchesSearchFilters(link, searchFilters),
-    )
-  }, [status?.links?.top_util_links, searchFilters])
+    );
+  }, [status?.links?.top_util_links, searchFilters]);
 
   // Filter top device utilization by search filters
   const filteredTopDevices = useMemo(() => {
     if (!status?.top_device_util || searchFilters.length === 0) {
-      return status?.top_device_util ?? []
+      return status?.top_device_util ?? [];
     }
     return status.top_device_util.filter((device) =>
       deviceUtilMatchesSearchFilters(device, searchFilters),
-    )
-  }, [status?.top_device_util, searchFilters])
+    );
+  }, [status?.top_device_util, searchFilters]);
 
   if (isLoading && showSkeleton) {
-    return <StatusPageSkeleton />
+    return <StatusPageSkeleton />;
   }
 
   if (isLoading) {
-    return null
+    return null;
   }
 
   if (error || !status) {
@@ -3955,10 +4236,12 @@ export function StatusPage() {
         <div className="text-center">
           <XCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Unable to load status</div>
-          <div className="text-sm text-muted-foreground">{error?.message || 'Unknown error'}</div>
+          <div className="text-sm text-muted-foreground">
+            {error?.message || "Unknown error"}
+          </div>
         </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -3989,17 +4272,39 @@ export function StatusPage() {
             format="number"
             href="/dz/devices"
           />
-          <StatCard label="Links" value={status.network.links} format="number" href="/dz/links" />
-          <StatCard label="Users" value={status.network.users} format="number" href="/dz/users" />
+          <StatCard
+            label="Links"
+            value={status.network.links}
+            format="number"
+            href="/dz/links"
+          />
+          <StatCard
+            label="Users"
+            value={status.network.users}
+            format="number"
+            href="/dz/users"
+          />
           <StatCard
             label="Validators on DZ"
             value={status.network.validators_on_dz}
             format="number"
             href="/solana/validators"
           />
-          <StatCard label="SOL Connected" value={status.network.total_stake_sol} format="stake" />
-          <StatCard label="Stake Share" value={status.network.stake_share_pct} format="percent" />
-          <StatCard label="Capacity" value={status.network.bandwidth_bps} format="bandwidth" />
+          <StatCard
+            label="SOL Connected"
+            value={status.network.total_stake_sol}
+            format="stake"
+          />
+          <StatCard
+            label="Stake Share"
+            value={status.network.stake_share_pct}
+            format="percent"
+          />
+          <StatCard
+            label="Capacity"
+            value={status.network.bandwidth_bps}
+            format="bandwidth"
+          />
           <StatCard
             label="User Inbound"
             value={status.network.user_inbound_bps}
@@ -4018,9 +4323,13 @@ export function StatusPage() {
         <TabNavigation activeTab={activeTab} />
 
         {/* Tab Content */}
-        {activeTab === 'links' ? (
-          <LinksContent status={status} linkHistory={linkHistory} criticalLinks={criticalLinks} />
-        ) : activeTab === 'devices' ? (
+        {activeTab === "links" ? (
+          <LinksContent
+            status={status}
+            linkHistory={linkHistory}
+            criticalLinks={criticalLinks}
+          />
+        ) : activeTab === "devices" ? (
           <DevicesContent status={status} />
         ) : (
           <MetrosContent
@@ -4031,18 +4340,18 @@ export function StatusPage() {
         )}
       </div>
     </div>
-  )
+  );
 }
 
 // Export for routes
 export function StatusLinksPage() {
-  return <StatusPage />
+  return <StatusPage />;
 }
 
 export function StatusDevicesPage() {
-  return <StatusPage />
+  return <StatusPage />;
 }
 
 export function StatusMetrosPage() {
-  return <StatusPage />
+  return <StatusPage />;
 }

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -3,17 +3,67 @@ import { useState, useEffect, useMemo } from 'react'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { CheckCircle2, AlertTriangle, XCircle, ArrowUpDown, Cpu, ChevronDown, ChevronUp, Info, WifiOff } from 'lucide-react'
-import { fetchStatus, fetchLinkHistory, fetchDeviceHistory, fetchInterfaceIssues, fetchCriticalLinks, fetchMetros, type StatusResponse, type InterfaceIssue, type NonActivatedLink, type NonActivatedDevice, type ISISDeviceIssue, type LinkHistory, type DeviceHistory, type LinkMetric, type DeviceUtilization, type CriticalLinksResponse, type LinkIssue } from '@/lib/api'
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  ArrowUpDown,
+  Cpu,
+  ChevronDown,
+  ChevronUp,
+  Info,
+  WifiOff,
+} from 'lucide-react'
+import {
+  fetchStatus,
+  fetchLinkHistory,
+  fetchDeviceHistory,
+  fetchInterfaceIssues,
+  fetchCriticalLinks,
+  fetchMetros,
+  type StatusResponse,
+  type InterfaceIssue,
+  type NonActivatedLink,
+  type NonActivatedDevice,
+  type ISISDeviceIssue,
+  type LinkHistory,
+  type DeviceHistory,
+  type LinkMetric,
+  type DeviceUtilization,
+  type CriticalLinksResponse,
+  type LinkIssue,
+} from '@/lib/api'
 import { StatusFilters, useStatusFilters, type StatusFilter } from '@/components/status-search-bar'
 import { StatCard } from '@/components/stat-card'
 import { LinkStatusTimelines } from '@/components/link-status-timelines'
 import { DeviceStatusTimelines } from '@/components/device-status-timelines'
-import { MetroStatusTimelines, type MetroHealthFilter, type MetroIssueFilter } from '@/components/metro-status-timelines'
+import {
+  MetroStatusTimelines,
+  type MetroHealthFilter,
+  type MetroIssueFilter,
+} from '@/components/metro-status-timelines'
 
 type TimeRange = '3h' | '6h' | '12h' | '24h' | '3d' | '7d'
-type IssueFilter = 'packet_loss' | 'high_latency' | 'no_data' | 'missing_adjacency' | 'interface_errors' | 'fcs_errors' | 'discards' | 'carrier_transitions' | 'high_utilization' | 'no_issues'
-type DeviceIssueFilter = 'interface_errors' | 'fcs_errors' | 'discards' | 'carrier_transitions' | 'drained' | 'isis_overload' | 'isis_unreachable' | 'no_issues'
+type IssueFilter =
+  | 'packet_loss'
+  | 'high_latency'
+  | 'no_data'
+  | 'missing_adjacency'
+  | 'interface_errors'
+  | 'fcs_errors'
+  | 'discards'
+  | 'carrier_transitions'
+  | 'high_utilization'
+  | 'no_issues'
+type DeviceIssueFilter =
+  | 'interface_errors'
+  | 'fcs_errors'
+  | 'discards'
+  | 'carrier_transitions'
+  | 'drained'
+  | 'isis_overload'
+  | 'isis_unreachable'
+  | 'no_issues'
 type HealthFilter = 'healthy' | 'degraded' | 'unhealthy' | 'disabled'
 
 const timeRangeLabels: Record<TimeRange, string> = {
@@ -41,7 +91,7 @@ function StatusPageSkeleton() {
             <Skeleton key={i} className="h-12 w-24" />
           ))}
         </div>
-        <div className="mb-6">
+        <div className="mb-4">
           <Skeleton className="h-10 w-48" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
@@ -90,7 +140,11 @@ function filterSignificantDeviceIssues(issues: InterfaceIssue[]): InterfaceIssue
   // Group by device and compute totals
   const deviceTotals = new Map<string, { errors: number; discards: number; carrier: number }>()
   for (const i of issues) {
-    const prev = deviceTotals.get(i.device_pk) ?? { errors: 0, discards: 0, carrier: 0 }
+    const prev = deviceTotals.get(i.device_pk) ?? {
+      errors: 0,
+      discards: 0,
+      carrier: 0,
+    }
     prev.errors += i.in_errors + i.out_errors + i.in_fcs_errors
     prev.discards += i.in_discards + i.out_discards
     prev.carrier += i.carrier_transitions
@@ -100,14 +154,16 @@ function filterSignificantDeviceIssues(issues: InterfaceIssue[]): InterfaceIssue
   // Keep only devices that exceed at least one threshold
   const significantDevices = new Set<string>()
   for (const [pk, totals] of deviceTotals) {
-    if (totals.errors >= DEVICE_ISSUE_MIN_ERRORS ||
-        totals.discards >= DEVICE_ISSUE_MIN_DISCARDS ||
-        totals.carrier >= DEVICE_ISSUE_MIN_CARRIER) {
+    if (
+      totals.errors >= DEVICE_ISSUE_MIN_ERRORS ||
+      totals.discards >= DEVICE_ISSUE_MIN_DISCARDS ||
+      totals.carrier >= DEVICE_ISSUE_MIN_CARRIER
+    ) {
       significantDevices.add(pk)
     }
   }
 
-  return issues.filter(i => significantDevices.has(i.device_pk))
+  return issues.filter((i) => significantDevices.has(i.device_pk))
 }
 
 function getStatusReasons(status: StatusResponse): string[] {
@@ -117,20 +173,26 @@ function getStatusReasons(status: StatusResponse): string[] {
     reasons.push(`${status.links.down} link${status.links.down > 1 ? 's' : ''} down`)
   }
   if (status.links.unhealthy > 0) {
-    reasons.push(`${status.links.unhealthy} link${status.links.unhealthy > 1 ? 's' : ''} with critical issues`)
+    reasons.push(
+      `${status.links.unhealthy} link${status.links.unhealthy > 1 ? 's' : ''} with critical issues`,
+    )
   }
   if (status.links.degraded > 0) {
-    reasons.push(`${status.links.degraded} link${status.links.degraded > 1 ? 's' : ''} with degraded performance`)
+    reasons.push(
+      `${status.links.degraded} link${status.links.degraded > 1 ? 's' : ''} with degraded performance`,
+    )
   }
 
   // Count telemetry stopped issues
-  const noDataCount = (status.links.issues || []).filter(i => i.issue === 'no_data').length
+  const noDataCount = (status.links.issues || []).filter((i) => i.issue === 'no_data').length
   if (noDataCount > 0) {
     reasons.push(`${noDataCount} link${noDataCount > 1 ? 's' : ''} with telemetry stopped`)
   }
 
   // Count missing ISIS adjacency issues
-  const missingAdjCount = (status.links.issues || []).filter(i => i.issue === 'missing_adjacency').length
+  const missingAdjCount = (status.links.issues || []).filter(
+    (i) => i.issue === 'missing_adjacency',
+  ).length
   if (missingAdjCount > 0) {
     reasons.push(`${missingAdjCount} link${missingAdjCount > 1 ? 's' : ''} with ISIS down`)
   }
@@ -138,21 +200,26 @@ function getStatusReasons(status: StatusResponse): string[] {
   // Count ISIS device issues
   const isisDeviceCount = (status.alerts?.isis_devices || []).length
   if (isisDeviceCount > 0) {
-    const overloadCount = status.alerts.isis_devices.filter(d => d.issue === 'overload').length
-    const unreachableCount = status.alerts.isis_devices.filter(d => d.issue === 'unreachable').length
+    const overloadCount = status.alerts.isis_devices.filter((d) => d.issue === 'overload').length
+    const unreachableCount = status.alerts.isis_devices.filter(
+      (d) => d.issue === 'unreachable',
+    ).length
     const parts: string[] = []
     if (unreachableCount > 0) parts.push(`${unreachableCount} unreachable`)
     if (overloadCount > 0) parts.push(`${overloadCount} overloaded`)
-    reasons.push(`${isisDeviceCount} device${isisDeviceCount > 1 ? 's' : ''} with ISIS issues (${parts.join(', ')})`)
+    reasons.push(
+      `${isisDeviceCount} device${isisDeviceCount > 1 ? 's' : ''} with ISIS issues (${parts.join(', ')})`,
+    )
   }
 
   // Count devices with significant interface issues (exclude minor/transient)
   const significantDeviceIssues = filterSignificantDeviceIssues(status.interfaces?.issues || [])
-  const devicesWithIssues = new Set(significantDeviceIssues.map(i => i.device_pk)).size
+  const devicesWithIssues = new Set(significantDeviceIssues.map((i) => i.device_pk)).size
   if (devicesWithIssues > 0) {
-    reasons.push(`${devicesWithIssues} device${devicesWithIssues > 1 ? 's' : ''} with interface issues`)
+    reasons.push(
+      `${devicesWithIssues} device${devicesWithIssues > 1 ? 's' : ''} with interface issues`,
+    )
   }
-
 
   const nonActivatedDevices = Object.entries(status.network.devices_by_status)
     .filter(([s]) => s !== 'activated')
@@ -275,14 +342,49 @@ function IssueDetails({
       acc[severity].push(issue)
       return acc
     },
-    { down: [] as LinkIssue[], critical: [] as LinkIssue[], degraded: [] as LinkIssue[], no_data: [] as LinkIssue[] }
+    {
+      down: [] as LinkIssue[],
+      critical: [] as LinkIssue[],
+      degraded: [] as LinkIssue[],
+      no_data: [] as LinkIssue[],
+    },
   )
 
-  const sections: { key: IssueSeverity; label: string; icon: typeof XCircle; iconColor: string; valueColor: string }[] = [
-    { key: 'down', label: 'Links Down', icon: XCircle, iconColor: 'text-red-500', valueColor: 'text-red-600 dark:text-red-400' },
-    { key: 'critical', label: 'Critical Issues', icon: XCircle, iconColor: 'text-red-500', valueColor: 'text-red-500' },
-    { key: 'degraded', label: 'Degraded Performance', icon: AlertTriangle, iconColor: 'text-orange-500', valueColor: 'text-orange-500' },
-    { key: 'no_data', label: 'Telemetry Stopped', icon: WifiOff, iconColor: 'text-amber-500', valueColor: 'text-amber-500' },
+  const sections: {
+    key: IssueSeverity
+    label: string
+    icon: typeof XCircle
+    iconColor: string
+    valueColor: string
+  }[] = [
+    {
+      key: 'down',
+      label: 'Links Down',
+      icon: XCircle,
+      iconColor: 'text-red-500',
+      valueColor: 'text-red-600 dark:text-red-400',
+    },
+    {
+      key: 'critical',
+      label: 'Critical Issues',
+      icon: XCircle,
+      iconColor: 'text-red-500',
+      valueColor: 'text-red-500',
+    },
+    {
+      key: 'degraded',
+      label: 'Degraded Performance',
+      icon: AlertTriangle,
+      iconColor: 'text-orange-500',
+      valueColor: 'text-orange-500',
+    },
+    {
+      key: 'no_data',
+      label: 'Telemetry Stopped',
+      icon: WifiOff,
+      iconColor: 'text-amber-500',
+      valueColor: 'text-amber-500',
+    },
   ]
 
   // Group device issues by device
@@ -300,14 +402,21 @@ function IssueDetails({
       acc[issue.device_pk].issues.push(issue)
       return acc
     },
-    {} as Record<string, { device_code: string; device_type: string; contributor: string; metro: string; issues: InterfaceIssue[] }>
+    {} as Record<
+      string,
+      {
+        device_code: string
+        device_type: string
+        contributor: string
+        metro: string
+        issues: InterfaceIssue[]
+      }
+    >,
   )
 
   return (
-    <div className="border-t border-border px-6 py-4 space-y-4">
-      <div className="text-xs text-muted-foreground">
-        Showing issues from the last hour
-      </div>
+    <div className="border-t border-border px-3 lg:px-6 py-4 space-y-4">
+      <div className="text-xs text-muted-foreground">Showing issues from the last hour</div>
       {sections.map(({ key, label, icon: Icon, iconColor, valueColor }) => {
         const sectionIssues = grouped[key]
         if (sectionIssues.length === 0) return null
@@ -336,35 +445,56 @@ function IssueDetails({
                   <button
                     key={code}
                     onClick={() => onIssueClick(code)}
-                    className="flex items-center justify-between w-full py-2 px-3 rounded-md bg-muted/50 hover:bg-muted transition-colors text-left"
+                    className="flex w-full py-2 px-3 rounded-md bg-muted/50 hover:bg-muted transition-colors text-left items-start md:items-center justify-between"
                   >
-                    <div className="flex items-center gap-3">
+                    {/* Mobile: compact two-line */}
+                    <div className="md:hidden flex flex-col items-start gap-1">
+                      <div className="flex items-center gap-1.5 font-medium text-sm">
+                        <Icon className={`h-3.5 w-3.5 ${iconColor} shrink-0`} />
+                        {code}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {first.side_a_metro} → {first.side_z_metro} · {first.link_type}
+                        {first.contributor && ` · ${first.contributor}`}
+                        {mostRecentSince && (
+                          <span
+                            className="text-muted-foreground font-normal"
+                            title={new Date(mostRecentSince).toLocaleString()}
+                          >
+                            {' '}
+                            · for {formatDuration(mostRecentSince)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {/* Desktop: original layout */}
+                    <div className="hidden md:flex items-center gap-3">
                       <Icon className={`h-4 w-4 ${iconColor}`} />
                       <div>
                         <div className="font-medium text-sm">{code}</div>
                         <div className="text-xs text-muted-foreground">
-                          {first.side_a_metro} → {first.side_z_metro} · {first.link_type}{first.contributor && ` · ${first.contributor}`}
+                          {first.side_a_metro} → {first.side_z_metro} · {first.link_type}
+                          {first.contributor && ` · ${first.contributor}`}
                         </div>
                       </div>
                     </div>
-                    <div className="text-right">
+                    <div className="hidden md:block text-right">
                       {(() => {
-                        const hasISISDown = linkIssues.some(i => i.issue === 'missing_adjacency')
+                        const hasISISDown = linkIssues.some((i) => i.issue === 'missing_adjacency')
                         return linkIssues.map((issue, idx) => (
                           <div key={idx}>
                             {issue.issue === 'missing_adjacency' && (
-                              <div className={`text-sm font-medium ${valueColor}`}>
-                                ISIS down
-                              </div>
+                              <div className={`text-sm font-medium ${valueColor}`}>ISIS down</div>
                             )}
-                            {issue.issue !== 'no_data' && issue.issue !== 'missing_adjacency' &&
+                            {issue.issue !== 'no_data' &&
+                              issue.issue !== 'missing_adjacency' &&
                               !(hasISISDown && issue.issue === 'packet_loss') && (
-                              <div className={`text-sm font-medium ${valueColor}`}>
-                                {issue.issue === 'packet_loss'
-                                  ? `${issue.value.toFixed(1)}% loss`
-                                  : `${issue.value.toFixed(0)}% over SLO`}
-                              </div>
-                            )}
+                                <div className={`text-sm font-medium ${valueColor}`}>
+                                  {issue.issue === 'packet_loss'
+                                    ? `${issue.value.toFixed(1)}% loss`
+                                    : `${issue.value.toFixed(0)}% over SLO`}
+                                </div>
+                              )}
                           </div>
                         ))
                       })()}
@@ -386,7 +516,9 @@ function IssueDetails({
       })}
       {Object.keys(deviceIssuesByDevice).length > 0 && (
         <div>
-          <div className="text-sm font-medium text-muted-foreground mb-2">Device Interface Issues</div>
+          <div className="text-sm font-medium text-muted-foreground mb-2">
+            Device Interface Issues
+          </div>
           <div className="space-y-2">
             {Object.entries(deviceIssuesByDevice).map(([devicePk, device]) => {
               // Aggregate totals across all interfaces for this device
@@ -396,7 +528,7 @@ function IssueDetails({
                   discards: acc.discards + i.in_discards + i.out_discards,
                   carrierTransitions: acc.carrierTransitions + i.carrier_transitions,
                 }),
-                { errors: 0, discards: 0, carrierTransitions: 0 }
+                { errors: 0, discards: 0, carrierTransitions: 0 },
               )
               // Find the most recent last_seen among all interfaces
               const lastSeen = device.issues.reduce((latest, i) => {
@@ -406,8 +538,10 @@ function IssueDetails({
               }, '' as string)
               const detailParts: string[] = []
               if (totals.errors > 0) detailParts.push(`${totals.errors.toLocaleString()} errors`)
-              if (totals.discards > 0) detailParts.push(`${totals.discards.toLocaleString()} discards`)
-              if (totals.carrierTransitions > 0) detailParts.push(`${totals.carrierTransitions} carrier transitions`)
+              if (totals.discards > 0)
+                detailParts.push(`${totals.discards.toLocaleString()} discards`)
+              if (totals.carrierTransitions > 0)
+                detailParts.push(`${totals.carrierTransitions} carrier transitions`)
 
               return (
                 <button
@@ -420,7 +554,8 @@ function IssueDetails({
                     <div>
                       <div className="font-medium text-sm">{device.device_code}</div>
                       <div className="text-xs text-muted-foreground">
-                        {device.metro} · {device.device_type}{device.contributor && ` · ${device.contributor}`}
+                        {device.metro} · {device.device_type}
+                        {device.contributor && ` · ${device.contributor}`}
                       </div>
                     </div>
                   </div>
@@ -429,7 +564,8 @@ function IssueDetails({
                       {detailParts.join(', ')}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {device.issues.length} interface{device.issues.length > 1 ? 's' : ''}
+                      {device.issues.length} interface
+                      {device.issues.length > 1 ? 's' : ''}
                       {lastSeen && (
                         <span title={new Date(lastSeen).toLocaleString()}>
                           {' · '}last seen {formatDuration(lastSeen)} ago
@@ -458,7 +594,8 @@ function IssueDetails({
                   <div>
                     <div className="font-medium text-sm">{device.code}</div>
                     <div className="text-xs text-muted-foreground">
-                      {device.metro && `${device.metro} · `}{device.device_type || 'ISIS device'}
+                      {device.metro && `${device.metro} · `}
+                      {device.device_type || 'ISIS device'}
                     </div>
                   </div>
                 </div>
@@ -488,11 +625,35 @@ function IssueDetails({
               <button
                 key={`${link.code}-${idx}`}
                 onClick={() => onNonActivatedClick(link.code)}
-                className="flex items-center justify-between w-full py-2 px-3 rounded-md bg-muted/50 hover:bg-muted transition-colors text-left"
+                className="flex w-full py-2 px-3 rounded-md bg-muted/50 hover:bg-muted transition-colors text-left items-start md:items-center justify-between"
               >
-                <div className="flex items-center gap-3">
+                {/* Mobile: compact two-line */}
+                <div className="md:hidden flex flex-col items-start gap-1">
+                  <div className="flex items-center gap-1.5 font-medium text-sm">
+                    <Info className="hidden xs:block h-3.5 w-3.5 text-slate-500 shrink-0" />
+
+                    {link.code}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {link.side_a_metro} → {link.side_z_metro} · {link.link_type}
+                    <span className="hidden xs:inline"> · </span>
+                    <span className="block xs:inline">
+                      <span className="capitalize text-slate-600 dark:text-slate-400 font-bold">
+                        {link.status.replace(/-/g, ' ')}
+                      </span>
+                      {link.since && (
+                        <span className="text-muted-foreground font-normal">
+                          {' '}
+                          · for {formatDuration(link.since)}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+                {/* Desktop: original layout */}
+                <div className="hidden md:flex items-center gap-3">
                   <Info className="h-4 w-4 text-slate-500" />
-                  <div>
+                  <div className="flex flex-col items-start">
                     <div className="font-medium text-sm">{link.code}</div>
                     <div className="text-xs text-muted-foreground">
                       {link.side_a_metro} → {link.side_z_metro} · {link.link_type}
@@ -517,7 +678,7 @@ function IssueDetails({
                     )}
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="hidden md:block text-right">
                   <div className="text-sm font-medium text-slate-600 dark:text-slate-400 capitalize">
                     {link.status.replace(/-/g, ' ')}
                   </div>
@@ -585,7 +746,7 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
   const location = useLocation()
 
   useEffect(() => {
-    const interval = setInterval(() => forceUpdate(n => n + 1), 10000)
+    const interval = setInterval(() => forceUpdate((n) => n + 1), 10000)
     return () => clearInterval(interval)
   }, [])
 
@@ -660,7 +821,10 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
       navigate('/status/devices', { state: { expandDevice: devicePk } })
       setTimeout(scrollToDevice, 200)
     } else {
-      navigate(location.pathname + location.search, { state: { expandDevice: devicePk }, replace: true })
+      navigate(location.pathname + location.search, {
+        state: { expandDevice: devicePk },
+        replace: true,
+      })
       setTimeout(scrollToDevice, 50)
     }
   }
@@ -690,25 +854,38 @@ function StatusIndicator({ statusData }: { statusData: StatusResponse }) {
 
   // Check if there are issues to show (filter out minor/transient device interface issues)
   const linkIssues = statusData.links.issues || []
-  const nonActivatedLinks = (statusData.alerts?.links || []).filter(l => l.status !== 'provisioning')
+  const nonActivatedLinks = (statusData.alerts?.links || []).filter(
+    (l) => l.status !== 'provisioning',
+  )
   const deviceIssues = filterSignificantDeviceIssues(statusData.interfaces?.issues || [])
   const nonActivatedDevices = statusData.alerts?.devices || []
-  const hasExpandableContent = linkIssues.length > 0 || nonActivatedLinks.length > 0 || deviceIssues.length > 0 || nonActivatedDevices.length > 0
+  const hasExpandableContent =
+    linkIssues.length > 0 ||
+    nonActivatedLinks.length > 0 ||
+    deviceIssues.length > 0 ||
+    nonActivatedDevices.length > 0
 
   return (
     <div className={`rounded-lg bg-card border border-border border-l-4 ${borderClassName}`}>
       <div
-        className={`flex items-center gap-3 px-6 py-4 ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`}
+        className={`flex flex-col md:flex-row md:items-center gap-2 md:gap-3 px-3 lg:px-6 py-4 ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`}
         onClick={hasExpandableContent ? () => setExpanded(!expanded) : undefined}
       >
-        <Icon className={`h-8 w-8 ${className}`} />
-        <div className="flex-1">
-          <div className={`text-lg font-medium ${className}`}>{label}</div>
+        {/* Desktop: icon standalone */}
+        <Icon className={`hidden md:block size-8 shrink-0 ${className}`} />
+        <div className="flex-1 flex flex-col gap-1 md:gap-0">
+          {/* Mobile: icon left of title */}
+          <div className="flex items-center gap-1 md:block">
+            <Icon className={`hidden xs:block md:hidden size-5.5 shrink-0 ${className}`} />
+            <div className={`text-base xs:text-lg font-medium ${className}`}>{label}</div>
+          </div>
           {reasons.length > 0 && (
-            <div className="text-sm text-muted-foreground">{reasons.slice(0, 2).join(' · ')}</div>
+            <div className="text-sm text-muted-foreground md:mt-0 mt-0">
+              {reasons.slice(0, 2).join(' · ')}
+            </div>
           )}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 justify-between md:justify-start">
           <div className="text-xs text-muted-foreground/60">
             Updated {formatRelativeTime(statusData.timestamp)}
           </div>
@@ -746,40 +923,43 @@ function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros
   }
 
   return (
-    <div className="flex items-center justify-between border-b border-border mb-6">
-      <div className="flex gap-1">
-        <button
-          onClick={() => navigateWithParams('/status/links')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            activeTab === 'links'
-              ? 'border-primary text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          Links
-        </button>
-        <button
-          onClick={() => navigateWithParams('/status/devices')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            activeTab === 'devices'
-              ? 'border-primary text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          Devices
-        </button>
-        <button
-          onClick={() => navigateWithParams('/status/metros')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            activeTab === 'metros'
-              ? 'border-primary text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          Metros
-        </button>
+    <div className="mb-4">
+      <div className="flex items-center justify-between border-b border-border">
+        <div className="flex gap-1">
+          <button
+            onClick={() => navigateWithParams('/status/links')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === 'links'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Links
+          </button>
+          <button
+            onClick={() => navigateWithParams('/status/devices')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === 'devices'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Devices
+          </button>
+          <button
+            onClick={() => navigateWithParams('/status/metros')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === 'metros'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Metros
+          </button>
+        </div>
+        <StatusFilters className="pb-2 hidden sm:block" />
       </div>
-      <StatusFilters className="pb-2" />
+      <StatusFilters className="pt-4 sm:hidden" />
     </div>
   )
 }
@@ -835,11 +1015,23 @@ function HealthFilterItem({
 }) {
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const issueLabels: { key: keyof HealthIssueBreakdown; label: string; color: string }[] = [
+  const issueLabels: {
+    key: keyof HealthIssueBreakdown
+    label: string
+    color: string
+  }[] = [
     { key: 'packet_loss', label: 'Packet Loss', color: 'bg-purple-500' },
     { key: 'high_latency', label: 'High Latency', color: 'bg-blue-500' },
-    { key: 'high_utilization', label: 'High Utilization', color: 'bg-indigo-500' },
-    { key: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-yellow-500' },
+    {
+      key: 'high_utilization',
+      label: 'High Utilization',
+      color: 'bg-indigo-500',
+    },
+    {
+      key: 'carrier_transitions',
+      label: 'Carrier Transitions',
+      color: 'bg-yellow-500',
+    },
     { key: 'discards', label: 'Discards', color: 'bg-teal-500' },
     { key: 'interface_errors', label: 'Errors', color: 'bg-red-500' },
     { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-500' },
@@ -847,22 +1039,39 @@ function HealthFilterItem({
     { key: 'missing_adjacency', label: 'ISIS Down', color: 'bg-rose-600' },
   ]
 
-  const deviceIssueLabels: { key: keyof DeviceIssueBreakdown; label: string; color: string }[] = [
-    { key: 'interface_errors', label: 'Interface Errors', color: 'bg-fuchsia-500' },
+  const deviceIssueLabels: {
+    key: keyof DeviceIssueBreakdown
+    label: string
+    color: string
+  }[] = [
+    {
+      key: 'interface_errors',
+      label: 'Interface Errors',
+      color: 'bg-fuchsia-500',
+    },
     { key: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600' },
     { key: 'discards', label: 'Discards', color: 'bg-rose-500' },
-    { key: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-orange-500' },
+    {
+      key: 'carrier_transitions',
+      label: 'Carrier Transitions',
+      color: 'bg-orange-500',
+    },
   ]
 
-  const healthLabels: { key: keyof IssueHealthBreakdown; label: string; color: string }[] = [
+  const healthLabels: {
+    key: keyof IssueHealthBreakdown
+    label: string
+    color: string
+  }[] = [
     { key: 'healthy', label: 'Healthy', color: 'bg-green-500' },
     { key: 'degraded', label: 'Degraded', color: 'bg-amber-500' },
     { key: 'unhealthy', label: 'Unhealthy', color: 'bg-red-500' },
   ]
 
-  const hasIssues = issueBreakdown && Object.values(issueBreakdown).some(v => v > 0)
-  const hasDeviceIssues = deviceIssueBreakdown && Object.values(deviceIssueBreakdown).some(v => v > 0)
-  const hasHealth = healthBreakdown && Object.values(healthBreakdown).some(v => v > 0)
+  const hasIssues = issueBreakdown && Object.values(issueBreakdown).some((v) => v > 0)
+  const hasDeviceIssues =
+    deviceIssueBreakdown && Object.values(deviceIssueBreakdown).some((v) => v > 0)
+  const hasHealth = healthBreakdown && Object.values(healthBreakdown).some((v) => v > 0)
 
   return (
     <button
@@ -874,8 +1083,14 @@ function HealthFilterItem({
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
       >
-        <div className={`h-2.5 w-2.5 rounded-full ${color} transition-opacity ${!selected ? 'opacity-25' : ''}`} />
-        <span className={`transition-colors ${selected ? 'text-foreground' : 'text-muted-foreground/50'}`}>{label}</span>
+        <div
+          className={`h-2.5 w-2.5 rounded-full ${color} transition-opacity ${!selected ? 'opacity-25' : ''}`}
+        />
+        <span
+          className={`transition-colors ${selected ? 'text-foreground' : 'text-muted-foreground/50'}`}
+        >
+          {label}
+        </span>
         {showTooltip && (
           <div className="absolute left-0 bottom-full mb-1 z-50 bg-popover border border-border rounded-lg shadow-lg p-2 text-xs w-52">
             <div className="mb-1">{description}</div>
@@ -933,7 +1148,11 @@ function HealthFilterItem({
           </div>
         )}
       </div>
-      <span className={`font-medium tabular-nums transition-colors ${!selected ? 'text-muted-foreground/50' : ''}`}>{count}</span>
+      <span
+        className={`font-medium tabular-nums transition-colors ${!selected ? 'text-muted-foreground/50' : ''}`}
+      >
+        {count}
+      </span>
     </button>
   )
 }
@@ -964,7 +1183,12 @@ function LinkHealthFilterCard({
   issuesByHealth,
   timeRange,
 }: {
-  links: { healthy: number; degraded: number; unhealthy: number; total: number }
+  links: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    total: number
+  }
   selected: HealthFilter[]
   onChange: (filters: HealthFilter[]) => void
   issuesByHealth?: IssuesByHealth
@@ -973,7 +1197,7 @@ function LinkHealthFilterCard({
   const toggleFilter = (filter: HealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -988,39 +1212,52 @@ function LinkHealthFilterCard({
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Link Health</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <ArrowUpDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Link Health</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {healthyPct > 0 && (
-          <div
-            className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${healthyPct}%` }}
-          />
-        )}
-        {degradedPct > 0 && (
-          <div
-            className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
-            style={{ width: `${degradedPct}%` }}
-          />
-        )}
-        {unhealthyPct > 0 && (
-          <div
-            className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${unhealthyPct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {healthyPct > 0 && (
+            <div
+              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${healthyPct}%` }}
+            />
+          )}
+          {degradedPct > 0 && (
+            <div
+              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              style={{ width: `${degradedPct}%` }}
+            />
+          )}
+          {unhealthyPct > 0 && (
+            <div
+              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${unhealthyPct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -1069,12 +1306,23 @@ function LinkIssuesFilterCard({
   healthByIssue?: HealthByIssue
   timeRange: TimeRange
 }) {
-  const allFilters: IssueFilter[] = ['packet_loss', 'high_latency', 'high_utilization', 'no_data', 'missing_adjacency', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'no_issues']
+  const allFilters: IssueFilter[] = [
+    'packet_loss',
+    'high_latency',
+    'high_utilization',
+    'no_data',
+    'missing_adjacency',
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+    'no_issues',
+  ]
 
   const toggleFilter = (filter: IssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -1083,17 +1331,72 @@ function LinkIssuesFilterCard({
 
   const allSelected = selected.length === allFilters.length
 
-  const itemDefs: { filter: IssueFilter; label: string; color: string; description: string }[] = [
-    { filter: 'packet_loss', label: 'Packet Loss', color: 'bg-purple-500', description: 'Link experiencing measurable packet loss (>= 1%).' },
-    { filter: 'high_latency', label: 'High Latency', color: 'bg-blue-500', description: 'Link latency exceeds committed RTT.' },
-    { filter: 'high_utilization', label: 'High Utilization', color: 'bg-indigo-500', description: 'Link utilization exceeds 80%.' },
-    { filter: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-yellow-500', description: 'Carrier transitions (interface up/down) on link endpoints.' },
-    { filter: 'discards', label: 'Discards', color: 'bg-teal-500', description: 'Interface discards detected on link endpoints.' },
-    { filter: 'interface_errors', label: 'Errors', color: 'bg-red-500', description: 'Interface errors detected on link endpoints.' },
-    { filter: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-500', description: 'FCS (Frame Check Sequence) errors detected on link endpoints.' },
-    { filter: 'no_data', label: 'No Data', color: 'bg-pink-500', description: 'No telemetry received for this link.' },
-    { filter: 'missing_adjacency', label: 'ISIS Down', color: 'bg-rose-600', description: 'Activated link with no ISIS adjacency detected.' },
-    { filter: 'no_issues', label: 'No Issues', color: 'bg-cyan-500', description: 'Link with no detected issues in the time range.' },
+  const itemDefs: {
+    filter: IssueFilter
+    label: string
+    color: string
+    description: string
+  }[] = [
+    {
+      filter: 'packet_loss',
+      label: 'Packet Loss',
+      color: 'bg-purple-500',
+      description: 'Link experiencing measurable packet loss (>= 1%).',
+    },
+    {
+      filter: 'high_latency',
+      label: 'High Latency',
+      color: 'bg-blue-500',
+      description: 'Link latency exceeds committed RTT.',
+    },
+    {
+      filter: 'high_utilization',
+      label: 'High Utilization',
+      color: 'bg-indigo-500',
+      description: 'Link utilization exceeds 80%.',
+    },
+    {
+      filter: 'carrier_transitions',
+      label: 'Carrier Transitions',
+      color: 'bg-yellow-500',
+      description: 'Carrier transitions (interface up/down) on link endpoints.',
+    },
+    {
+      filter: 'discards',
+      label: 'Discards',
+      color: 'bg-teal-500',
+      description: 'Interface discards detected on link endpoints.',
+    },
+    {
+      filter: 'interface_errors',
+      label: 'Errors',
+      color: 'bg-red-500',
+      description: 'Interface errors detected on link endpoints.',
+    },
+    {
+      filter: 'fcs_errors',
+      label: 'FCS Errors',
+      color: 'bg-orange-500',
+      description: 'FCS (Frame Check Sequence) errors detected on link endpoints.',
+    },
+    {
+      filter: 'no_data',
+      label: 'No Data',
+      color: 'bg-pink-500',
+      description: 'No telemetry received for this link.',
+    },
+    {
+      filter: 'missing_adjacency',
+      label: 'ISIS Down',
+      color: 'bg-rose-600',
+      description: 'Activated link with no ISIS adjacency detected.',
+    },
+    {
+      filter: 'no_issues',
+      label: 'No Issues',
+      color: 'bg-cyan-500',
+      description: 'Link with no detected issues in the time range.',
+    },
   ]
 
   const [expanded, setExpanded] = useState(false)
@@ -1111,7 +1414,7 @@ function LinkIssuesFilterCard({
   const shouldCollapse = items.length > 4
   const visibleItems = shouldCollapse && !expanded ? items.slice(0, 4) : items
 
-  const grandTotal = (counts.total + counts.no_issues) || 1
+  const grandTotal = counts.total + counts.no_issues || 1
   const packetLossPct = (counts.packet_loss / grandTotal) * 100
   const highLatencyPct = (counts.high_latency / grandTotal) * 100
   const noDataPct = (counts.no_data / grandTotal) * 100
@@ -1120,51 +1423,64 @@ function LinkIssuesFilterCard({
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Link Issues</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Link Issues</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(allFilters)}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {noIssuesPct > 0 && (
-          <div
-            className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
-            style={{ width: `${noIssuesPct}%` }}
-          />
-        )}
-        {packetLossPct > 0 && (
-          <div
-            className={`bg-purple-500 h-full transition-all ${!selected.includes('packet_loss') ? 'opacity-30' : ''}`}
-            style={{ width: `${packetLossPct}%` }}
-          />
-        )}
-        {highLatencyPct > 0 && (
-          <div
-            className={`bg-blue-500 h-full transition-all ${!selected.includes('high_latency') ? 'opacity-30' : ''}`}
-            style={{ width: `${highLatencyPct}%` }}
-          />
-        )}
-        {noDataPct > 0 && (
-          <div
-            className={`bg-pink-500 h-full transition-all ${!selected.includes('no_data') ? 'opacity-30' : ''}`}
-            style={{ width: `${noDataPct}%` }}
-          />
-        )}
-        {missingAdjPct > 0 && (
-          <div
-            className={`bg-rose-600 h-full transition-all ${!selected.includes('missing_adjacency') ? 'opacity-30' : ''}`}
-            style={{ width: `${missingAdjPct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {noIssuesPct > 0 && (
+            <div
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              style={{ width: `${noIssuesPct}%` }}
+            />
+          )}
+          {packetLossPct > 0 && (
+            <div
+              className={`bg-purple-500 h-full transition-all ${!selected.includes('packet_loss') ? 'opacity-30' : ''}`}
+              style={{ width: `${packetLossPct}%` }}
+            />
+          )}
+          {highLatencyPct > 0 && (
+            <div
+              className={`bg-blue-500 h-full transition-all ${!selected.includes('high_latency') ? 'opacity-30' : ''}`}
+              style={{ width: `${highLatencyPct}%` }}
+            />
+          )}
+          {noDataPct > 0 && (
+            <div
+              className={`bg-pink-500 h-full transition-all ${!selected.includes('no_data') ? 'opacity-30' : ''}`}
+              style={{ width: `${noDataPct}%` }}
+            />
+          )}
+          {missingAdjPct > 0 && (
+            <div
+              className={`bg-rose-600 h-full transition-all ${!selected.includes('missing_adjacency') ? 'opacity-30' : ''}`}
+              style={{ width: `${missingAdjPct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -1220,25 +1536,63 @@ function TopLinkUtilization({ links }: { links: StatusResponse['links']['top_uti
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Max Link Utilization</h3>
-        <span className="text-xs text-muted-foreground ml-auto">p95 - Last 24h</span>
+      <div className="flex flex-col gap-0.5 mb-3">
+        <div className="flex items-center gap-2">
+          <ArrowUpDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Max Link Utilization</h3>
+          <span className="text-xs text-muted-foreground ml-auto hidden sm:block">
+            p95 - Last 24h
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground sm:hidden">p95 - Last 24h</span>
       </div>
       <div className="space-y-2">
         {links.slice(0, 5).map((link) => {
           const maxUtil = Math.max(link.utilization_in, link.utilization_out)
           const peakBps = Math.max(link.in_bps, link.out_bps)
           return (
-            <div key={link.pk} className="flex items-center gap-3">
-              <div className="flex-1 min-w-0">
-                <Link to={`/dz/links/${link.pk}`} state={{ backLabel: 'status' }} className="font-mono text-xs truncate hover:underline" title={link.code}>{link.code}</Link>
-                <div className="text-[10px] text-muted-foreground">{link.side_a_metro} - {link.side_z_metro}</div>
+            <div key={link.pk} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+              {/* Mobile layout */}
+              <div className="sm:hidden flex flex-col gap-1">
+                <div className="flex items-center justify-between gap-2">
+                  <Link
+                    to={`/dz/links/${link.pk}`}
+                    state={{ backLabel: 'status' }}
+                    className="font-mono text-xs truncate hover:underline"
+                    title={link.code}
+                  >
+                    {link.code}
+                  </Link>
+                  <span className="text-xs tabular-nums shrink-0">{maxUtil.toFixed(0)}%</span>
+                </div>
+                <div className="text-[10px] text-muted-foreground">
+                  {link.side_a_metro} - {link.side_z_metro} · {formatBandwidth(peakBps)}
+                </div>
+                <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${maxUtil >= 90 ? 'bg-red-500' : maxUtil >= 70 ? 'bg-amber-500' : 'bg-green-500'}`}
+                    style={{ width: `${Math.min(maxUtil, 100)}%` }}
+                  />
+                </div>
               </div>
-              <div className="text-xs text-muted-foreground tabular-nums w-16 text-right">
+              {/* Desktop layout */}
+              <div className="hidden sm:flex flex-1 min-w-0 flex-col">
+                <Link
+                  to={`/dz/links/${link.pk}`}
+                  state={{ backLabel: 'status' }}
+                  className="font-mono text-xs truncate hover:underline"
+                  title={link.code}
+                >
+                  {link.code}
+                </Link>
+                <div className="text-[10px] text-muted-foreground">
+                  {link.side_a_metro} - {link.side_z_metro}
+                </div>
+              </div>
+              <div className="hidden sm:block text-xs text-muted-foreground tabular-nums w-16 text-right">
                 {formatBandwidth(peakBps)}
               </div>
-              <div className="w-20 flex items-center gap-2">
+              <div className="hidden sm:flex w-20 items-center gap-2">
                 <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
                     className={`h-full rounded-full ${maxUtil >= 90 ? 'bg-red-500' : maxUtil >= 70 ? 'bg-amber-500' : 'bg-green-500'}`}
@@ -1271,26 +1625,66 @@ function TopDeviceUtilization({ devices }: { devices: StatusResponse['top_device
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <Cpu className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Top Device Utilization</h3>
-        <span className="text-xs text-muted-foreground ml-auto">Current</span>
+      <div className="flex flex-col gap-0.5 mb-3">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Top Device Utilization</h3>
+          <span className="text-xs text-muted-foreground ml-auto hidden sm:block">Current</span>
+        </div>
+        <span className="text-xs text-muted-foreground sm:hidden">Current</span>
       </div>
       <div className="space-y-2">
         {devices.slice(0, 5).map((device) => (
-          <div key={device.pk} className="flex items-center gap-3">
-            <div className="flex-1 min-w-0">
-              <Link to={`/dz/devices/${device.pk}`} className="font-mono text-xs truncate hover:underline" title={device.code}>{device.code}</Link>
-              <div className="text-[10px] text-muted-foreground">{device.current_users}/{device.max_users} users • {device.metro} • {device.contributor}</div>
+          <div key={device.pk} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+            {/* Mobile layout */}
+            <div className="sm:hidden flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-2">
+                <Link
+                  to={`/dz/devices/${device.pk}`}
+                  className="font-mono text-xs truncate hover:underline"
+                  title={device.code}
+                >
+                  {device.code}
+                </Link>
+                <span className="text-xs tabular-nums shrink-0">
+                  {device.utilization.toFixed(0)}%
+                </span>
+              </div>
+              <div className="text-[10px] text-muted-foreground">
+                {device.current_users}/{device.max_users} users • {device.metro} •{' '}
+                {device.contributor}
+              </div>
+              <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${device.utilization >= 80 ? 'bg-amber-500' : 'bg-green-500'}`}
+                  style={{ width: `${Math.min(device.utilization, 100)}%` }}
+                />
+              </div>
             </div>
-            <div className="w-24 flex items-center gap-2">
+            {/* Desktop layout */}
+            <div className="hidden sm:flex flex-1 min-w-0 flex-col">
+              <Link
+                to={`/dz/devices/${device.pk}`}
+                className="font-mono text-xs truncate hover:underline"
+                title={device.code}
+              >
+                {device.code}
+              </Link>
+              <div className="text-[10px] text-muted-foreground">
+                {device.current_users}/{device.max_users} users • {device.metro} •{' '}
+                {device.contributor}
+              </div>
+            </div>
+            <div className="hidden sm:flex w-24 items-center gap-2">
               <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
                 <div
                   className={`h-full rounded-full ${device.utilization >= 80 ? 'bg-amber-500' : 'bg-green-500'}`}
                   style={{ width: `${Math.min(device.utilization, 100)}%` }}
                 />
               </div>
-              <span className="text-xs tabular-nums w-10 text-right">{device.utilization.toFixed(0)}%</span>
+              <span className="text-xs tabular-nums w-10 text-right">
+                {device.utilization.toFixed(0)}%
+              </span>
             </div>
           </div>
         ))}
@@ -1310,7 +1704,7 @@ interface DisabledLinkRow {
 
 function DisabledLinksTable({
   drainedLinks,
-  packetLossLinks
+  packetLossLinks,
 }: {
   drainedLinks: NonActivatedLink[] | null
   packetLossLinks: DisabledLinkRow[]
@@ -1319,7 +1713,12 @@ function DisabledLinksTable({
     const linkMap = new Map<string, DisabledLinkRow>()
 
     for (const link of drainedLinks || []) {
-      const reason = link.status === 'provisioning' ? 'provisioning' : link.status === 'hard-drained' ? 'hard drained' : 'soft drained'
+      const reason =
+        link.status === 'provisioning'
+          ? 'provisioning'
+          : link.status === 'hard-drained'
+            ? 'hard drained'
+            : 'soft drained'
       linkMap.set(link.code, {
         pk: link.pk,
         code: link.code,
@@ -1342,7 +1741,7 @@ function DisabledLinksTable({
   if (allLinks.length === 0) return null
 
   const reasonColors: Record<string, string> = {
-    'provisioning': 'text-blue-600 dark:text-blue-400',
+    provisioning: 'text-blue-600 dark:text-blue-400',
     'soft drained': 'text-amber-600 dark:text-amber-400',
     'hard drained': 'text-orange-600 dark:text-orange-400',
     'isis delay override': 'text-amber-600 dark:text-amber-400',
@@ -1367,13 +1766,27 @@ function DisabledLinksTable({
           </thead>
           <tbody>
             {allLinks.map((link, idx) => (
-              <tr key={`${link.code}-${idx}`} id={`disabled-link-${link.code}`} className="border-b border-border last:border-b-0">
-                <td className="px-4 py-2.5">
-                  <Link to={`/dz/links/${link.pk}`} state={{ backLabel: 'status' }} className="font-mono text-sm hover:underline">{link.code}</Link>
+              <tr
+                key={`${link.code}-${idx}`}
+                id={`disabled-link-${link.code}`}
+                className="border-b border-border last:border-b-0"
+              >
+                <td className="px-4 py-2.5 whitespace-nowrap">
+                  <Link
+                    to={`/dz/links/${link.pk}`}
+                    state={{ backLabel: 'status' }}
+                    className="font-mono text-sm hover:underline"
+                  >
+                    {link.code}
+                  </Link>
                   <span className="text-xs text-muted-foreground ml-2">{link.link_type}</span>
                 </td>
-                <td className="px-4 py-2.5 text-sm text-muted-foreground">{link.side_a_metro} - {link.side_z_metro}</td>
-                <td className={`px-4 py-2.5 text-sm capitalize ${reasonColors[link.reason] || ''}`}>
+                <td className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">
+                  {link.side_a_metro} - {link.side_z_metro}
+                </td>
+                <td
+                  className={`px-4 py-2.5 text-sm capitalize whitespace-nowrap ${reasonColors[link.reason] || ''}`}
+                >
                   {link.reason}
                 </td>
               </tr>
@@ -1385,7 +1798,11 @@ function DisabledLinksTable({
   )
 }
 
-function DisabledDevicesTable({ devices }: { devices: StatusResponse['alerts']['devices'] | null }) {
+function DisabledDevicesTable({
+  devices,
+}: {
+  devices: StatusResponse['alerts']['devices'] | null
+}) {
   if (!devices || devices.length === 0) return null
 
   const statusColors: Record<string, string> = {
@@ -1416,13 +1833,24 @@ function DisabledDevicesTable({ devices }: { devices: StatusResponse['alerts']['
           </thead>
           <tbody>
             {devices.map((device, idx) => (
-              <tr key={`${device.code}-${idx}`} id={`disabled-device-${device.code}`} className="border-b border-border last:border-b-0">
+              <tr
+                key={`${device.code}-${idx}`}
+                id={`disabled-device-${device.code}`}
+                className="border-b border-border last:border-b-0"
+              >
                 <td className="px-4 py-2.5">
-                  <Link to={`/dz/devices/${device.pk}`} className="font-mono text-sm hover:underline">{device.code}</Link>
+                  <Link
+                    to={`/dz/devices/${device.pk}`}
+                    className="font-mono text-sm hover:underline"
+                  >
+                    {device.code}
+                  </Link>
                   <span className="text-xs text-muted-foreground ml-2">{device.device_type}</span>
                 </td>
                 <td className="px-4 py-2.5 text-sm text-muted-foreground">{device.metro}</td>
-                <td className={`px-4 py-2.5 text-sm capitalize ${statusColors[device.status] || ''}`}>
+                <td
+                  className={`px-4 py-2.5 text-sm capitalize ${statusColors[device.status] || ''}`}
+                >
                   {device.status.replace('-', ' ')}
                 </td>
                 <td className="px-4 py-2.5 text-sm tabular-nums text-right text-muted-foreground">
@@ -1541,17 +1969,33 @@ function InterfaceIssuesTable({
               const totalErrors = issue.in_errors + issue.out_errors
               const totalDiscards = issue.in_discards + issue.out_discards
               return (
-                <tr key={`${issue.device_code}-${issue.interface_name}-${idx}`} className="border-b border-border last:border-b-0">
+                <tr
+                  key={`${issue.device_code}-${issue.interface_name}-${idx}`}
+                  className="border-b border-border last:border-b-0"
+                >
                   <td className="px-4 py-2.5">
-                    <Link to={`/dz/devices/${issue.device_pk}`} className="font-mono text-sm hover:underline">{issue.device_code}</Link>
-                    <div className="text-xs text-muted-foreground">{issue.contributor || issue.device_type}</div>
+                    <Link
+                      to={`/dz/devices/${issue.device_pk}`}
+                      className="font-mono text-sm hover:underline"
+                    >
+                      {issue.device_code}
+                    </Link>
+                    <div className="text-xs text-muted-foreground">
+                      {issue.contributor || issue.device_type}
+                    </div>
                   </td>
                   <td className="px-4 py-2.5 text-sm">
                     <span className="font-mono">{issue.interface_name}</span>
                     {issue.interface_type && (
-                      <span className={`ml-1.5 px-1 py-0.5 rounded text-[10px] leading-none ${
-                        issue.interface_type === 'loopback' ? 'bg-purple-500/15 text-purple-400' : 'bg-muted text-muted-foreground'
-                      }`}>{issue.interface_type}</span>
+                      <span
+                        className={`ml-1.5 px-1 py-0.5 rounded text-[10px] leading-none ${
+                          issue.interface_type === 'loopback'
+                            ? 'bg-purple-500/15 text-purple-400'
+                            : 'bg-muted text-muted-foreground'
+                        }`}
+                      >
+                        {issue.interface_type}
+                      </span>
                     )}
                     {issue.cyoa_type && issue.cyoa_type !== 'none' && (
                       <span className="ml-1 px-1 py-0.5 rounded text-[10px] leading-none bg-amber-500/15 text-amber-400">
@@ -1562,7 +2006,13 @@ function InterfaceIssuesTable({
                   <td className="px-4 py-2.5 text-sm">
                     {issue.link_code && issue.link_pk ? (
                       <div>
-                        <Link to={`/dz/links/${issue.link_pk}`} state={{ backLabel: 'status' }} className="font-mono hover:underline">{issue.link_code}</Link>
+                        <Link
+                          to={`/dz/links/${issue.link_pk}`}
+                          state={{ backLabel: 'status' }}
+                          className="font-mono hover:underline"
+                        >
+                          {issue.link_code}
+                        </Link>
                         <span className="text-xs text-muted-foreground ml-1">
                           ({issue.link_type} side {issue.link_side})
                         </span>
@@ -1571,17 +2021,27 @@ function InterfaceIssuesTable({
                       <span className="text-muted-foreground">-</span>
                     )}
                   </td>
-                  <td className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalErrors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}>
+                  <td
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalErrors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
+                  >
                     {totalErrors > 0 ? totalErrors.toLocaleString() : '-'}
                   </td>
-                  <td className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.in_fcs_errors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}>
+                  <td
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.in_fcs_errors > 0 ? 'text-red-600 dark:text-red-400' : ''}`}
+                  >
                     {issue.in_fcs_errors > 0 ? issue.in_fcs_errors.toLocaleString() : '-'}
                   </td>
-                  <td className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalDiscards > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+                  <td
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${totalDiscards > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}
+                  >
                     {totalDiscards > 0 ? totalDiscards.toLocaleString() : '-'}
                   </td>
-                  <td className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.carrier_transitions > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
-                    {issue.carrier_transitions > 0 ? issue.carrier_transitions.toLocaleString() : '-'}
+                  <td
+                    className={`px-4 py-2.5 text-sm tabular-nums text-right ${issue.carrier_transitions > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}
+                  >
+                    {issue.carrier_transitions > 0
+                      ? issue.carrier_transitions.toLocaleString()
+                      : '-'}
                   </td>
                   <td className="px-4 py-2.5 text-sm tabular-nums text-right text-muted-foreground">
                     {issue.first_seen ? formatTimeAgo(issue.first_seen) : '-'}
@@ -1624,10 +2084,31 @@ function useBucketCount() {
 
 // Links tab content
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusResponse; linkHistory: any; criticalLinks: CriticalLinksResponse | undefined }) {
+function LinksContent({
+  status,
+  linkHistory,
+  criticalLinks,
+}: {
+  status: StatusResponse
+  linkHistory: any
+  criticalLinks: CriticalLinksResponse | undefined
+}) {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
-  const [issueFilters, setIssueFilters] = useState<IssueFilter[]>(['packet_loss', 'high_latency', 'high_utilization', 'missing_adjacency', 'interface_errors', 'fcs_errors', 'discards', 'carrier_transitions'])
-  const [healthFilters, setHealthFilters] = useState<HealthFilter[]>(['healthy', 'degraded', 'unhealthy'])
+  const [issueFilters, setIssueFilters] = useState<IssueFilter[]>([
+    'packet_loss',
+    'high_latency',
+    'high_utilization',
+    'missing_adjacency',
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+  ])
+  const [healthFilters, setHealthFilters] = useState<HealthFilter[]>([
+    'healthy',
+    'degraded',
+    'unhealthy',
+  ])
   const [showDrained, setShowDrained] = useState(false)
   const [showProvisioning, setShowProvisioning] = useState(false)
 
@@ -1637,13 +2118,20 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h': return 36
-      case '6h': return 36
-      case '12h': return 48
-      case '24h': return 72
-      case '3d': return 72
-      case '7d': return 84
-      default: return 72
+      case '3h':
+        return 36
+      case '6h':
+        return 36
+      case '12h':
+        return 48
+      case '24h':
+        return 72
+      case '3d':
+        return 72
+      case '7d':
+        return 84
+      default:
+        return 72
     }
   })()
 
@@ -1663,7 +2151,9 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
     }
     return {
       ...linkHistoryData,
-      links: linkHistoryData.links.filter((link: LinkHistory) => linkMatchesSearchFilters(link, searchFilters))
+      links: linkHistoryData.links.filter((link: LinkHistory) =>
+        linkMatchesSearchFilters(link, searchFilters),
+      ),
     }
   }, [linkHistoryData, searchFilters])
 
@@ -1678,10 +2168,10 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
 
     // Priority from worst to best (lower index = worse)
     const statusPriority: Record<string, number> = {
-      'unhealthy': 0,
-      'no_data': 1,
-      'degraded': 2,
-      'healthy': 3,
+      unhealthy: 0,
+      no_data: 1,
+      degraded: 2,
+      healthy: 3,
     }
 
     let worstStatus = 'healthy'
@@ -1727,7 +2217,8 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
       const status = getEffectiveHealth(link)
       if (status === 'healthy') counts.healthy++
       else if (status === 'degraded') counts.degraded++
-      else if (status === 'down' || status === 'unhealthy' || status === 'no_data') counts.unhealthy++ // down, no_data map to unhealthy
+      else if (status === 'down' || status === 'unhealthy' || status === 'no_data')
+        counts.unhealthy++ // down, no_data map to unhealthy
     }
 
     return counts
@@ -1758,7 +2249,7 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
     for (const link of visibleLinks) {
       const rawHealth = getEffectiveHealth(link)
       // Map no_data and down to unhealthy for categorization
-      const health = (rawHealth === 'no_data' || rawHealth === 'down') ? 'unhealthy' : rawHealth
+      const health = rawHealth === 'no_data' || rawHealth === 'down' ? 'unhealthy' : rawHealth
       if (!(health in result)) continue
 
       const breakdown = result[health as keyof IssuesByHealth]
@@ -1803,7 +2294,9 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
     for (const link of visibleLinks) {
       const rawHealth = getEffectiveHealth(link)
       // Map no_data and down to unhealthy for categorization
-      const health = ((rawHealth === 'no_data' || rawHealth === 'down') ? 'unhealthy' : rawHealth) as keyof IssueHealthBreakdown
+      const health = (
+        rawHealth === 'no_data' || rawHealth === 'down' ? 'unhealthy' : rawHealth
+      ) as keyof IssueHealthBreakdown
       const issues = link.issue_reasons ?? []
 
       if (issues.length === 0) {
@@ -1827,10 +2320,34 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
   // Issue counts from filter time range
   const issueCounts = useMemo((): IssueCounts => {
     if (visibleLinks.length === 0) {
-      return { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, missing_adjacency: 0, interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
+      return {
+        packet_loss: 0,
+        high_latency: 0,
+        high_utilization: 0,
+        no_data: 0,
+        missing_adjacency: 0,
+        interface_errors: 0,
+        fcs_errors: 0,
+        discards: 0,
+        carrier_transitions: 0,
+        no_issues: 0,
+        total: 0,
+      }
     }
 
-    const counts = { packet_loss: 0, high_latency: 0, high_utilization: 0, no_data: 0, missing_adjacency: 0, interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, no_issues: 0, total: 0 }
+    const counts = {
+      packet_loss: 0,
+      high_latency: 0,
+      high_utilization: 0,
+      no_data: 0,
+      missing_adjacency: 0,
+      interface_errors: 0,
+      fcs_errors: 0,
+      discards: 0,
+      carrier_transitions: 0,
+      no_issues: 0,
+      total: 0,
+    }
     const seenLinks = new Set<string>()
 
     for (const link of visibleLinks) {
@@ -1912,8 +2429,8 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
 
     const drainedCodes = new Set(
       (status.alerts?.links || [])
-        .filter(l => l.status === 'soft-drained' || l.status === 'hard-drained')
-        .map(l => l.code)
+        .filter((l) => l.status === 'soft-drained' || l.status === 'hard-drained')
+        .map((l) => l.code),
     )
 
     const bucketsFor2Hours = Math.ceil(120 / (linkHistory.bucket_minutes || 20))
@@ -1921,11 +2438,14 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
     const isCurrentlyDisabledByPacketLoss = (hours: { status: string }[]): boolean => {
       if (!hours || hours.length < bucketsFor2Hours) return false
       const recentBuckets = hours.slice(-bucketsFor2Hours)
-      return recentBuckets.every(h => h.status === 'disabled')
+      return recentBuckets.every((h) => h.status === 'disabled')
     }
 
     return linkHistory.links
-      .filter((link: LinkHistory) => !drainedCodes.has(link.code) && isCurrentlyDisabledByPacketLoss(link.hours))
+      .filter(
+        (link: LinkHistory) =>
+          !drainedCodes.has(link.code) && isCurrentlyDisabledByPacketLoss(link.hours),
+      )
       .map((link: LinkHistory) => ({
         pk: link.pk,
         code: link.code,
@@ -1958,7 +2478,19 @@ function LinksContent({ status, linkHistory, criticalLinks }: { status: StatusRe
 
       {/* Link Status History */}
       <div id="link-status-history" className="mb-8 scroll-mt-8">
-        <LinkStatusTimelines timeRange={timeRange} onTimeRangeChange={setTimeRange} issueFilters={issueFilters} healthFilters={healthFilters} showDrained={showDrained} onShowDrainedChange={setShowDrained} showProvisioning={showProvisioning} onShowProvisioningChange={setShowProvisioning} linksWithIssues={linksWithIssues} linksWithHealth={linksWithHealth} criticalityMap={criticalityMap} />
+        <LinkStatusTimelines
+          timeRange={timeRange}
+          onTimeRangeChange={setTimeRange}
+          issueFilters={issueFilters}
+          healthFilters={healthFilters}
+          showDrained={showDrained}
+          onShowDrainedChange={setShowDrained}
+          showProvisioning={showProvisioning}
+          onShowProvisioningChange={setShowProvisioning}
+          linksWithIssues={linksWithIssues}
+          linksWithHealth={linksWithHealth}
+          criticalityMap={criticalityMap}
+        />
       </div>
 
       {/* Disabled Links */}
@@ -1994,22 +2526,94 @@ interface DeviceIssueCounts {
 
 // Device issues breakdown per health category
 interface DeviceIssuesByHealth {
-  healthy: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number; isis_overload: number; isis_unreachable: number }
-  degraded: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number; isis_overload: number; isis_unreachable: number }
-  unhealthy: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number; isis_overload: number; isis_unreachable: number }
-  disabled: { interface_errors: number; fcs_errors: number; discards: number; carrier_transitions: number; drained: number; isis_overload: number; isis_unreachable: number }
+  healthy: {
+    interface_errors: number
+    fcs_errors: number
+    discards: number
+    carrier_transitions: number
+    drained: number
+    isis_overload: number
+    isis_unreachable: number
+  }
+  degraded: {
+    interface_errors: number
+    fcs_errors: number
+    discards: number
+    carrier_transitions: number
+    drained: number
+    isis_overload: number
+    isis_unreachable: number
+  }
+  unhealthy: {
+    interface_errors: number
+    fcs_errors: number
+    discards: number
+    carrier_transitions: number
+    drained: number
+    isis_overload: number
+    isis_unreachable: number
+  }
+  disabled: {
+    interface_errors: number
+    fcs_errors: number
+    discards: number
+    carrier_transitions: number
+    drained: number
+    isis_overload: number
+    isis_unreachable: number
+  }
 }
 
 // Device health breakdown per issue type
 interface DeviceHealthByIssue {
-  interface_errors: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  fcs_errors: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  discards: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  carrier_transitions: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  drained: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  isis_overload: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  isis_unreachable: { healthy: number; degraded: number; unhealthy: number; disabled: number }
-  no_issues: { healthy: number; degraded: number; unhealthy: number; disabled: number }
+  interface_errors: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  fcs_errors: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  discards: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  carrier_transitions: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  drained: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  isis_overload: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  isis_unreachable: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
+  no_issues: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+  }
 }
 
 function DeviceHealthFilterCard({
@@ -2019,7 +2623,13 @@ function DeviceHealthFilterCard({
   issuesByHealth,
   timeRange,
 }: {
-  devices: { healthy: number; degraded: number; unhealthy: number; disabled: number; total: number }
+  devices: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    disabled: number
+    total: number
+  }
   selected: HealthFilter[]
   onChange: (filters: HealthFilter[]) => void
   issuesByHealth?: DeviceIssuesByHealth
@@ -2028,7 +2638,7 @@ function DeviceHealthFilterCard({
   const toggleFilter = (filter: HealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -2044,45 +2654,58 @@ function DeviceHealthFilterCard({
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <Cpu className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Device Health</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Device Health</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(['healthy', 'degraded', 'unhealthy', 'disabled'])}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(['healthy', 'degraded', 'unhealthy', 'disabled'])}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {healthyPct > 0 && (
-          <div
-            className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${healthyPct}%` }}
-          />
-        )}
-        {degradedPct > 0 && (
-          <div
-            className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
-            style={{ width: `${degradedPct}%` }}
-          />
-        )}
-        {unhealthyPct > 0 && (
-          <div
-            className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${unhealthyPct}%` }}
-          />
-        )}
-        {disabledPct > 0 && (
-          <div
-            className={`bg-gray-500 dark:bg-gray-700 h-full transition-all ${!selected.includes('disabled') ? 'opacity-30' : ''}`}
-            style={{ width: `${disabledPct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {healthyPct > 0 && (
+            <div
+              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${healthyPct}%` }}
+            />
+          )}
+          {degradedPct > 0 && (
+            <div
+              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              style={{ width: `${degradedPct}%` }}
+            />
+          )}
+          {unhealthyPct > 0 && (
+            <div
+              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${unhealthyPct}%` }}
+            />
+          )}
+          {disabledPct > 0 && (
+            <div
+              className={`bg-gray-500 dark:bg-gray-700 h-full transition-all ${!selected.includes('disabled') ? 'opacity-30' : ''}`}
+              style={{ width: `${disabledPct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -2140,12 +2763,21 @@ function DeviceIssuesFilterCard({
   healthByIssue?: DeviceHealthByIssue
   timeRange: TimeRange
 }) {
-  const allFilters: DeviceIssueFilter[] = ['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained', 'isis_overload', 'isis_unreachable', 'no_issues']
+  const allFilters: DeviceIssueFilter[] = [
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+    'drained',
+    'isis_overload',
+    'isis_unreachable',
+    'no_issues',
+  ]
 
   const toggleFilter = (filter: DeviceIssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -2154,7 +2786,7 @@ function DeviceIssuesFilterCard({
 
   const allSelected = selected.length === allFilters.length
 
-  const grandTotal = (counts.total + counts.no_issues) || 1
+  const grandTotal = counts.total + counts.no_issues || 1
   const interfaceErrorsPct = (counts.interface_errors / grandTotal) * 100
   const fcsErrorsPct = (counts.fcs_errors / grandTotal) * 100
   const discardsPct = (counts.discards / grandTotal) * 100
@@ -2164,82 +2796,140 @@ function DeviceIssuesFilterCard({
   const isisUnreachablePct = (counts.isis_unreachable / grandTotal) * 100
   const noIssuesPct = (counts.no_issues / grandTotal) * 100
 
-  const items: { filter: DeviceIssueFilter; label: string; color: string; description: string }[] = [
-    { filter: 'interface_errors', label: 'Interface Errors', color: 'bg-fuchsia-500', description: 'Device experiencing interface errors.' },
-    { filter: 'fcs_errors', label: 'FCS Errors', color: 'bg-orange-600', description: 'Device experiencing FCS (Frame Check Sequence) errors.' },
-    { filter: 'discards', label: 'Discards', color: 'bg-rose-500', description: 'Device experiencing interface discards.' },
-    { filter: 'carrier_transitions', label: 'Carrier Transitions', color: 'bg-orange-500', description: 'Device experiencing carrier state changes (link up/down).' },
-    { filter: 'drained', label: 'Drained', color: 'bg-slate-500 dark:bg-slate-600', description: 'Device is soft-drained, hard-drained, or suspended.' },
-    { filter: 'isis_overload', label: 'ISIS Overload', color: 'bg-red-600', description: 'Device is in ISIS overload state.' },
-    { filter: 'isis_unreachable', label: 'ISIS Unreachable', color: 'bg-red-800', description: 'Device is unreachable in the ISIS topology.' },
-    { filter: 'no_issues', label: 'No Issues', color: 'bg-cyan-500', description: 'Device with no detected issues in the time range.' },
+  const items: {
+    filter: DeviceIssueFilter
+    label: string
+    color: string
+    description: string
+  }[] = [
+    {
+      filter: 'interface_errors',
+      label: 'Interface Errors',
+      color: 'bg-fuchsia-500',
+      description: 'Device experiencing interface errors.',
+    },
+    {
+      filter: 'fcs_errors',
+      label: 'FCS Errors',
+      color: 'bg-orange-600',
+      description: 'Device experiencing FCS (Frame Check Sequence) errors.',
+    },
+    {
+      filter: 'discards',
+      label: 'Discards',
+      color: 'bg-rose-500',
+      description: 'Device experiencing interface discards.',
+    },
+    {
+      filter: 'carrier_transitions',
+      label: 'Carrier Transitions',
+      color: 'bg-orange-500',
+      description: 'Device experiencing carrier state changes (link up/down).',
+    },
+    {
+      filter: 'drained',
+      label: 'Drained',
+      color: 'bg-slate-500 dark:bg-slate-600',
+      description: 'Device is soft-drained, hard-drained, or suspended.',
+    },
+    {
+      filter: 'isis_overload',
+      label: 'ISIS Overload',
+      color: 'bg-red-600',
+      description: 'Device is in ISIS overload state.',
+    },
+    {
+      filter: 'isis_unreachable',
+      label: 'ISIS Unreachable',
+      color: 'bg-red-800',
+      description: 'Device is unreachable in the ISIS topology.',
+    },
+    {
+      filter: 'no_issues',
+      label: 'No Issues',
+      color: 'bg-cyan-500',
+      description: 'Device with no detected issues in the time range.',
+    },
   ]
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Device Issues</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Device Issues</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(allFilters)}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {noIssuesPct > 0 && (
-          <div
-            className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
-            style={{ width: `${noIssuesPct}%` }}
-          />
-        )}
-        {interfaceErrorsPct > 0 && (
-          <div
-            className={`bg-fuchsia-500 h-full transition-all ${!selected.includes('interface_errors') ? 'opacity-30' : ''}`}
-            style={{ width: `${interfaceErrorsPct}%` }}
-          />
-        )}
-        {fcsErrorsPct > 0 && (
-          <div
-            className={`bg-orange-600 h-full transition-all ${!selected.includes('fcs_errors') ? 'opacity-30' : ''}`}
-            style={{ width: `${fcsErrorsPct}%` }}
-          />
-        )}
-        {discardsPct > 0 && (
-          <div
-            className={`bg-rose-500 h-full transition-all ${!selected.includes('discards') ? 'opacity-30' : ''}`}
-            style={{ width: `${discardsPct}%` }}
-          />
-        )}
-        {carrierTransitionsPct > 0 && (
-          <div
-            className={`bg-orange-500 h-full transition-all ${!selected.includes('carrier_transitions') ? 'opacity-30' : ''}`}
-            style={{ width: `${carrierTransitionsPct}%` }}
-          />
-        )}
-        {drainedPct > 0 && (
-          <div
-            className={`bg-slate-500 dark:bg-slate-600 h-full transition-all ${!selected.includes('drained') ? 'opacity-30' : ''}`}
-            style={{ width: `${drainedPct}%` }}
-          />
-        )}
-        {isisOverloadPct > 0 && (
-          <div
-            className={`bg-red-600 h-full transition-all ${!selected.includes('isis_overload') ? 'opacity-30' : ''}`}
-            style={{ width: `${isisOverloadPct}%` }}
-          />
-        )}
-        {isisUnreachablePct > 0 && (
-          <div
-            className={`bg-red-800 h-full transition-all ${!selected.includes('isis_unreachable') ? 'opacity-30' : ''}`}
-            style={{ width: `${isisUnreachablePct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {noIssuesPct > 0 && (
+            <div
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              style={{ width: `${noIssuesPct}%` }}
+            />
+          )}
+          {interfaceErrorsPct > 0 && (
+            <div
+              className={`bg-fuchsia-500 h-full transition-all ${!selected.includes('interface_errors') ? 'opacity-30' : ''}`}
+              style={{ width: `${interfaceErrorsPct}%` }}
+            />
+          )}
+          {fcsErrorsPct > 0 && (
+            <div
+              className={`bg-orange-600 h-full transition-all ${!selected.includes('fcs_errors') ? 'opacity-30' : ''}`}
+              style={{ width: `${fcsErrorsPct}%` }}
+            />
+          )}
+          {discardsPct > 0 && (
+            <div
+              className={`bg-rose-500 h-full transition-all ${!selected.includes('discards') ? 'opacity-30' : ''}`}
+              style={{ width: `${discardsPct}%` }}
+            />
+          )}
+          {carrierTransitionsPct > 0 && (
+            <div
+              className={`bg-orange-500 h-full transition-all ${!selected.includes('carrier_transitions') ? 'opacity-30' : ''}`}
+              style={{ width: `${carrierTransitionsPct}%` }}
+            />
+          )}
+          {drainedPct > 0 && (
+            <div
+              className={`bg-slate-500 dark:bg-slate-600 h-full transition-all ${!selected.includes('drained') ? 'opacity-30' : ''}`}
+              style={{ width: `${drainedPct}%` }}
+            />
+          )}
+          {isisOverloadPct > 0 && (
+            <div
+              className={`bg-red-600 h-full transition-all ${!selected.includes('isis_overload') ? 'opacity-30' : ''}`}
+              style={{ width: `${isisOverloadPct}%` }}
+            />
+          )}
+          {isisUnreachablePct > 0 && (
+            <div
+              className={`bg-red-800 h-full transition-all ${!selected.includes('isis_unreachable') ? 'opacity-30' : ''}`}
+              style={{ width: `${isisUnreachablePct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -2278,14 +2968,12 @@ function matchesGroupedFilters(
 ): boolean {
   if (filters.length === 0) return true
   const grouped = groupFiltersByType(filters)
-  return Array.from(grouped.values()).every(group =>
-    group.some(matchSingle)
-  )
+  return Array.from(grouped.values()).every((group) => group.some(matchSingle))
 }
 
 // Helper to check if a device matches search filters
 function deviceMatchesSearchFilters(device: DeviceHistory, filters: StatusFilter[]): boolean {
-  return matchesGroupedFilters(filters, filter => {
+  return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
       case 'device':
         return device.code.toLowerCase().includes(filter.value.toLowerCase())
@@ -2300,8 +2988,11 @@ function deviceMatchesSearchFilters(device: DeviceHistory, filters: StatusFilter
 }
 
 // Helper to check if an interface issue matches search filters
-function interfaceIssueMatchesSearchFilters(issue: InterfaceIssue, filters: StatusFilter[]): boolean {
-  return matchesGroupedFilters(filters, filter => {
+function interfaceIssueMatchesSearchFilters(
+  issue: InterfaceIssue,
+  filters: StatusFilter[],
+): boolean {
+  return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
       case 'device':
         return issue.device_code.toLowerCase().includes(filter.value.toLowerCase())
@@ -2319,16 +3010,21 @@ function interfaceIssueMatchesSearchFilters(issue: InterfaceIssue, filters: Stat
 
 // Helper to check if a link matches search filters
 function linkMatchesSearchFilters(link: LinkHistory, filters: StatusFilter[]): boolean {
-  return matchesGroupedFilters(filters, filter => {
+  return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
       case 'link':
         return link.code.toLowerCase().includes(filter.value.toLowerCase())
       case 'device':
-        return link.side_a_device?.toLowerCase().includes(filter.value.toLowerCase()) ||
-               link.side_z_device?.toLowerCase().includes(filter.value.toLowerCase()) || false
+        return (
+          link.side_a_device?.toLowerCase().includes(filter.value.toLowerCase()) ||
+          link.side_z_device?.toLowerCase().includes(filter.value.toLowerCase()) ||
+          false
+        )
       case 'metro':
-        return link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
-               link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
+        return (
+          link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
+          link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
+        )
       case 'contributor':
         return link.contributor?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
       default:
@@ -2339,13 +3035,15 @@ function linkMatchesSearchFilters(link: LinkHistory, filters: StatusFilter[]): b
 
 // Helper to check if a link metric (for utilization) matches search filters
 function linkMetricMatchesSearchFilters(link: LinkMetric, filters: StatusFilter[]): boolean {
-  return matchesGroupedFilters(filters, filter => {
+  return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
       case 'link':
         return link.code.toLowerCase().includes(filter.value.toLowerCase())
       case 'metro':
-        return link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
-               link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
+        return (
+          link.side_a_metro?.toLowerCase() === filter.value.toLowerCase() ||
+          link.side_z_metro?.toLowerCase() === filter.value.toLowerCase()
+        )
       case 'contributor':
         return link.contributor?.toLowerCase().includes(filter.value.toLowerCase()) ?? false
       default:
@@ -2355,8 +3053,11 @@ function linkMetricMatchesSearchFilters(link: LinkMetric, filters: StatusFilter[
 }
 
 // Helper to check if a device utilization matches search filters
-function deviceUtilMatchesSearchFilters(device: DeviceUtilization, filters: StatusFilter[]): boolean {
-  return matchesGroupedFilters(filters, filter => {
+function deviceUtilMatchesSearchFilters(
+  device: DeviceUtilization,
+  filters: StatusFilter[],
+): boolean {
+  return matchesGroupedFilters(filters, (filter) => {
     switch (filter.type) {
       case 'device':
         return device.code.toLowerCase().includes(filter.value.toLowerCase())
@@ -2373,8 +3074,21 @@ function deviceUtilMatchesSearchFilters(device: DeviceUtilization, filters: Stat
 // Devices tab content
 function DevicesContent({ status }: { status: StatusResponse }) {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
-  const [issueFilters, setIssueFilters] = useState<DeviceIssueFilter[]>(['interface_errors', 'fcs_errors', 'discards', 'carrier_transitions', 'drained', 'isis_overload', 'isis_unreachable'])
-  const [healthFilters, setHealthFilters] = useState<HealthFilter[]>(['healthy', 'degraded', 'unhealthy', 'disabled'])
+  const [issueFilters, setIssueFilters] = useState<DeviceIssueFilter[]>([
+    'interface_errors',
+    'fcs_errors',
+    'discards',
+    'carrier_transitions',
+    'drained',
+    'isis_overload',
+    'isis_unreachable',
+  ])
+  const [healthFilters, setHealthFilters] = useState<HealthFilter[]>([
+    'healthy',
+    'degraded',
+    'unhealthy',
+    'disabled',
+  ])
   const location = useLocation()
 
   // Get expanded device from navigation state
@@ -2386,13 +3100,20 @@ function DevicesContent({ status }: { status: StatusResponse }) {
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h': return 36
-      case '6h': return 36
-      case '12h': return 48
-      case '24h': return 72
-      case '3d': return 72
-      case '7d': return 84
-      default: return 72
+      case '3h':
+        return 36
+      case '6h':
+        return 36
+      case '12h':
+        return 48
+      case '24h':
+        return 72
+      case '3d':
+        return 72
+      case '7d':
+        return 84
+      default:
+        return 72
     }
   })()
 
@@ -2420,7 +3141,9 @@ function DevicesContent({ status }: { status: StatusResponse }) {
     }
     return {
       ...deviceHistoryData,
-      devices: deviceHistoryData.devices.filter(d => deviceMatchesSearchFilters(d, searchFilters))
+      devices: deviceHistoryData.devices.filter((d) =>
+        deviceMatchesSearchFilters(d, searchFilters),
+      ),
     }
   }, [deviceHistoryData, searchFilters])
 
@@ -2429,7 +3152,9 @@ function DevicesContent({ status }: { status: StatusResponse }) {
     if (!interfaceIssuesData?.issues || searchFilters.length === 0) {
       return interfaceIssuesData?.issues ?? null
     }
-    return interfaceIssuesData.issues.filter(i => interfaceIssueMatchesSearchFilters(i, searchFilters))
+    return interfaceIssuesData.issues.filter((i) =>
+      interfaceIssueMatchesSearchFilters(i, searchFilters),
+    )
   }, [interfaceIssuesData, searchFilters])
 
   // Helper to get the effective health status from a device's hours
@@ -2437,11 +3162,11 @@ function DevicesContent({ status }: { status: StatusResponse }) {
     if (!device.hours || device.hours.length === 0) return 'healthy'
 
     const statusPriority: Record<string, number> = {
-      'unhealthy': 0,
-      'no_data': 1,
-      'disabled': 2,
-      'degraded': 3,
-      'healthy': 4,
+      unhealthy: 0,
+      no_data: 1,
+      disabled: 2,
+      degraded: 3,
+      healthy: 4,
     }
 
     let worstStatus = 'healthy'
@@ -2470,7 +3195,13 @@ function DevicesContent({ status }: { status: StatusResponse }) {
       return { healthy: 0, degraded: 0, unhealthy: 0, disabled: 0, total: 0 }
     }
 
-    const counts = { healthy: 0, degraded: 0, unhealthy: 0, disabled: 0, total: 0 }
+    const counts = {
+      healthy: 0,
+      degraded: 0,
+      unhealthy: 0,
+      disabled: 0,
+      total: 0,
+    }
 
     for (const device of filteredDeviceHistory.devices) {
       counts.total++
@@ -2486,7 +3217,15 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
   // Calculate issue breakdown per health category
   const issuesByHealth = useMemo((): DeviceIssuesByHealth => {
-    const emptyBreakdown = () => ({ interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, isis_overload: 0, isis_unreachable: 0 })
+    const emptyBreakdown = () => ({
+      interface_errors: 0,
+      fcs_errors: 0,
+      discards: 0,
+      carrier_transitions: 0,
+      drained: 0,
+      isis_overload: 0,
+      isis_unreachable: 0,
+    })
 
     const result: DeviceIssuesByHealth = {
       healthy: emptyBreakdown(),
@@ -2519,7 +3258,12 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
   // Calculate health breakdown per issue type
   const healthByIssue = useMemo((): DeviceHealthByIssue => {
-    const emptyBreakdown = () => ({ healthy: 0, degraded: 0, unhealthy: 0, disabled: 0 })
+    const emptyBreakdown = () => ({
+      healthy: 0,
+      degraded: 0,
+      unhealthy: 0,
+      disabled: 0,
+    })
 
     const result: DeviceHealthByIssue = {
       interface_errors: emptyBreakdown(),
@@ -2536,7 +3280,9 @@ function DevicesContent({ status }: { status: StatusResponse }) {
 
     for (const device of filteredDeviceHistory.devices) {
       const rawHealth = getEffectiveHealth(device)
-      const health = (rawHealth === 'no_data' ? 'unhealthy' : rawHealth) as keyof IssueHealthBreakdown
+      const health = (
+        rawHealth === 'no_data' ? 'unhealthy' : rawHealth
+      ) as keyof IssueHealthBreakdown
       const issues = device.issue_reasons ?? []
 
       if (issues.length === 0) {
@@ -2558,10 +3304,30 @@ function DevicesContent({ status }: { status: StatusResponse }) {
   // Issue counts from filter time range
   const issueCounts = useMemo((): DeviceIssueCounts => {
     if (!filteredDeviceHistory?.devices) {
-      return { interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, isis_overload: 0, isis_unreachable: 0, no_issues: 0, total: 0 }
+      return {
+        interface_errors: 0,
+        fcs_errors: 0,
+        discards: 0,
+        carrier_transitions: 0,
+        drained: 0,
+        isis_overload: 0,
+        isis_unreachable: 0,
+        no_issues: 0,
+        total: 0,
+      }
     }
 
-    const counts = { interface_errors: 0, fcs_errors: 0, discards: 0, carrier_transitions: 0, drained: 0, isis_overload: 0, isis_unreachable: 0, no_issues: 0, total: 0 }
+    const counts = {
+      interface_errors: 0,
+      fcs_errors: 0,
+      discards: 0,
+      carrier_transitions: 0,
+      drained: 0,
+      isis_overload: 0,
+      isis_unreachable: 0,
+      no_issues: 0,
+      total: 0,
+    }
     const seenDevices = new Set<string>()
 
     for (const device of filteredDeviceHistory.devices) {
@@ -2671,7 +3437,12 @@ function MetroHealthFilterCard({
   onChange,
   timeRange,
 }: {
-  metros: { healthy: number; degraded: number; unhealthy: number; total: number }
+  metros: {
+    healthy: number
+    degraded: number
+    unhealthy: number
+    total: number
+  }
   selected: MetroHealthFilter[]
   onChange: (filters: MetroHealthFilter[]) => void
   timeRange: TimeRange
@@ -2679,7 +3450,7 @@ function MetroHealthFilterCard({
   const toggleFilter = (filter: MetroHealthFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -2694,39 +3465,52 @@ function MetroHealthFilterCard({
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Metro Health</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Metro Health</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(['healthy', 'degraded', 'unhealthy'])}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {healthyPct > 0 && (
-          <div
-            className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${healthyPct}%` }}
-          />
-        )}
-        {degradedPct > 0 && (
-          <div
-            className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
-            style={{ width: `${degradedPct}%` }}
-          />
-        )}
-        {unhealthyPct > 0 && (
-          <div
-            className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
-            style={{ width: `${unhealthyPct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {healthyPct > 0 && (
+            <div
+              className={`bg-green-500 h-full transition-all ${!selected.includes('healthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${healthyPct}%` }}
+            />
+          )}
+          {degradedPct > 0 && (
+            <div
+              className={`bg-amber-500 h-full transition-all ${!selected.includes('degraded') ? 'opacity-30' : ''}`}
+              style={{ width: `${degradedPct}%` }}
+            />
+          )}
+          {unhealthyPct > 0 && (
+            <div
+              className={`bg-red-500 h-full transition-all ${!selected.includes('unhealthy') ? 'opacity-30' : ''}`}
+              style={{ width: `${unhealthyPct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -2766,7 +3550,12 @@ function MetroIssuesFilterCard({
   onChange,
   timeRange,
 }: {
-  counts: { has_issues: number; has_spof: number; no_issues: number; total: number }
+  counts: {
+    has_issues: number
+    has_spof: number
+    no_issues: number
+    total: number
+  }
   selected: MetroIssueFilter[]
   onChange: (filters: MetroIssueFilter[]) => void
   timeRange: TimeRange
@@ -2776,7 +3565,7 @@ function MetroIssuesFilterCard({
   const toggleFilter = (filter: MetroIssueFilter) => {
     if (selected.includes(filter)) {
       if (selected.length > 1) {
-        onChange(selected.filter(f => f !== filter))
+        onChange(selected.filter((f) => f !== filter))
       }
     } else {
       onChange([...selected, filter])
@@ -2792,39 +3581,52 @@ function MetroIssuesFilterCard({
 
   return (
     <div className="border border-border rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-        <h3 className="font-medium">Metro Issues</h3>
-        <span className="text-xs text-muted-foreground">({timeRangeLabels[timeRange]})</span>
+      <div className="flex flex-col xs:flex-row gap-0.5 xs:gap-2 xs:items-center mb-1">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-muted-foreground shrink-0" />
+          <h3 className="font-medium">Metro Issues</h3>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            ({timeRangeLabels[timeRange]})
+          </span>
+          <button
+            onClick={() => onChange(allFilters)}
+            className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors hidden sm:inline-block ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
+          >
+            {allSelected ? 'All selected' : 'Select all'}
+          </button>
+        </div>
+        <span className="sm:hidden text-xs text-muted-foreground">
+          ({timeRangeLabels[timeRange]})
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end gap-2 mb-3">
         <button
           onClick={() => onChange(allFilters)}
-          className={`text-xs ml-auto px-1.5 py-0.5 rounded transition-colors ${
-            allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'
-          }`}
+          className={`sm:hidden text-xs px-1.5 py-0.5 rounded transition-colors shrink-0 ${allSelected ? 'text-muted-foreground' : 'text-primary hover:underline'}`}
         >
           {allSelected ? 'All selected' : 'Select all'}
         </button>
-      </div>
-
-      <div className="h-2 rounded-full overflow-hidden flex mb-3 bg-muted">
-        {noIssuesPct > 0 && (
-          <div
-            className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
-            style={{ width: `${noIssuesPct}%` }}
-          />
-        )}
-        {hasIssuesPct > 0 && (
-          <div
-            className={`bg-purple-500 h-full transition-all ${!selected.includes('has_issues') ? 'opacity-30' : ''}`}
-            style={{ width: `${hasIssuesPct}%` }}
-          />
-        )}
-        {hasSpofPct > 0 && (
-          <div
-            className={`bg-red-500 h-full transition-all ${!selected.includes('has_spof') ? 'opacity-30' : ''}`}
-            style={{ width: `${hasSpofPct}%` }}
-          />
-        )}
+        <div className="w-full h-2 rounded-full overflow-hidden flex bg-muted">
+          {noIssuesPct > 0 && (
+            <div
+              className={`bg-cyan-500 h-full transition-all ${!selected.includes('no_issues') ? 'opacity-30' : ''}`}
+              style={{ width: `${noIssuesPct}%` }}
+            />
+          )}
+          {hasIssuesPct > 0 && (
+            <div
+              className={`bg-purple-500 h-full transition-all ${!selected.includes('has_issues') ? 'opacity-30' : ''}`}
+              style={{ width: `${hasIssuesPct}%` }}
+            />
+          )}
+          {hasSpofPct > 0 && (
+            <div
+              className={`bg-red-500 h-full transition-all ${!selected.includes('has_spof') ? 'opacity-30' : ''}`}
+              style={{ width: `${hasSpofPct}%` }}
+            />
+          )}
+        </div>
       </div>
 
       <div className="space-y-0.5 text-sm">
@@ -2868,19 +3670,34 @@ function MetrosContent({
   metroNames: Map<string, string>
 }) {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
-  const [healthFilters, setHealthFilters] = useState<MetroHealthFilter[]>(['healthy', 'degraded', 'unhealthy'])
-  const [issueFilters, setIssueFilters] = useState<MetroIssueFilter[]>(['has_issues', 'has_spof', 'no_issues'])
+  const [healthFilters, setHealthFilters] = useState<MetroHealthFilter[]>([
+    'healthy',
+    'degraded',
+    'unhealthy',
+  ])
+  const [issueFilters, setIssueFilters] = useState<MetroIssueFilter[]>([
+    'has_issues',
+    'has_spof',
+    'no_issues',
+  ])
 
   // Bucket count based on time range
   const buckets = (() => {
     switch (timeRange) {
-      case '3h': return 36
-      case '6h': return 36
-      case '12h': return 48
-      case '24h': return 72
-      case '3d': return 72
-      case '7d': return 84
-      default: return 72
+      case '3h':
+        return 36
+      case '6h':
+        return 36
+      case '12h':
+        return 48
+      case '24h':
+        return 72
+      case '3d':
+        return 72
+      case '7d':
+        return 84
+      default:
+        return 72
     }
   })()
 
@@ -2919,13 +3736,16 @@ function MetrosContent({
     }
 
     // Track link counts per metro for current status (last bucket)
-    const metroMap = new Map<string, {
-      workingLinks: number  // healthy or degraded
-      downLinks: number     // unhealthy, disabled, no_data
-      totalLinks: number
-      hasIssues: boolean    // had any non-healthy status in time range
-      hasSpof: boolean
-    }>()
+    const metroMap = new Map<
+      string,
+      {
+        workingLinks: number // healthy or degraded
+        downLinks: number // unhealthy, disabled, no_data
+        totalLinks: number
+        hasIssues: boolean // had any non-healthy status in time range
+        hasSpof: boolean
+      }
+    >()
 
     for (const link of linkHistory.links) {
       if (!link.hours || link.hours.length === 0) continue
@@ -2937,20 +3757,31 @@ function MetrosContent({
       // If last bucket is no_data (still collecting), use the previous bucket
       const lastBucket = link.hours[link.hours.length - 1]
       const prevBucket = link.hours.length > 1 ? link.hours[link.hours.length - 2] : null
-      const currentStatus = (lastBucket?.status === 'no_data' && prevBucket)
-        ? (prevBucket.status || 'healthy')
-        : (lastBucket?.status || 'healthy')
+      const currentStatus =
+        lastBucket?.status === 'no_data' && prevBucket
+          ? prevBucket.status || 'healthy'
+          : lastBucket?.status || 'healthy'
       const isWorking = currentStatus === 'healthy' || currentStatus === 'degraded'
 
       // Check if link had any issues in time range (no_data is also an issue)
-      const hadIssues = link.hours.some((h: { status: string }) =>
-        h.status === 'unhealthy' || h.status === 'degraded' || h.status === 'disabled' || h.status === 'no_data'
+      const hadIssues = link.hours.some(
+        (h: { status: string }) =>
+          h.status === 'unhealthy' ||
+          h.status === 'degraded' ||
+          h.status === 'disabled' ||
+          h.status === 'no_data',
       )
 
       for (const metroCode of [link.side_a_metro, link.side_z_metro]) {
         if (!metroCode) continue
         if (!metroMap.has(metroCode)) {
-          metroMap.set(metroCode, { workingLinks: 0, downLinks: 0, totalLinks: 0, hasIssues: false, hasSpof: false })
+          metroMap.set(metroCode, {
+            workingLinks: 0,
+            downLinks: 0,
+            totalLinks: 0,
+            hasIssues: false,
+            hasSpof: false,
+          })
         }
         const metro = metroMap.get(metroCode)!
         metro.totalLinks++
@@ -3031,8 +3862,11 @@ export function StatusPage() {
   const buckets = useBucketCount()
 
   // Determine active tab from URL
-  const activeTab = location.pathname.includes('/devices') ? 'devices' :
-                    location.pathname.includes('/metros') ? 'metros' : 'links'
+  const activeTab = location.pathname.includes('/devices')
+    ? 'devices'
+    : location.pathname.includes('/metros')
+      ? 'metros'
+      : 'links'
 
   // Redirect /status to /status/links (preserving query params)
   useEffect(() => {
@@ -3041,7 +3875,11 @@ export function StatusPage() {
     }
   }, [location.pathname, location.search, navigate])
 
-  const { data: status, isLoading, error } = useQuery({
+  const {
+    data: status,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['status'],
     queryFn: fetchStatus,
     refetchInterval: 30_000,
@@ -3088,7 +3926,9 @@ export function StatusPage() {
     if (!status?.links?.top_util_links || searchFilters.length === 0) {
       return status?.links?.top_util_links ?? []
     }
-    return status.links.top_util_links.filter(link => linkMetricMatchesSearchFilters(link, searchFilters))
+    return status.links.top_util_links.filter((link) =>
+      linkMetricMatchesSearchFilters(link, searchFilters),
+    )
   }, [status?.links?.top_util_links, searchFilters])
 
   // Filter top device utilization by search filters
@@ -3096,7 +3936,9 @@ export function StatusPage() {
     if (!status?.top_device_util || searchFilters.length === 0) {
       return status?.top_device_util ?? []
     }
-    return status.top_device_util.filter(device => deviceUtilMatchesSearchFilters(device, searchFilters))
+    return status.top_device_util.filter((device) =>
+      deviceUtilMatchesSearchFilters(device, searchFilters),
+    )
   }, [status?.top_device_util, searchFilters])
 
   if (isLoading && showSkeleton) {
@@ -3128,17 +3970,42 @@ export function StatusPage() {
         </div>
 
         {/* Network Stats Grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-x-8 gap-y-6 mb-8">
-          <StatCard label="Contributors" value={status.network.contributors} format="number" href="/dz/contributors" />
-          <StatCard label="Metros" value={status.network.metros} format="number" href="/dz/metros" />
-          <StatCard label="Devices" value={status.network.devices} format="number" href="/dz/devices" />
+        <div className="grid grid-cols-1 xss:grid-cols-2 md:grid-cols-5 gap-4 md:gap-6 mb-8">
+          <StatCard
+            label="Contributors"
+            value={status.network.contributors}
+            format="number"
+            href="/dz/contributors"
+          />
+          <StatCard
+            label="Metros"
+            value={status.network.metros}
+            format="number"
+            href="/dz/metros"
+          />
+          <StatCard
+            label="Devices"
+            value={status.network.devices}
+            format="number"
+            href="/dz/devices"
+          />
           <StatCard label="Links" value={status.network.links} format="number" href="/dz/links" />
           <StatCard label="Users" value={status.network.users} format="number" href="/dz/users" />
-          <StatCard label="Validators on DZ" value={status.network.validators_on_dz} format="number" href="/solana/validators" />
+          <StatCard
+            label="Validators on DZ"
+            value={status.network.validators_on_dz}
+            format="number"
+            href="/solana/validators"
+          />
           <StatCard label="SOL Connected" value={status.network.total_stake_sol} format="stake" />
           <StatCard label="Stake Share" value={status.network.stake_share_pct} format="percent" />
           <StatCard label="Capacity" value={status.network.bandwidth_bps} format="bandwidth" />
-          <StatCard label="User Inbound" value={status.network.user_inbound_bps} format="bandwidth" decimals={0} />
+          <StatCard
+            label="User Inbound"
+            value={status.network.user_inbound_bps}
+            format="bandwidth"
+            decimals={0}
+          />
         </div>
 
         {/* Utilization Charts */}
@@ -3156,7 +4023,11 @@ export function StatusPage() {
         ) : activeTab === 'devices' ? (
           <DevicesContent status={status} />
         ) : (
-          <MetrosContent criticalLinks={criticalLinks} criticalLinksLoading={criticalLinksLoading} metroNames={metroNames} />
+          <MetrosContent
+            criticalLinks={criticalLinks}
+            criticalLinksLoading={criticalLinksLoading}
+            metroNames={metroNames}
+          />
         )}
       </div>
     </div>

--- a/web/src/components/status-search-bar.tsx
+++ b/web/src/components/status-search-bar.tsx
@@ -42,19 +42,23 @@ export interface StatusFilter {
 
 export function parseStatusFilters(searchParam: string): StatusFilter[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean).map(f => {
-    const [type, ...rest] = f.split(':')
-    const value = rest.join(':')
-    if (type && value && statusEntityTypes.includes(type as SearchEntityType)) {
-      return { type: type as SearchEntityType, value, label: value }
-    }
-    // Plain value without type prefix - treat as device code
-    return { type: 'device' as SearchEntityType, value: f, label: f }
-  })
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .map((f) => {
+      const [type, ...rest] = f.split(':')
+      const value = rest.join(':')
+      if (type && value && statusEntityTypes.includes(type as SearchEntityType)) {
+        return { type: type as SearchEntityType, value, label: value }
+      }
+      // Plain value without type prefix - treat as device code
+      return { type: 'device' as SearchEntityType, value: f, label: f }
+    })
 }
 
 export function serializeStatusFilters(filters: StatusFilter[]): string {
-  return filters.map(f => `${f.type}:${f.value}`).join(',')
+  return filters.map((f) => `${f.type}:${f.value}`).join(',')
 }
 
 // Hook to get current filters for use in other components
@@ -68,21 +72,24 @@ export function useStatusFilters(): StatusFilter[] {
 export function useAddStatusFilter() {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  return useCallback((type: SearchEntityType, value: string, label?: string) => {
-    const currentParam = searchParams.get('filter') || ''
-    const filters = parseStatusFilters(currentParam)
+  return useCallback(
+    (type: SearchEntityType, value: string, label?: string) => {
+      const currentParam = searchParams.get('filter') || ''
+      const filters = parseStatusFilters(currentParam)
 
-    const newFilter: StatusFilter = { type, value, label: label || value }
-    const exists = filters.some(f => f.type === newFilter.type && f.value === newFilter.value)
+      const newFilter: StatusFilter = { type, value, label: label || value }
+      const exists = filters.some((f) => f.type === newFilter.type && f.value === newFilter.value)
 
-    if (!exists) {
-      const newFilters = [...filters, newFilter]
-      setSearchParams(prev => {
-        prev.set('filter', serializeStatusFilters(newFilters))
-        return prev
-      })
-    }
-  }, [searchParams, setSearchParams])
+      if (!exists) {
+        const newFilters = [...filters, newFilter]
+        setSearchParams((prev) => {
+          prev.set('filter', serializeStatusFilters(newFilters))
+          return prev
+        })
+      }
+    },
+    [searchParams, setSearchParams],
+  )
 }
 
 // Inline filter input with autocomplete dropdown for status page
@@ -110,10 +117,17 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
     const value = query.slice(colonIndex + 1).toLowerCase()
     const config = autocompleteConfig[field]
     if (!config) return null
-    return { field, value, entity: config.entity, acField: config.field, minChars: config.minChars }
+    return {
+      field,
+      value,
+      entity: config.entity,
+      acField: config.field,
+      minChars: config.minChars,
+    }
   }, [query])
 
-  const meetsMinChars = fieldValueMatch != null && (fieldValueMatch.value.length >= fieldValueMatch.minChars)
+  const meetsMinChars =
+    fieldValueMatch != null && fieldValueMatch.value.length >= fieldValueMatch.minChars
 
   // Fetch field values when a valid field prefix is detected
   const { data: fieldValuesData, isLoading: fieldValuesLoading } = useQuery({
@@ -128,15 +142,13 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
     if (!fieldValueMatch || !fieldValuesData) return []
     const needle = fieldValueMatch.value
     if (!needle) return fieldValuesData
-    return fieldValuesData.filter(v => v.toLowerCase().includes(needle))
+    return fieldValuesData.filter((v) => v.toLowerCase().includes(needle))
   }, [fieldValueMatch, fieldValuesData])
 
   // Check if query matches any field prefix
   const matchingPrefixes = useMemo(() => {
     if (query.length === 0 || query.includes(':')) return []
-    return fieldPrefixes.filter(p =>
-      p.prefix.toLowerCase().startsWith(query.toLowerCase())
-    )
+    return fieldPrefixes.filter((p) => p.prefix.toLowerCase().startsWith(query.toLowerCase()))
   }, [query])
 
   const showAllPrefixes = query.length === 0 && isFocused
@@ -155,25 +167,31 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
     }
 
     if (filteredFieldValues.length > 0 && fieldValueMatch) {
-      result.push(...filteredFieldValues.map(v => ({
-        type: 'field-value' as const,
-        field: fieldValueMatch.field,
-        value: v,
-      })))
+      result.push(
+        ...filteredFieldValues.map((v) => ({
+          type: 'field-value' as const,
+          field: fieldValueMatch.field,
+          value: v,
+        })),
+      )
     }
 
     if (showAllPrefixes) {
-      result.push(...fieldPrefixes.map(p => ({
-        type: 'prefix' as const,
-        prefix: p.prefix,
-        description: p.description,
-      })))
+      result.push(
+        ...fieldPrefixes.map((p) => ({
+          type: 'prefix' as const,
+          prefix: p.prefix,
+          description: p.description,
+        })),
+      )
     } else if (matchingPrefixes.length > 0 && filteredFieldValues.length === 0) {
-      result.push(...matchingPrefixes.map(p => ({
-        type: 'prefix' as const,
-        prefix: p.prefix,
-        description: p.description,
-      })))
+      result.push(
+        ...matchingPrefixes.map((p) => ({
+          type: 'prefix' as const,
+          prefix: p.prefix,
+          description: p.description,
+        })),
+      )
     }
 
     return result
@@ -184,57 +202,63 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
     setSelectedIndex(-1)
   }, [debouncedQuery, matchingPrefixes.length, showAllPrefixes])
 
-  const commitFieldValue = useCallback((field: string, value: string) => {
-    onCommit(field, value)
-    setQuery('')
-    inputRef.current?.focus()
-  }, [onCommit])
+  const commitFieldValue = useCallback(
+    (field: string, value: string) => {
+      onCommit(field, value)
+      setQuery('')
+      inputRef.current?.focus()
+    },
+    [onCommit],
+  )
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const isDropdownOpen = isFocused && items.length > 0
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const isDropdownOpen = isFocused && items.length > 0
 
-    switch (e.key) {
-      case 'ArrowDown':
-        if (isDropdownOpen) {
-          e.preventDefault()
-          setSelectedIndex(prev => Math.min(prev + 1, items.length - 1))
-        }
-        break
-      case 'ArrowUp':
-        if (isDropdownOpen) {
-          e.preventDefault()
-          setSelectedIndex(prev => Math.max(prev - 1, -1))
-        }
-        break
-      case 'Enter': {
-        e.preventDefault()
-        const indexToUse = selectedIndex >= 0 ? selectedIndex : 0
-        if (indexToUse < items.length) {
-          const item = items[indexToUse]
-          if (item.type === 'prefix') {
-            setQuery(item.prefix)
-          } else if (item.type === 'field-value') {
-            commitFieldValue(item.field, item.value)
-          }
-        }
-        break
-      }
-      case 'Tab':
-        if (selectedIndex >= 0 && selectedIndex < items.length) {
-          const item = items[selectedIndex]
-          if (item.type === 'prefix') {
+      switch (e.key) {
+        case 'ArrowDown':
+          if (isDropdownOpen) {
             e.preventDefault()
-            setQuery(item.prefix)
+            setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1))
           }
+          break
+        case 'ArrowUp':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.max(prev - 1, -1))
+          }
+          break
+        case 'Enter': {
+          e.preventDefault()
+          const indexToUse = selectedIndex >= 0 ? selectedIndex : 0
+          if (indexToUse < items.length) {
+            const item = items[indexToUse]
+            if (item.type === 'prefix') {
+              setQuery(item.prefix)
+            } else if (item.type === 'field-value') {
+              commitFieldValue(item.field, item.value)
+            }
+          }
+          break
         }
-        break
-      case 'Escape':
-        e.preventDefault()
-        setQuery('')
-        inputRef.current?.blur()
-        break
-    }
-  }, [items, selectedIndex, commitFieldValue, isFocused])
+        case 'Tab':
+          if (selectedIndex >= 0 && selectedIndex < items.length) {
+            const item = items[selectedIndex]
+            if (item.type === 'prefix') {
+              e.preventDefault()
+              setQuery(item.prefix)
+            }
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          setQuery('')
+          inputRef.current?.blur()
+          break
+      }
+    },
+    [items, selectedIndex, commitFieldValue, isFocused],
+  )
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -250,7 +274,7 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
   const showDropdown = isFocused && items.length > 0
 
   return (
-    <div ref={containerRef} className="relative">
+    <div ref={containerRef} className="relative w-full">
       <div className="flex items-center gap-1.5 px-2 py-1 text-xs border border-border rounded-md bg-background hover:bg-muted/50 focus-within:ring-1 focus-within:ring-ring transition-colors">
         <Search className="h-3 w-3 text-muted-foreground flex-shrink-0" />
         <input
@@ -261,11 +285,9 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
           onKeyDown={handleKeyDown}
           onFocus={() => setIsFocused(true)}
           placeholder="Filter..."
-          className="w-28 bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-xs"
+          className="bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-xs w-full"
         />
-        {fieldValuesLoading && (
-          <Loader2 className="h-3 w-3 text-muted-foreground animate-spin" />
-        )}
+        {fieldValuesLoading && <Loader2 className="h-3 w-3 text-muted-foreground animate-spin" />}
       </div>
 
       {showDropdown && (
@@ -280,10 +302,7 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
           {items.map((item, index) => {
             if (item.type === 'type-more') {
               return (
-                <div
-                  key="type-more"
-                  className="px-3 py-2 text-xs text-muted-foreground"
-                >
+                <div key="type-more" className="px-3 py-2 text-xs text-muted-foreground">
                   Type at least {item.minChars} characters to see suggestions
                 </div>
               )
@@ -296,7 +315,7 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
                   onClick={() => commitFieldValue(item.field, item.value)}
                   className={cn(
                     'w-full flex items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted transition-colors',
-                    index === selectedIndex && 'bg-muted'
+                    index === selectedIndex && 'bg-muted',
                   )}
                 >
                   <span className="flex-1 truncate">{item.value}</span>
@@ -317,7 +336,7 @@ function StatusInlineFilter({ onCommit }: { onCommit: (type: string, value: stri
                   }}
                   className={cn(
                     'w-full flex flex-col gap-0.5 px-3 py-2 text-left text-xs hover:bg-muted transition-colors',
-                    index === selectedIndex && 'bg-muted'
+                    index === selectedIndex && 'bg-muted',
                   )}
                 >
                   <div className="flex items-center gap-2">
@@ -349,40 +368,52 @@ export function StatusFilters({ className }: StatusFiltersProps) {
   const searchParam = searchParams.get('filter') || ''
   const filters = parseStatusFilters(searchParam)
 
-  const removeFilter = useCallback((filterToRemove: StatusFilter) => {
-    const newFilters = filters.filter(f => !(f.type === filterToRemove.type && f.value === filterToRemove.value))
-    setSearchParams(prev => {
-      if (newFilters.length === 0) {
-        prev.delete('filter')
-      } else {
-        prev.set('filter', serializeStatusFilters(newFilters))
-      }
-      return prev
-    })
-  }, [filters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: StatusFilter) => {
+      const newFilters = filters.filter(
+        (f) => !(f.type === filterToRemove.type && f.value === filterToRemove.value),
+      )
+      setSearchParams((prev) => {
+        if (newFilters.length === 0) {
+          prev.delete('filter')
+        } else {
+          prev.set('filter', serializeStatusFilters(newFilters))
+        }
+        return prev
+      })
+    },
+    [filters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       prev.delete('filter')
       return prev
     })
   }, [setSearchParams])
 
-  const addFilter = useCallback((type: string, value: string) => {
-    const newFilter: StatusFilter = { type: type as SearchEntityType, value, label: value }
-    const exists = filters.some(f => f.type === newFilter.type && f.value === newFilter.value)
-    if (!exists) {
-      const newFilters = [...filters, newFilter]
-      setSearchParams(prev => {
-        prev.set('filter', serializeStatusFilters(newFilters))
-        return prev
-      })
-    }
-  }, [filters, setSearchParams])
+  const addFilter = useCallback(
+    (type: string, value: string) => {
+      const newFilter: StatusFilter = {
+        type: type as SearchEntityType,
+        value,
+        label: value,
+      }
+      const exists = filters.some((f) => f.type === newFilter.type && f.value === newFilter.value)
+      if (!exists) {
+        const newFilters = [...filters, newFilter]
+        setSearchParams((prev) => {
+          prev.set('filter', serializeStatusFilters(newFilters))
+          return prev
+        })
+      }
+    },
+    [filters, setSearchParams],
+  )
 
   return (
     <div className={className}>
-      <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex items-center gap-2 flex-wrap w-full">
         {/* Filter tags */}
         {filters.map((filter, idx) => {
           const Icon = entityIcons[filter.type] || Server

--- a/web/src/components/timeline-filters.tsx
+++ b/web/src/components/timeline-filters.tsx
@@ -43,6 +43,7 @@ import {
   DEFAULT_ENTITY_TYPES,
   presets,
 } from './timeline-constants'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 const minStakeOptions: { value: MinStakeOption; label: string }[] = [
   { value: '0', label: 'Any' },
@@ -134,9 +135,9 @@ function FilterDropdown<T extends string>({
     }
   }, [open])
 
-  const allSelected = allValues.every(v => selected.has(v))
-  const noneSelected = allValues.every(v => !selected.has(v))
-  const selectedCount = allValues.filter(v => selected.has(v)).length
+  const allSelected = allValues.every((v) => selected.has(v))
+  const noneSelected = allValues.every((v) => !selected.has(v))
+  const selectedCount = allValues.filter((v) => selected.has(v)).length
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -146,7 +147,7 @@ function FilterDropdown<T extends string>({
           'flex items-center gap-1.5 px-2 py-1 text-xs rounded-md border transition-colors',
           open || (!allSelected && !noneSelected)
             ? 'bg-background border-border text-foreground'
-            : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50'
+            : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50',
         )}
       >
         <span className="uppercase tracking-wide">{label}</span>
@@ -160,7 +161,7 @@ function FilterDropdown<T extends string>({
 
       {open && (
         <div className="absolute top-full left-0 mt-1 z-50 min-w-[160px] bg-popover border border-border rounded-md shadow-lg py-1 whitespace-nowrap">
-          {options.map(option => {
+          {options.map((option) => {
             const Icon = option.icon
             const isSelected = selected.has(option.value)
             return (
@@ -169,14 +170,18 @@ function FilterDropdown<T extends string>({
                 onClick={() => onToggle(option.value)}
                 className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted transition-colors"
               >
-                <div className={cn(
-                  'w-3.5 h-3.5 rounded border flex items-center justify-center',
-                  isSelected ? 'bg-primary border-primary' : 'border-muted-foreground/30'
-                )}>
+                <div
+                  className={cn(
+                    'w-3.5 h-3.5 rounded border flex items-center justify-center',
+                    isSelected ? 'bg-primary border-primary' : 'border-muted-foreground/30',
+                  )}
+                >
                   {isSelected && <CheckCircle2 className="h-2.5 w-2.5 text-primary-foreground" />}
                 </div>
                 {Icon && <Icon className="h-3 w-3 text-muted-foreground" />}
-                <span className={isSelected ? 'text-foreground' : 'text-muted-foreground'}>{option.label}</span>
+                <span className={isSelected ? 'text-foreground' : 'text-muted-foreground'}>
+                  {option.label}
+                </span>
               </button>
             )
           })}
@@ -193,7 +198,7 @@ function PresetsDropdown({
   onResetAll,
 }: {
   searchParams: URLSearchParams
-  onApplyPreset: (preset: typeof presets[0]) => void
+  onApplyPreset: (preset: (typeof presets)[0]) => void
   onResetAll: () => void
 }) {
   const [open, setOpen] = useState(false)
@@ -211,9 +216,12 @@ function PresetsDropdown({
     }
   }, [open])
 
-  const activePreset = presets.find(preset =>
-    Object.entries(preset.params).every(([k, v]) => searchParams.get(k) === v) &&
-    [...searchParams.keys()].filter(k => k !== 'search' && k !== 'internal' && k !== 'start' && k !== 'end').every(k => k in preset.params)
+  const activePreset = presets.find(
+    (preset) =>
+      Object.entries(preset.params).every(([k, v]) => searchParams.get(k) === v) &&
+      [...searchParams.keys()]
+        .filter((k) => k !== 'search' && k !== 'internal' && k !== 'start' && k !== 'end')
+        .every((k) => k in preset.params),
   )
 
   return (
@@ -224,7 +232,7 @@ function PresetsDropdown({
           'flex items-center gap-1.5 px-2.5 py-1 text-sm rounded-md border transition-colors',
           activePreset
             ? 'bg-primary text-primary-foreground border-primary'
-            : 'border-border text-muted-foreground hover:text-foreground bg-background'
+            : 'border-border text-muted-foreground hover:text-foreground bg-background',
         )}
       >
         <span>{activePreset ? activePreset.label : 'Presets'}</span>
@@ -232,7 +240,7 @@ function PresetsDropdown({
       </button>
       {open && (
         <div className="absolute top-full left-0 mt-1 z-50 min-w-[200px] bg-popover border border-border rounded-md shadow-lg py-1 whitespace-nowrap">
-          {presets.map(preset => {
+          {presets.map((preset) => {
             const isActive = preset === activePreset
             return (
               <button
@@ -247,7 +255,7 @@ function PresetsDropdown({
                 }}
                 className={cn(
                   'w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted transition-colors',
-                  isActive ? 'text-foreground font-medium' : 'text-muted-foreground'
+                  isActive ? 'text-foreground font-medium' : 'text-muted-foreground',
                 )}
               >
                 {isActive && <Check className="h-3.5 w-3.5 text-primary" />}
@@ -282,7 +290,11 @@ function countActiveAdvancedFilters({
   if (selectedCategories.size !== ALL_CATEGORIES.length) count++
   if (selectedActions.size !== ALL_ACTIONS.length) count++
   const defaultEntitySet = new Set(DEFAULT_ENTITY_TYPES)
-  if (selectedEntityTypes.size !== defaultEntitySet.size || !DEFAULT_ENTITY_TYPES.every(e => selectedEntityTypes.has(e))) count++
+  if (
+    selectedEntityTypes.size !== defaultEntitySet.size ||
+    !DEFAULT_ENTITY_TYPES.every((e) => selectedEntityTypes.has(e))
+  )
+    count++
   if (dzFilter !== 'on_dz') count++
   if (minStake !== '0') count++
   if (includeInternal) count++
@@ -300,7 +312,10 @@ const searchFieldPrefixes = [
   { prefix: 'user:', description: 'Filter by user pubkey' },
 ]
 
-const searchAutocompleteConfig: Record<string, { entity: string; field: string; minChars: number }> = {
+const searchAutocompleteConfig: Record<
+  string,
+  { entity: string; field: string; minChars: number }
+> = {
   device: { entity: 'devices', field: 'code', minChars: 2 },
   link: { entity: 'links', field: 'code', minChars: 2 },
   metro: { entity: 'devices', field: 'metro', minChars: 0 },
@@ -332,7 +347,8 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
     return { field, value, entity: config.entity, acField: config.field, minChars: config.minChars }
   }, [query])
 
-  const meetsMinChars = fieldValueMatch != null && (fieldValueMatch.value.length >= fieldValueMatch.minChars)
+  const meetsMinChars =
+    fieldValueMatch != null && fieldValueMatch.value.length >= fieldValueMatch.minChars
 
   const { data: fieldValuesData, isLoading: fieldValuesLoading } = useQuery({
     queryKey: ['field-values', fieldValueMatch?.entity, fieldValueMatch?.acField],
@@ -345,14 +361,12 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
     if (!fieldValueMatch || !fieldValuesData) return []
     const needle = fieldValueMatch.value
     if (!needle) return fieldValuesData
-    return fieldValuesData.filter(v => v.toLowerCase().includes(needle))
+    return fieldValuesData.filter((v) => v.toLowerCase().includes(needle))
   }, [fieldValueMatch, fieldValuesData])
 
   const matchingPrefixes = useMemo(() => {
     if (query.length === 0 || query.includes(':')) return []
-    return searchFieldPrefixes.filter(p =>
-      p.prefix.toLowerCase().startsWith(query.toLowerCase())
-    )
+    return searchFieldPrefixes.filter((p) => p.prefix.toLowerCase().startsWith(query.toLowerCase()))
   }, [query])
 
   const showAllPrefixes = query.length === 0 && isFocused
@@ -370,79 +384,108 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
     }
 
     if (filteredFieldValues.length > 0 && fieldValueMatch) {
-      result.push(...filteredFieldValues.map(v => ({
-        type: 'field-value' as const,
-        field: fieldValueMatch.field,
-        value: v,
-      })))
+      result.push(
+        ...filteredFieldValues.map((v) => ({
+          type: 'field-value' as const,
+          field: fieldValueMatch.field,
+          value: v,
+        })),
+      )
     }
 
     if (showAllPrefixes) {
-      result.push(...searchFieldPrefixes.map(p => ({
-        type: 'prefix' as const,
-        prefix: p.prefix,
-        description: p.description,
-      })))
+      result.push(
+        ...searchFieldPrefixes.map((p) => ({
+          type: 'prefix' as const,
+          prefix: p.prefix,
+          description: p.description,
+        })),
+      )
     } else if (matchingPrefixes.length > 0 && filteredFieldValues.length === 0) {
-      result.push(...matchingPrefixes.map(p => ({
-        type: 'prefix' as const,
-        prefix: p.prefix,
-        description: p.description,
-      })))
+      result.push(
+        ...matchingPrefixes.map((p) => ({
+          type: 'prefix' as const,
+          prefix: p.prefix,
+          description: p.description,
+        })),
+      )
     }
 
     return result
-  }, [query, filteredFieldValues, fieldValueMatch, showAllPrefixes, matchingPrefixes, meetsMinChars])
+  }, [
+    query,
+    filteredFieldValues,
+    fieldValueMatch,
+    showAllPrefixes,
+    matchingPrefixes,
+    meetsMinChars,
+  ])
 
   useEffect(() => {
     setSelectedIndex(-1)
   }, [debouncedQuery, matchingPrefixes.length, showAllPrefixes])
 
-  const commitFilter = useCallback((value: string) => {
-    onCommit(value)
-    setQuery('')
-    inputRef.current?.focus()
-  }, [onCommit])
+  const commitFilter = useCallback(
+    (value: string) => {
+      onCommit(value)
+      setQuery('')
+      inputRef.current?.focus()
+    },
+    [onCommit],
+  )
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const isDropdownOpen = isFocused && items.length > 0
-    switch (e.key) {
-      case 'ArrowDown':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.min(prev + 1, items.length - 1)) }
-        break
-      case 'ArrowUp':
-        if (isDropdownOpen) { e.preventDefault(); setSelectedIndex(prev => Math.max(prev - 1, -1)) }
-        break
-      case 'Enter': {
-        e.preventDefault()
-        const idx = selectedIndex >= 0 ? selectedIndex : 0
-        if (idx < items.length) {
-          const item = items[idx]
-          if (item.type === 'prefix') {
-            setQuery(item.prefix)
-          } else if (item.type === 'field-value') {
-            commitFilter(`${item.field}:${item.value}`)
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const isDropdownOpen = isFocused && items.length > 0
+      switch (e.key) {
+        case 'ArrowDown':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1))
           }
+          break
+        case 'ArrowUp':
+          if (isDropdownOpen) {
+            e.preventDefault()
+            setSelectedIndex((prev) => Math.max(prev - 1, -1))
+          }
+          break
+        case 'Enter': {
+          e.preventDefault()
+          const idx = selectedIndex >= 0 ? selectedIndex : 0
+          if (idx < items.length) {
+            const item = items[idx]
+            if (item.type === 'prefix') {
+              setQuery(item.prefix)
+            } else if (item.type === 'field-value') {
+              commitFilter(`${item.field}:${item.value}`)
+            }
+          }
+          break
         }
-        break
+        case 'Tab':
+          if (selectedIndex >= 0 && selectedIndex < items.length) {
+            const item = items[selectedIndex]
+            if (item.type === 'prefix') {
+              e.preventDefault()
+              setQuery(item.prefix)
+            }
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          setQuery('')
+          inputRef.current?.blur()
+          break
       }
-      case 'Tab':
-        if (selectedIndex >= 0 && selectedIndex < items.length) {
-          const item = items[selectedIndex]
-          if (item.type === 'prefix') { e.preventDefault(); setQuery(item.prefix) }
-        }
-        break
-      case 'Escape':
-        e.preventDefault()
-        setQuery('')
-        inputRef.current?.blur()
-        break
-    }
-  }, [items, selectedIndex, query, commitFilter, isFocused])
+    },
+    [items, selectedIndex, query, commitFilter, isFocused],
+  )
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setIsFocused(false)
+      if (containerRef.current && !containerRef.current.contains(e.target as Node))
+        setIsFocused(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -464,7 +507,9 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
           placeholder="Search..."
           className="w-28 bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-sm"
         />
-        {fieldValuesLoading && <Loader2 className="h-3.5 w-3.5 text-muted-foreground animate-spin" />}
+        {fieldValuesLoading && (
+          <Loader2 className="h-3.5 w-3.5 text-muted-foreground animate-spin" />
+        )}
       </div>
 
       {showDropdown && (
@@ -492,11 +537,13 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
                   onClick={() => commitFilter(`${item.field}:${item.value}`)}
                   className={cn(
                     'w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted transition-colors',
-                    index === selectedIndex && 'bg-muted'
+                    index === selectedIndex && 'bg-muted',
                   )}
                 >
                   <span className="flex-1 truncate">{item.value}</span>
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{item.field}</span>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                    {item.field}
+                  </span>
                 </button>
               )
             }
@@ -505,15 +552,20 @@ function TimelineSearchInput({ onCommit }: { onCommit: (filter: string) => void 
               return (
                 <button
                   key={item.prefix}
-                  onClick={() => { setQuery(item.prefix); inputRef.current?.focus() }}
+                  onClick={() => {
+                    setQuery(item.prefix)
+                    inputRef.current?.focus()
+                  }}
                   className={cn(
                     'w-full flex flex-col gap-0.5 px-3 py-2 text-left text-sm hover:bg-muted transition-colors',
-                    index === selectedIndex && 'bg-muted'
+                    index === selectedIndex && 'bg-muted',
                   )}
                 >
                   <div className="flex items-center gap-2">
                     <span className="font-medium">{item.prefix.slice(0, -1)}</span>
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">filter</span>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                      filter
+                    </span>
                   </div>
                   <span className="text-xs text-muted-foreground">{item.description}</span>
                 </button>
@@ -552,7 +604,7 @@ export interface TimelineFiltersProps {
   onCustomEndChange: (value: string) => void
   onRefetch: () => void
   onResetAll: () => void
-  onApplyPreset: (preset: typeof presets[0]) => void
+  onApplyPreset: (preset: (typeof presets)[0]) => void
   searchFilters: string[]
   onAddSearchFilter: (filter: string) => void
   onRemoveSearchFilter: (filter: string) => void
@@ -591,7 +643,7 @@ export function TimelineFilters({
 }: TimelineFiltersProps) {
   const [advancedOpen, setAdvancedOpen] = useState(false)
 
-  const hasSolanaEntities = ALL_SOLANA_ENTITIES.some(e => selectedEntityTypes.has(e))
+  const hasSolanaEntities = ALL_SOLANA_ENTITIES.some((e) => selectedEntityTypes.has(e))
   const maxDate = new Date().toISOString().slice(0, 16)
 
   const activeAdvancedCount = countActiveAdvancedFilters({
@@ -616,7 +668,7 @@ export function TimelineFilters({
       <div className="flex items-center gap-3">
         {/* Time range segmented control */}
         <div className="inline-flex rounded-md border border-border bg-background p-0.5">
-          {timeRangeOptions.map(option => (
+          {timeRangeOptions.map((option) => (
             <button
               key={option.value}
               onClick={() => onTimeRangeChange(option.value)}
@@ -624,7 +676,7 @@ export function TimelineFilters({
                 'px-2.5 py-1 text-sm rounded transition-colors',
                 timeRange === option.value
                   ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
               )}
             >
               {option.label}
@@ -657,7 +709,11 @@ export function TimelineFilters({
         <div className="flex-1" />
 
         {/* Presets dropdown */}
-        <PresetsDropdown searchParams={searchParams} onApplyPreset={onApplyPreset} onResetAll={onResetAll} />
+        <PresetsDropdown
+          searchParams={searchParams}
+          onApplyPreset={onApplyPreset}
+          onResetAll={onResetAll}
+        />
 
         {/* Inline search */}
         <TimelineSearchInput onCommit={onAddSearchFilter} />
@@ -680,7 +736,14 @@ export function TimelineFilters({
             const colonIdx = filter.indexOf(':')
             const field = colonIdx > 0 ? filter.slice(0, colonIdx).toLowerCase() : ''
             const value = colonIdx > 0 ? filter.slice(colonIdx + 1) : filter
-            const fieldIcons: Record<string, React.ElementType> = { device: Server, link: Link2, metro: MapPin, contributor: Building2, validator: Landmark, user: Users }
+            const fieldIcons: Record<string, React.ElementType> = {
+              device: Server,
+              link: Link2,
+              metro: MapPin,
+              contributor: Building2,
+              validator: Landmark,
+              user: Users,
+            }
             const Icon = fieldIcons[field] || Search
             return (
               <button
@@ -724,7 +787,9 @@ export function TimelineFilters({
         <div
           className={cn(
             'transition-[max-height,opacity] duration-200',
-            advancedOpen ? 'max-h-[200px] opacity-100 mt-2 overflow-visible' : 'max-h-0 opacity-0 overflow-hidden'
+            advancedOpen
+              ? 'max-h-[200px] opacity-100 mt-2 overflow-visible'
+              : 'max-h-0 opacity-0 overflow-hidden',
           )}
         >
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-border bg-muted/20 p-3">
@@ -764,7 +829,7 @@ export function TimelineFilters({
 
             {hasSolanaEntities && (
               <div className="inline-flex rounded-md border border-border bg-background p-0.5 gap-0.5">
-                {dzFilterOptions.map(option => (
+                {dzFilterOptions.map((option) => (
                   <button
                     key={option.value}
                     onClick={() => onDzFilterChange(option.value)}
@@ -772,7 +837,7 @@ export function TimelineFilters({
                       'px-2 py-0.5 text-xs rounded transition-colors',
                       dzFilter === option.value
                         ? 'bg-primary text-primary-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
+                        : 'text-muted-foreground hover:text-foreground',
                     )}
                   >
                     {option.label}
@@ -783,16 +848,14 @@ export function TimelineFilters({
 
             {hasSolanaEntities && (
               <div className="flex items-center gap-1.5">
-                <span className="text-xs text-muted-foreground uppercase tracking-wide">DZ Stake Change</span>
-                <select
+                <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                  DZ Stake Change
+                </span>
+                <SmallDropdown
                   value={minStake}
-                  onChange={(e) => onMinStakeChange(e.target.value as MinStakeOption)}
-                  className="px-2 py-0.5 text-xs rounded-md border border-border bg-background text-foreground cursor-pointer"
-                >
-                  {minStakeOptions.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                  ))}
-                </select>
+                  options={minStakeOptions}
+                  onChange={(v) => onMinStakeChange(v as MinStakeOption)}
+                />
               </div>
             )}
 
@@ -803,14 +866,18 @@ export function TimelineFilters({
               className="inline-flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               <span>Internal users</span>
-              <div className={cn(
-                'relative w-7 h-4 rounded-full transition-colors',
-                includeInternal ? 'bg-primary' : 'bg-muted-foreground/30'
-              )}>
-                <div className={cn(
-                  'absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform',
-                  includeInternal ? 'translate-x-3.5' : 'translate-x-0.5'
-                )} />
+              <div
+                className={cn(
+                  'relative w-7 h-4 rounded-full transition-colors',
+                  includeInternal ? 'bg-primary' : 'bg-muted-foreground/30',
+                )}
+              >
+                <div
+                  className={cn(
+                    'absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform',
+                    includeInternal ? 'translate-x-3.5' : 'translate-x-0.5',
+                  )}
+                />
               </div>
             </button>
 
@@ -821,7 +888,7 @@ export function TimelineFilters({
                 'inline-flex items-center gap-1 text-xs transition-colors',
                 hasActiveFilters
                   ? 'text-muted-foreground hover:text-foreground cursor-pointer'
-                  : 'text-muted-foreground/40 cursor-not-allowed'
+                  : 'text-muted-foreground/40 cursor-not-allowed',
               )}
             >
               <RotateCw className="h-3 w-3" />

--- a/web/src/components/topology/TimeRangeSelector.tsx
+++ b/web/src/components/topology/TimeRangeSelector.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { ChevronDown } from 'lucide-react'
 import type { TimeRange, TimeRangePreset, BucketSize, TrafficMetric, TrafficView } from './utils'
 import { bucketLabels, TIME_RANGE_OPTIONS } from './utils'
 
-
 const BUCKET_OPTIONS: { value: BucketSize; label: string }[] = Object.entries(bucketLabels).map(
-  ([value, label]) => ({ value: value as BucketSize, label })
+  ([value, label]) => ({ value: value as BucketSize, label }),
 )
 
 const METRIC_OPTIONS: { value: TrafficMetric; label: string }[] = [
@@ -27,7 +27,7 @@ function cn(...classes: (string | false | undefined)[]) {
   return classes.filter(Boolean).join(' ')
 }
 
-function SmallDropdown<T extends string>({
+export function SmallDropdown<T extends string>({
   value,
   displayLabel,
   options,
@@ -39,38 +39,69 @@ function SmallDropdown<T extends string>({
   onChange: (v: T) => void
 }) {
   const [isOpen, setIsOpen] = useState(false)
-  const selectedLabel = displayLabel ?? options.find(o => o.value === value)?.label ?? value
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({} as React.CSSProperties)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const selectedLabel = displayLabel ?? options.find((o) => o.value === value)?.label ?? value
+
+  const handleOpen = () => {
+    if (!isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect()
+      const margin = 8
+      const onRightHalf = rect.left > window.innerWidth / 2
+      setMenuStyle(
+        onRightHalf
+          ? {
+              position: 'fixed',
+              top: rect.bottom + 4,
+              right: Math.max(margin, window.innerWidth - rect.right),
+            }
+          : {
+              position: 'fixed',
+              top: rect.bottom + 4,
+              left: Math.max(margin, rect.left),
+            },
+      )
+    }
+    setIsOpen(!isOpen)
+  }
 
   return (
     <div className="relative inline-block">
       <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 px-2 py-1 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors"
+        ref={buttonRef}
+        onClick={handleOpen}
+        className="flex w-full! items-center gap-1 px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors"
       >
         <span>{selectedLabel}</span>
         <ChevronDown className="h-3 w-3 text-muted-foreground" />
       </button>
-      {isOpen && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 top-full mt-1 z-50 bg-popover border border-border rounded-md shadow-lg py-1 min-w-[120px]">
-            {options.map(opt => (
-              <button
-                key={opt.value}
-                onClick={() => { onChange(opt.value); setIsOpen(false) }}
-                className={cn(
-                  'w-full text-left px-3 py-1.5 text-xs transition-colors',
-                  opt.value === value
-                    ? 'bg-accent text-accent-foreground'
-                    : 'hover:bg-muted'
-                )}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
+      {isOpen &&
+        createPortal(
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+            <div
+              style={menuStyle}
+              className="z-50 bg-popover border border-border rounded-md shadow-lg py-1"
+            >
+              {options.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => {
+                    onChange(opt.value)
+                    setIsOpen(false)
+                  }}
+                  className={cn(
+                    'block w-full min-w-24 text-left px-3 py-1.5 text-xs whitespace-nowrap transition-colors',
+                    opt.value === value ? 'bg-accent text-accent-foreground' : 'hover:bg-muted',
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </>,
+          document.body,
+        )}
     </div>
   )
 }
@@ -104,15 +135,11 @@ export function TimeRangeSelector({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <select
+        <SmallDropdown
           value={value.preset}
-          onChange={(e) => handlePresetChange(e.target.value)}
-          className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-        >
-          {TIME_RANGE_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
+          options={TIME_RANGE_OPTIONS as { value: string; label: string }[]}
+          onChange={handlePresetChange}
+        />
       </div>
       {showCustom && (
         <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -167,9 +194,8 @@ export function TrafficFilters({
   trafficView?: TrafficView
   onTrafficViewChange?: (view: TrafficView) => void
 }) {
-  const bucketDisplayLabel = bucket === 'auto' && effectiveBucketLabel
-    ? `Auto (${effectiveBucketLabel})`
-    : undefined
+  const bucketDisplayLabel =
+    bucket === 'auto' && effectiveBucketLabel ? `Auto (${effectiveBucketLabel})` : undefined
 
   return (
     <div className="flex items-center gap-2">
@@ -182,11 +208,7 @@ export function TrafficFilters({
         />
       )}
       {metric && onMetricChange && (
-        <SmallDropdown
-          value={metric}
-          options={METRIC_OPTIONS}
-          onChange={onMetricChange}
-        />
+        <SmallDropdown value={metric} options={METRIC_OPTIONS} onChange={onMetricChange} />
       )}
       {trafficView && onTrafficViewChange && (
         <SmallDropdown

--- a/web/src/components/topology/modes/PathModePanel.tsx
+++ b/web/src/components/topology/modes/PathModePanel.tsx
@@ -3,19 +3,20 @@ import type { MultiPathResponse, SinglePath } from '@/lib/api'
 import { useTheme } from '@/hooks/use-theme'
 import { DeviceSelector, type DeviceOption } from '../DeviceSelector'
 import { cn } from '@/lib/utils'
+import { SmallDropdown } from '../TimeRangeSelector'
 
 // Path colors for K-shortest paths visualization
 const PATH_COLORS = [
-  { light: '#16a34a', dark: '#22c55e' },  // green
-  { light: '#2563eb', dark: '#3b82f6' },  // blue
-  { light: '#9333ea', dark: '#a855f7' },  // purple
-  { light: '#ea580c', dark: '#f97316' },  // orange
-  { light: '#0891b2', dark: '#06b6d4' },  // cyan
-  { light: '#dc2626', dark: '#ef4444' },  // red
-  { light: '#ca8a04', dark: '#eab308' },  // yellow
-  { light: '#db2777', dark: '#ec4899' },  // pink
-  { light: '#059669', dark: '#10b981' },  // emerald
-  { light: '#7c3aed', dark: '#8b5cf6' },  // violet
+  { light: '#16a34a', dark: '#22c55e' }, // green
+  { light: '#2563eb', dark: '#3b82f6' }, // blue
+  { light: '#9333ea', dark: '#a855f7' }, // purple
+  { light: '#ea580c', dark: '#f97316' }, // orange
+  { light: '#0891b2', dark: '#06b6d4' }, // cyan
+  { light: '#dc2626', dark: '#ef4444' }, // red
+  { light: '#ca8a04', dark: '#eab308' }, // yellow
+  { light: '#db2777', dark: '#ec4899' }, // pink
+  { light: '#059669', dark: '#10b981' }, // emerald
+  { light: '#7c3aed', dark: '#8b5cf6' }, // violet
 ]
 
 interface PathModePanelProps {
@@ -63,8 +64,8 @@ export function PathModePanel({
   const isDark = resolvedTheme === 'dark'
 
   // Get source and target device codes for labels
-  const sourceDevice = devices.find(d => d.pk === pathSource)
-  const targetDevice = devices.find(d => d.pk === pathTarget)
+  const sourceDevice = devices.find((d) => d.pk === pathSource)
+  const targetDevice = devices.find((d) => d.pk === pathTarget)
 
   // Pick which result set to show based on reverse toggle
   const activeResult = showReverse ? reversePathsResult : pathsResult
@@ -84,7 +85,11 @@ export function PathModePanel({
           Device Paths
         </span>
         {(pathSource || pathTarget) && (
-          <button onClick={onClearPath} className="p-1 hover:bg-[var(--muted)] rounded" title="Clear path">
+          <button
+            onClick={onClearPath}
+            className="p-1 hover:bg-[var(--muted)] rounded"
+            title="Clear path"
+          >
             <X className="h-3 w-3" />
           </button>
         )}
@@ -101,7 +106,7 @@ export function PathModePanel({
           labelColor="#22c55e"
         />
         <DeviceSelector
-          devices={devices.filter(d => d.pk !== pathSource)}
+          devices={devices.filter((d) => d.pk !== pathSource)}
           value={pathTarget}
           onChange={onSetTarget}
           placeholder="Search target device..."
@@ -127,7 +132,7 @@ export function PathModePanel({
               'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] transition-colors',
               showReverse
                 ? 'bg-primary/15 text-primary'
-                : 'text-muted-foreground hover:text-foreground hover:bg-[var(--muted)]'
+                : 'text-muted-foreground hover:text-foreground hover:bg-[var(--muted)]',
             )}
             title={showReverse ? 'Show forward path' : 'Show reverse path'}
           >
@@ -137,9 +142,7 @@ export function PathModePanel({
         </div>
       )}
 
-      {activeLoading && (
-        <div className="text-muted-foreground">Finding paths...</div>
-      )}
+      {activeLoading && <div className="text-muted-foreground">Finding paths...</div>}
 
       {/* Path results */}
       {activeResult && !activeResult.error && activeResult.paths.length > 0 && (
@@ -149,15 +152,14 @@ export function PathModePanel({
             <div className="mb-3">
               <div className="flex items-center gap-1.5 text-muted-foreground mb-1">
                 <span>Showing</span>
-                <select
-                  value={pathK}
-                  onChange={e => onPathKChange(Number(e.target.value))}
-                  className="bg-muted text-foreground rounded px-1 py-0.5 text-[10px] border border-[var(--border)]"
-                >
-                  {[3, 5, 10, 15, 20, 25].map(n => (
-                    <option key={n} value={n}>{n}</option>
-                  ))}
-                </select>
+                <SmallDropdown
+                  value={String(pathK)}
+                  options={[3, 5, 10, 15, 20, 25].map((n) => ({
+                    value: String(n),
+                    label: String(n),
+                  }))}
+                  onChange={(v) => onPathKChange(Number(v))}
+                />
               </div>
               <div className="flex flex-wrap gap-1">
                 {activeResult.paths.map((_, i) => (
@@ -168,7 +170,7 @@ export function PathModePanel({
                       'px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors',
                       activeSelectedIndex === i
                         ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted hover:bg-muted/80 text-muted-foreground'
+                        : 'bg-muted hover:bg-muted/80 text-muted-foreground',
                     )}
                     style={{
                       borderLeft: `3px solid ${isDark ? PATH_COLORS[i % PATH_COLORS.length].dark : PATH_COLORS[i % PATH_COLORS.length].light}`,
@@ -183,17 +185,12 @@ export function PathModePanel({
 
           {/* Selected path stepper */}
           {activeResult.paths[activeSelectedIndex] && (
-            <PathStepper
-              path={activeResult.paths[activeSelectedIndex]}
-              isReverse={showReverse}
-            />
+            <PathStepper path={activeResult.paths[activeSelectedIndex]} isReverse={showReverse} />
           )}
         </div>
       )}
 
-      {activeResult?.error && (
-        <div className="text-destructive">{activeResult.error}</div>
-      )}
+      {activeResult?.error && <div className="text-destructive">{activeResult.error}</div>}
     </div>
   )
 }
@@ -210,7 +207,9 @@ function PathStepper({ path, isReverse }: { path: SinglePath; isReverse: boolean
         <span>{path.hopCount} hops</span>
         <span className="text-foreground font-medium">{isisLatencyMs.toFixed(2)}ms</span>
         {measuredLatencyMs != null && measuredLatencyMs > 0 && (
-          <span className="text-muted-foreground" title="Measured latency">({measuredLatencyMs.toFixed(2)}ms measured)</span>
+          <span className="text-muted-foreground" title="Measured latency">
+            ({measuredLatencyMs.toFixed(2)}ms measured)
+          </span>
         )}
       </div>
 
@@ -231,19 +230,21 @@ function PathStepper({ path, isReverse }: { path: SinglePath; isReverse: boolean
             <div key={hop.devicePK} className="flex items-stretch gap-3">
               {/* Timeline rail */}
               <div className="flex flex-col items-center w-5 flex-shrink-0">
-                <div className={cn(
-                  'w-2.5 h-2.5 rounded-full flex-shrink-0 ring-2 ring-background mt-1',
-                  isSource ? 'bg-green-500' : isTarget ? 'bg-red-500' : 'bg-muted-foreground/60'
-                )} />
-                {!isLast && (
-                  <div className="w-px flex-1 bg-border min-h-[28px]" />
-                )}
+                <div
+                  className={cn(
+                    'w-2.5 h-2.5 rounded-full flex-shrink-0 ring-2 ring-background mt-1',
+                    isSource ? 'bg-green-500' : isTarget ? 'bg-red-500' : 'bg-muted-foreground/60',
+                  )}
+                />
+                {!isLast && <div className="w-px flex-1 bg-border min-h-[28px]" />}
               </div>
 
               {/* Content */}
               <div className={cn('flex-1 flex items-start justify-between', !isLast && 'pb-2')}>
                 <div className="flex items-center gap-2 pt-0.5">
-                  <span className="font-mono text-[11px] font-medium leading-none">{hop.deviceCode}</span>
+                  <span className="font-mono text-[11px] font-medium leading-none">
+                    {hop.deviceCode}
+                  </span>
                   {hop.metroCode && (
                     <span className="text-[9px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
                       {hop.metroCode}

--- a/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/MulticastTreesOverlayPanel.tsx
@@ -1,11 +1,25 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { Radio, X, ChevronDown, ChevronRight, Settings2, User, Server, BarChart3, Info, Search, Loader2, RefreshCw } from 'lucide-react'
+import {
+  Radio,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Settings2,
+  User,
+  Server,
+  BarChart3,
+  Info,
+  Search,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import { useTopology } from '../TopologyContext'
 import { EntityLink } from '../EntityLink'
 import { formatBandwidth } from '../utils'
+import { SmallDropdown } from '../TimeRangeSelector'
 import {
   fetchMulticastGroups,
   fetchMulticastGroupTraffic,
@@ -18,24 +32,24 @@ import {
 // Colors for multicast publishers — exported so map/globe/graph views use the same palette
 // eslint-disable-next-line react-refresh/only-export-components
 export const MULTICAST_PUBLISHER_COLORS = [
-  { light: '#7c5cbf', dark: '#a78bda' },  // soft purple
-  { light: '#4a8fe7', dark: '#6ba8f2' },  // soft blue
-  { light: '#3dad6f', dark: '#5ec98d' },  // soft green
-  { light: '#d4854a', dark: '#e8a06e' },  // soft orange
-  { light: '#2ba3a8', dark: '#4fc5ca' },  // soft teal
-  { light: '#d46a7e', dark: '#e88d9e' },  // soft rose
-  { light: '#c4a23d', dark: '#dbbe5c' },  // soft gold
-  { light: '#c45fa0', dark: '#da82b8' },  // soft magenta
+  { light: '#7c5cbf', dark: '#a78bda' }, // soft purple
+  { light: '#4a8fe7', dark: '#6ba8f2' }, // soft blue
+  { light: '#3dad6f', dark: '#5ec98d' }, // soft green
+  { light: '#d4854a', dark: '#e8a06e' }, // soft orange
+  { light: '#2ba3a8', dark: '#4fc5ca' }, // soft teal
+  { light: '#d46a7e', dark: '#e88d9e' }, // soft rose
+  { light: '#c4a23d', dark: '#dbbe5c' }, // soft gold
+  { light: '#c45fa0', dark: '#da82b8' }, // soft magenta
 ]
 
 interface MulticastTreesOverlayPanelProps {
   isDark: boolean
-  selectedGroup: string | null  // Single selected group code
+  selectedGroup: string | null // Single selected group code
   onSelectGroup: (code: string | null) => void
-  groupDetails: Map<string, MulticastGroupDetail>  // Cached group details
+  groupDetails: Map<string, MulticastGroupDetail> // Cached group details
   // Publisher/subscriber filtering
-  enabledPublishers: Set<string>  // user PKs of enabled publishers
-  enabledSubscribers: Set<string>  // user PKs of enabled subscribers
+  enabledPublishers: Set<string> // user PKs of enabled publishers
+  enabledSubscribers: Set<string> // user PKs of enabled subscribers
   onSetEnabledPublishers: (updater: Set<string> | ((prev: Set<string>) => Set<string>)) => void
   onSetEnabledSubscribers: (updater: Set<string> | ((prev: Set<string>) => Set<string>)) => void
   // Publisher color map for consistent colors
@@ -80,9 +94,15 @@ function SelectionHint() {
       <Info className="h-3 w-3 text-muted-foreground/50 group-hover:text-muted-foreground cursor-help" />
       <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 hidden group-hover:block z-50 pointer-events-none">
         <div className="bg-[var(--popover)] text-[var(--popover-foreground)] border border-[var(--border)] rounded-md px-2 py-1.5 text-[10px] leading-relaxed whitespace-nowrap shadow-md">
-          <div><strong>Click</strong> — solo select</div>
-          <div><strong>{navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click</strong> — toggle</div>
-          <div><strong>Shift+click</strong> — range select</div>
+          <div>
+            <strong>Click</strong> — solo select
+          </div>
+          <div>
+            <strong>{navigator.platform.includes('Mac') ? 'Cmd' : 'Ctrl'}+click</strong> — toggle
+          </div>
+          <div>
+            <strong>Shift+click</strong> — range select
+          </div>
         </div>
       </div>
     </div>
@@ -93,7 +113,6 @@ function shortenPubkey(pk: string, chars = 6): string {
   if (pk.length <= chars * 2 + 2) return pk
   return `${pk.slice(0, chars)}..${pk.slice(-chars)}`
 }
-
 
 function formatStake(sol: number): string {
   if (sol >= 1e6) return `${(sol / 1e6).toFixed(1)}M SOL`
@@ -131,7 +150,15 @@ interface MemberRowProps {
   accentColor: string
 }
 
-function MemberRow({ member, isEnabled, isHovered, onClick, onMouseEnter, onMouseLeave, accentColor }: MemberRowProps) {
+function MemberRow({
+  member,
+  isEnabled,
+  isHovered,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  accentColor,
+}: MemberRowProps) {
   const isValidator = !!member.node_pubkey
   return (
     <div
@@ -168,16 +195,16 @@ function MemberRow({ member, isEnabled, isHovered, onClick, onMouseEnter, onMous
               LEADER
             </span>
           )}
-          {member.stake_sol > 0 && (
-            <span>{formatStake(member.stake_sol)}</span>
-          )}
+          {member.stake_sol > 0 && <span>{formatStake(member.stake_sol)}</span>}
         </div>
       </div>
       {(member.device_code || member.is_leader || leaderTimingText(member)) && (
         <div className="flex items-center gap-1.5 ml-4.5 mt-0.5 text-[10px] text-muted-foreground">
           {(() => {
             const timing = leaderTimingText(member)
-            return timing ? <span className={member.is_leader ? 'text-amber-500' : ''}>{timing}</span> : null
+            return timing ? (
+              <span className={member.is_leader ? 'text-amber-500' : ''}>{timing}</span>
+            ) : null
           })()}
           {member.device_code && (
             <EntityLink
@@ -237,8 +264,8 @@ export function MulticastTreesOverlayPanel({
   useEffect(() => {
     setError(null)
     fetchMulticastGroups()
-      .then(res => setGroups(res.items))
-      .catch(err => {
+      .then((res) => setGroups(res.items))
+      .catch((err) => {
         console.error('Failed to fetch multicast groups:', err)
         setError('Failed to load multicast groups. The database table may not exist yet.')
       })
@@ -249,33 +276,32 @@ export function MulticastTreesOverlayPanel({
   const getMemberCounts = (group: MulticastGroupListItem) => {
     const detail = groupDetails.get(group.code)
     if (detail?.members) {
-      const pubs = detail.members.filter(m => m.mode === 'P' || m.mode === 'P+S').length
-      const subs = detail.members.filter(m => m.mode === 'S' || m.mode === 'P+S').length
+      const pubs = detail.members.filter((m) => m.mode === 'P' || m.mode === 'P+S').length
+      const subs = detail.members.filter((m) => m.mode === 'S' || m.mode === 'P+S').length
       return { pubs, subs }
     }
     return { pubs: group.publisher_count, subs: group.subscriber_count }
   }
 
-
   // Get selected group detail and split members
   const selectedDetail = selectedGroup ? groupDetails.get(selectedGroup) : null
-  const selectedGroupItem = selectedGroup ? groups.find(g => g.code === selectedGroup) : null
+  const selectedGroupItem = selectedGroup ? groups.find((g) => g.code === selectedGroup) : null
 
-  const publishers = useMemo(() =>
-    selectedDetail?.members.filter(m => m.mode === 'P' || m.mode === 'P+S') ?? [],
-    [selectedDetail]
+  const publishers = useMemo(
+    () => selectedDetail?.members.filter((m) => m.mode === 'P' || m.mode === 'P+S') ?? [],
+    [selectedDetail],
   )
 
-  const subscribers = useMemo(() =>
-    selectedDetail?.members.filter(m => m.mode === 'S' || m.mode === 'P+S') ?? [],
-    [selectedDetail]
+  const subscribers = useMemo(
+    () => selectedDetail?.members.filter((m) => m.mode === 'S' || m.mode === 'P+S') ?? [],
+    [selectedDetail],
   )
 
   // Filter members by search query (matches shortened pubkey, device_code, metro_code)
   const filterMembers = useCallback((members: MulticastMember[], query: string) => {
     if (!query) return members
     const q = query.toLowerCase()
-    return members.filter(m => {
+    return members.filter((m) => {
       const shortKey = shortenPubkey(m.user_pk).toLowerCase()
       const fullKey = m.user_pk.toLowerCase()
       const device = (m.device_code || '').toLowerCase()
@@ -296,17 +322,23 @@ export function MulticastTreesOverlayPanel({
     return [...map.entries()].sort((a, b) => b[1].length - a[1].length)
   }
 
-  const publishersByMetro = useMemo(() => groupByMetro(filterMembers(publishers, publisherSearch)), [publishers, publisherSearch, filterMembers])
-  const subscribersByMetro = useMemo(() => groupByMetro(filterMembers(subscribers, subscriberSearch)), [subscribers, subscriberSearch, filterMembers])
+  const publishersByMetro = useMemo(
+    () => groupByMetro(filterMembers(publishers, publisherSearch)),
+    [publishers, publisherSearch, filterMembers],
+  )
+  const subscribersByMetro = useMemo(
+    () => groupByMetro(filterMembers(subscribers, subscriberSearch)),
+    [subscribers, subscriberSearch, filterMembers],
+  )
 
   // Build ordered user_pk arrays from metro-grouped render order (for shift-click range selection)
-  const orderedPublisherUserPKs = useMemo(() =>
-    publishersByMetro.flatMap(([, members]) => members.map(m => m.user_pk)),
-    [publishersByMetro]
+  const orderedPublisherUserPKs = useMemo(
+    () => publishersByMetro.flatMap(([, members]) => members.map((m) => m.user_pk)),
+    [publishersByMetro],
   )
-  const orderedSubscriberUserPKs = useMemo(() =>
-    subscribersByMetro.flatMap(([, members]) => members.map(m => m.user_pk)),
-    [subscribersByMetro]
+  const orderedSubscriberUserPKs = useMemo(
+    () => subscribersByMetro.flatMap(([, members]) => members.map((m) => m.user_pk)),
+    [subscribersByMetro],
   )
 
   // Build userPK -> devicePK lookup
@@ -333,70 +365,90 @@ export function MulticastTreesOverlayPanel({
   // Derive tunnelId from hoveredUserPK for traffic chart coordination
   const hoveredTunnelId = useMemo(() => {
     if (!hoveredUserPK || !selectedDetail?.members) return null
-    const member = selectedDetail.members.find(m => m.user_pk === hoveredUserPK && m.tunnel_id > 0)
+    const member = selectedDetail.members.find(
+      (m) => m.user_pk === hoveredUserPK && m.tunnel_id > 0,
+    )
     return member?.tunnel_id ?? null
   }, [hoveredUserPK, selectedDetail])
 
   // Solo/cmd/shift click handler for publishers
-  const handlePublisherClick = useCallback((userPK: string, index: number, event: React.MouseEvent) => {
-    if (event.shiftKey && lastClickedPubIndex !== null) {
-      const start = Math.min(lastClickedPubIndex, index)
-      const end = Math.max(lastClickedPubIndex, index)
-      onSetEnabledPublishers(prev => {
-        const next = new Set(prev)
-        for (let i = start; i <= end; i++) {
-          next.add(orderedPublisherUserPKs[i])
-        }
-        return next
-      })
-    } else if (event.ctrlKey || event.metaKey) {
-      onSetEnabledPublishers(prev => {
-        const next = new Set(prev)
-        if (next.has(userPK)) next.delete(userPK)
-        else next.add(userPK)
-        return next
-      })
-    } else {
-      // Solo click: if already solo-selected, show all; otherwise solo-select
-      const isSolo = enabledPublishers.size === 1 && enabledPublishers.has(userPK)
-      if (isSolo) {
-        onSetEnabledPublishers(new Set(publishers.map(m => m.user_pk)))
+  const handlePublisherClick = useCallback(
+    (userPK: string, index: number, event: React.MouseEvent) => {
+      if (event.shiftKey && lastClickedPubIndex !== null) {
+        const start = Math.min(lastClickedPubIndex, index)
+        const end = Math.max(lastClickedPubIndex, index)
+        onSetEnabledPublishers((prev) => {
+          const next = new Set(prev)
+          for (let i = start; i <= end; i++) {
+            next.add(orderedPublisherUserPKs[i])
+          }
+          return next
+        })
+      } else if (event.ctrlKey || event.metaKey) {
+        onSetEnabledPublishers((prev) => {
+          const next = new Set(prev)
+          if (next.has(userPK)) next.delete(userPK)
+          else next.add(userPK)
+          return next
+        })
       } else {
-        onSetEnabledPublishers(new Set([userPK]))
+        // Solo click: if already solo-selected, show all; otherwise solo-select
+        const isSolo = enabledPublishers.size === 1 && enabledPublishers.has(userPK)
+        if (isSolo) {
+          onSetEnabledPublishers(new Set(publishers.map((m) => m.user_pk)))
+        } else {
+          onSetEnabledPublishers(new Set([userPK]))
+        }
       }
-    }
-    setLastClickedPubIndex(index)
-  }, [lastClickedPubIndex, orderedPublisherUserPKs, enabledPublishers, publishers, onSetEnabledPublishers])
+      setLastClickedPubIndex(index)
+    },
+    [
+      lastClickedPubIndex,
+      orderedPublisherUserPKs,
+      enabledPublishers,
+      publishers,
+      onSetEnabledPublishers,
+    ],
+  )
 
   // Solo/cmd/shift click handler for subscribers
-  const handleSubscriberClick = useCallback((userPK: string, index: number, event: React.MouseEvent) => {
-    if (event.shiftKey && lastClickedSubIndex !== null) {
-      const start = Math.min(lastClickedSubIndex, index)
-      const end = Math.max(lastClickedSubIndex, index)
-      onSetEnabledSubscribers(prev => {
-        const next = new Set(prev)
-        for (let i = start; i <= end; i++) {
-          next.add(orderedSubscriberUserPKs[i])
-        }
-        return next
-      })
-    } else if (event.ctrlKey || event.metaKey) {
-      onSetEnabledSubscribers(prev => {
-        const next = new Set(prev)
-        if (next.has(userPK)) next.delete(userPK)
-        else next.add(userPK)
-        return next
-      })
-    } else {
-      const isSolo = enabledSubscribers.size === 1 && enabledSubscribers.has(userPK)
-      if (isSolo) {
-        onSetEnabledSubscribers(new Set(subscribers.map(m => m.user_pk)))
+  const handleSubscriberClick = useCallback(
+    (userPK: string, index: number, event: React.MouseEvent) => {
+      if (event.shiftKey && lastClickedSubIndex !== null) {
+        const start = Math.min(lastClickedSubIndex, index)
+        const end = Math.max(lastClickedSubIndex, index)
+        onSetEnabledSubscribers((prev) => {
+          const next = new Set(prev)
+          for (let i = start; i <= end; i++) {
+            next.add(orderedSubscriberUserPKs[i])
+          }
+          return next
+        })
+      } else if (event.ctrlKey || event.metaKey) {
+        onSetEnabledSubscribers((prev) => {
+          const next = new Set(prev)
+          if (next.has(userPK)) next.delete(userPK)
+          else next.add(userPK)
+          return next
+        })
       } else {
-        onSetEnabledSubscribers(new Set([userPK]))
+        const isSolo = enabledSubscribers.size === 1 && enabledSubscribers.has(userPK)
+        if (isSolo) {
+          onSetEnabledSubscribers(new Set(subscribers.map((m) => m.user_pk)))
+        } else {
+          onSetEnabledSubscribers(new Set([userPK]))
+        }
       }
-    }
-    setLastClickedSubIndex(index)
-  }, [lastClickedSubIndex, orderedSubscriberUserPKs, enabledSubscribers, subscribers, onSetEnabledSubscribers])
+      setLastClickedSubIndex(index)
+    },
+    [
+      lastClickedSubIndex,
+      orderedSubscriberUserPKs,
+      enabledSubscribers,
+      subscribers,
+      onSetEnabledSubscribers,
+    ],
+  )
 
   // Callback for traffic chart legend hover -> set hoveredUserPK
   const handleTrafficChartHoverUserPK = useCallback((userPK: string | null) => {
@@ -420,13 +472,9 @@ export function MulticastTreesOverlayPanel({
         </button>
       </div>
 
-      {loading && (
-        <div className="text-muted-foreground">Loading groups...</div>
-      )}
+      {loading && <div className="text-muted-foreground">Loading groups...</div>}
 
-      {!loading && error && (
-        <div className="text-red-500 text-xs">{error}</div>
-      )}
+      {!loading && error && <div className="text-red-500 text-xs">{error}</div>}
 
       {!loading && !error && groups.length === 0 && (
         <div className="text-muted-foreground">No multicast groups found</div>
@@ -437,12 +485,16 @@ export function MulticastTreesOverlayPanel({
           {/* Groups list — collapsible */}
           <div>
             <button
-              onClick={() => setGroupsOpen(o => !o)}
+              onClick={() => setGroupsOpen((o) => !o)}
               className="flex items-center gap-1.5 text-[10px] text-muted-foreground uppercase tracking-wider w-full hover:text-foreground transition-colors mb-1.5"
             >
               <Radio className="h-3 w-3" />
               Groups
-              {groupsOpen ? <ChevronDown className="h-3 w-3 ml-auto" /> : <ChevronRight className="h-3 w-3 ml-auto" />}
+              {groupsOpen ? (
+                <ChevronDown className="h-3 w-3 ml-auto" />
+              ) : (
+                <ChevronRight className="h-3 w-3 ml-auto" />
+              )}
             </button>
             {groupsOpen && (
               <div className="space-y-0.5">
@@ -464,9 +516,11 @@ export function MulticastTreesOverlayPanel({
                         isSelected ? 'bg-purple-500/20 text-purple-500' : 'hover:bg-[var(--muted)]'
                       }`}
                     >
-                      <div className={`w-3 h-3 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${
-                        isSelected ? 'border-purple-500' : 'border-[var(--border)]'
-                      }`}>
+                      <div
+                        className={`w-3 h-3 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${
+                          isSelected ? 'border-purple-500' : 'border-[var(--border)]'
+                        }`}
+                      >
                         {isSelected && <div className="w-1.5 h-1.5 rounded-full bg-purple-500" />}
                       </div>
                       <span className="font-medium">{group.code}</span>
@@ -498,19 +552,27 @@ export function MulticastTreesOverlayPanel({
                   {/* Collapsible members section */}
                   <div className="border-t border-[var(--border)] pt-2">
                     <button
-                      onClick={() => setMembersOpen(o => !o)}
+                      onClick={() => setMembersOpen((o) => !o)}
                       className="flex items-center gap-1.5 text-[10px] text-muted-foreground uppercase tracking-wider w-full hover:text-foreground transition-colors"
                     >
                       <User className="h-3 w-3" />
                       Members
-                      {membersOpen ? <ChevronDown className="h-3 w-3 ml-auto" /> : <ChevronRight className="h-3 w-3 ml-auto" />}
+                      {membersOpen ? (
+                        <ChevronDown className="h-3 w-3 ml-auto" />
+                      ) : (
+                        <ChevronRight className="h-3 w-3 ml-auto" />
+                      )}
                     </button>
                     {membersOpen && (
                       <div className="mt-2">
                         {/* Tabs */}
                         <div className="flex border-b border-[var(--border)] mb-2">
                           <button
-                            onClick={() => { setActiveTab('publishers'); setPublisherSearch(''); setSubscriberSearch('') }}
+                            onClick={() => {
+                              setActiveTab('publishers')
+                              setPublisherSearch('')
+                              setSubscriberSearch('')
+                            }}
                             className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors -mb-px ${
                               activeTab === 'publishers'
                                 ? 'border-purple-500 text-purple-500'
@@ -520,7 +582,11 @@ export function MulticastTreesOverlayPanel({
                             Publishers ({publishers.length})
                           </button>
                           <button
-                            onClick={() => { setActiveTab('subscribers'); setPublisherSearch(''); setSubscriberSearch('') }}
+                            onClick={() => {
+                              setActiveTab('subscribers')
+                              setPublisherSearch('')
+                              setSubscriberSearch('')
+                            }}
                             className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors -mb-px ${
                               activeTab === 'subscribers'
                                 ? 'border-purple-500 text-purple-500'
@@ -540,7 +606,7 @@ export function MulticastTreesOverlayPanel({
                                 <input
                                   type="text"
                                   value={publisherSearch}
-                                  onChange={e => setPublisherSearch(e.target.value)}
+                                  onChange={(e) => setPublisherSearch(e.target.value)}
                                   placeholder="Search publishers..."
                                   className="w-full text-[10px] bg-[var(--muted)] border border-[var(--border)] rounded-md pl-6 pr-6 py-1 text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-purple-500/50"
                                 />
@@ -557,7 +623,11 @@ export function MulticastTreesOverlayPanel({
                             {publishers.length > 1 && (
                               <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
                                 <button
-                                  onClick={() => onSetEnabledPublishers(new Set(publishers.map(m => m.user_pk)))}
+                                  onClick={() =>
+                                    onSetEnabledPublishers(
+                                      new Set(publishers.map((m) => m.user_pk)),
+                                    )
+                                  }
                                   className="hover:text-foreground transition-colors"
                                 >
                                   all
@@ -573,7 +643,9 @@ export function MulticastTreesOverlayPanel({
                               </div>
                             )}
                             {publishers.length === 0 && (
-                              <div className="text-muted-foreground text-[10px] py-2">No publishers</div>
+                              <div className="text-muted-foreground text-[10px] py-2">
+                                No publishers
+                              </div>
                             )}
                             <div className="max-h-[300px] overflow-y-auto space-y-2">
                               {publishersByMetro.map(([metro, members]) => (
@@ -581,18 +653,18 @@ export function MulticastTreesOverlayPanel({
                                   key={metro}
                                   metro={metro}
                                   members={members}
-
                                   enabledMembers={enabledPublishers}
                                   onMemberClick={handlePublisherClick}
                                   orderedUserPKs={orderedPublisherUserPKs}
-
                                   hoveredUserPK={hoveredUserPK}
                                   onHoverUserPK={setHoveredUserPK}
-
                                   keySuffix="-pub"
                                   accentColorForMember={(m) => {
                                     const pubColorIndex = publisherColorMap.get(m.device_pk) ?? 0
-                                    const pubColor = MULTICAST_PUBLISHER_COLORS[pubColorIndex % MULTICAST_PUBLISHER_COLORS.length]
+                                    const pubColor =
+                                      MULTICAST_PUBLISHER_COLORS[
+                                        pubColorIndex % MULTICAST_PUBLISHER_COLORS.length
+                                      ]
                                     return isDark ? pubColor.dark : pubColor.light
                                   }}
                                 />
@@ -610,7 +682,7 @@ export function MulticastTreesOverlayPanel({
                                 <input
                                   type="text"
                                   value={subscriberSearch}
-                                  onChange={e => setSubscriberSearch(e.target.value)}
+                                  onChange={(e) => setSubscriberSearch(e.target.value)}
                                   placeholder="Search subscribers..."
                                   className="w-full text-[10px] bg-[var(--muted)] border border-[var(--border)] rounded-md pl-6 pr-6 py-1 text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-purple-500/50"
                                 />
@@ -627,7 +699,11 @@ export function MulticastTreesOverlayPanel({
                             {subscribers.length > 1 && (
                               <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
                                 <button
-                                  onClick={() => onSetEnabledSubscribers(new Set(subscribers.map(m => m.user_pk)))}
+                                  onClick={() =>
+                                    onSetEnabledSubscribers(
+                                      new Set(subscribers.map((m) => m.user_pk)),
+                                    )
+                                  }
                                   className="hover:text-foreground transition-colors"
                                 >
                                   all
@@ -643,7 +719,9 @@ export function MulticastTreesOverlayPanel({
                               </div>
                             )}
                             {subscribers.length === 0 && (
-                              <div className="text-muted-foreground text-[10px] py-2">No subscribers</div>
+                              <div className="text-muted-foreground text-[10px] py-2">
+                                No subscribers
+                              </div>
                             )}
                             <div className="max-h-[300px] overflow-y-auto space-y-2">
                               {subscribersByMetro.map(([metro, members]) => (
@@ -651,14 +729,11 @@ export function MulticastTreesOverlayPanel({
                                   key={metro}
                                   metro={metro}
                                   members={members}
-
                                   enabledMembers={enabledSubscribers}
                                   onMemberClick={handleSubscriberClick}
                                   orderedUserPKs={orderedSubscriberUserPKs}
-
                                   hoveredUserPK={hoveredUserPK}
                                   onHoverUserPK={setHoveredUserPK}
-
                                   keySuffix="-sub"
                                   accentColorForMember={() => '#14b8a6'}
                                 />
@@ -693,12 +768,16 @@ export function MulticastTreesOverlayPanel({
           {/* Options — collapsible */}
           <div className="border-t border-[var(--border)] pt-2">
             <button
-              onClick={() => setOptionsOpen(o => !o)}
+              onClick={() => setOptionsOpen((o) => !o)}
               className="flex items-center gap-1.5 text-[10px] text-muted-foreground uppercase tracking-wider w-full hover:text-foreground transition-colors"
             >
               <Settings2 className="h-3 w-3" />
               Options
-              {optionsOpen ? <ChevronDown className="h-3 w-3 ml-auto" /> : <ChevronRight className="h-3 w-3 ml-auto" />}
+              {optionsOpen ? (
+                <ChevronDown className="h-3 w-3 ml-auto" />
+              ) : (
+                <ChevronRight className="h-3 w-3 ml-auto" />
+              )}
             </button>
             {optionsOpen && (
               <div className="mt-2 space-y-2">
@@ -728,21 +807,48 @@ export function MulticastTreesOverlayPanel({
 }
 
 const TRAFFIC_TIME_RANGES = ['1h', '3h', '6h', '12h', '24h', '3d', '7d', '14d', '30d'] as const
-const BUCKET_OPTIONS = ['auto', '10 SECOND', '30 SECOND', '1 MINUTE', '5 MINUTE', '10 MINUTE', '15 MINUTE', '30 MINUTE', '1 HOUR', '4 HOUR'] as const
+const BUCKET_OPTIONS = [
+  'auto',
+  '10 SECOND',
+  '30 SECOND',
+  '1 MINUTE',
+  '5 MINUTE',
+  '10 MINUTE',
+  '15 MINUTE',
+  '30 MINUTE',
+  '1 HOUR',
+  '4 HOUR',
+] as const
 const BUCKET_LABELS: Record<string, string> = {
-  'auto': 'Auto', '10 SECOND': '10s', '30 SECOND': '30s', '1 MINUTE': '1m', '5 MINUTE': '5m',
-  '10 MINUTE': '10m', '15 MINUTE': '15m', '30 MINUTE': '30m', '1 HOUR': '1h', '4 HOUR': '4h',
+  auto: 'Auto',
+  '10 SECOND': '10s',
+  '30 SECOND': '30s',
+  '1 MINUTE': '1m',
+  '5 MINUTE': '5m',
+  '10 MINUTE': '10m',
+  '15 MINUTE': '15m',
+  '30 MINUTE': '30m',
+  '1 HOUR': '1h',
+  '4 HOUR': '4h',
 }
 function resolveOverlayAutoBucket(timeRange: string): string {
   switch (timeRange) {
-    case '1h': return '10 SECOND'
-    case '3h': return '30 SECOND'
-    case '6h': return '1 MINUTE'
-    case '12h': return '10 MINUTE'
-    case '24h': return '15 MINUTE'
-    case '3d': return '30 MINUTE'
-    case '7d': return '4 HOUR'
-    default: return '5 MINUTE'
+    case '1h':
+      return '10 SECOND'
+    case '3h':
+      return '30 SECOND'
+    case '6h':
+      return '1 MINUTE'
+    case '12h':
+      return '10 MINUTE'
+    case '24h':
+      return '15 MINUTE'
+    case '3d':
+      return '30 MINUTE'
+    case '7d':
+      return '4 HOUR'
+    default:
+      return '5 MINUTE'
   }
 }
 
@@ -838,7 +944,8 @@ function MulticastTrafficChartSection({
   // Device out_bps = user inbound (positive), device in_bps = user outbound (negative).
   // Filtered by active tab (publishers or subscribers).
   const { chartData, tunnelIds } = useMemo(() => {
-    if (!trafficData || trafficData.length === 0) return { chartData: [], tunnelIds: [] as number[] }
+    if (!trafficData || trafficData.length === 0)
+      return { chartData: [], tunnelIds: [] as number[] }
 
     const showPubs = activeTab === 'publishers'
     const tunnels = new Set<number>()
@@ -873,9 +980,7 @@ function MulticastTrafficChartSection({
       }
     }
 
-    const data = [...timeMap.values()].sort((a, b) =>
-      String(a.time).localeCompare(String(b.time))
-    )
+    const data = [...timeMap.values()].sort((a, b) => String(a.time).localeCompare(String(b.time)))
     return { chartData: data, tunnelIds: [...tunnels].sort((a, b) => a - b) }
   }, [trafficData, activeTab, metric])
 
@@ -904,13 +1009,13 @@ function MulticastTrafficChartSection({
     return visible
   }, [tunnelIds, tunnelInfo, enabledMembers])
 
-
   // Values to display in the legend: hovered point or latest
   const displayValues = useMemo(() => {
     if (chartData.length === 0) return new Map<number, { inBps: number; outBps: number }>()
-    const row = hoveredIdx !== null && hoveredIdx < chartData.length
-      ? chartData[hoveredIdx]
-      : chartData[chartData.length - 1]
+    const row =
+      hoveredIdx !== null && hoveredIdx < chartData.length
+        ? chartData[hoveredIdx]
+        : chartData[chartData.length - 1]
     const map = new Map<number, { inBps: number; outBps: number }>()
     for (const tid of tunnelIds) {
       map.set(tid, {
@@ -924,10 +1029,14 @@ function MulticastTrafficChartSection({
   // Build uPlot columnar data from chartData
   const { uplotData, uplotSeries, serisTidMap } = useMemo(() => {
     if (chartData.length === 0 || tunnelIds.length === 0) {
-      return { uplotData: [[]] as uPlot.AlignedData, uplotSeries: [] as uPlot.Series[], serisTidMap: [] as number[] }
+      return {
+        uplotData: [[]] as uPlot.AlignedData,
+        uplotSeries: [] as uPlot.Series[],
+        serisTidMap: [] as number[],
+      }
     }
 
-    const timestamps = chartData.map(row => new Date(row.time as string).getTime() / 1000)
+    const timestamps = chartData.map((row) => new Date(row.time as string).getTime() / 1000)
     const splinePaths = uPlot.paths.spline?.()
     const dataArrays: (number | null)[][] = [timestamps]
     const series: uPlot.Series[] = [{}]
@@ -936,7 +1045,7 @@ function MulticastTrafficChartSection({
     for (const tid of tunnelIds) {
       const color = getTunnelColor(tid)
 
-      dataArrays.push(chartData.map(row => (row[`t${tid}_in`] as number) ?? null))
+      dataArrays.push(chartData.map((row) => (row[`t${tid}_in`] as number) ?? null))
       series.push({
         label: `t${tid}_in`,
         stroke: color,
@@ -947,7 +1056,7 @@ function MulticastTrafficChartSection({
       } as uPlot.Series)
       tidMap.push(tid)
 
-      dataArrays.push(chartData.map(row => (row[`t${tid}_out`] as number) ?? null))
+      dataArrays.push(chartData.map((row) => (row[`t${tid}_out`] as number) ?? null))
       series.push({
         label: `t${tid}_out`,
         stroke: color,
@@ -983,9 +1092,10 @@ function MulticastTrafficChartSection({
         {
           stroke: 'rgba(128,128,128,0.4)',
           grid: { stroke: 'rgba(128,128,128,0.06)' },
-          values: (_: uPlot, vals: number[]) => vals.map(v =>
-            metric === 'throughput' ? formatAxisBps(Math.abs(v)) : formatAxisPps(Math.abs(v))
-          ),
+          values: (_: uPlot, vals: number[]) =>
+            vals.map((v) =>
+              metric === 'throughput' ? formatAxisBps(Math.abs(v)) : formatAxisPps(Math.abs(v)),
+            ),
           size: 45,
         },
       ],
@@ -993,16 +1103,18 @@ function MulticastTrafficChartSection({
         points: { size: 10, width: 2 },
       },
       hooks: {
-        setCursor: [(u: uPlot) => {
-          setHoveredIdx(u.cursor.idx ?? null)
-        }],
+        setCursor: [
+          (u: uPlot) => {
+            setHoveredIdx(u.cursor.idx ?? null)
+          },
+        ],
       },
       legend: { show: false },
     }
 
     plotRef.current = new uPlot(opts, uplotData, chartRef.current)
 
-    const ro = new ResizeObserver(entries => {
+    const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         plotRef.current?.setSize({ width: entry.contentRect.width, height: 176 })
       }
@@ -1025,54 +1137,49 @@ function MulticastTrafficChartSection({
     <div className="border-t border-[var(--border)] pt-2">
       <div className="flex items-center gap-1.5">
         <button
-          onClick={() => setOpen(o => !o)}
+          onClick={() => setOpen((o) => !o)}
           className="flex items-center gap-1.5 text-[10px] text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors"
         >
           <BarChart3 className="h-3 w-3" />
           Traffic ({activeTab})
           {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
         </button>
-        {open && (
-          isFetching ? (
+        {open &&
+          (isFetching ? (
             <Loader2 className="h-3 w-3 animate-spin text-muted-foreground ml-1" />
           ) : (
             <button
-              onClick={(e) => { e.stopPropagation(); queryClient.invalidateQueries({ queryKey: ['multicast-traffic', groupCode] }) }}
+              onClick={(e) => {
+                e.stopPropagation()
+                queryClient.invalidateQueries({ queryKey: ['multicast-traffic', groupCode] })
+              }}
               className="opacity-0 group-hover/chart:opacity-100 transition-opacity text-muted-foreground hover:text-foreground ml-1"
               title="Refresh"
             >
               <RefreshCw className="h-3 w-3" />
             </button>
-          )
-        )}
+          ))}
         {open && (
-          <div className="flex gap-1 ml-auto" onClick={e => e.stopPropagation()}>
-            <select
+          <div className="flex gap-1 ml-auto" onClick={(e) => e.stopPropagation()}>
+            <SmallDropdown
               value={metric}
-              onChange={e => setMetric(e.target.value as 'throughput' | 'packets')}
-              className="text-[10px] bg-transparent border border-border rounded px-1 py-0.5 text-foreground cursor-pointer"
-            >
-              <option value="throughput">bps</option>
-              <option value="packets">pps</option>
-            </select>
-            <select
+              options={[
+                { value: 'throughput', label: 'bps' },
+                { value: 'packets', label: 'pps' },
+              ]}
+              onChange={(v) => setMetric(v as 'throughput' | 'packets')}
+            />
+            <SmallDropdown
               value={bucket}
-              onChange={e => setBucket(e.target.value)}
-              className="text-[10px] bg-transparent border border-border rounded px-1 py-0.5 text-foreground cursor-pointer"
-            >
-              {BUCKET_OPTIONS.map(b => (
-                <option key={b} value={b}>{b === 'auto' ? `Auto (${autoBucketLabel})` : BUCKET_LABELS[b] || b}</option>
-              ))}
-            </select>
-            <select
+              displayLabel={bucket === 'auto' ? `Auto (${autoBucketLabel})` : undefined}
+              options={BUCKET_OPTIONS.map((b) => ({ value: b, label: BUCKET_LABELS[b] || b }))}
+              onChange={(v) => setBucket(v)}
+            />
+            <SmallDropdown
               value={timeRange}
-              onChange={e => setTimeRange(e.target.value)}
-              className="text-[10px] bg-transparent border border-border rounded px-1 py-0.5 text-foreground cursor-pointer"
-            >
-              {TRAFFIC_TIME_RANGES.map(r => (
-                <option key={r} value={r}>{r}</option>
-              ))}
-            </select>
+              options={TRAFFIC_TIME_RANGES.map((r) => ({ value: r, label: r }))}
+              onChange={(v) => setTimeRange(v)}
+            />
           </div>
         )}
       </div>
@@ -1085,15 +1192,21 @@ function MulticastTrafficChartSection({
           </div>
 
           {!trafficData && !isFetching && (
-            <div className="text-[10px] text-muted-foreground py-4 text-center">No traffic data</div>
+            <div className="text-[10px] text-muted-foreground py-4 text-center">
+              No traffic data
+            </div>
           )}
 
           {(trafficData || isFetching) && (
             <div>
               {/* Chart */}
               <div className="relative" style={{ minHeight: 176 }}>
-                <span className="absolute top-0.5 right-1 text-[8px] text-muted-foreground/50 pointer-events-none z-10">▲ In</span>
-                <span className="absolute bottom-4 right-1 text-[8px] text-muted-foreground/50 pointer-events-none z-10">▼ Out</span>
+                <span className="absolute top-0.5 right-1 text-[8px] text-muted-foreground/50 pointer-events-none z-10">
+                  ▲ In
+                </span>
+                <span className="absolute bottom-4 right-1 text-[8px] text-muted-foreground/50 pointer-events-none z-10">
+                  ▼ Out
+                </span>
                 <div ref={chartRef} className="w-full" />
               </div>
 
@@ -1106,43 +1219,64 @@ function MulticastTrafficChartSection({
                   <div className="text-right">↑ Out</div>
                 </div>
                 <div className="max-h-[200px] overflow-y-auto">
-                {tunnelIds.map((tid) => {
-                  const info = tunnelInfo.get(tid)
-                  const vals = displayValues.get(tid)
-                  const isVisible = visibleSeries.has(tid)
-                  const isHighlighted = hoveredTunnelId === tid
-                  return (
-                    <div
-                      key={tid}
-                      className={`flex items-center gap-2 px-1 py-0.5 rounded select-none transition-colors ${
-                        isHighlighted ? 'bg-muted/80' : 'hover:bg-muted/60'
-                      } ${!isVisible ? 'opacity-55' : ''}`}
-                      onMouseEnter={() => {
-                        if (isVisible) {
-                          setLocalHoveredSeries(tid)
-                          // Coordinate back to member list
-                          if (info?.userPk) onHoverUserPK(info.userPk)
-                        }
-                      }}
-                      onMouseLeave={() => {
-                        setLocalHoveredSeries(null)
-                        onHoverUserPK(null)
-                      }}
-                    >
-                      <div className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: !isVisible ? 'var(--muted-foreground)' : getTunnelColor(tid) }} />
-                      <div className="flex-1 min-w-0 text-foreground truncate font-mono">
-                        {info?.code ?? `t${tid}`} <span className="text-muted-foreground">t{tid}</span>
-                        {info?.userPk && <span className="text-muted-foreground"> · {shortenPubkey(info.userPk, 4)}</span>}
+                  {tunnelIds.map((tid) => {
+                    const info = tunnelInfo.get(tid)
+                    const vals = displayValues.get(tid)
+                    const isVisible = visibleSeries.has(tid)
+                    const isHighlighted = hoveredTunnelId === tid
+                    return (
+                      <div
+                        key={tid}
+                        className={`flex items-center gap-2 px-1 py-0.5 rounded select-none transition-colors ${
+                          isHighlighted ? 'bg-muted/80' : 'hover:bg-muted/60'
+                        } ${!isVisible ? 'opacity-55' : ''}`}
+                        onMouseEnter={() => {
+                          if (isVisible) {
+                            setLocalHoveredSeries(tid)
+                            // Coordinate back to member list
+                            if (info?.userPk) onHoverUserPK(info.userPk)
+                          }
+                        }}
+                        onMouseLeave={() => {
+                          setLocalHoveredSeries(null)
+                          onHoverUserPK(null)
+                        }}
+                      >
+                        <div
+                          className="w-2 h-2 rounded-sm flex-shrink-0"
+                          style={{
+                            backgroundColor: !isVisible
+                              ? 'var(--muted-foreground)'
+                              : getTunnelColor(tid),
+                          }}
+                        />
+                        <div className="flex-1 min-w-0 text-foreground truncate font-mono">
+                          {info?.code ?? `t${tid}`}{' '}
+                          <span className="text-muted-foreground">t{tid}</span>
+                          {info?.userPk && (
+                            <span className="text-muted-foreground">
+                              {' '}
+                              · {shortenPubkey(info.userPk, 4)}
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-right font-mono tabular-nums text-foreground">
+                          {vals && isVisible
+                            ? metric === 'throughput'
+                              ? formatBandwidth(vals.inBps)
+                              : formatPps(vals.inBps)
+                            : '—'}
+                        </div>
+                        <div className="text-right font-mono tabular-nums text-muted-foreground">
+                          {vals && isVisible
+                            ? metric === 'throughput'
+                              ? formatBandwidth(vals.outBps)
+                              : formatPps(vals.outBps)
+                            : '—'}
+                        </div>
                       </div>
-                      <div className="text-right font-mono tabular-nums text-foreground">
-                        {vals && isVisible ? (metric === 'throughput' ? formatBandwidth(vals.inBps) : formatPps(vals.inBps)) : '—'}
-                      </div>
-                      <div className="text-right font-mono tabular-nums text-muted-foreground">
-                        {vals && isVisible ? (metric === 'throughput' ? formatBandwidth(vals.outBps) : formatPps(vals.outBps)) : '—'}
-                      </div>
-                    </div>
-                  )
-                })}
+                    )
+                  })}
                 </div>
               </div>
             </div>
@@ -1180,7 +1314,7 @@ function MetroGroup({
   return (
     <div>
       <button
-        onClick={() => setOpen(o => !o)}
+        onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-1.5 text-[10px] text-muted-foreground w-full hover:text-foreground transition-colors py-0.5"
       >
         {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
@@ -1189,7 +1323,7 @@ function MetroGroup({
       </button>
       {open && (
         <div className="space-y-1 mt-1 ml-1">
-          {members.map(m => {
+          {members.map((m) => {
             const orderedIndex = orderedUserPKs.indexOf(m.user_pk)
             return (
               <MemberRow

--- a/web/src/components/traffic-dashboard/burstiness-panel.tsx
+++ b/web/src/components/traffic-dashboard/burstiness-panel.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
 import { fetchDashboardBurstiness, type DashboardBurstinessEntity } from '@/lib/api'
 import { useDashboard, dashboardFilterParams } from './dashboard-context'
 import { cn } from '@/lib/utils'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 function formatRate(val: number): string {
   if (val >= 1e12) return (val / 1e12).toFixed(1) + ' Tbps'
@@ -65,22 +66,20 @@ function SpikeTable({
 }) {
   const SortIcon = ({ field }: { field: SortField }) => {
     if (sortField !== field) return null
-    return sortDir === 'asc'
-      ? <ChevronUp className="h-3 w-3" />
-      : <ChevronDown className="h-3 w-3" />
+    return sortDir === 'asc' ? (
+      <ChevronUp className="h-3 w-3" />
+    ) : (
+      <ChevronDown className="h-3 w-3" />
+    )
   }
 
   const sortAria = (field: SortField) => {
     if (sortField !== field) return 'none' as const
-    return sortDir === 'asc' ? 'ascending' as const : 'descending' as const
+    return sortDir === 'asc' ? ('ascending' as const) : ('descending' as const)
   }
 
   if (entities.length === 0) {
-    return (
-      <div className="py-4 text-center text-sm text-muted-foreground">
-        No spikes detected
-      </div>
-    )
+    return <div className="py-4 text-center text-sm text-muted-foreground">No spikes detected</div>
   }
 
   return (
@@ -91,23 +90,47 @@ function SpikeTable({
             <th className="text-left py-1.5 px-2 font-medium text-muted-foreground">Interface</th>
             <th className="text-left py-1.5 px-2 font-medium text-muted-foreground">Metro</th>
             <th className="text-left py-1.5 px-2 font-medium text-muted-foreground">Contributor</th>
-            <th className="text-right py-1.5 px-2 font-medium text-muted-foreground" aria-sort={sortAria('spike_count')}>
-              <button className="inline-flex items-center gap-0.5" onClick={() => handleSort('spike_count')}>
+            <th
+              className="text-right py-1.5 px-2 font-medium text-muted-foreground"
+              aria-sort={sortAria('spike_count')}
+            >
+              <button
+                className="inline-flex items-center gap-0.5"
+                onClick={() => handleSort('spike_count')}
+              >
                 Spikes <SortIcon field="spike_count" />
               </button>
             </th>
-            <th className="text-right py-1.5 px-2 font-medium text-muted-foreground" aria-sort={sortAria('max_spike_ratio')}>
-              <button className="inline-flex items-center gap-0.5" onClick={() => handleSort('max_spike_ratio')}>
+            <th
+              className="text-right py-1.5 px-2 font-medium text-muted-foreground"
+              aria-sort={sortAria('max_spike_ratio')}
+            >
+              <button
+                className="inline-flex items-center gap-0.5"
+                onClick={() => handleSort('max_spike_ratio')}
+              >
                 Worst Spike <SortIcon field="max_spike_ratio" />
               </button>
             </th>
-            <th className="text-right py-1.5 px-2 font-medium text-muted-foreground" aria-sort={sortAria('p50_bps')}>
-              <button className="inline-flex items-center gap-0.5" onClick={() => handleSort('p50_bps')}>
+            <th
+              className="text-right py-1.5 px-2 font-medium text-muted-foreground"
+              aria-sort={sortAria('p50_bps')}
+            >
+              <button
+                className="inline-flex items-center gap-0.5"
+                onClick={() => handleSort('p50_bps')}
+              >
                 Baseline (P50) <SortIcon field="p50_bps" />
               </button>
             </th>
-            <th className="text-right py-1.5 px-2 font-medium text-muted-foreground" aria-sort={sortAria('max_spike_bps')}>
-              <button className="inline-flex items-center gap-0.5" onClick={() => handleSort('max_spike_bps')}>
+            <th
+              className="text-right py-1.5 px-2 font-medium text-muted-foreground"
+              aria-sort={sortAria('max_spike_bps')}
+            >
+              <button
+                className="inline-flex items-center gap-0.5"
+                onClick={() => handleSort('max_spike_bps')}
+              >
                 Peak Spike <SortIcon field="max_spike_bps" />
               </button>
             </th>
@@ -116,7 +139,8 @@ function SpikeTable({
         </thead>
         <tbody>
           {entities.map((e, i) => {
-            const isSelected = state.selectedEntity?.devicePk === e.device_pk &&
+            const isSelected =
+              state.selectedEntity?.devicePk === e.device_pk &&
               state.selectedEntity?.intf === e.intf
             return (
               <tr
@@ -140,30 +164,35 @@ function SpikeTable({
                 }}
                 className={cn(
                   'border-b border-border/50 cursor-pointer transition-colors',
-                  isSelected ? 'bg-blue-500/10 ring-1 ring-blue-500/30' : 'hover:bg-muted/50'
+                  isSelected ? 'bg-blue-500/10 ring-1 ring-blue-500/30' : 'hover:bg-muted/50',
                 )}
               >
                 <td className="py-1.5 px-2 font-mono">
                   {e.device_code} <span className="text-muted-foreground">{e.intf}</span>
-                  <span className="text-[10px] text-muted-foreground ml-1">{e.peak_direction === 'rx' ? 'Rx' : 'Tx'}</span>
+                  <span className="text-[10px] text-muted-foreground ml-1">
+                    {e.peak_direction === 'rx' ? 'Rx' : 'Tx'}
+                  </span>
                 </td>
                 <td className="py-1.5 px-2">{e.metro_code}</td>
                 <td className="py-1.5 px-2">{e.contributor_code}</td>
                 <td className="py-1.5 px-2 text-right font-mono">
                   {e.spike_count}
-                  <span className="text-[10px] text-muted-foreground ml-1">/ {e.total_buckets}</span>
+                  <span className="text-[10px] text-muted-foreground ml-1">
+                    / {e.total_buckets}
+                  </span>
                 </td>
                 <td className="py-1.5 px-2 text-right">
-                  <span className={cn('px-1.5 py-0.5 rounded text-xs border', spikeColor(e.max_spike_ratio))}>
+                  <span
+                    className={cn(
+                      'px-1.5 py-0.5 rounded text-xs border',
+                      spikeColor(e.max_spike_ratio),
+                    )}
+                  >
                     {formatRatio(e.max_spike_ratio)}
                   </span>
                 </td>
-                <td className="py-1.5 px-2 text-right font-mono">
-                  {formatRate(e.p50_bps)}
-                </td>
-                <td className="py-1.5 px-2 text-right font-mono">
-                  {formatRate(e.max_spike_bps)}
-                </td>
+                <td className="py-1.5 px-2 text-right font-mono">{formatRate(e.p50_bps)}</td>
+                <td className="py-1.5 px-2 text-right font-mono">{formatRate(e.max_spike_bps)}</td>
                 <td className="py-1.5 px-2 text-right text-muted-foreground">
                   {e.last_spike_time ? formatTimeAgo(e.last_spike_time) : '\u2014'}
                 </td>
@@ -190,7 +219,7 @@ export function BurstinessPanel() {
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
     } else {
       setSortField(field)
       setSortDir('desc')
@@ -198,15 +227,18 @@ export function BurstinessPanel() {
     setPage(0)
   }
 
-  const baseParams = useMemo(() => ({
-    ...dashboardFilterParams(state),
-    sort: sortField,
-    dir: sortDir,
-    limit,
-    offset: page * limit,
-    min_bps: minBps,
-    min_peak_bps: minPeakBps,
-  }), [state, sortField, sortDir, limit, page, minBps, minPeakBps])
+  const baseParams = useMemo(
+    () => ({
+      ...dashboardFilterParams(state),
+      sort: sortField,
+      dir: sortDir,
+      limit,
+      offset: page * limit,
+      min_bps: minBps,
+      min_peak_bps: minPeakBps,
+    }),
+    [state, sortField, sortDir, limit, page, minBps, minPeakBps],
+  )
 
   // Single query for when a specific type is selected
   const singleQuery = useQuery({
@@ -269,12 +301,19 @@ export function BurstinessPanel() {
       ]
     }
     return singleQuery.data?.entities ?? []
-  }, [isAllMode, linkQuery.data, tunnelQuery.data, cyoaQuery.data, otherQuery.data, singleQuery.data])
+  }, [
+    isAllMode,
+    linkQuery.data,
+    tunnelQuery.data,
+    cyoaQuery.data,
+    otherQuery.data,
+    singleQuery.data,
+  ])
 
   useEffect(() => {
     if (!selectedEntity || state.referenceLines.size > 0) return
     const match = allEntities.find(
-      e => e.device_pk === selectedEntity.devicePk && e.intf === selectedEntity.intf
+      (e) => e.device_pk === selectedEntity.devicePk && e.intf === selectedEntity.intf,
     )
     if (match) {
       state.setReferenceLines(match.device_pk, match.intf, {
@@ -298,23 +337,33 @@ export function BurstinessPanel() {
       <div className="flex items-center justify-between mt-2">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {total > 0 ? (
-            <span>{start}{'\u2013'}{end} of {total}</span>
+            <span>
+              {start}
+              {'\u2013'}
+              {end} of {total}
+            </span>
           ) : (
             <span>No results</span>
           )}
           {totalPages > 1 && (
             <div className="flex items-center gap-1">
               <button
-                onClick={() => setPage(p => Math.max(0, p - 1))}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
                 disabled={page === 0}
-                className={cn('px-1.5 py-0.5 rounded transition-colors', page === 0 ? 'opacity-30' : 'hover:bg-muted/50')}
+                className={cn(
+                  'px-1.5 py-0.5 rounded transition-colors',
+                  page === 0 ? 'opacity-30' : 'hover:bg-muted/50',
+                )}
               >
                 {'\u2039'}
               </button>
               <button
-                onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
                 disabled={page >= totalPages - 1}
-                className={cn('px-1.5 py-0.5 rounded transition-colors', page >= totalPages - 1 ? 'opacity-30' : 'hover:bg-muted/50')}
+                className={cn(
+                  'px-1.5 py-0.5 rounded transition-colors',
+                  page >= totalPages - 1 ? 'opacity-30' : 'hover:bg-muted/50',
+                )}
               >
                 {'\u203A'}
               </button>
@@ -322,42 +371,33 @@ export function BurstinessPanel() {
           )}
         </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <label className="flex items-center gap-1">
-            <span className="text-foreground/60">Baseline</span>
-            <select
-              value={minBps}
-              onChange={e => { setMinBps(Number(e.target.value)); setPage(0) }}
-              className="bg-muted border-none rounded px-1.5 py-0.5 text-xs text-foreground cursor-pointer"
-            >
-              {bpsFilterOptions.map(opt => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-1">
-            <span className="text-foreground/60">Peak</span>
-            <select
-              value={minPeakBps}
-              onChange={e => { setMinPeakBps(Number(e.target.value)); setPage(0) }}
-              className="bg-muted border-none rounded px-1.5 py-0.5 text-xs text-foreground cursor-pointer"
-            >
-              {bpsFilterOptions.map(opt => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-1">
-            <span className="text-foreground/60">Show</span>
-            <select
-              value={limit}
-              onChange={e => { setLimit(Number(e.target.value)); setPage(0) }}
-              className="bg-muted border-none rounded px-1.5 py-0.5 text-xs text-foreground cursor-pointer"
-            >
-              {pageSizeOptions.map(n => (
-                <option key={n} value={n}>{n}</option>
-              ))}
-            </select>
-          </label>
+          <span className="text-foreground/60">Baseline</span>
+          <SmallDropdown
+            value={String(minBps)}
+            options={bpsFilterOptions.map((o) => ({ value: String(o.value), label: o.label }))}
+            onChange={(v) => {
+              setMinBps(Number(v))
+              setPage(0)
+            }}
+          />
+          <span className="text-foreground/60">Peak</span>
+          <SmallDropdown
+            value={String(minPeakBps)}
+            options={bpsFilterOptions.map((o) => ({ value: String(o.value), label: o.label }))}
+            onChange={(v) => {
+              setMinPeakBps(Number(v))
+              setPage(0)
+            }}
+          />
+          <span className="text-foreground/60">Show</span>
+          <SmallDropdown
+            value={String(limit)}
+            options={pageSizeOptions.map((n) => ({ value: String(n), label: String(n) }))}
+            onChange={(v) => {
+              setLimit(Number(v))
+              setPage(0)
+            }}
+          />
         </div>
       </div>
     )
@@ -404,7 +444,9 @@ export function BurstinessPanel() {
     { key: 'other' as const, label: 'Other', query: otherQuery },
   ]
 
-  const allEmpty = tabs.every(t => (t.query.data?.total ?? 0) === 0 && (t.query.data?.entities ?? []).length === 0)
+  const allEmpty = tabs.every(
+    (t) => (t.query.data?.total ?? 0) === 0 && (t.query.data?.entities ?? []).length === 0,
+  )
   if (allEmpty && page === 0) {
     return (
       <div className="h-[200px] flex items-center justify-center text-sm text-muted-foreground">
@@ -413,7 +455,7 @@ export function BurstinessPanel() {
     )
   }
 
-  const activeQuery = tabs.find(t => t.key === activeTab)?.query
+  const activeQuery = tabs.find((t) => t.key === activeTab)?.query
   const activeEntities = activeQuery?.data?.entities ?? []
   const activeTotal = activeQuery?.data?.total ?? 0
   const activePlaceholder = activeQuery?.isPlaceholderData ?? false
@@ -426,20 +468,25 @@ export function BurstinessPanel() {
           return (
             <button
               key={key}
-              onClick={() => { setActiveTab(key); setPage(0) }}
+              onClick={() => {
+                setActiveTab(key)
+                setPage(0)
+              }}
               className={cn(
                 'px-3 py-1.5 text-xs font-medium transition-colors relative -mb-px',
                 activeTab === key
                   ? 'text-foreground border-b-2 border-foreground'
-                  : 'text-muted-foreground hover:text-foreground/70'
+                  : 'text-muted-foreground hover:text-foreground/70',
               )}
             >
               {label}
               {total > 0 && (
-                <span className={cn(
-                  'ml-1.5 text-[10px]',
-                  activeTab === key ? 'text-muted-foreground' : 'text-muted-foreground/60'
-                )}>
+                <span
+                  className={cn(
+                    'ml-1.5 text-[10px]',
+                    activeTab === key ? 'text-muted-foreground' : 'text-muted-foreground/60',
+                  )}
+                >
                   {total}
                 </span>
               )}

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -8,6 +8,7 @@ import 'uplot/dist/uPlot.min.css'
 import { fetchUser, fetchUserTraffic, fetchUserMulticastGroups } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useTheme } from '@/hooks/use-theme'
+import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -44,37 +45,81 @@ function formatStake(sol: number): string {
 }
 
 const TUNNEL_COLORS = [
-  '#2563eb', '#9333ea', '#16a34a', '#ea580c', '#0891b2', '#dc2626', '#ca8a04', '#db2777',
+  '#2563eb',
+  '#9333ea',
+  '#16a34a',
+  '#ea580c',
+  '#0891b2',
+  '#dc2626',
+  '#ca8a04',
+  '#db2777',
 ]
 
 const TIME_RANGES = ['1h', '3h', '6h', '12h', '24h', '3d', '7d', '14d', '30d'] as const
 
-const BUCKET_OPTIONS = ['auto', '10 SECOND', '30 SECOND', '1 MINUTE', '5 MINUTE', '10 MINUTE', '15 MINUTE', '30 MINUTE', '1 HOUR', '4 HOUR', '12 HOUR', '1 DAY'] as const
+const BUCKET_OPTIONS = [
+  'auto',
+  '10 SECOND',
+  '30 SECOND',
+  '1 MINUTE',
+  '5 MINUTE',
+  '10 MINUTE',
+  '15 MINUTE',
+  '30 MINUTE',
+  '1 HOUR',
+  '4 HOUR',
+  '12 HOUR',
+  '1 DAY',
+] as const
 const BUCKET_LABELS: Record<string, string> = {
-  'auto': 'Auto',
-  '10 SECOND': '10s', '30 SECOND': '30s', '1 MINUTE': '1m', '5 MINUTE': '5m',
-  '10 MINUTE': '10m', '15 MINUTE': '15m', '30 MINUTE': '30m', '1 HOUR': '1h',
-  '4 HOUR': '4h', '12 HOUR': '12h', '1 DAY': '1d',
+  auto: 'Auto',
+  '10 SECOND': '10s',
+  '30 SECOND': '30s',
+  '1 MINUTE': '1m',
+  '5 MINUTE': '5m',
+  '10 MINUTE': '10m',
+  '15 MINUTE': '15m',
+  '30 MINUTE': '30m',
+  '1 HOUR': '1h',
+  '4 HOUR': '4h',
+  '12 HOUR': '12h',
+  '1 DAY': '1d',
 }
 
 type AggMethod = 'max' | 'avg' | 'min' | 'p50' | 'p90' | 'p95' | 'p99'
 const AGG_OPTIONS: AggMethod[] = ['max', 'p99', 'p95', 'p90', 'p50', 'avg', 'min']
 const AGG_LABELS: Record<AggMethod, string> = {
-  max: 'Max', p99: 'P99', p95: 'P95', p90: 'P90', p50: 'P50', avg: 'Avg', min: 'Min',
+  max: 'Max',
+  p99: 'P99',
+  p95: 'P95',
+  p90: 'P90',
+  p50: 'P50',
+  avg: 'Avg',
+  min: 'Min',
 }
 
 function resolveAutoBucket(timeRange: string): string {
   switch (timeRange) {
-    case '1h': return '10 SECOND'
-    case '3h': return '30 SECOND'
-    case '6h': return '1 MINUTE'
-    case '12h': return '10 MINUTE'
-    case '24h': return '15 MINUTE'
-    case '3d': return '30 MINUTE'
-    case '7d': return '4 HOUR'
-    case '14d': return '12 HOUR'
-    case '30d': return '1 DAY'
-    default: return '5 MINUTE'
+    case '1h':
+      return '10 SECOND'
+    case '3h':
+      return '30 SECOND'
+    case '6h':
+      return '1 MINUTE'
+    case '12h':
+      return '10 MINUTE'
+    case '24h':
+      return '15 MINUTE'
+    case '3d':
+      return '30 MINUTE'
+    case '7d':
+      return '4 HOUR'
+    case '14d':
+      return '12 HOUR'
+    case '30d':
+      return '1 DAY'
+    default:
+      return '5 MINUTE'
   }
 }
 
@@ -193,7 +238,7 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
         {
           stroke: axisStroke,
           grid: { stroke: 'rgba(128,128,128,0.06)' },
-          values: (_: uPlot, vals: number[]) => vals.map(v => formatAxisBps(Math.abs(v))),
+          values: (_: uPlot, vals: number[]) => vals.map((v) => formatAxisBps(Math.abs(v))),
           size: 60,
         },
       ],
@@ -201,16 +246,18 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
         points: { size: 12, width: 2 },
       },
       hooks: {
-        setCursor: [(u: uPlot) => {
-          setHoveredIdx(u.cursor.idx ?? null)
-        }],
+        setCursor: [
+          (u: uPlot) => {
+            setHoveredIdx(u.cursor.idx ?? null)
+          },
+        ],
       },
       legend: { show: false },
     }
 
     plotRef.current = new uPlot(opts, uplotData, chartRef.current)
 
-    const ro = new ResizeObserver(entries => {
+    const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         plotRef.current?.setSize({ width: entry.contentRect.width, height: 224 })
       }
@@ -226,9 +273,11 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
 
   // Values to display in legend: hovered or latest
   const displayValues = useMemo(() => {
-    if (!uplotData || tunnelIds.length === 0) return new Map<number, { inVal: number; outVal: number }>()
+    if (!uplotData || tunnelIds.length === 0)
+      return new Map<number, { inVal: number; outVal: number }>()
     const timestamps = uplotData[0] as number[]
-    const idx = hoveredIdx != null && hoveredIdx < timestamps.length ? hoveredIdx : timestamps.length - 1
+    const idx =
+      hoveredIdx != null && hoveredIdx < timestamps.length ? hoveredIdx : timestamps.length - 1
     const map = new Map<number, { inVal: number; outVal: number }>()
     for (let i = 0; i < tunnelIds.length; i++) {
       const rxArr = uplotData[1 + i * 2] as (number | null)[]
@@ -246,9 +295,16 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
     if (!uplotData) return undefined
     const timestamps = uplotData[0] as number[]
     if (timestamps.length === 0) return undefined
-    const idx = hoveredIdx != null && hoveredIdx < timestamps.length ? hoveredIdx : timestamps.length - 1
+    const idx =
+      hoveredIdx != null && hoveredIdx < timestamps.length ? hoveredIdx : timestamps.length - 1
     const d = new Date(timestamps[idx] * 1000)
-    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false })
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
   }, [uplotData, hoveredIdx])
 
   return (
@@ -269,41 +325,30 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <select
+          <SmallDropdown
             value={metric}
-            onChange={e => setMetric(e.target.value as TrafficMetric)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            <option value="throughput">bps</option>
-            <option value="packets">pps</option>
-          </select>
-          <select
+            options={[
+              { value: 'throughput', label: 'bps' },
+              { value: 'packets', label: 'pps' },
+            ]}
+            onChange={(v) => setMetric(v as TrafficMetric)}
+          />
+          <SmallDropdown
             value={agg}
-            onChange={e => setAgg(e.target.value as AggMethod)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {AGG_OPTIONS.map(a => (
-              <option key={a} value={a}>{AGG_LABELS[a]}</option>
-            ))}
-          </select>
-          <select
+            options={AGG_OPTIONS.map((a) => ({ value: a, label: AGG_LABELS[a] }))}
+            onChange={(v) => setAgg(v as AggMethod)}
+          />
+          <SmallDropdown
             value={bucket}
-            onChange={e => setBucket(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {BUCKET_OPTIONS.map(b => (
-              <option key={b} value={b}>{b === 'auto' ? `Auto (${autoBucketLabel})` : BUCKET_LABELS[b] || b}</option>
-            ))}
-          </select>
-          <select
+            displayLabel={bucket === 'auto' ? `Auto (${autoBucketLabel})` : undefined}
+            options={BUCKET_OPTIONS.map((b) => ({ value: b, label: BUCKET_LABELS[b] || b }))}
+            onChange={(v) => setBucket(v)}
+          />
+          <SmallDropdown
             value={timeRange}
-            onChange={e => setTimeRange(e.target.value)}
-            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-foreground cursor-pointer"
-          >
-            {TIME_RANGES.map(r => (
-              <option key={r} value={r}>{r}</option>
-            ))}
-          </select>
+            options={TIME_RANGES.map((r) => ({ value: r, label: r }))}
+            onChange={(v) => setTimeRange(v)}
+          />
         </div>
       </div>
 
@@ -324,25 +369,39 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
         <div>
           <div className="relative" style={{ minHeight: 224 }}>
             <div ref={chartRef} className="w-full" />
-            <span className="absolute top-1 right-3 text-[10px] text-muted-foreground/50 pointer-events-none">▲ Rx (in)</span>
-            <span className="absolute bottom-8 right-3 text-[10px] text-muted-foreground/50 pointer-events-none">▼ Tx (out)</span>
+            <span className="absolute top-1 right-3 text-[10px] text-muted-foreground/50 pointer-events-none">
+              ▲ Rx (in)
+            </span>
+            <span className="absolute bottom-8 right-3 text-[10px] text-muted-foreground/50 pointer-events-none">
+              ▼ Tx (out)
+            </span>
           </div>
           {/* Legend table */}
           {tunnelIds.length > 0 && (
             <div className="mt-2 text-xs">
-              <div className="grid gap-x-4 gap-y-0.5" style={{ gridTemplateColumns: 'auto 1fr 1fr' }}>
+              <div
+                className="grid gap-x-4 gap-y-0.5"
+                style={{ gridTemplateColumns: 'auto 1fr 1fr' }}
+              >
                 <div className="text-muted-foreground font-medium">Tunnel</div>
                 <div className="text-muted-foreground font-medium text-right">Rx (in)</div>
                 <div className="text-right">
-                  {hoveredTime && <span className="text-[10px] text-muted-foreground">{hoveredTime}</span>}
-                  {!hoveredTime && <span className="text-muted-foreground font-medium">Tx (out)</span>}
+                  {hoveredTime && (
+                    <span className="text-[10px] text-muted-foreground">{hoveredTime}</span>
+                  )}
+                  {!hoveredTime && (
+                    <span className="text-muted-foreground font-medium">Tx (out)</span>
+                  )}
                 </div>
                 {tunnelIds.map((tid, i) => {
                   const vals = displayValues.get(tid)
                   return (
                     <div key={tid} className="contents">
                       <div className="flex items-center gap-1.5">
-                        <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: TUNNEL_COLORS[i % TUNNEL_COLORS.length] }} />
+                        <div
+                          className="w-2.5 h-2.5 rounded-sm"
+                          style={{ backgroundColor: TUNNEL_COLORS[i % TUNNEL_COLORS.length] }}
+                        />
                         <span className="text-muted-foreground">{tid}</span>
                       </div>
                       <div className="text-right tabular-nums">{fmtValue(vals?.inVal ?? 0)}</div>
@@ -372,7 +431,11 @@ export function UserDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
 
-  const { data: user, isLoading, error } = useQuery({
+  const {
+    data: user,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['user', pk],
     queryFn: () => fetchUser(pk!),
     enabled: !!pk,
@@ -429,10 +492,14 @@ export function UserDetailPage() {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-medium font-mono">
-                <CopyableText text={user.pk}>{user.pk.slice(0, 8)}...{user.pk.slice(-4)}</CopyableText>
+                <CopyableText text={user.pk}>
+                  {user.pk.slice(0, 8)}...{user.pk.slice(-4)}
+                </CopyableText>
               </h1>
               {user.is_deleted && (
-                <span className="text-xs px-2 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">Deleted</span>
+                <span className="text-xs px-2 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">
+                  Deleted
+                </span>
               )}
             </div>
             <div className="text-sm text-muted-foreground">{user.kind || 'Unknown type'}</div>
@@ -447,7 +514,9 @@ export function UserDetailPage() {
             <dl className="space-y-2">
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Status</dt>
-                <dd className={`text-sm capitalize ${statusColors[user.status] || ''}`}>{user.status}</dd>
+                <dd className={`text-sm capitalize ${statusColors[user.status] || ''}`}>
+                  {user.status}
+                </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Kind</dt>
@@ -457,7 +526,10 @@ export function UserDetailPage() {
                 <dt className="text-sm text-muted-foreground">Owner Pubkey</dt>
                 <dd className="text-sm">
                   <CopyableText text={user.owner_pubkey} className="font-mono" iconPosition="left">
-                    <Link to={`/dz/users?search=owner:${user.owner_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                    <Link
+                      to={`/dz/users?search=owner:${user.owner_pubkey}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
                       {user.owner_pubkey.slice(0, 6)}...{user.owner_pubkey.slice(-4)}
                     </Link>
                   </CopyableText>
@@ -468,11 +540,16 @@ export function UserDetailPage() {
                 <dd className="text-sm">
                   {user.client_ip ? (
                     <CopyableText text={user.client_ip} className="font-mono" iconPosition="left">
-                      <Link to={`/dz/users?search=ip:${user.client_ip}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                      <Link
+                        to={`/dz/users?search=ip:${user.client_ip}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
                         {user.client_ip}
                       </Link>
                     </CopyableText>
-                  ) : '—'}
+                  ) : (
+                    '—'
+                  )}
                 </dd>
               </div>
               <div className="flex justify-between">
@@ -480,7 +557,9 @@ export function UserDetailPage() {
                 <dd className="text-sm">
                   {user.dz_ip ? (
                     <CopyableText text={user.dz_ip} className="font-mono" iconPosition="left" />
-                  ) : '—'}
+                  ) : (
+                    '—'
+                  )}
                 </dd>
               </div>
               {user.tunnel_id > 0 && (
@@ -500,30 +579,45 @@ export function UserDetailPage() {
                 <dt className="text-sm text-muted-foreground">Device</dt>
                 <dd className="text-sm">
                   {user.device_pk ? (
-                    <Link to={`/dz/devices/${user.device_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                    <Link
+                      to={`/dz/devices/${user.device_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                    >
                       {user.device_code}
                     </Link>
-                  ) : '—'}
+                  ) : (
+                    '—'
+                  )}
                 </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Metro</dt>
                 <dd className="text-sm">
                   {user.metro_pk ? (
-                    <Link to={`/dz/metros/${user.metro_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                    <Link
+                      to={`/dz/metros/${user.metro_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
                       {user.metro_name || user.metro_code}
                     </Link>
-                  ) : '—'}
+                  ) : (
+                    '—'
+                  )}
                 </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-sm text-muted-foreground">Contributor</dt>
                 <dd className="text-sm">
                   {user.contributor_pk ? (
-                    <Link to={`/dz/contributors/${user.contributor_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                    <Link
+                      to={`/dz/contributors/${user.contributor_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
                       {user.contributor_code}
                     </Link>
-                  ) : '—'}
+                  ) : (
+                    '—'
+                  )}
                 </dd>
               </div>
             </dl>
@@ -537,17 +631,23 @@ export function UserDetailPage() {
                 <div className="flex justify-between">
                   <dt className="text-sm text-muted-foreground">Node Pubkey</dt>
                   <dd className="text-sm">
-                        <Link to={`/solana/gossip-nodes/${user.node_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
-                          {user.node_pubkey.slice(0, 6)}...{user.node_pubkey.slice(-4)}
-                        </Link>
-                      </dd>
+                    <Link
+                      to={`/solana/gossip-nodes/${user.node_pubkey}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                    >
+                      {user.node_pubkey.slice(0, 6)}...{user.node_pubkey.slice(-4)}
+                    </Link>
+                  </dd>
                 </div>
                 {user.is_validator && (
                   <>
                     <div className="flex justify-between">
                       <dt className="text-sm text-muted-foreground">Vote Account</dt>
                       <dd className="text-sm">
-                        <Link to={`/solana/validators/${user.vote_pubkey}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                        <Link
+                          to={`/solana/validators/${user.vote_pubkey}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                        >
                           {user.vote_pubkey.slice(0, 6)}...{user.vote_pubkey.slice(-4)}
                         </Link>
                       </dd>
@@ -558,7 +658,9 @@ export function UserDetailPage() {
                     </div>
                     <div className="flex justify-between">
                       <dt className="text-sm text-muted-foreground">Stake Weight</dt>
-                      <dd className="text-sm">{user.stake_weight_pct > 0 ? `${user.stake_weight_pct.toFixed(2)}%` : '—'}</dd>
+                      <dd className="text-sm">
+                        {user.stake_weight_pct > 0 ? `${user.stake_weight_pct.toFixed(2)}%` : '—'}
+                      </dd>
                     </div>
                   </>
                 )}
@@ -571,21 +673,30 @@ export function UserDetailPage() {
             <div className="border border-border rounded-lg p-4 bg-card">
               <h3 className="text-sm font-medium text-muted-foreground mb-3">Multicast Groups</h3>
               <div className="space-y-2">
-                {multicastGroups.map(g => (
+                {multicastGroups.map((g) => (
                   <div key={g.group_pk} className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">
-                      <Link to={`/dz/multicast-groups/${g.group_pk}`} className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                      <Link
+                        to={`/dz/multicast-groups/${g.group_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
                         {g.group_code}
                       </Link>
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
-                        g.mode === 'P' ? 'bg-purple-500/15 text-purple-500' :
-                        g.mode === 'S' ? 'bg-blue-500/15 text-blue-500' :
-                        'bg-amber-500/15 text-amber-500'
-                      }`}>
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+                          g.mode === 'P'
+                            ? 'bg-purple-500/15 text-purple-500'
+                            : g.mode === 'S'
+                              ? 'bg-blue-500/15 text-blue-500'
+                              : 'bg-amber-500/15 text-amber-500'
+                        }`}
+                      >
                         {g.mode === 'P' ? 'Publisher' : g.mode === 'S' ? 'Subscriber' : 'Pub + Sub'}
                       </span>
                     </div>
-                    <span className="text-xs text-muted-foreground font-mono">{g.multicast_ip}</span>
+                    <span className="text-xs text-muted-foreground font-mono">
+                      {g.multicast_ip}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/web/src/components/users-page.tsx
+++ b/web/src/components/users-page.tsx
@@ -35,11 +35,32 @@ function truncatePubkey(pubkey: string): string {
   return `${pubkey.slice(0, 6)}...${pubkey.slice(-4)}`
 }
 
-type SortField = 'owner' | 'kind' | 'dzip' | 'clientip' | 'device' | 'metro' | 'tenant' | 'status' | 'in' | 'out'
+type SortField =
+  | 'owner'
+  | 'kind'
+  | 'dzip'
+  | 'clientip'
+  | 'device'
+  | 'metro'
+  | 'tenant'
+  | 'status'
+  | 'in'
+  | 'out'
 type SortDirection = 'asc' | 'desc'
 
 // Valid filter field names as accepted by the API
-const validFilterFields = ['owner', 'kind', 'dzip', 'clientip', 'device', 'metro', 'tenant', 'status', 'in', 'out']
+const validFilterFields = [
+  'owner',
+  'kind',
+  'dzip',
+  'clientip',
+  'device',
+  'metro',
+  'tenant',
+  'status',
+  'in',
+  'out',
+]
 
 const userFieldPrefixes = [
   { prefix: 'owner:', description: 'Filter by owner pubkey' },
@@ -54,11 +75,19 @@ const userFieldPrefixes = [
   { prefix: 'out:', description: 'Filter by outbound traffic (e.g., >1gbps)' },
 ]
 
-const userAutocompleteFields: (string | { field: string; minChars: number })[] = ['status', 'kind', 'metro', { field: 'device', minChars: 2 }]
+const userAutocompleteFields: (string | { field: string; minChars: number })[] = [
+  'status',
+  'kind',
+  'metro',
+  { field: 'device', minChars: 2 },
+]
 
 function parseSearchFilters(searchParam: string): string[] {
   if (!searchParam) return []
-  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+  return searchParam
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean)
 }
 
 function toFilterParam(filter: string): string {
@@ -80,9 +109,13 @@ export function UsersPage() {
 
   const showDeleted = searchParams.get('deleted') === '1'
   const toggleDeleted = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
-      if (showDeleted) { newParams.delete('deleted') } else { newParams.set('deleted', '1') }
+      if (showDeleted) {
+        newParams.delete('deleted')
+      } else {
+        newParams.set('deleted', '1')
+      }
       newParams.delete('page')
       return newParams
     })
@@ -90,14 +123,21 @@ export function UsersPage() {
 
   const page = parseInt(searchParams.get('page') || '1')
   const offset = (page - 1) * PAGE_SIZE
-  const setOffset = useCallback((newOffset: number) => {
-    setSearchParams(prev => {
-      const newParams = new URLSearchParams(prev)
-      const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
-      if (newPage <= 1) { newParams.delete('page') } else { newParams.set('page', String(newPage)) }
-      return newParams
-    })
-  }, [setSearchParams])
+  const setOffset = useCallback(
+    (newOffset: number) => {
+      setSearchParams((prev) => {
+        const newParams = new URLSearchParams(prev)
+        const newPage = Math.floor(newOffset / PAGE_SIZE) + 1
+        if (newPage <= 1) {
+          newParams.delete('page')
+        } else {
+          newParams.set('page', String(newPage))
+        }
+        return newParams
+      })
+    },
+    [setSearchParams],
+  )
 
   const sortField = (searchParams.get('sort') || 'owner') as SortField
   const sortDirection = (searchParams.get('dir') || 'asc') as SortDirection
@@ -109,37 +149,45 @@ export function UsersPage() {
   const filterParams = useMemo(() => allFilters.map(toFilterParam), [allFilters])
   const filterKey = filterParams.join(',')
 
-  const { data: response, isLoading, error } = useQuery({
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['users', offset, sortField, sortDirection, filterKey, showDeleted],
-    queryFn: () => fetchUsers(
-      PAGE_SIZE,
-      offset,
-      sortField,
-      sortDirection,
-      filterParams.length > 0 ? filterParams : undefined,
-      showDeleted
-    ),
+    queryFn: () =>
+      fetchUsers(
+        PAGE_SIZE,
+        offset,
+        sortField,
+        sortDirection,
+        filterParams.length > 0 ? filterParams : undefined,
+        showDeleted,
+      ),
     refetchInterval: 30000,
     placeholderData: keepPreviousData,
   })
 
   const users = response?.items ?? []
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    const newFilters = searchFilters.filter(f => f !== filterToRemove)
-    setSearchParams(prev => {
-      const newParams = new URLSearchParams(prev)
-      if (newFilters.length === 0) {
-        newParams.delete('search')
-      } else {
-        newParams.set('search', newFilters.join(','))
-      }
-      return newParams
-    })
-  }, [searchFilters, setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      const newFilters = searchFilters.filter((f) => f !== filterToRemove)
+      setSearchParams((prev) => {
+        const newParams = new URLSearchParams(prev)
+        if (newFilters.length === 0) {
+          newParams.delete('search')
+        } else {
+          newParams.set('search', newFilters.join(','))
+        }
+        return newParams
+      })
+    },
+    [searchFilters, setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('search')
       return newParams
@@ -147,7 +195,7 @@ export function UsersPage() {
   }, [setSearchParams])
 
   const handleSort = (field: SortField) => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
       if (sortField === field) {
         newParams.set('dir', sortDirection === 'asc' ? 'desc' : 'asc')
@@ -162,9 +210,11 @@ export function UsersPage() {
 
   const SortIcon = ({ field }: { field: SortField }) => {
     if (sortField !== field) return null
-    return sortDirection === 'asc'
-      ? <ChevronUp className="h-3 w-3" />
-      : <ChevronDown className="h-3 w-3" />
+    return sortDirection === 'asc' ? (
+      <ChevronUp className="h-3 w-3" />
+    ) : (
+      <ChevronDown className="h-3 w-3" />
+    )
   }
 
   const sortAria = (field: SortField) => {
@@ -177,7 +227,7 @@ export function UsersPage() {
   useEffect(() => {
     if (prevFilterRef.current === filterKey) return
     prevFilterRef.current = filterKey
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev)
       newParams.delete('page')
       return newParams
@@ -233,7 +283,7 @@ export function UsersPage() {
               )}
               <button
                 onClick={toggleDeleted}
-                className={`text-xs px-2 py-1 rounded-md border transition-colors ${
+                className={`text-sm px-2 py-1 rounded-md border transition-colors ${
                   showDeleted
                     ? 'bg-gray-500/15 text-gray-500 border-gray-500/30 hover:bg-gray-500/25'
                     : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
@@ -259,61 +309,101 @@ export function UsersPage() {
               <thead>
                 <tr className="text-sm text-left text-muted-foreground border-b border-border">
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('owner')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('owner')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('owner')}
+                    >
                       Owner
                       <SortIcon field="owner" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('kind')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('kind')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('kind')}
+                    >
                       Kind
                       <SortIcon field="kind" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('clientip')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('clientip')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('clientip')}
+                    >
                       Client IP
                       <SortIcon field="clientip" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('dzip')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('dzip')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('dzip')}
+                    >
                       DZ IP
                       <SortIcon field="dzip" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('device')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('device')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('device')}
+                    >
                       Device
                       <SortIcon field="device" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('metro')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('metro')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('metro')}
+                    >
                       Metro
                       <SortIcon field="metro" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('tenant')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('tenant')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('tenant')}
+                    >
                       Tenant
                       <SortIcon field="tenant" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium" aria-sort={sortAria('status')}>
-                    <button className="inline-flex items-center gap-1" type="button" onClick={() => handleSort('status')}>
+                    <button
+                      className="inline-flex items-center gap-1"
+                      type="button"
+                      onClick={() => handleSort('status')}
+                    >
                       Status
                       <SortIcon field="status" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('in')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('in')}>
+                    <button
+                      className="inline-flex items-center gap-1 justify-end w-full"
+                      type="button"
+                      onClick={() => handleSort('in')}
+                    >
                       In
                       <SortIcon field="in" />
                     </button>
                   </th>
                   <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('out')}>
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('out')}>
+                    <button
+                      className="inline-flex items-center gap-1 justify-end w-full"
+                      type="button"
+                      onClick={() => handleSort('out')}
+                    >
                       Out
                       <SortIcon field="out" />
                     </button>
@@ -332,36 +422,70 @@ export function UsersPage() {
                         <span title={user.owner_pubkey}>{truncatePubkey(user.owner_pubkey)}</span>
                       </CopyableText>
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">
-                      {user.kind || '—'}
+                    <td className="px-4 py-3 text-sm text-muted-foreground">{user.kind || '—'}</td>
+                    <td className="px-4 py-3 text-sm whitespace-nowrap">
+                      {user.client_ip ? (
+                        <CopyableText text={user.client_ip} className="font-mono" />
+                      ) : (
+                        <span className="font-mono text-muted-foreground">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm whitespace-nowrap">
-                      {user.client_ip ? <CopyableText text={user.client_ip} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
+                      {user.dz_ip ? (
+                        <CopyableText text={user.dz_ip} className="font-mono" />
+                      ) : (
+                        <span className="font-mono text-muted-foreground">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm whitespace-nowrap">
-                      {user.dz_ip ? <CopyableText text={user.dz_ip} className="font-mono" /> : <span className="font-mono text-muted-foreground">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-sm whitespace-nowrap">
-                      {user.device_pk
-                        ? <Link to={`/dz/devices/${user.device_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{user.device_code}</Link>
-                        : <span className="font-mono text-muted-foreground">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-sm">
-                      {user.metro_pk
-                        ? <Link to={`/dz/metros/${user.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline" onClick={e => e.stopPropagation()}>{user.metro_name || user.metro_code}</Link>
-                        : <span className="text-muted-foreground">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-sm">
-                      {user.tenant_code
-                        ? <Link to={`/dz/tenants/${user.tenant_pk}`} className="font-mono hover:underline" onClick={e => e.stopPropagation()}>{user.tenant_code}</Link>
-                        : <span className="text-muted-foreground">—</span>
-                      }
+                      {user.device_pk ? (
+                        <Link
+                          to={`/dz/devices/${user.device_pk}`}
+                          className="font-mono text-foreground/85 hover:text-foreground hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {user.device_code}
+                        </Link>
+                      ) : (
+                        <span className="font-mono text-muted-foreground">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm">
-                      {user.is_deleted
-                        ? <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">Deleted</span>
-                        : <span className={`capitalize ${statusColors[user.status] || ''}`}>{user.status}</span>
-                      }
+                      {user.metro_pk ? (
+                        <Link
+                          to={`/dz/metros/${user.metro_pk}`}
+                          className="text-foreground/85 hover:text-foreground hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {user.metro_name || user.metro_code}
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {user.tenant_code ? (
+                        <Link
+                          to={`/dz/tenants/${user.tenant_pk}`}
+                          className="font-mono hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {user.tenant_code}
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {user.is_deleted ? (
+                        <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-gray-500/15 text-gray-500">
+                          Deleted
+                        </span>
+                      ) : (
+                        <span className={`capitalize ${statusColors[user.status] || ''}`}>
+                          {user.status}
+                        </span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm tabular-nums text-right text-muted-foreground">
                       {formatBps(user.in_bps)}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 
 /* Use class-based dark mode instead of prefers-color-scheme */
@@ -79,7 +79,7 @@
 
   /* Additional accent colors - neutral for dark mode */
   --accent-orange-10: oklch(0.22 0 0);
-  --accent-orange-20: oklch(0.30 0 0);
+  --accent-orange-20: oklch(0.3 0 0);
   --accent-orange-50: oklch(0.8502 0.0978 57.42);
   --accent-orange-100: oklch(0.65 0.18 31.82);
 
@@ -90,6 +90,9 @@
 }
 
 @theme {
+  --breakpoint-xss: 360px;
+  --breakpoint-xs: 400px;
+
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
   --font-serif: var(--font-heading);
@@ -159,7 +162,10 @@
 }
 
 /* Serif for headlines */
-h1, h2, h3, .headline {
+h1,
+h2,
+h3,
+.headline {
   font-family: var(--font-heading);
   font-weight: 400;
   letter-spacing: -0.02em;
@@ -170,7 +176,7 @@ h1, h2, h3, .headline {
   font-family: var(--font-wordmark);
   font-weight: 500;
   letter-spacing: -0.015em;
-  line-height: 1.0;
+  line-height: 1;
 }
 
 /* CodeMirror - de-emphasized, content-focused */
@@ -227,7 +233,7 @@ h1, h2, h3, .headline {
   padding: 4px 8px !important;
 }
 
-.cm-tooltip-autocomplete ul li[aria-selected="true"],
+.cm-tooltip-autocomplete ul li[aria-selected='true'],
 .cm-tooltip-autocomplete ul li:hover {
   background: var(--muted) !important;
   color: var(--foreground) !important;
@@ -265,7 +271,10 @@ table {
   line-height: 1.7;
 }
 
-.prose h1, .prose h2, .prose h3, .prose h4 {
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
   font-family: var(--font-sans);
   font-weight: 500;
   color: var(--foreground);
@@ -308,7 +317,8 @@ table {
   font-size: 0.875em;
 }
 
-.prose th, .prose td {
+.prose th,
+.prose td {
   border: 1px solid var(--border);
   padding: 0.5em 0.75em;
   text-align: left;
@@ -385,6 +395,10 @@ table {
 }
 
 @keyframes shimmer {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(400%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
 }

--- a/web/src/pages/link-latency-page.tsx
+++ b/web/src/pages/link-latency-page.tsx
@@ -3,8 +3,15 @@ import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronDown, ChevronUp, ArrowRightLeft, X, ArrowUpToLine, Loader2 } from 'lucide-react'
 import { fetchLinkLatencySummary, type LinkLatencySummary } from '@/lib/api'
-import { DashboardProvider, useDashboard, dashboardFilterParams } from '@/components/traffic-dashboard/dashboard-context'
-import { DashboardFilters, DashboardFilterBadges } from '@/components/traffic-dashboard/dashboard-filters'
+import {
+  DashboardProvider,
+  useDashboard,
+  dashboardFilterParams,
+} from '@/components/traffic-dashboard/dashboard-context'
+import {
+  DashboardFilters,
+  DashboardFilterBadges,
+} from '@/components/traffic-dashboard/dashboard-filters'
 import { PageHeader } from '@/components/page-header'
 import { InlineFilter } from '@/components/inline-filter'
 import { MultiLinkLatencyCharts } from '@/components/multi-link-latency-charts'
@@ -14,13 +21,13 @@ import { useTheme } from '@/hooks/use-theme'
 type AggMethod = 'max' | 'avg' | 'min' | 'p50' | 'p90' | 'p95' | 'p99'
 
 const aggLabels: Record<AggMethod, string> = {
-  'max': 'Max',
-  'p99': 'P99',
-  'p95': 'P95',
-  'p90': 'P90',
-  'p50': 'P50',
-  'avg': 'Average',
-  'min': 'Min',
+  max: 'Max',
+  p99: 'P99',
+  p95: 'P95',
+  p90: 'P90',
+  p50: 'P50',
+  avg: 'Average',
+  min: 'Min',
 }
 
 const COMMITTED_RTT_PROVISIONING_MS = 1000
@@ -73,7 +80,8 @@ function AggSelector({
 // Color based on ratio to committed value. No committed = no color.
 function ratioColor(measured: number, committed: number | undefined): string {
   if (measured <= 0) return 'text-muted-foreground'
-  if (!committed || committed <= 0 || committed >= COMMITTED_RTT_PROVISIONING_MS) return 'text-foreground'
+  if (!committed || committed <= 0 || committed >= COMMITTED_RTT_PROVISIONING_MS)
+    return 'text-foreground'
   const ratio = measured / committed
   if (ratio <= 1.0) return 'text-emerald-600 dark:text-emerald-400/80'
   if (ratio <= 1.2) return 'text-amber-600 dark:text-amber-400/80'
@@ -93,10 +101,29 @@ function fmt(v: number | undefined, decimals = 2): string {
   return v.toFixed(decimals)
 }
 
-type SortField = 'link_code' | 'link_type' | 'contributor_code' | 'side_a_code' | 'side_z_code' | 'committed_rtt_ms' | 'committed_jitter_ms' | 'rtt_a_to_z_ms' | 'rtt_z_to_a_ms' | 'jitter_a_to_z_ms' | 'jitter_z_to_a_ms' | 'loss_a_pct' | 'loss_z_pct'
+type SortField =
+  | 'link_code'
+  | 'link_type'
+  | 'contributor_code'
+  | 'side_a_code'
+  | 'side_z_code'
+  | 'committed_rtt_ms'
+  | 'committed_jitter_ms'
+  | 'rtt_a_to_z_ms'
+  | 'rtt_z_to_a_ms'
+  | 'jitter_a_to_z_ms'
+  | 'jitter_z_to_a_ms'
+  | 'loss_a_pct'
+  | 'loss_z_pct'
 type SortDir = 'asc' | 'desc'
 
-const textFields: SortField[] = ['link_code', 'link_type', 'contributor_code', 'side_a_code', 'side_z_code']
+const textFields: SortField[] = [
+  'link_code',
+  'link_type',
+  'contributor_code',
+  'side_a_code',
+  'side_z_code',
+]
 
 // InlineFilter config
 const filterFieldPrefixes = [
@@ -135,19 +162,26 @@ function matchesFilter(link: LinkLatencySummary, filterRaw: string): boolean {
 
   const getField = (f: string) => {
     switch (f) {
-      case 'code': return link.link_code
-      case 'type': return link.link_type
-      case 'contributor': return link.contributor_code
-      case 'sideA': return link.side_a_code
-      case 'sideZ': return link.side_z_code
-      case 'status': return link.link_status
-      default: return ''
+      case 'code':
+        return link.link_code
+      case 'type':
+        return link.link_type
+      case 'contributor':
+        return link.contributor_code
+      case 'sideA':
+        return link.side_a_code
+      case 'sideZ':
+        return link.side_z_code
+      case 'status':
+        return link.link_status
+      default:
+        return ''
     }
   }
 
   if (field === 'all') {
-    return ['code', 'type', 'contributor', 'sideA', 'sideZ'].some(f =>
-      getField(f).toLowerCase().includes(needle)
+    return ['code', 'type', 'contributor', 'sideA', 'sideZ'].some((f) =>
+      getField(f).toLowerCase().includes(needle),
     )
   }
   return getField(field).toLowerCase().includes(needle)
@@ -169,12 +203,27 @@ const columns: { field: SortField; label: string; align?: 'right' }[] = [
   { field: 'loss_z_pct', label: 'Loss Z%', align: 'right' },
 ]
 
-
 const EXCLUDED_CATEGORIES = [
-  { key: 'isis-down', label: 'ISIS Down', color: 'bg-red-500/10 text-red-600 dark:text-red-400' },
-  { key: 'soft-drained', label: 'Soft Drained', color: 'bg-amber-500/10 text-amber-600 dark:text-amber-400' },
-  { key: 'hard-drained', label: 'Hard Drained', color: 'bg-amber-500/10 text-amber-600 dark:text-amber-400' },
-  { key: 'provisioning', label: 'Provisioning', color: 'bg-blue-500/10 text-blue-600 dark:text-blue-400' },
+  {
+    key: 'isis-down',
+    label: 'ISIS Down',
+    color: 'bg-red-500/10 text-red-600 dark:text-red-400',
+  },
+  {
+    key: 'soft-drained',
+    label: 'Soft Drained',
+    color: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  },
+  {
+    key: 'hard-drained',
+    label: 'Hard Drained',
+    color: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  },
+  {
+    key: 'provisioning',
+    label: 'Provisioning',
+    color: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  },
 ]
 
 function StatusFilterDropdown({
@@ -205,18 +254,28 @@ function StatusFilterDropdown({
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
           <div className="absolute right-0 top-full mt-1 z-50 bg-popover border border-border rounded-md shadow-lg py-1 min-w-[180px]">
-            {EXCLUDED_CATEGORIES.map(cat => (
+            {EXCLUDED_CATEGORIES.map((cat) => (
               <button
                 key={cat.key}
                 onClick={() => onToggle(cat.key)}
                 className="w-full px-3 py-1.5 text-left text-sm flex items-center gap-2 hover:bg-muted/50 transition-colors"
               >
-                <span className={`w-3.5 h-3.5 rounded border flex items-center justify-center ${
-                  showCategories.has(cat.key) ? 'border-foreground bg-foreground' : 'border-muted-foreground'
-                }`}>
-                  {showCategories.has(cat.key) && <span className="text-[10px] text-background">&#10003;</span>}
+                <span
+                  className={`w-3.5 h-3.5 rounded border flex items-center justify-center ${
+                    showCategories.has(cat.key)
+                      ? 'border-foreground bg-foreground'
+                      : 'border-muted-foreground'
+                  }`}
+                >
+                  {showCategories.has(cat.key) && (
+                    <span className="text-[10px] text-background">&#10003;</span>
+                  )}
                 </span>
-                <span className={showCategories.has(cat.key) ? 'text-foreground' : 'text-muted-foreground'}>
+                <span
+                  className={
+                    showCategories.has(cat.key) ? 'text-foreground' : 'text-muted-foreground'
+                  }
+                >
                   {cat.label}
                 </span>
               </button>
@@ -228,8 +287,17 @@ function StatusFilterDropdown({
   )
 }
 
-function SortIcon({ field, sortField, sortDir }: { field: SortField; sortField: SortField; sortDir: SortDir }) {
-  if (field !== sortField) return <ChevronDown className="h-3 w-3 opacity-0 group-hover/th:opacity-40" />
+function SortIcon({
+  field,
+  sortField,
+  sortDir,
+}: {
+  field: SortField
+  sortField: SortField
+  sortDir: SortDir
+}) {
+  if (field !== sortField)
+    return <ChevronDown className="h-3 w-3 opacity-0 group-hover/th:opacity-40" />
   return sortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
 }
 
@@ -244,20 +312,25 @@ function LinkLatencyPageContent() {
   const [, startTransition] = useTransition()
   const setSearchParams = useCallback(
     (updater: (prev: URLSearchParams) => URLSearchParams) => {
-      startTransition(() => { setSearchParamsRaw(updater) })
+      startTransition(() => {
+        setSearchParamsRaw(updater)
+      })
     },
-    [setSearchParamsRaw, startTransition]
+    [setSearchParamsRaw, startTransition],
   )
 
   // URL-backed state helpers
-  const setUrlParam = useCallback((key: string, value: string, defaultValue: string) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      if (value === defaultValue) next.delete(key)
-      else next.set(key, value)
-      return next
-    })
-  }, [setSearchParams])
+  const setUrlParam = useCallback(
+    (key: string, value: string, defaultValue: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (value === defaultValue) next.delete(key)
+        else next.set(key, value)
+        return next
+      })
+    },
+    [setSearchParams],
+  )
 
   // Read state from URL with defaults
   const aggMethod = (searchParams.get('agg') || 'avg') as AggMethod
@@ -268,21 +341,32 @@ function LinkLatencyPageContent() {
 
   // Filter state: committed filters in URL, live filter in local state
   const [liveFilter, setLiveFilter] = useState('')
-  const searchFilters = useMemo(() => parseSearchFilters(searchParams.get('search') || ''), [searchParams])
-  const allFilters = useMemo(() => liveFilter ? [...searchFilters, liveFilter] : searchFilters, [searchFilters, liveFilter])
+  const searchFilters = useMemo(
+    () => parseSearchFilters(searchParams.get('search') || ''),
+    [searchParams],
+  )
+  const allFilters = useMemo(
+    () => (liveFilter ? [...searchFilters, liveFilter] : searchFilters),
+    [searchFilters, liveFilter],
+  )
 
-  const removeFilter = useCallback((filterToRemove: string) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      const filters = parseSearchFilters(prev.get('search') || '').filter(f => f !== filterToRemove)
-      if (filters.length === 0) next.delete('search')
-      else next.set('search', filters.join(','))
-      return next
-    })
-  }, [setSearchParams])
+  const removeFilter = useCallback(
+    (filterToRemove: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        const filters = parseSearchFilters(prev.get('search') || '').filter(
+          (f) => f !== filterToRemove,
+        )
+        if (filters.length === 0) next.delete('search')
+        else next.set('search', filters.join(','))
+        return next
+      })
+    },
+    [setSearchParams],
+  )
 
   const clearAllFilters = useCallback(() => {
-    setSearchParams(prev => {
+    setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
       next.delete('search')
       return next
@@ -290,16 +374,22 @@ function LinkLatencyPageContent() {
   }, [setSearchParams])
 
   const tableCollapsed = searchParams.get('table') === 'collapsed'
-  const setTableCollapsed = useCallback((fn: (prev: boolean) => boolean) => {
-    const next = fn(searchParams.get('table') === 'collapsed')
-    setUrlParam('table', next ? 'collapsed' : '', '')
-  }, [setUrlParam, searchParams])
+  const setTableCollapsed = useCallback(
+    (fn: (prev: boolean) => boolean) => {
+      const next = fn(searchParams.get('table') === 'collapsed')
+      setUrlParam('table', next ? 'collapsed' : '', '')
+    },
+    [setUrlParam, searchParams],
+  )
 
   const selectedToTop = searchParams.get('top') === '1'
-  const setSelectedToTop = useCallback((fn: (prev: boolean) => boolean) => {
-    const next = fn(searchParams.get('top') === '1')
-    setUrlParam('top', next ? '1' : '', '')
-  }, [setUrlParam, searchParams])
+  const setSelectedToTop = useCallback(
+    (fn: (prev: boolean) => boolean) => {
+      const next = fn(searchParams.get('top') === '1')
+      setUrlParam('top', next ? '1' : '', '')
+    },
+    [setUrlParam, searchParams],
+  )
 
   // Which excluded categories to show (empty = hide all excluded)
   const showCategories = useMemo(() => {
@@ -308,17 +398,20 @@ function LinkLatencyPageContent() {
     return new Set(raw.split(',').filter(Boolean))
   }, [searchParams])
 
-  const toggleShowCategory = useCallback((category: string) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      const current = new Set((prev.get('show') || '').split(',').filter(Boolean))
-      if (current.has(category)) current.delete(category)
-      else current.add(category)
-      if (current.size === 0) next.delete('show')
-      else next.set('show', [...current].join(','))
-      return next
-    })
-  }, [setSearchParams])
+  const toggleShowCategory = useCallback(
+    (category: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        const current = new Set((prev.get('show') || '').split(',').filter(Boolean))
+        if (current.has(category)) current.delete(category)
+        else current.add(category)
+        if (current.size === 0) next.delete('show')
+        else next.set('show', [...current].join(','))
+        return next
+      })
+    },
+    [setSearchParams],
+  )
 
   // Fetch all links when any excluded category is shown
   const showExcluded = showCategories.size > 0
@@ -330,14 +423,17 @@ function LinkLatencyPageContent() {
     return new Set(raw.split(',').filter(Boolean))
   }, [searchParams])
 
-  const setSelectedLinkPks = useCallback((next: Set<string>) => {
-    setSearchParams(prev => {
-      const p = new URLSearchParams(prev)
-      if (next.size === 0) p.delete('sel')
-      else p.set('sel', [...next].join(','))
-      return p
-    })
-  }, [setSearchParams])
+  const setSelectedLinkPks = useCallback(
+    (next: Set<string>) => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev)
+        if (next.size === 0) p.delete('sel')
+        else p.set('sel', [...next].join(','))
+        return p
+      })
+    },
+    [setSearchParams],
+  )
 
   const filterParams = useMemo(() => dashboardFilterParams(dashboardState), [dashboardState])
 
@@ -373,7 +469,7 @@ function LinkLatencyPageContent() {
 
     // Filter out excluded categories unless toggled on
     if (showExcluded) {
-      result = result.filter(l => {
+      result = result.filter((l) => {
         if (l.isis_down) return showCategories.has('isis-down')
         if (l.provisioning) return showCategories.has('provisioning')
         if (l.link_status === 'soft-drained') return showCategories.has('soft-drained')
@@ -392,10 +488,8 @@ function LinkLatencyPageContent() {
         existing.push(f)
         grouped.set(field, existing)
       }
-      result = result.filter(l =>
-        [...grouped.values()].every(group =>
-          group.some(f => matchesFilter(l, f))
-        )
+      result = result.filter((l) =>
+        [...grouped.values()].every((group) => group.some((f) => matchesFilter(l, f))),
       )
     }
 
@@ -407,38 +501,54 @@ function LinkLatencyPageContent() {
       }
       const av = a[sortField] as string | number
       const bv = b[sortField] as string | number
-      const cmp = typeof av === 'string' ? av.localeCompare(bv as string) : (av as number) - (bv as number)
+      const cmp =
+        typeof av === 'string' ? av.localeCompare(bv as string) : (av as number) - (bv as number)
       return sortDir === 'asc' ? cmp : -cmp
     })
-  }, [links, allFilters, sortField, sortDir, selectedToTop, selectedLinkPks, showExcluded, showCategories])
+  }, [
+    links,
+    allFilters,
+    sortField,
+    sortDir,
+    selectedToTop,
+    selectedLinkPks,
+    showExcluded,
+    showCategories,
+  ])
 
-  const handleSort = useCallback((field: SortField) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      if (prev.get('sort') === field || (!prev.get('sort') && field === 'rtt_a_to_z_ms')) {
-        // Toggle direction
-        const curDir = prev.get('sort_dir') || 'desc'
-        const newDir = curDir === 'asc' ? 'desc' : 'asc'
-        if (newDir === 'desc') next.delete('sort_dir')
-        else next.set('sort_dir', 'asc')
-      } else {
-        // New field
-        if (field === 'rtt_a_to_z_ms') next.delete('sort')
-        else next.set('sort', field)
-        const defaultDir = textFields.includes(field) ? 'asc' : 'desc'
-        if (defaultDir === 'desc') next.delete('sort_dir')
-        else next.set('sort_dir', defaultDir)
-      }
-      return next
-    })
-  }, [setSearchParams])
+  const handleSort = useCallback(
+    (field: SortField) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (prev.get('sort') === field || (!prev.get('sort') && field === 'rtt_a_to_z_ms')) {
+          // Toggle direction
+          const curDir = prev.get('sort_dir') || 'desc'
+          const newDir = curDir === 'asc' ? 'desc' : 'asc'
+          if (newDir === 'desc') next.delete('sort_dir')
+          else next.set('sort_dir', 'asc')
+        } else {
+          // New field
+          if (field === 'rtt_a_to_z_ms') next.delete('sort')
+          else next.set('sort', field)
+          const defaultDir = textFields.includes(field) ? 'asc' : 'desc'
+          if (defaultDir === 'desc') next.delete('sort_dir')
+          else next.set('sort_dir', defaultDir)
+        }
+        return next
+      })
+    },
+    [setSearchParams],
+  )
 
-  const toggleSelect = useCallback((pk: string) => {
-    const next = new Set(selectedLinkPks)
-    if (next.has(pk)) next.delete(pk)
-    else next.add(pk)
-    setSelectedLinkPks(next)
-  }, [selectedLinkPks, setSelectedLinkPks])
+  const toggleSelect = useCallback(
+    (pk: string) => {
+      const next = new Set(selectedLinkPks)
+      if (next.has(pk)) next.delete(pk)
+      else next.add(pk)
+      setSelectedLinkPks(next)
+    },
+    [selectedLinkPks, setSelectedLinkPks],
+  )
 
   // Build chart filter params — same filters as the table query so charts match
   const chartFilters = useMemo(() => {
@@ -487,21 +597,52 @@ function LinkLatencyPageContent() {
   }, [customStart, customEnd, filterParams, allFilters])
 
   const deltaBadge = (measured: number, committed: number | undefined) => {
-    if (!committed || committed <= 0 || committed >= COMMITTED_RTT_PROVISIONING_MS || measured <= 0) return null
+    if (!committed || committed <= 0 || committed >= COMMITTED_RTT_PROVISIONING_MS || measured <= 0)
+      return null
     const pct = ((measured - committed) / committed) * 100
     const rounded = Math.round(pct)
     if (rounded === 0) return <span className="ml-1.5 text-[10px] text-muted-foreground">0%</span>
     const sign = rounded > 0 ? '+' : ''
     const color = ratioColor(measured, committed)
-    return <span className={`ml-1.5 text-[10px] ${color}`}>{sign}{rounded}%</span>
+    return (
+      <span className={`ml-1.5 text-[10px] ${color}`}>
+        {sign}
+        {rounded}%
+      </span>
+    )
   }
 
   const statusBadge = (link: LinkLatencySummary) => {
-    if (link.isis_down) return <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-red-500/10 text-red-600 dark:text-red-400">isis down</span>
-    if (link.provisioning) return <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">provisioning</span>
-    if (link.link_status === 'soft-drained') return <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">soft-drained</span>
-    if (link.link_status === 'hard-drained') return <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">hard-drained</span>
-    if (link.link_status === 'suspended') return <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-red-500/10 text-red-600 dark:text-red-400">suspended</span>
+    if (link.isis_down)
+      return (
+        <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-red-500/10 text-red-600 dark:text-red-400">
+          isis down
+        </span>
+      )
+    if (link.provisioning)
+      return (
+        <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400">
+          provisioning
+        </span>
+      )
+    if (link.link_status === 'soft-drained')
+      return (
+        <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">
+          soft-drained
+        </span>
+      )
+    if (link.link_status === 'hard-drained')
+      return (
+        <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">
+          hard-drained
+        </span>
+      )
+    if (link.link_status === 'suspended')
+      return (
+        <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-red-500/10 text-red-600 dark:text-red-400">
+          suspended
+        </span>
+      )
     return null
   }
 
@@ -509,13 +650,19 @@ function LinkLatencyPageContent() {
     const v = link[field]
     if (typeof v === 'string') {
       if (field === 'link_code') {
-        return <span className="text-foreground">{v || '—'}{statusBadge(link)}</span>
+        return (
+          <span className="text-foreground">
+            {v || '—'}
+            {statusBadge(link)}
+          </span>
+        )
       }
       return <span className="text-foreground">{v || '—'}</span>
     }
     const n = v ?? 0
     if (field === 'committed_rtt_ms' || field === 'committed_jitter_ms') {
-      if (n <= 0 || n >= COMMITTED_RTT_PROVISIONING_MS) return <span className="text-muted-foreground">—</span>
+      if (n <= 0 || n >= COMMITTED_RTT_PROVISIONING_MS)
+        return <span className="text-muted-foreground">—</span>
       return <span className="text-muted-foreground">{fmt(n)} ms</span>
     }
     if (field.startsWith('rtt_')) {
@@ -540,53 +687,54 @@ function LinkLatencyPageContent() {
   const [maxTableHeight, setMaxTableHeight] = useState(320)
   const dragRef = useRef<{ startY: number; startHeight: number } | null>(null)
 
-  const handleDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    dragRef.current = { startY: e.clientY, startHeight: maxTableHeight }
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      dragRef.current = { startY: e.clientY, startHeight: maxTableHeight }
 
-    const handleDragMove = (ev: MouseEvent) => {
-      if (!dragRef.current) return
-      const delta = ev.clientY - dragRef.current.startY
-      setMaxTableHeight(Math.max(120, Math.min(800, dragRef.current.startHeight + delta)))
-    }
-    const handleDragEnd = () => {
-      dragRef.current = null
-      document.removeEventListener('mousemove', handleDragMove)
-      document.removeEventListener('mouseup', handleDragEnd)
-    }
-    document.addEventListener('mousemove', handleDragMove)
-    document.addEventListener('mouseup', handleDragEnd)
-  }, [maxTableHeight])
+      const handleDragMove = (ev: MouseEvent) => {
+        if (!dragRef.current) return
+        const delta = ev.clientY - dragRef.current.startY
+        setMaxTableHeight(Math.max(120, Math.min(800, dragRef.current.startHeight + delta)))
+      }
+      const handleDragEnd = () => {
+        dragRef.current = null
+        document.removeEventListener('mousemove', handleDragMove)
+        document.removeEventListener('mouseup', handleDragEnd)
+      }
+      document.addEventListener('mousemove', handleDragMove)
+      document.addEventListener('mouseup', handleDragEnd)
+    },
+    [maxTableHeight],
+  )
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Sticky header */}
       <div className="flex-none bg-background border-b border-border px-4 sm:px-8 pt-6 pb-4 z-10">
-        <div className="[&>div]:mb-0">
-          <PageHeader
-            icon={ArrowRightLeft}
-            title="Link Latency"
-            actions={<DashboardFilters hideMetric hideIntfType hideSearch />}
-          />
-        </div>
-        <div className="flex items-center gap-2 mt-3 flex-wrap">
-          <div className="flex items-center gap-2 ml-auto">
-            <DashboardFilterBadges />
-            {searchFilters.map((filter, idx) => (
-              <button
-                key={`${filter}-${idx}`}
-                onClick={() => removeFilter(filter)}
-                className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
-              >
-                {filter}
-                <X className="h-3 w-3" />
-              </button>
-            ))}
-            {searchFilters.length > 1 && (
-              <button onClick={clearAllFilters} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                Clear all
-              </button>
-            )}
+        <PageHeader icon={ArrowRightLeft} title="Link Latency" />
+        <div className="flex 2xl:items-center gap-2 mt-3 w-full flex-col 2xl:flex-row justify-between">
+          <DashboardFilters hideMetric hideIntfType hideSearch />
+          <DashboardFilterBadges />
+          {searchFilters.map((filter, idx) => (
+            <button
+              key={`${filter}-${idx}`}
+              onClick={() => removeFilter(filter)}
+              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
+            >
+              {filter}
+              <X className="h-3 w-3" />
+            </button>
+          ))}
+          {searchFilters.length > 1 && (
+            <button
+              onClick={clearAllFilters}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Clear all
+            </button>
+          )}
+          <div className="flex items-center gap-2 flex-wrap ">
             <InlineFilter
               fieldPrefixes={filterFieldPrefixes}
               entity="links"
@@ -603,15 +751,20 @@ function LinkLatencyPageContent() {
       {/* Scrollable content */}
       <div className="flex-1 overflow-auto px-4 sm:px-8 py-6 space-y-6">
         {/* Link Table — collapsible, resizable with internal scroll */}
-        <div className="border border-border rounded-lg overflow-hidden flex flex-col" style={tableCollapsed ? undefined : { maxHeight: maxTableHeight }}>
+        <div
+          className="border border-border rounded-lg overflow-hidden flex flex-col"
+          style={tableCollapsed ? undefined : { maxHeight: maxTableHeight }}
+        >
           {/* Table header */}
           <div className="flex-none px-3 py-2 flex items-center gap-2 border-b border-border">
             <button
-              onClick={() => setTableCollapsed(c => !c)}
+              onClick={() => setTableCollapsed((c) => !c)}
               className="text-muted-foreground hover:text-foreground transition-colors"
               title={tableCollapsed ? 'Show table' : 'Hide table'}
             >
-              <ChevronDown className={`h-4 w-4 transition-transform ${tableCollapsed ? '-rotate-90' : ''}`} />
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${tableCollapsed ? '-rotate-90' : ''}`}
+              />
             </button>
             <span className="text-xs text-muted-foreground">{filteredLinks.length} links</span>
             {isFetching && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
@@ -619,7 +772,7 @@ function LinkLatencyPageContent() {
             {selectedLinkPks.size > 0 && (
               <>
                 <button
-                  onClick={() => setSelectedToTop(p => !p)}
+                  onClick={() => setSelectedToTop((p) => !p)}
                   className={`px-1.5 py-0.5 rounded transition-colors ${selectedToTop ? 'text-foreground bg-muted' : 'text-muted-foreground hover:text-foreground'}`}
                   title={selectedToTop ? 'Stop sorting selected to top' : 'Sort selected to top'}
                 >
@@ -636,7 +789,11 @@ function LinkLatencyPageContent() {
           </div>
           {/* Shimmer loading bar - overlays below header, no layout shift */}
           <div className="flex-none h-0 w-full relative z-[2]">
-            {isFetching && <div className="absolute top-0 left-0 right-0 h-0.5 overflow-hidden"><div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" /></div>}
+            {isFetching && (
+              <div className="absolute top-0 left-0 right-0 h-0.5 overflow-hidden">
+                <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
+              </div>
+            )}
           </div>
           {!tableCollapsed && (
             <>
@@ -654,7 +811,7 @@ function LinkLatencyPageContent() {
                     <thead className="sticky top-0 z-[1] bg-muted/80 backdrop-blur-sm">
                       <tr className="border-b border-border">
                         <th className="w-1 px-0" />
-                        {columns.map(col => (
+                        {columns.map((col) => (
                           <th
                             key={col.field}
                             className={`px-3 py-2 font-medium text-muted-foreground cursor-pointer select-none group/th whitespace-nowrap ${
@@ -671,9 +828,11 @@ function LinkLatencyPageContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredLinks.map(link => {
+                      {filteredLinks.map((link) => {
                         const isSelected = selectedLinkPks.has(link.link_pk)
-                        const selectColor = isSelected ? selectedColorMap.get(link.link_pk) : undefined
+                        const selectColor = isSelected
+                          ? selectedColorMap.get(link.link_pk)
+                          : undefined
                         return (
                           <tr
                             key={link.link_pk}
@@ -682,10 +841,13 @@ function LinkLatencyPageContent() {
                           >
                             <td className="w-1 px-0">
                               {selectColor && (
-                                <div className="w-1 h-full min-h-[32px] rounded-r-sm" style={{ backgroundColor: selectColor }} />
+                                <div
+                                  className="w-1 h-full min-h-[32px] rounded-r-sm"
+                                  style={{ backgroundColor: selectColor }}
+                                />
                               )}
                             </td>
-                            {columns.map(col => (
+                            {columns.map((col) => (
                               <td
                                 key={col.field}
                                 className={`px-3 py-1.5 whitespace-nowrap ${col.align === 'right' ? 'text-right tabular-nums' : ''}`}

--- a/web/src/pages/traffic-dashboard-page.tsx
+++ b/web/src/pages/traffic-dashboard-page.tsx
@@ -1,12 +1,18 @@
 import { BarChart3 } from 'lucide-react'
 import { useIsFetching } from '@tanstack/react-query'
 import { DashboardProvider, useDashboard } from '@/components/traffic-dashboard/dashboard-context'
-import { DashboardFilters, DashboardFilterBadges } from '@/components/traffic-dashboard/dashboard-filters'
+import {
+  DashboardFilters,
+  DashboardFilterBadges,
+} from '@/components/traffic-dashboard/dashboard-filters'
 import { PageHeader } from '@/components/page-header'
 import { Section } from '@/components/traffic-dashboard/section'
 import { StressPanel } from '@/components/traffic-dashboard/stress-panel'
 import { LocalizationPanel } from '@/components/traffic-dashboard/localization-panel'
-import { TopDevicesPanel, TopInterfacesPanel } from '@/components/traffic-dashboard/attribution-panel'
+import {
+  TopDevicesPanel,
+  TopInterfacesPanel,
+} from '@/components/traffic-dashboard/attribution-panel'
 import { DrilldownPanel } from '@/components/traffic-dashboard/drilldown-panel'
 import { BurstinessPanel } from '@/components/traffic-dashboard/burstiness-panel'
 import { HealthPanel } from '@/components/traffic-dashboard/health-panel'
@@ -29,11 +35,7 @@ function DashboardContent() {
       {/* Sticky header */}
       <div className="flex-none bg-background border-b border-border px-4 sm:px-8 pt-6 pb-4 z-10">
         <div className="[&>div]:mb-0">
-          <PageHeader
-            icon={BarChart3}
-            title="Traffic Overview"
-            actions={<DashboardFilters />}
-          />
+          <PageHeader icon={BarChart3} title="Traffic Overview" actions={<DashboardFilters />} />
         </div>
         <div className="flex items-center mt-3">
           <div className="flex items-center gap-3 ml-auto">
@@ -46,30 +48,46 @@ function DashboardContent() {
       <div className="flex-1 overflow-auto px-4 sm:px-8 py-6">
         <div className="space-y-4">
           <Section
-            title={isUtil ? 'System Stress' : metric === 'packets' ? 'Aggregate Packet Rate' : 'Aggregate Throughput'}
-            description={isUtil
-              ? 'P50, P95, and max utilization across all interfaces per time bucket. Spikes indicate widespread congestion.'
-              : metric === 'packets'
-                ? 'P50, P95, and max packet rate across all interfaces per time bucket.'
-                : 'P50, P95, and max throughput across all interfaces per time bucket.'}
+            title={
+              isUtil
+                ? 'System Stress'
+                : metric === 'packets'
+                  ? 'Aggregate Packet Rate'
+                  : 'Aggregate Throughput'
+            }
+            description={
+              isUtil
+                ? 'P50, P95, and max utilization across all interfaces per time bucket. Spikes indicate widespread congestion.'
+                : metric === 'packets'
+                  ? 'P50, P95, and max packet rate across all interfaces per time bucket.'
+                  : 'P50, P95, and max throughput across all interfaces per time bucket.'
+            }
             loading={stressFetching}
           >
             <StressPanel />
           </Section>
 
           <Section
-            title={isUtil ? 'Utilization by Group' : metric === 'packets' ? 'Packet Rate by Group' : 'Throughput by Group'}
-            description={isUtil
-              ? 'Average P95 utilization per group. Click a group to filter the panels below.'
-              : metric === 'packets'
-                ? 'Average P95 packet rate per group. Click a group to filter the panels below.'
-                : 'Average P95 throughput per group. Click a group to filter the panels below.'}
+            title={
+              isUtil
+                ? 'Utilization by Group'
+                : metric === 'packets'
+                  ? 'Packet Rate by Group'
+                  : 'Throughput by Group'
+            }
+            description={
+              isUtil
+                ? 'Average P95 utilization per group. Click a group to filter the panels below.'
+                : metric === 'packets'
+                  ? 'Average P95 packet rate per group. Click a group to filter the panels below.'
+                  : 'Average P95 throughput per group. Click a group to filter the panels below.'
+            }
             loading={groupFetching}
           >
             <LocalizationPanel />
           </Section>
 
-          <div className="grid grid-cols-2 gap-4 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
             <Section
               title="Top Devices"
               description="Devices ranked by peak aggregate throughput. Click a row to drill down."
@@ -79,11 +97,13 @@ function DashboardContent() {
             </Section>
             <Section
               title="Top Interfaces"
-              description={isUtil
-                ? 'Interfaces ranked by utilization. Click a row to drill down.'
-                : metric === 'packets'
-                  ? 'Interfaces ranked by peak packet rate. Click a row to drill down.'
-                  : 'Interfaces ranked by peak throughput. Click a row to drill down.'}
+              description={
+                isUtil
+                  ? 'Interfaces ranked by utilization. Click a row to drill down.'
+                  : metric === 'packets'
+                    ? 'Interfaces ranked by peak packet rate. Click a row to drill down.'
+                    : 'Interfaces ranked by peak throughput. Click a row to drill down.'
+              }
               loading={topFetching}
             >
               <TopInterfacesPanel />

--- a/web/src/pages/traffic-page.tsx
+++ b/web/src/pages/traffic-page.tsx
@@ -4,8 +4,16 @@ import { useSearchParams } from 'react-router-dom'
 import { ChevronDown, Network, Sigma } from 'lucide-react'
 import { fetchTrafficData, fetchTopology, type TrafficPoint, type SeriesInfo } from '@/lib/api'
 import { TrafficChart } from '@/components/traffic-chart-uplot'
-import { DashboardProvider, useDashboard, dashboardFilterParams, resolveAutoBucket } from '@/components/traffic-dashboard/dashboard-context'
-import { DashboardFilters, DashboardFilterBadges } from '@/components/traffic-dashboard/dashboard-filters'
+import {
+  DashboardProvider,
+  useDashboard,
+  dashboardFilterParams,
+  resolveAutoBucket,
+} from '@/components/traffic-dashboard/dashboard-context'
+import {
+  DashboardFilters,
+  DashboardFilterBadges,
+} from '@/components/traffic-dashboard/dashboard-filters'
 import { PageHeader } from '@/components/page-header'
 
 export interface LinkLookupInfo {
@@ -31,7 +39,7 @@ function LazyChart({ children, height = 600 }: { children: React.ReactNode; heig
           observer.disconnect()
         }
       },
-      { rootMargin: '100px' } // Start loading 100px before visible
+      { rootMargin: '100px' }, // Start loading 100px before visible
     )
 
     if (ref.current) {
@@ -43,9 +51,7 @@ function LazyChart({ children, height = 600 }: { children: React.ReactNode; heig
 
   return (
     <div ref={ref} style={{ minHeight: height }}>
-      {isVisible ? children : (
-        <div className="animate-pulse bg-muted rounded h-full" />
-      )}
+      {isVisible ? children : <div className="animate-pulse bg-muted rounded h-full" />}
     </div>
   )
 }
@@ -53,26 +59,49 @@ function LazyChart({ children, height = 600 }: { children: React.ReactNode; heig
 type AggMethod = 'max' | 'avg' | 'min' | 'p50' | 'p90' | 'p95' | 'p99'
 
 const aggLabels: Record<AggMethod, string> = {
-  'max': 'Max',
-  'p99': 'P99',
-  'p95': 'P95',
-  'p90': 'P90',
-  'p50': 'P50',
-  'avg': 'Average',
-  'min': 'Min',
+  max: 'Max',
+  p99: 'P99',
+  p95: 'P95',
+  p90: 'P90',
+  p50: 'P50',
+  avg: 'Average',
+  min: 'Min',
 }
 
-type ChartSection = 'tunnel-stacked' | 'tunnel' | 'link-stacked' | 'link' | 'cyoa-stacked' | 'cyoa' | 'other-stacked' | 'other' | 'discards'
+type ChartSection =
+  | 'tunnel-stacked'
+  | 'tunnel'
+  | 'link-stacked'
+  | 'link'
+  | 'cyoa-stacked'
+  | 'cyoa'
+  | 'other-stacked'
+  | 'other'
+  | 'discards'
 
-const ALL_KNOWN_SECTIONS: ChartSection[] = ['tunnel-stacked', 'tunnel', 'link-stacked', 'link', 'cyoa-stacked', 'cyoa', 'other-stacked', 'other', 'discards']
+const ALL_KNOWN_SECTIONS: ChartSection[] = [
+  'tunnel-stacked',
+  'tunnel',
+  'link-stacked',
+  'link',
+  'cyoa-stacked',
+  'cyoa',
+  'other-stacked',
+  'other',
+  'discards',
+]
 
 type IntfCategory = 'tunnel' | 'link' | 'cyoa' | 'other'
 
 const SECTION_CATEGORY: Partial<Record<ChartSection, IntfCategory>> = {
-  'tunnel-stacked': 'tunnel', 'tunnel': 'tunnel',
-  'link-stacked': 'link', 'link': 'link',
-  'cyoa-stacked': 'cyoa', 'cyoa': 'cyoa',
-  'other-stacked': 'other', 'other': 'other',
+  'tunnel-stacked': 'tunnel',
+  tunnel: 'tunnel',
+  'link-stacked': 'link',
+  link: 'link',
+  'cyoa-stacked': 'cyoa',
+  cyoa: 'cyoa',
+  'other-stacked': 'other',
+  other: 'other',
 }
 
 type Layout = '1x4' | '2x2'
@@ -81,8 +110,6 @@ const layoutLabels: Record<Layout, string> = {
   '1x4': '1',
   '2x2': '2',
 }
-
-
 
 function AggSelector({
   value,
@@ -129,13 +156,7 @@ function AggSelector({
   )
 }
 
-function LayoutSelector({
-  value,
-  onChange,
-}: {
-  value: Layout
-  onChange: (value: Layout) => void
-}) {
+function LayoutSelector({ value, onChange }: { value: Layout; onChange: (value: Layout) => void }) {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
@@ -217,7 +238,10 @@ function aggregateTrafficData(
     const computed = {
       P50: { in: percentile(sortedIn, 50), out: percentile(sortedOut, 50) },
       P95: { in: percentile(sortedIn, 95), out: percentile(sortedOut, 95) },
-      Max: { in: sortedIn[sortedIn.length - 1] ?? 0, out: sortedOut[sortedOut.length - 1] ?? 0 },
+      Max: {
+        in: sortedIn[sortedIn.length - 1] ?? 0,
+        out: sortedOut[sortedOut.length - 1] ?? 0,
+      },
     }
 
     for (const stat of stats) {
@@ -228,13 +252,17 @@ function aggregateTrafficData(
         intf: '',
         in_bps: computed[stat].in,
         out_bps: computed[stat].out,
-        in_discards: 0, out_discards: 0, in_errors: 0, out_errors: 0,
-        in_fcs_errors: 0, carrier_transitions: 0,
+        in_discards: 0,
+        out_discards: 0,
+        in_errors: 0,
+        out_errors: 0,
+        in_fcs_errors: 0,
+        carrier_transitions: 0,
       })
     }
   }
 
-  const aggSeries: SeriesInfo[] = stats.flatMap(stat => [
+  const aggSeries: SeriesInfo[] = stats.flatMap((stat) => [
     { key: `${stat} (in)`, device: stat, intf: '', direction: 'in', mean: 0 },
     { key: `${stat} (out)`, device: stat, intf: '', direction: 'out', mean: 0 },
   ])
@@ -271,14 +299,24 @@ function aggregateTrafficDataTotal(
       intf: '',
       in_bps: inSum,
       out_bps: outSum,
-      in_discards: 0, out_discards: 0, in_errors: 0, out_errors: 0,
-      in_fcs_errors: 0, carrier_transitions: 0,
+      in_discards: 0,
+      out_discards: 0,
+      in_errors: 0,
+      out_errors: 0,
+      in_fcs_errors: 0,
+      carrier_transitions: 0,
     })
   }
 
   const aggSeries: SeriesInfo[] = [
     { key: 'Total (in)', device: 'Total', intf: '', direction: 'in', mean: 0 },
-    { key: 'Total (out)', device: 'Total', intf: '', direction: 'out', mean: 0 },
+    {
+      key: 'Total (out)',
+      device: 'Total',
+      intf: '',
+      direction: 'out',
+      mean: 0,
+    },
   ]
 
   return { points: aggPoints, series: aggSeries }
@@ -291,8 +329,15 @@ function TrafficPageContent() {
   const timeRangeSeconds = useMemo(() => {
     if (customStart && customEnd) return customEnd - customStart
     const map: Record<string, number> = {
-      '1h': 3600, '3h': 10800, '6h': 21600, '12h': 43200, '24h': 86400,
-      '3d': 259200, '7d': 604800, '14d': 1209600, '30d': 2592000,
+      '1h': 3600,
+      '3h': 10800,
+      '6h': 21600,
+      '12h': 43200,
+      '24h': 86400,
+      '3d': 259200,
+      '7d': 604800,
+      '14d': 1209600,
+      '30d': 2592000,
     }
     return map[timeRange] || 86400
   }, [timeRange, customStart, customEnd])
@@ -305,12 +350,19 @@ function TrafficPageContent() {
     return 'max'
   }, [searchParams])
 
-  const setAggMethod = useCallback((m: AggMethod) => {
-    setSearchParams(prev => {
-      if (m === 'max') { prev.delete('agg') } else { prev.set('agg', m) }
-      return prev
-    })
-  }, [setSearchParams])
+  const setAggMethod = useCallback(
+    (m: AggMethod) => {
+      setSearchParams((prev) => {
+        if (m === 'max') {
+          prev.delete('agg')
+        } else {
+          prev.set('agg', m)
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   // aggregate param: absent = auto, 'on' = force all on, 'off' = force all off
   const aggregateOverride = useMemo<boolean | null>(() => {
@@ -320,13 +372,19 @@ function TrafficPageContent() {
     return null
   }, [searchParams])
 
-  const setAggregateOverride = useCallback((v: boolean | null) => {
-    setSearchParams(prev => {
-      if (v === null) { prev.delete('aggregate') }
-      else { prev.set('aggregate', v ? 'on' : 'off') }
-      return prev
-    })
-  }, [setSearchParams])
+  const setAggregateOverride = useCallback(
+    (v: boolean | null) => {
+      setSearchParams((prev) => {
+        if (v === null) {
+          prev.delete('aggregate')
+        } else {
+          prev.set('aggregate', v ? 'on' : 'off')
+        }
+        return prev
+      })
+    },
+    [setSearchParams],
+  )
 
   const [aggregateProcessing, setAggregateProcessing] = useState(false)
 
@@ -366,7 +424,6 @@ function TrafficPageContent() {
     return dashboardState.bucket
   }, [dashboardState.bucket, timeRange])
 
-
   // Determine which chart categories to show based on intf type filter
   const showCategory: Record<IntfCategory, boolean> = {
     tunnel: intfType === 'all' || intfType === 'tunnel',
@@ -393,7 +450,8 @@ function TrafficPageContent() {
     error: trafficError,
   } = useQuery({
     queryKey: ['traffic-intf', timeRange, actualBucketSize, aggMethod, filterParams, metric],
-    queryFn: () => fetchTrafficData(timeRange, null, actualBucketSize, aggMethod, filterParams, metric),
+    queryFn: () =>
+      fetchTrafficData(timeRange, null, actualBucketSize, aggMethod, filterParams, metric),
     staleTime: 30000,
     refetchInterval: dashboardState.refetchInterval,
   })
@@ -420,7 +478,12 @@ function TrafficPageContent() {
 
   // Per-category interface counts for auto-detect
   const categoryCounts = useMemo(() => {
-    const counts: Record<IntfCategory, number> = { tunnel: 0, link: 0, cyoa: 0, other: 0 }
+    const counts: Record<IntfCategory, number> = {
+      tunnel: 0,
+      link: 0,
+      cyoa: 0,
+      other: 0,
+    }
     for (const cat of intfCategoryMap.values()) {
       counts[cat]++
     }
@@ -431,37 +494,51 @@ function TrafficPageContent() {
   const totalCount = intfCategoryMap.size
   const prevTotalCount = useRef(totalCount)
   useEffect(() => {
-    if (prevTotalCount.current !== 0 && totalCount !== prevTotalCount.current && aggregateOverride !== null) {
+    if (
+      prevTotalCount.current !== 0 &&
+      totalCount !== prevTotalCount.current &&
+      aggregateOverride !== null
+    ) {
       setAggregateOverride(null)
     }
     prevTotalCount.current = totalCount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [totalCount])
 
   // Resolve whether a given category should be aggregated
-  const shouldAggregate = useCallback((cat: IntfCategory): boolean => {
-    if (aggregateOverride !== null) return aggregateOverride
-    const count = intfType !== 'all' ? intfCategoryMap.size : categoryCounts[cat]
-    return count > 10
-  }, [aggregateOverride, intfType, intfCategoryMap.size, categoryCounts])
+  const shouldAggregate = useCallback(
+    (cat: IntfCategory): boolean => {
+      if (aggregateOverride !== null) return aggregateOverride
+      const count = intfType !== 'all' ? intfCategoryMap.size : categoryCounts[cat]
+      return count > 10
+    },
+    [aggregateOverride, intfType, intfCategoryMap.size, categoryCounts],
+  )
 
   // For the sigma button display: true = forced on, false = forced off, null = auto
-  const anyAutoAggregate = useMemo(() =>
-    Object.values(categoryCounts).some(c => c > 10),
-  [categoryCounts])
+  const anyAutoAggregate = useMemo(
+    () => Object.values(categoryCounts).some((c) => c > 10),
+    [categoryCounts],
+  )
 
   // Split data by interface category client-side
   const categoryData = useMemo(() => {
     if (!allTrafficData || intfType !== 'all') {
-      return { tunnel: allTrafficData, link: allTrafficData, cyoa: allTrafficData, other: allTrafficData }
+      return {
+        tunnel: allTrafficData,
+        link: allTrafficData,
+        cyoa: allTrafficData,
+        other: allTrafficData,
+      }
     }
     const filterByCategory = (cat: IntfCategory) => {
-      const match = (device: string, intf: string) => (intfCategoryMap.get(`${device}:${intf}`) ?? 'other') === cat
+      const match = (device: string, intf: string) =>
+        (intfCategoryMap.get(`${device}:${intf}`) ?? 'other') === cat
       return {
         ...allTrafficData,
-        points: allTrafficData.points.filter(p => match(p.device, p.intf)),
-        series: allTrafficData.series.filter(s => match(s.device, s.intf)),
-        discards_series: allTrafficData.discards_series.filter(s => match(s.device, s.intf)),
+        points: allTrafficData.points.filter((p) => match(p.device, p.intf)),
+        series: allTrafficData.series.filter((s) => match(s.device, s.intf)),
+        discards_series: allTrafficData.discards_series.filter((s) => match(s.device, s.intf)),
       }
     }
     return {
@@ -483,13 +560,25 @@ function TrafficPageContent() {
   const aggregatedCategoryData = useMemo(() => {
     const maybeAgg = (cat: IntfCategory) =>
       shouldAggregate(cat) ? aggHelper(categoryData[cat], aggregateTrafficData) : categoryData[cat]
-    return { tunnel: maybeAgg('tunnel'), link: maybeAgg('link'), cyoa: maybeAgg('cyoa'), other: maybeAgg('other') }
+    return {
+      tunnel: maybeAgg('tunnel'),
+      link: maybeAgg('link'),
+      cyoa: maybeAgg('cyoa'),
+      other: maybeAgg('other'),
+    }
   }, [categoryData, shouldAggregate, aggHelper])
 
   const aggregatedCategoryDataStacked = useMemo(() => {
     const maybeAgg = (cat: IntfCategory) =>
-      shouldAggregate(cat) ? aggHelper(categoryData[cat], aggregateTrafficDataTotal) : categoryData[cat]
-    return { tunnel: maybeAgg('tunnel'), link: maybeAgg('link'), cyoa: maybeAgg('cyoa'), other: maybeAgg('other') }
+      shouldAggregate(cat)
+        ? aggHelper(categoryData[cat], aggregateTrafficDataTotal)
+        : categoryData[cat]
+    return {
+      tunnel: maybeAgg('tunnel'),
+      link: maybeAgg('link'),
+      cyoa: maybeAgg('cyoa'),
+      other: maybeAgg('other'),
+    }
   }, [categoryData, shouldAggregate, aggHelper])
 
   // Keep processing indicator visible until the browser is idle (charts done painting)
@@ -506,9 +595,7 @@ function TrafficPageContent() {
   }, [aggregateProcessing])
 
   // Fetch topology data for link metadata
-  const {
-    data: topologyData,
-  } = useQuery({
+  const { data: topologyData } = useQuery({
     queryKey: ['topology'],
     queryFn: () => fetchTopology(),
     staleTime: 60000,
@@ -520,16 +607,30 @@ function TrafficPageContent() {
   const countersData = useMemo(() => {
     if (!allTrafficData) return null
     // Sum all counter types per interface to find which interfaces have any events
-    const intfTotals = new Map<string, { device: string; devicePk: string; intf: string; total: number }>()
+    const intfTotals = new Map<
+      string,
+      { device: string; devicePk: string; intf: string; total: number }
+    >()
     for (const p of allTrafficData.points) {
-      const total = p.in_discards + p.out_discards + p.in_errors + p.out_errors + p.in_fcs_errors + p.carrier_transitions
+      const total =
+        p.in_discards +
+        p.out_discards +
+        p.in_errors +
+        p.out_errors +
+        p.in_fcs_errors +
+        p.carrier_transitions
       if (total === 0) continue
       const key = `${p.device}-${p.intf}`
       const existing = intfTotals.get(key)
       if (existing) {
         existing.total += total
       } else {
-        intfTotals.set(key, { device: p.device, devicePk: p.device_pk, intf: p.intf, total })
+        intfTotals.set(key, {
+          device: p.device,
+          devicePk: p.device_pk,
+          intf: p.intf,
+          total,
+        })
       }
     }
     if (intfTotals.size === 0) return null
@@ -538,11 +639,17 @@ function TrafficPageContent() {
     // in = in_discards + in_errors + in_fcs_errors + carrier_transitions
     // out = out_discards + out_errors (negated for bidirectional)
     const points = allTrafficData.points
-      .filter(p => {
-        const total = p.in_discards + p.out_discards + p.in_errors + p.out_errors + p.in_fcs_errors + p.carrier_transitions
+      .filter((p) => {
+        const total =
+          p.in_discards +
+          p.out_discards +
+          p.in_errors +
+          p.out_errors +
+          p.in_fcs_errors +
+          p.carrier_transitions
         return total > 0
       })
-      .map(p => ({
+      .map((p) => ({
         ...p,
         in_bps: p.in_discards + p.in_errors + p.in_fcs_errors + p.carrier_transitions,
         out_bps: p.out_discards + p.out_errors,
@@ -552,7 +659,10 @@ function TrafficPageContent() {
     const seriesMeta = new Map<string, { link_pk?: string; cyoa_type?: string }>()
     for (const s of allTrafficData.series) {
       if (s.direction === 'in') {
-        seriesMeta.set(`${s.device}-${s.intf}`, { link_pk: s.link_pk, cyoa_type: s.cyoa_type })
+        seriesMeta.set(`${s.device}-${s.intf}`, {
+          link_pk: s.link_pk,
+          cyoa_type: s.cyoa_type,
+        })
       }
     }
 
@@ -561,8 +671,24 @@ function TrafficPageContent() {
     const series = sorted.flatMap(([, info]) => {
       const meta = seriesMeta.get(`${info.device}-${info.intf}`)
       return [
-        { key: `${info.device}-${info.intf} (in)`, device: info.device, intf: info.intf, direction: 'in' as const, mean: 0, link_pk: meta?.link_pk, cyoa_type: meta?.cyoa_type },
-        { key: `${info.device}-${info.intf} (out)`, device: info.device, intf: info.intf, direction: 'out' as const, mean: 0, link_pk: meta?.link_pk, cyoa_type: meta?.cyoa_type },
+        {
+          key: `${info.device}-${info.intf} (in)`,
+          device: info.device,
+          intf: info.intf,
+          direction: 'in' as const,
+          mean: 0,
+          link_pk: meta?.link_pk,
+          cyoa_type: meta?.cyoa_type,
+        },
+        {
+          key: `${info.device}-${info.intf} (out)`,
+          device: info.device,
+          intf: info.intf,
+          direction: 'out' as const,
+          mean: 0,
+          link_pk: meta?.link_pk,
+          cyoa_type: meta?.cyoa_type,
+        },
       ]
     })
 
@@ -611,8 +737,13 @@ function TrafficPageContent() {
     if (section === 'discards') {
       if (!countersData && !countersLoading) {
         return (
-          <div key={section} className="border border-border rounded-lg p-4 flex items-center justify-center h-[400px]">
-            <p className="text-sm text-muted-foreground">No errors or discards in the selected time range</p>
+          <div
+            key={section}
+            className="border border-border rounded-lg p-4 flex items-center justify-center h-[400px]"
+          >
+            <p className="text-sm text-muted-foreground">
+              No errors or discards in the selected time range
+            </p>
           </div>
         )
       }
@@ -657,7 +788,7 @@ function TrafficPageContent() {
 
     // Count original interfaces for this category (in-direction series = one per interface)
     const rawSeries = categoryData[cat]?.series
-    const originalIntfCount = rawSeries ? rawSeries.filter(s => s.direction === 'in').length : 0
+    const originalIntfCount = rawSeries ? rawSeries.filter((s) => s.direction === 'in').length : 0
 
     return (
       <div key={section} className="border border-border rounded-lg p-4">
@@ -668,7 +799,9 @@ function TrafficPageContent() {
                 <h3 className="text-lg font-semibold">{title}</h3>
               </div>
               <div className="border border-border rounded-lg p-8 flex items-center justify-center h-[400px]">
-                <p className="text-muted-foreground">Error: {(error as Error).message || String(error)}</p>
+                <p className="text-muted-foreground">
+                  Error: {(error as Error).message || String(error)}
+                </p>
               </div>
             </div>
           ) : (
@@ -683,7 +816,9 @@ function TrafficPageContent() {
               metric={metric}
               loading={fetching}
               timeRangeSeconds={timeRangeSeconds}
-              legendHeader={catAggregated ? `Summary of ${originalIntfCount} interfaces` : undefined}
+              legendHeader={
+                catAggregated ? `Summary of ${originalIntfCount} interfaces` : undefined
+              }
             />
           )}
         </LazyChart>
@@ -697,16 +832,11 @@ function TrafficPageContent() {
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Sticky header */}
       <div className="flex-none bg-background border-b border-border px-4 sm:px-8 pt-6 pb-4 z-10">
-        <div className="[&>div]:mb-0">
-          <PageHeader
-            icon={Network}
-            title="Interfaces"
-            actions={<DashboardFilters excludeMetrics={['utilization']} />}
-          />
-        </div>
-        <div className="flex items-center gap-3 mt-3">
-          <div className="flex items-center gap-3 flex-shrink-0 ml-auto">
-            <DashboardFilterBadges />
+        <PageHeader icon={Network} title="Interfaces" />
+        <div className="flex items-center gap-3 mt-3 w-full flex-wrap justify-between">
+          <DashboardFilters excludeMetrics={['utilization']} />
+          <DashboardFilterBadges />
+          <div className="flex items-center gap-3 flex-wrap">
             <button
               onClick={toggleAggregate}
               className={`px-2 border rounded-md transition-colors inline-flex items-center justify-center h-[34px] gap-1 ${
@@ -724,8 +854,12 @@ function TrafficPageContent() {
                     : 'Auto: charts with >10 interfaces are aggregated. Click to show all per-interface.'
               }
             >
-              <Sigma className={`h-4 w-4 transition-opacity ${aggregateProcessing ? 'opacity-30 animate-pulse' : ''}`} />
-              {aggregateOverride === null && <span className="text-[9px] leading-none opacity-60">A</span>}
+              <Sigma
+                className={`h-4 w-4 transition-opacity ${aggregateProcessing ? 'opacity-30 animate-pulse' : ''}`}
+              />
+              {aggregateOverride === null && (
+                <span className="text-[9px] leading-none opacity-60">A</span>
+              )}
             </button>
             <button
               onClick={() => setBidirectional(!bidirectional)}
@@ -734,7 +868,11 @@ function TrafficPageContent() {
                   ? 'border-foreground/30 text-foreground bg-muted'
                   : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
-              title={bidirectional ? 'Rx and Tx are shown separately (Rx up, Tx down). Click to combine into a single line per interface.' : 'Rx and Tx are combined into a single line per interface. Click to split into separate Rx (up) and Tx (down).'}
+              title={
+                bidirectional
+                  ? 'Rx and Tx are shown separately (Rx up, Tx down). Click to combine into a single line per interface.'
+                  : 'Rx and Tx are combined into a single line per interface. Click to split into separate Rx (up) and Tx (down).'
+              }
             >
               {bidirectional ? 'Rx / Tx' : 'Rx+Tx'}
             </button>
@@ -749,13 +887,14 @@ function TrafficPageContent() {
         {/* Truncation warning */}
         {(allTrafficData?.truncated || allTrafficData?.truncated) && (
           <div className="mb-4 px-4 py-3 bg-yellow-500/10 border border-yellow-500/30 rounded-md text-sm text-yellow-700 dark:text-yellow-200">
-            Results were truncated due to data volume. Try a larger bucket size or shorter time range to see all data.
+            Results were truncated due to data volume. Try a larger bucket size or shorter time
+            range to see all data.
           </div>
         )}
 
         {/* Charts */}
         <div className={gridClass}>
-          {ALL_KNOWN_SECTIONS.map(section => renderChartSection(section))}
+          {ALL_KNOWN_SECTIONS.map((section) => renderChartSection(section))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR focuses on fixing several frontend issues that were affecting usability across the app, with a strong focus on mobile.

Many components became unreadable, hid important information, or introduced unwanted horizontal scrolling, especially on smaller screens. While some of these issues were not noticeable on desktop, others impacted the overall layout and consistency as well.

The sections below highlight the most significant fixes, along with a number of smaller improvements across various components.



**_Sidebar_** 
Previously, the sidebar pushed all page content sideways on small screens, completely breaking the layout. Now it appears as an overlay on top of the content on mobile, auto-collapses on navigation, and does not persist the open/closed state on small devices.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/5f080be9-94e4-4cc0-8508-121fc4a411a8" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/ebf0c430-f7d2-4932-992b-d4e0d86788af" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a5dad408-24bf-4871-bbe6-7a2fa15237c3" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/fe75e4f8-4a38-4d0a-9c61-c9e2a258ad42" width="100%" /></td>
  </tr>
</table>

_**Dropdowns**_
All native browser selects (the default ugly system element) were replaced with a custom dropdown, styled consistently with the rest of the UI. The dropdown was also fixed to always open in the correct position regardless of where it sits on the page. Previously it would appear clipped or misplaced in certain contexts.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/67b134e2-60f0-459e-ab25-b7608b1174b9" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/d4b7abd8-c05f-4107-b5f4-116e3af6bb98" width="100%" /></td>
  </tr>
</table>


_**Tables**_
Tables that broke or hid columns on mobile now have horizontal scroll, keeping all data accessible without distorting the layout.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/02bf9d8f-1cad-45e9-97f9-fa94811b704d" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/b5822104-acf3-483d-bc16-d94491790382" width="100%" /></td>
  </tr>
</table>

_**Filters and controls**_
On some pages (Traffic, Link Latency), filter controls would misalign when the screen shrank. Half would stick to the left, half to the right. Everything now wraps together consistently.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a1a71327-bbae-4e80-a69b-87af7e4330b8" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/7568830c-1b4a-40e2-8a7f-10694368b41b" width="100%" /></td>
  </tr>
</table>


_**Path Calculator**_
The arrow between source and destination flips downward on mobile where the fields are stacked vertically. Hop rows that broke badly on small screens were reorganized to show metrics on a second line.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4c3d0600-5ea2-4496-8008-fd484d2429e1" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/881f0947-69ed-4b3b-b78f-1254b9e8be39" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/57211521-b3ec-4d9b-96ef-a307399ba99a" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/472e79b6-0049-47d6-b250-cc06e74ad9e3" width="100%" /></td>
  </tr>
</table>


_**Path Latency**_
The detail panel that previously got squeezed next to the table now opens as a centered modal on mobile. The latency table no longer has a fixed height and grows freely with its content.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8170bfac-3063-4439-8c63-4ce33261327e" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/d4b9d797-1225-4331-8124-a84a5aab4204" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/5abcfeaf-9523-4c3c-9a65-7bfec0b98388" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/739950e3-062a-4dbf-aadc-f691c767cf1b" width="100%" /></td>
  </tr>
</table>


_**DZ vs Internet and Metro Connectivity**_
The detail panel that opens when clicking a route or matrix cell now appears as a centered modal on mobile, with a dark backdrop and a close button. Previously it was clipped off-screen.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3cb1d944-8e1e-44a7-a50e-6b838f481e06" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/6096224e-b0ac-441b-8156-eacec1c45700" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/719b235c-85ce-4502-9e36-e0f7acbd817e" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/f736d72b-be33-40e3-b22a-48d426de7f45" width="100%" /></td>
  </tr>
</table>


_**Status Page**_
Issue section rows (Telemetry Stopped, etc.) now follow the same mobile layout as Drained Links: two compact lines with the duration shown inline, instead of trying to fit everything on a single line.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/2c5d1af9-32e8-4886-97f0-6c4cf7e56e91" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/d00882dc-87d0-4e0f-b72d-720eaa957ce1" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/9c54ef31-7cc4-4e7b-bb1a-9cee8b21bc8a" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/f9ff0904-abb4-493e-8d5f-ef7af12e406b" width="100%" /></td>
  </tr>
</table>


_**Incidents**_
The summary cards at the top of the page were changed from a fixed 4-column grid to a responsive grid that adjusts based on available space.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/87218df4-5b37-4ddb-832c-1f802d7df363" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/d9e81b15-e228-49b7-8d21-a35f0bb4e6f4" width="100%" /></td>
  </tr>
</table>


_**Minor visual fixes**_
Stat cards use a smaller font and padding on mobile. PageHeader adjusted so the subtitle wraps naturally when it does not fit on the same line. Metro Connectivity detail reorganized into two lines to avoid crowding on mobile. The "Close" text button in the Metro Connectivity detail was replaced with an X icon.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/1183d643-33f1-41a2-a3c5-1d3fd4ae4da0" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/67fa7b9b-a2f7-4589-a47a-fdd6ff0d261e" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/f0b3116f-da5f-465b-9e45-21e229075117" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/9d61d297-230d-4425-9fd5-ab90e119b0b2" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/cce967ca-0d0c-42c5-8e0d-6a651b3c5bdc" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/05e75ccc-5720-4b29-9ea5-451d333dbbb6" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/08d426fb-e1dc-41fd-ad4f-aae1506e5846" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/dc950103-b345-47d2-adb4-377b2dda5113" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/acf5bf52-51b8-4470-ac6d-1510f2583948" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/cd598d9a-c6c8-479c-8f31-04d5f4bad146" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/26a11f48-aee7-48eb-b4bb-14ec5e6a3e72" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/4f1c6bae-bfc5-4748-9988-489c1ccd8511" width="100%" /></td>
  </tr>

  <tr>
    <td><img src="https://github.com/user-attachments/assets/a715d918-61c4-4d5d-b3ad-a82be7aa135b" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/bafbdf22-0866-4b6c-8884-d9231a5c09cb" width="100%" /></td>
  </tr>

</table>

**_Pagination:_**
Fixed pagination layout."Page X of Y" was wrapping across multiple lines on mobile.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3bba7885-0166-40e9-9a3a-e6a1bbe6fd19" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/f46a34c5-0a8b-4d47-9741-a62e482c855b" width="100%" /></td>
  </tr>
</table>

