### PR TITLE
indexer: add new version and commit fields from DeviceLatencySamplesHeader to fact_dz_device_link_latency_sample_header table

### DIFF
--- a/indexer/db/clickhouse/migrations/20260414000001_sample_header_agent_version.sql
+++ b/indexer/db/clickhouse/migrations/20260414000001_sample_header_agent_version.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- +goose StatementBegin
+ALTER TABLE fact_dz_device_link_latency_sample_header
+    ADD COLUMN IF NOT EXISTS agent_version String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS agent_commit String DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+ALTER TABLE fact_dz_device_link_latency_sample_header
+    DROP COLUMN IF EXISTS agent_commit,
+    DROP COLUMN IF EXISTS agent_version;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/telemetry/latency/sample_header.go
+++ b/indexer/pkg/dz/telemetry/latency/sample_header.go
@@ -18,6 +18,8 @@ type DeviceLinkLatencySampleHeader struct {
 	StartTimestampUs   uint64
 	SamplingIntervalUs uint64
 	LatestSampleIndex  int
+	AgentVersion       string
+	AgentCommit        string
 }
 
 // InternetMetroLatencySampleHeader mirrors the on-chain latency sample header
@@ -54,6 +56,8 @@ func (s *Store) AppendDeviceLinkLatencySampleHeaders(ctx context.Context, header
 			int64(h.StartTimestampUs),
 			h.SamplingIntervalUs,
 			int32(h.LatestSampleIndex),
+			h.AgentVersion,
+			h.AgentCommit,
 		}
 	}); err != nil {
 		return fmt.Errorf("failed to write device link latency sample headers: %w", err)

--- a/indexer/pkg/dz/telemetry/latency/view_device.go
+++ b/indexer/pkg/dz/telemetry/latency/view_device.go
@@ -1,6 +1,7 @@
 package dztelemlatency
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -147,6 +148,8 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 							StartTimestampUs:   hdr.StartTimestampMicroseconds,
 							SamplingIntervalUs: hdr.SamplingIntervalMicroseconds,
 							LatestSampleIndex:  latestIdx,
+							AgentVersion:       trimNullBytes(hdr.AgentVersion[:]),
+							AgentCommit:        trimNullBytes(hdr.AgentCommit[:]),
 						})
 
 						if len(tail) > 0 {
@@ -202,4 +205,9 @@ done:
 		v.log.Debug("telemetry/device-link: sample refresh completed", "links", linksProcessed, "samples", len(allSamples), "headers", len(allHeaders))
 	}
 	return nil
+}
+
+// trimNullBytes converts a null-padded byte array to a string, removing trailing zero bytes.
+func trimNullBytes(b []byte) string {
+	return string(bytes.TrimRight(b, "\x00"))
 }

--- a/indexer/pkg/dz/telemetry/latency/view_test.go
+++ b/indexer/pkg/dz/telemetry/latency/view_test.go
@@ -1462,3 +1462,267 @@ func TestLake_TelemetryLatency_View_Refresh_ErrorHandling(t *testing.T) {
 		require.Equal(t, uint64(0), count, "should have no samples after error")
 	})
 }
+
+func TestTrimNullBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{"version string with trailing nulls", append([]byte("1.2.3"), make([]byte, 11)...), "1.2.3"},
+		{"full array with no nulls", []byte("1234567890abcdef"), "1234567890abcdef"},
+		{"all zeros", make([]byte, 16), ""},
+		{"single char", append([]byte("v"), make([]byte, 15)...), "v"},
+		{"commit hash", append([]byte("abc123de"), make([]byte, 0)...), "abc123de"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := trimNullBytes(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLake_TelemetryLatency_View_AgentVersionCommit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent version and commit are stored in sample headers", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+
+		devicePK1 := [32]byte{1, 2, 3, 4}
+		devicePK2 := [32]byte{5, 6, 7, 8}
+		linkPK := [32]byte{9, 10, 11, 12}
+		contributorPK := [32]byte{13, 14, 15, 16}
+		metroPK := [32]byte{17, 18, 19, 20}
+		ownerPubkey := [32]byte{21, 22, 23, 24}
+		publicIP1 := [4]byte{192, 168, 1, 1}
+		publicIP2 := [4]byte{192, 168, 1, 2}
+		tunnelNet := [5]byte{10, 0, 0, 0, 24}
+
+		svcMockRPC := &MockServiceabilityRPC{
+			getProgramDataFunc: func(ctx context.Context) (*serviceability.ProgramData, error) {
+				return &serviceability.ProgramData{
+					Contributors: []serviceability.Contributor{
+						{PubKey: contributorPK, Owner: ownerPubkey, Code: "CONTRIB"},
+					},
+					Devices: []serviceability.Device{
+						{
+							PubKey: devicePK1, Owner: ownerPubkey,
+							Status: serviceability.DeviceStatusActivated, DeviceType: serviceability.DeviceDeviceTypeHybrid,
+							Code: "DEV1", PublicIp: publicIP1,
+							ContributorPubKey: contributorPK, ExchangePubKey: metroPK,
+						},
+						{
+							PubKey: devicePK2, Owner: ownerPubkey,
+							Status: serviceability.DeviceStatusActivated, DeviceType: serviceability.DeviceDeviceTypeHybrid,
+							Code: "DEV2", PublicIp: publicIP2,
+							ContributorPubKey: contributorPK, ExchangePubKey: metroPK,
+						},
+					},
+					Links: []serviceability.Link{
+						{
+							PubKey: linkPK, Owner: ownerPubkey,
+							Status: serviceability.LinkStatusActivated, Code: "LINK1",
+							TunnelNet: tunnelNet, ContributorPubKey: contributorPK,
+							SideAPubKey: devicePK1, SideZPubKey: devicePK2,
+							SideAIfaceName: "eth0", SideZIfaceName: "eth1",
+							LinkType: serviceability.LinkLinkTypeWAN,
+						},
+					},
+					Exchanges: []serviceability.Exchange{
+						{PubKey: metroPK, Code: "METRO1", Name: "Test Metro"},
+					},
+				}, nil
+			},
+		}
+
+		svcView, err := dzsvc.NewView(dzsvc.ViewConfig{
+			Logger:            laketesting.NewLogger(),
+			Clock:             clockwork.NewFakeClock(),
+			ServiceabilityRPC: svcMockRPC,
+			RefreshInterval:   time.Second,
+			ClickHouse:        db,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = svcView.Refresh(ctx)
+		require.NoError(t, err)
+
+		originPK := solana.PublicKeyFromBytes(devicePK1[:])
+		targetPK := solana.PublicKeyFromBytes(devicePK2[:])
+		linkPKPubKey := solana.PublicKeyFromBytes(linkPK[:])
+
+		// Set up agent version and commit as null-padded byte arrays
+		var agentVersion [16]uint8
+		copy(agentVersion[:], "1.5.0")
+		var agentCommit [8]uint8
+		copy(agentCommit[:], "abc123d")
+
+		mockTelemetryRPC := &mockTelemetryRPCWithSamples{
+			samples: map[string]*telemetry.DeviceLatencySamples{
+				key(originPK, targetPK, linkPKPubKey, 100): {
+					DeviceLatencySamplesHeader: telemetry.DeviceLatencySamplesHeader{
+						StartTimestampMicroseconds:   1_600_000_000_000_000,
+						SamplingIntervalMicroseconds: 100_000,
+						AgentVersion:                 agentVersion,
+						AgentCommit:                  agentCommit,
+					},
+					Samples: []uint32{5000},
+				},
+			},
+		}
+
+		view, err := NewView(ViewConfig{
+			Logger:                 laketesting.NewLogger(),
+			Clock:                  clockwork.NewFakeClock(),
+			TelemetryRPC:           mockTelemetryRPC,
+			EpochRPC:               &mockEpochRPCWithEpoch{epoch: 100},
+			MaxConcurrency:         32,
+			InternetLatencyAgentPK: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+			InternetDataProviders:  []string{"test-provider"},
+			ClickHouse:             db,
+			Serviceability:         svcView,
+			RefreshInterval:        time.Second,
+		})
+		require.NoError(t, err)
+
+		_, err = view.Refresh(ctx)
+		require.NoError(t, err)
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var storedVersion, storedCommit string
+		rows, err := conn.Query(ctx, "SELECT agent_version, agent_commit FROM fact_dz_device_link_latency_sample_header LIMIT 1")
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		require.NoError(t, rows.Scan(&storedVersion, &storedCommit))
+		rows.Close()
+
+		require.Equal(t, "1.5.0", storedVersion)
+		require.Equal(t, "abc123d", storedCommit)
+	})
+
+	t.Run("zero-value agent fields produce empty strings", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+
+		devicePK1 := [32]byte{1, 2, 3, 4}
+		devicePK2 := [32]byte{5, 6, 7, 8}
+		linkPK := [32]byte{9, 10, 11, 12}
+		contributorPK := [32]byte{13, 14, 15, 16}
+		metroPK := [32]byte{17, 18, 19, 20}
+		ownerPubkey := [32]byte{21, 22, 23, 24}
+		publicIP1 := [4]byte{192, 168, 1, 1}
+		publicIP2 := [4]byte{192, 168, 1, 2}
+		tunnelNet := [5]byte{10, 0, 0, 0, 24}
+
+		svcMockRPC := &MockServiceabilityRPC{
+			getProgramDataFunc: func(ctx context.Context) (*serviceability.ProgramData, error) {
+				return &serviceability.ProgramData{
+					Contributors: []serviceability.Contributor{
+						{PubKey: contributorPK, Owner: ownerPubkey, Code: "CONTRIB"},
+					},
+					Devices: []serviceability.Device{
+						{
+							PubKey: devicePK1, Owner: ownerPubkey,
+							Status: serviceability.DeviceStatusActivated, DeviceType: serviceability.DeviceDeviceTypeHybrid,
+							Code: "DEV1", PublicIp: publicIP1,
+							ContributorPubKey: contributorPK, ExchangePubKey: metroPK,
+						},
+						{
+							PubKey: devicePK2, Owner: ownerPubkey,
+							Status: serviceability.DeviceStatusActivated, DeviceType: serviceability.DeviceDeviceTypeHybrid,
+							Code: "DEV2", PublicIp: publicIP2,
+							ContributorPubKey: contributorPK, ExchangePubKey: metroPK,
+						},
+					},
+					Links: []serviceability.Link{
+						{
+							PubKey: linkPK, Owner: ownerPubkey,
+							Status: serviceability.LinkStatusActivated, Code: "LINK1",
+							TunnelNet: tunnelNet, ContributorPubKey: contributorPK,
+							SideAPubKey: devicePK1, SideZPubKey: devicePK2,
+							SideAIfaceName: "eth0", SideZIfaceName: "eth1",
+							LinkType: serviceability.LinkLinkTypeWAN,
+						},
+					},
+					Exchanges: []serviceability.Exchange{
+						{PubKey: metroPK, Code: "METRO1", Name: "Test Metro"},
+					},
+				}, nil
+			},
+		}
+
+		svcView, err := dzsvc.NewView(dzsvc.ViewConfig{
+			Logger:            laketesting.NewLogger(),
+			Clock:             clockwork.NewFakeClock(),
+			ServiceabilityRPC: svcMockRPC,
+			RefreshInterval:   time.Second,
+			ClickHouse:        db,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = svcView.Refresh(ctx)
+		require.NoError(t, err)
+
+		originPK := solana.PublicKeyFromBytes(devicePK1[:])
+		targetPK := solana.PublicKeyFromBytes(devicePK2[:])
+		linkPKPubKey := solana.PublicKeyFromBytes(linkPK[:])
+
+		// Zero-value agent version and commit (V0 accounts or pre-version agents)
+		mockTelemetryRPC := &mockTelemetryRPCWithSamples{
+			samples: map[string]*telemetry.DeviceLatencySamples{
+				key(originPK, targetPK, linkPKPubKey, 100): {
+					DeviceLatencySamplesHeader: telemetry.DeviceLatencySamplesHeader{
+						StartTimestampMicroseconds:   1_600_000_000_000_000,
+						SamplingIntervalMicroseconds: 100_000,
+						// AgentVersion and AgentCommit are zero-value
+					},
+					Samples: []uint32{5000},
+				},
+			},
+		}
+
+		view, err := NewView(ViewConfig{
+			Logger:                 laketesting.NewLogger(),
+			Clock:                  clockwork.NewFakeClock(),
+			TelemetryRPC:           mockTelemetryRPC,
+			EpochRPC:               &mockEpochRPCWithEpoch{epoch: 100},
+			MaxConcurrency:         32,
+			InternetLatencyAgentPK: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+			InternetDataProviders:  []string{"test-provider"},
+			ClickHouse:             db,
+			Serviceability:         svcView,
+			RefreshInterval:        time.Second,
+		})
+		require.NoError(t, err)
+
+		_, err = view.Refresh(ctx)
+		require.NoError(t, err)
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var storedVersion, storedCommit string
+		rows, err := conn.Query(ctx, "SELECT agent_version, agent_commit FROM fact_dz_device_link_latency_sample_header LIMIT 1")
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		require.NoError(t, rows.Scan(&storedVersion, &storedCommit))
+		rows.Close()
+
+		require.Equal(t, "", storedVersion, "zero-value AgentVersion should produce empty string")
+		require.Equal(t, "", storedCommit, "zero-value AgentCommit should produce empty string")
+	})
+}


### PR DESCRIPTION
## Summary of Changes
* Extract `AgentVersion` and `AgentCommit` from the on-chain `DeviceLatencySamplesHeader` and write them to the `fact_dz_device_link_latency_sample_header` ClickHouse table as new `agent_version` and `agent_commit` String columns
* The SDK stores these as null-padded fixed-size byte arrays (`[16]uint8` and `[8]uint8`), which are trimmed to Go strings before storage
* Enables operators to track which telemetry agent version each device is running and detect version transitions immediately
* Fixes #441

## Testing Verification
* Unit tests for `trimNullBytes` covering version strings with trailing nulls, full arrays, all-zero arrays, and short strings
* Integration test verifying agent version and commit flow from mock SDK header through to ClickHouse query results
* Integration test verifying zero-value (V0/pre-version) agent fields produce empty strings in the database
* `go build`, `go vet`, and `golangci-lint` pass cleanly on all indexer packages
* Tested devnet indexer in local Docker dev env - new columns are created and populated with version and commit hash'
<img width="800" height="301" alt="Screenshot 2026-04-14 at 18 41 35" src="https://github.com/user-attachments/assets/94e79b1e-65a3-4086-b72a-b7dce2ea3467" />
