### PR TITLE
web: replace edge scoreboard drag scroll with arrow navigation

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -147,7 +147,8 @@ func edgeScoreboardCacheKey(r *http.Request) string {
 	if window != "" && window != "24h" {
 		return ""
 	}
-	leadersOnly := strings.TrimSpace(r.URL.Query().Get("leaders_only")) == "true"
+	// Match the handler default in GetEdgeScoreboard: omitted leaders_only means true.
+	leadersOnly := strings.TrimSpace(r.URL.Query().Get("leaders_only")) != "false"
 	if leadersOnly {
 		return "edge_scoreboard:leaders"
 	}
@@ -692,40 +693,63 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				return fmt.Errorf("query2c rows: %w", err)
 			}
 
-			// q2b: pairwise lead times.
-			// p50_ms = median of per-slot p50 lead times.
-			// p95_ms = 95th percentile of per-slot p95 lead times (conservative tail estimate).
+			// q2b: pairwise lead times for the synthetic dz_edge feed.
+			// In leadersOnly mode this is dz only (leader path). Otherwise it's the
+			// best of dz + dz_rebop per slot (leader + retransmit), so the column
+			// matches the dz_edge win-rate framing.
+			// Per slot, pick the DZ feed with the smallest p50 lead vs the loser
+			// (argMin), then aggregate across slots:
+			//   p50_ms = median of per-slot best p50 leads.
+			//   p95_ms = 95th percentile of the matching feed's p95 (conservative tail).
 			var q2b string
+			edgeFeeds := "'dz', 'dz_rebop'"
 			if leadersOnly {
+				edgeFeeds = "'dz'"
 				q2b = fmt.Sprintf(`
-				WITH %s
+				WITH %s,
+				per_slot AS (
+					SELECT
+						host, slot, loser_feed,
+						argMin(lead_time_p50_ms, lead_time_p50_ms) AS p50,
+						argMin(lead_time_p95_ms, lead_time_p50_ms) AS p95
+					FROM %s.slot_feed_race_summary
+					WHERE feed_type = 'shred' AND feed IN (%s) AND loser_feed IN (%s)
+						AND slot IN (SELECT slot FROM dz_leader_slots)
+						AND lead_time_p50_ms <= 500
+						%s
+					GROUP BY host, slot, loser_feed
+				)
 				SELECT
-					host, feed, loser_feed,
+					host, loser_feed,
 					count() AS slot_count,
-					quantile(0.5)(lead_time_p50_ms) AS p50_ms,
-					quantile(0.95)(lead_time_p95_ms) AS p95_ms
-				FROM %s.slot_feed_race_summary
-				WHERE feed_type = 'shred' AND loser_feed IN (%s)
-					AND slot IN (SELECT slot FROM dz_leader_slots)
-					AND lead_time_p50_ms <= 500
-					%s
-				GROUP BY host, feed, loser_feed
+					quantile(0.5)(p50) AS p50_ms,
+					quantile(0.95)(p95) AS p95_ms
+				FROM per_slot
+				GROUP BY host, loser_feed
 			SETTINGS final=1
-`, dzLeaderCTE, shredderDB, scoreboardLoserFeeds, timeFilter)
+`, dzLeaderCTE, shredderDB, edgeFeeds, scoreboardLoserFeeds, timeFilter)
 			} else {
 				q2b = fmt.Sprintf(`
+				WITH per_slot AS (
+					SELECT
+						host, slot, loser_feed,
+						argMin(lead_time_p50_ms, lead_time_p50_ms) AS p50,
+						argMin(lead_time_p95_ms, lead_time_p50_ms) AS p95
+					FROM %s.slot_feed_race_summary
+					WHERE feed_type = 'shred' AND feed IN (%s) AND loser_feed IN (%s)
+						AND lead_time_p50_ms <= 500
+						%s
+					GROUP BY host, slot, loser_feed
+				)
 				SELECT
-					host, feed, loser_feed,
+					host, loser_feed,
 					count() AS slot_count,
-					quantile(0.5)(lead_time_p50_ms) AS p50_ms,
-					quantile(0.95)(lead_time_p95_ms) AS p95_ms
-				FROM %s.slot_feed_race_summary
-				WHERE feed_type = 'shred' AND loser_feed IN (%s)
-					AND lead_time_p50_ms <= 500
-					%s
-				GROUP BY host, feed, loser_feed
+					quantile(0.5)(p50) AS p50_ms,
+					quantile(0.95)(p95) AS p95_ms
+				FROM per_slot
+				GROUP BY host, loser_feed
 			SETTINGS final=1
-`, shredderDB, scoreboardLoserFeeds, timeFilter)
+`, shredderDB, edgeFeeds, scoreboardLoserFeeds, timeFilter)
 			}
 
 			t = time.Now()
@@ -736,14 +760,14 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			} else if err == nil {
 				defer rows2b.Close()
 				for rows2b.Next() {
-					var nodeID, feed, loserFeed string
+					var nodeID, loserFeed string
 					var slotCount uint64
 					var p50, p95 float64
-					if err := rows2b.Scan(&nodeID, &feed, &loserFeed, &slotCount, &p50, &p95); err != nil {
+					if err := rows2b.Scan(&nodeID, &loserFeed, &slotCount, &p50, &p95); err != nil {
 						log.Printf("EdgeScoreboard query2b scan error: %v", err)
 						break
 					}
-					key := feedKey{nodeID, feed}
+					key := feedKey{nodeID, "dz_edge"}
 					fs, ok := localFeedStats[key]
 					if !ok {
 						fs = &EdgeScoreboardFeedStats{}

--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -213,10 +213,13 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 	assert.Equal(t, uint64(100), dzFeed.TotalShreds)
 	assert.Equal(t, 80.0, dzFeed.WinRatePct)
 
-	// Check pairwise lead times for SLC DZ feed
-	assert.Len(t, dzFeed.LeadTimes, 2, "slc dz should have 2 pairwise lead times")
+	// Check pairwise lead times — now attached to the synthetic dz_edge feed
+	// (combines dz + dz_rebop best-per-slot lead vs each loser).
+	dzEdgeFeed, ok := slc.Feeds["dz_edge"]
+	require.True(t, ok, "dz_edge feed should exist for slc")
+	assert.Len(t, dzEdgeFeed.LeadTimes, 2, "slc dz_edge should have 2 pairwise lead times")
 	ltMap := make(map[string]handlers.EdgeScoreboardLeadTime)
-	for _, lt := range dzFeed.LeadTimes {
+	for _, lt := range dzEdgeFeed.LeadTimes {
 		ltMap[lt.LoserFeed] = lt
 	}
 	assert.InDelta(t, 1.5, ltMap["turbine"].P50Ms, 0.1)
@@ -240,8 +243,10 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 	assert.Equal(t, uint64(100), dzFeed.TotalShreds)
 	assert.Equal(t, 70.0, dzFeed.WinRatePct)
 
-	// Check pairwise lead times for FRA DZ feed
-	assert.Len(t, dzFeed.LeadTimes, 2, "fra dz should have 2 pairwise lead times")
+	// Check pairwise lead times for FRA — attached to dz_edge synthetic feed.
+	dzEdgeFeed, ok = fra.Feeds["dz_edge"]
+	require.True(t, ok, "dz_edge feed should exist for fra")
+	assert.Len(t, dzEdgeFeed.LeadTimes, 2, "fra dz_edge should have 2 pairwise lead times")
 }
 
 func TestGetEdgeScoreboard_WindowParam(t *testing.T) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -702,15 +702,16 @@ function AppContent() {
             <Route path="/dz/users/:pk" element={<UserDetailPage />} />
             <Route path="/dz/multicast-groups" element={<MulticastGroupsPage />} />
             <Route path="/dz/multicast-groups/:pk" element={<MulticastGroupDetailPage />} />
-            <Route path="/dz/shreds" element={<Navigate to="/dz/shreds/subscribers" replace />} />
+            <Route path="/dz/shreds" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
+            <Route path="/dz/shreds/scoreboard" element={<InternalOnly><EdgeScoreboardPage /></InternalOnly>} />
+            <Route path="/dz/shreds/publishers" element={<PublisherCheckPage />} />
+            <Route path="/dz/publisher-check" element={<Navigate to="/dz/shreds/publishers" replace />} />
             <Route path="/dz/shreds/subscribers" element={<ShredsSeatsPage />} />
             <Route path="/dz/shreds/seats" element={<Navigate to="/dz/shreds/subscribers" replace />} />
             <Route path="/dz/shreds/funders" element={<ShredsFundersPage />} />
             <Route path="/dz/shreds/devices" element={<ShredsDevicesPage />} />
             <Route path="/dz/shreds/activity" element={<ShredsEscrowEventsPage />} />
             {/* Subscribe page hidden for now — see shreds-subscribe-page.tsx */}
-            <Route path="/dz/publisher-check" element={<PublisherCheckPage />} />
-            <Route path="/dz/shreds/scoreboard" element={<InternalOnly><EdgeScoreboardPage /></InternalOnly>} />
             <Route path="/dz/edge/scoreboard" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
 
             {/* Solana entity routes */}

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1466,7 +1466,7 @@ function RecentSlotsChart({
           </div>
         ))}
         {/* Arrow navigation */}
-        <div className="flex items-center gap-1 pt-1 pl-[64px]">
+        <div className="flex items-center justify-center gap-1 pt-1">
           <button
             onClick={() => stepSlots(-1)}
             className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -919,6 +919,14 @@ function RecentSlotsChart({
             if (slotNum) { liveEdgeRef.current = slotNum }
           }
         }
+        // Drive dragFracPx at rAF rate (60fps) rather than pointer-event rate (~120Hz+)
+        // so sub-slot CSS updates don't trigger React re-renders faster than the display.
+        if (isDraggingRef.current && viewEndSlotRef.current !== null) {
+          const slotPxVal = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
+          const rawEnd = viewEndSlotRef.current
+          const frac = -(rawEnd - Math.floor(rawEnd)) * slotPxVal
+          setDragFracPx(frac)
+        }
       }
       drainRafId = requestAnimationFrame(tick)
     }
@@ -1236,11 +1244,9 @@ function RecentSlotsChart({
         } else {
           setOverscrollPx(0)
           viewEndSlotRef.current = rawEnd
-          // Only trigger re-render at slot boundaries (same pattern as inertia).
-          // dragFracPx provides smooth sub-slot positioning between boundaries.
-          const slotted = Math.floor(rawEnd)
-          setViewEndSlot(slotted)
-          setDragFracPx(-(rawEnd - slotted) * px())
+          // Only trigger re-render at slot boundaries — sub-slot CSS offset is driven
+          // by the rAF drain loop at 60fps rather than at pointer-event rate.
+          setViewEndSlot(Math.floor(rawEnd))
         }
         setIsDragging(true)
       }
@@ -1266,13 +1272,13 @@ function RecentSlotsChart({
         // drag right → slot decreases → inertia velocity is negative
         const slotVelocityPerSecond = -(vx * dirX) / px() * 1000
 
-        if (Math.abs(slotVelocityPerSecond) > 1) {
+        if (Math.abs(slotVelocityPerSecond) > 0.5) {
           // Custom rAF-based inertia with sub-slot CSS translate for smooth deceleration.
           // The fractional offset (inertiaFracPx) is updated every frame — since it's not
           // in activeSlots deps, those re-renders only update the CSS transform (cheap).
           // setViewEndSlot only fires at slot boundaries (expensive but infrequent).
-          const timeConstant = 600
-          const power = 0.8
+          const timeConstant = 1200
+          const power = 1.2
           const target = Math.max(minEnd, Math.min(liveEdge,
             currentEnd + slotVelocityPerSecond / 1000 * power * timeConstant))
           const from = currentEnd

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1,8 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
-import { useDrag } from '@use-gesture/react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useSearchParams, Link } from 'react-router-dom'
-import { Trophy, Loader2, ChevronsRight, Play, Square, Layers } from 'lucide-react'
+import { Trophy, Loader2, ChevronLeft, ChevronRight, Play, Square, Layers } from 'lucide-react'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 
@@ -876,7 +875,7 @@ function RecentSlotsChart({
       const dt = lastTime === null ? 0 : Math.min(now - lastTime, 400)
       lastTime = now
       const slotPx = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
-      const inTail = !isDraggingRef.current && viewEndSlotRef.current === null
+      const inTail = viewEndSlotRef.current === null
       if (inTail) {
         // Only advance when there's something to drain — prevents scroll from oscillating
         // back to 0 when the queue is empty (e.g. right after init or between polls).
@@ -964,8 +963,6 @@ function RecentSlotsChart({
     slotBufferRef.current = slots
   }
 
-  // Drag-to-scroll: click/touch and drag left/right to navigate the timeline with momentum.
-  const momentumStopRef = useRef<{ stop: () => void } | null>(null)
   const liveRef = useRef(live)
   liveRef.current = live
   // Info bar DOM refs — updated directly to avoid React re-render flicker.
@@ -1031,16 +1028,6 @@ function RecentSlotsChart({
     return () => document.removeEventListener('mousemove', onDocMove)
   }, [updateInfoBar])
 
-  const [isDragging, setIsDragging] = useState(false)
-  const isDraggingRef = useRef(isDragging)
-  isDraggingRef.current = isDragging
-  const [overscrollPx, setOverscrollPx] = useState(0)
-  // Sub-slot fractional offsets applied as CSS translate so bars glide smoothly between
-  // slot boundaries without triggering activeSlots recomputation.
-  // dragFracPx: set via CSS custom property (--drag-frac) on chartRowsRef so pointer
-  // events bypass React entirely between slot boundaries — zero re-renders during drag.
-  const [inertiaFracPx, setInertiaFracPx] = useState(0)
-  const [isInertia, setIsInertia] = useState(false)
   const [isScrollingToLive, setIsScrollingToLive] = useState(false)
   // scrollOffset: 0→slotPx at constant velocity, driven by a single rAF loop that also
   // pops the drain queue at rollover. Both setScrollOffset+setLiveEdge fire in the same
@@ -1059,11 +1046,6 @@ function RecentSlotsChart({
   //      then wait for drain to set liveEdgeRef before starting the tween.
   const scrollToLiveAnimRef = useRef<number | null>(null)
   const scrollToLive = () => {
-    momentumStopRef.current?.stop()
-    momentumStopRef.current = null
-    setInertiaFracPx(0)
-    setIsInertia(false)
-
     if (scrollToLiveAnimRef.current !== null) {
       cancelAnimationFrame(scrollToLiveAnimRef.current)
       scrollToLiveAnimRef.current = null
@@ -1189,157 +1171,22 @@ function RecentSlotsChart({
   if (scrollToLiveRef) scrollToLiveRef.current = scrollToLive
   if (toggleLiveRef) toggleLiveRef.current = toggleLive
 
-  // Captured at the start of each drag gesture so we can compute position from
-  // cumulative movement rather than accumulating per-frame incremental deltas.
-  const dragStartSlotRef = useRef<number>(0)
-
-  useDrag(
-    ({ movement: [mx], velocity: [vx], direction: [dirX], first, last, active }) => {
-      const slotNums = () => [...new Set(slotBufferRef.current.map(r => r.slot))].sort((a, b) => a - b)
-      const px = () => Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
-
-      if (active) {
-        // Cancel any running inertia — only when it's actually running to avoid no-op re-renders.
-        if (momentumStopRef.current) {
-          momentumStopRef.current.stop()
-          momentumStopRef.current = null
-          setInertiaFracPx(0)
-        }
-
-        const nums = slotNums()
-        const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
-        const oldestSlot = nums[0] ?? 0
-        const minEnd = oldestSlot + viewSlotCount - 1
-
-        if (first) {
-          // Capture the slot position at drag start so rawEnd = startSlot - totalMovement/px.
-          // This makes overscroll accumulate correctly — delta-based math resets each frame
-          // when viewEndSlotRef is frozen at minEnd during overscroll.
-          dragStartSlotRef.current = viewEndSlotRef.current ?? liveEdge
-          setIsDragging(true)
-        }
-
-        // Use cumulative movement from gesture start, not incremental delta.
-        // drag right (mx > 0) = back in time = rawEnd decreases
-        const rawEnd = dragStartSlotRef.current - mx / px()
-
-        if (rawEnd < minEnd) {
-          // Past the left edge: anchor data at minEnd (no content change), grow CSS transform.
-          const rawOverflowPx = (minEnd - rawEnd) * px()
-          setOverscrollPx(Math.min(350, rawOverflowPx * 0.35))
-          viewEndSlotRef.current = minEnd
-          setViewEndSlot(minEnd)
-          chartRowsRef.current?.style.removeProperty('--drag-frac')
-        } else if (rawEnd > liveEdge) {
-          // Past the right (live) edge: anchor at liveEdge, grow CSS transform leftward.
-          const rawOverflowPx = (rawEnd - liveEdge) * px()
-          setOverscrollPx(-Math.min(350, rawOverflowPx * 0.35))
-          viewEndSlotRef.current = liveEdge
-          setViewEndSlot(liveEdge)
-          chartRowsRef.current?.style.removeProperty('--drag-frac')
-        } else {
-          setOverscrollPx(0)
-          viewEndSlotRef.current = rawEnd
-          // Only trigger activeSlots recomputation at slot boundaries.
-          // Sub-slot glide uses a CSS custom property set directly on the DOM — zero React
-          // re-renders between slot boundaries, pointer events handled at native speed.
-          setViewEndSlot(Math.floor(rawEnd))
-          const slotPxVal = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCount)
-          chartRowsRef.current?.style.setProperty('--drag-frac', `${-(rawEnd - Math.floor(rawEnd)) * slotPxVal}px`)
-        }
-      }
-
-      if (last) {
-        setIsDragging(false)
-        setOverscrollPx(0)  // CSS transition snaps back
-        chartRowsRef.current?.style.removeProperty('--drag-frac')
-
-        const nums = slotNums()
-        const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
-        const oldestSlot = nums[0] ?? 0
-        const minEnd = oldestSlot + viewSlotCount - 1
-        const currentEnd = viewEndSlotRef.current ?? liveEdge
-
-        // If the user released at/past the live edge, animate smoothly into live.
-        if (currentEnd >= liveEdge) {
-          scrollToLive()
-          return
-        }
-
-        // velocity[0] = px/ms magnitude, direction[0] = sign.
-        // drag right → slot decreases → inertia velocity is negative
-        const slotVelocityPerSecond = -(vx * dirX) / px() * 1000
-
-        if (Math.abs(slotVelocityPerSecond) > 0.5) {
-          // Custom rAF-based inertia with sub-slot CSS translate for smooth deceleration.
-          // The fractional offset (inertiaFracPx) is updated every frame — since it's not
-          // in activeSlots deps, those re-renders only update the CSS transform (cheap).
-          // setViewEndSlot only fires at slot boundaries (expensive but infrequent).
-          const timeConstant = 1200
-          const power = 1.2
-          const target = Math.max(minEnd, Math.min(liveEdge,
-            currentEnd + slotVelocityPerSecond / 1000 * power * timeConstant))
-          const from = currentEnd
-          const startTime = performance.now()
-          let lastCommitted = Math.floor(currentEnd)
-          let rafHandle: number | null = null
-
-          const tick = () => {
-            const elapsed = performance.now() - startTime
-            const decay = Math.exp(-elapsed / timeConstant)
-            const value = target + (from - target) * decay
-            const clamped = Math.max(minEnd, Math.min(liveEdge, value))
-
-            const slotPxNow = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
-            const committed = Math.floor(clamped)
-            const fracPx = -(clamped - committed) * slotPxNow
-
-            viewEndSlotRef.current = clamped
-
-            // Only re-render with new slot data at boundaries; sub-slot moves use cheap fracPx re-render
-            if (committed !== lastCommitted) {
-              lastCommitted = committed
-              setViewEndSlot(committed)
-            }
-            setInertiaFracPx(fracPx)
-
-            // Stop when close enough to target
-            const remainingSlots = Math.abs(clamped - target)
-            const velocitySlotsSec = Math.abs((from - target) / timeConstant * decay * 1000)
-            if (remainingSlots < 0.5 || velocitySlotsSec < 0.5) {
-              const finalSlot = Math.round(clamped)
-              viewEndSlotRef.current = finalSlot
-              setViewEndSlot(finalSlot)
-              setInertiaFracPx(0)
-              setIsInertia(false)
-              momentumStopRef.current = null
-              if (finalSlot >= liveEdgeRef.current - 1) scrollToLive()
-              return
-            }
-
-            rafHandle = requestAnimationFrame(tick)
-          }
-
-          setIsInertia(true)
-          rafHandle = requestAnimationFrame(tick)
-          momentumStopRef.current = {
-            stop: () => {
-              if (rafHandle !== null) cancelAnimationFrame(rafHandle)
-              setInertiaFracPx(0)
-              setIsInertia(false)
-            }
-          }
-        }
-      }
-    },
-    {
-      target: containerRef,
-      axis: 'x',
-      pointer: { capture: true, touch: true },
-      filterTaps: true,
-      enabled: true,
+  // Step N slots forward (positive) or backward (negative).
+  const stepSlots = (direction: 1 | -1) => {
+    const nums = [...new Set(slotBufferRef.current.map(r => r.slot))].sort((a, b) => a - b)
+    const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
+    const oldestSlot = nums[0] ?? 0
+    const minEnd = oldestSlot + viewSlotCount - 1
+    const current = viewEndSlotRef.current ?? liveEdge
+    const next = current + direction * viewSlotCount
+    if (direction > 0 && next >= liveEdge) {
+      scrollToLive()
+      return
     }
-  )
+    const clamped = Math.max(minEnd, Math.min(liveEdge, next))
+    viewEndSlotRef.current = clamped
+    setViewEndSlot(clamped)
+  }
 
   // Prefetch older slots when user scrolls near the buffer start (infinite scroll backwards).
   useEffect(() => {
@@ -1365,7 +1212,7 @@ function RecentSlotsChart({
       // If the user is still pinned at the old left edge, shift the view to the new
       // left edge so the loaded history becomes immediately visible without another drag.
       const oldMinEnd = oldestSlot + viewSlotCountRef.current - 1
-      if (!isDraggingRef.current && viewEndSlotRef.current !== null && Math.abs(viewEndSlotRef.current - oldMinEnd) < 2) {
+      if (viewEndSlotRef.current !== null && Math.abs(viewEndSlotRef.current - oldMinEnd) < 2) {
         const newNums = [...new Set(slotBufferRef.current.map(r => r.slot))].sort((a, b) => a - b)
         const newMinEnd = (newNums[0] ?? 0) + viewSlotCountRef.current - 1
         viewEndSlotRef.current = newMinEnd
@@ -1497,8 +1344,6 @@ function RecentSlotsChart({
       ref={containerRef}
       className={bare ? "pt-2" : "rounded-lg border border-border bg-card p-4"}
       style={{
-        touchAction: 'pan-y',
-        cursor: isDragging ? 'grabbing' : 'grab',
         userSelect: 'none',
       }}
       onPointerDown={(e) => {
@@ -1559,7 +1404,7 @@ function RecentSlotsChart({
                 onClick={scrollToLive}
                 className="text-sky-400 hover:text-sky-300 transition-colors"
               >
-                <ChevronsRight size={16} />
+                <ChevronRight size={16} />
               </button>
             )}
             <button
@@ -1593,13 +1438,10 @@ function RecentSlotsChart({
       </div>}
       <div className="flex gap-0">
         <div ref={chartRowsRef} className="relative flex-1 min-w-0">
-        {/* Left-edge indicator: fixed at the chart boundary, shows while overscrolling or fetching */}
-        {(overscrollPx > 0 || isPrefetching) && (
-          <div className="absolute left-[138px] inset-y-0 flex items-center pointer-events-none z-10">
-            {isPrefetching
-              ? <Loader2 size={14} className="animate-spin text-muted-foreground/60" />
-              : <ChevronsRight size={14} className="text-muted-foreground/40 rotate-180" />
-            }
+        {/* Left-edge indicator: shows while fetching older history */}
+        {isPrefetching && (
+          <div className="absolute left-[64px] inset-y-0 flex items-center pointer-events-none z-10">
+            <Loader2 size={14} className="animate-spin text-muted-foreground/60" />
           </div>
         )}
         {nodeCharts.map((nc) => (
@@ -1615,16 +1457,32 @@ function RecentSlotsChart({
             <div
               className="flex"
               style={{
-                transform: `translateX(calc(var(--drag-frac, 0px) + ${overscrollPx + inertiaFracPx - (live && viewEndSlot === null && !isDragging ? scrollOffset : 0)}px))`,
-                transition: (isDragging || isInertia || (live && viewEndSlot === null)) ? undefined : 'transform 0.15s cubic-bezier(0.2, 0, 0, 1)',
-                willChange: 'transform',
+                transform: `translateX(${live && viewEndSlot === null ? -scrollOffset : 0}px)`,
               }}
             >
-              <SlotRaceNodeChart slotData={nc.data} feeds={feeds} slotLeaders={live ? (liveLeaders ?? slotLeaders) : slotLeaders} animated={viewEndSlot !== null} dragging={isDragging || isInertia || isScrollingToLive} liveScrollOffset={live && viewEndSlot === null && !isDragging ? scrollOffset : 0} viewSlotCount={viewSlotCount} onHover={updateInfoBar} />
+              <SlotRaceNodeChart slotData={nc.data} feeds={feeds} slotLeaders={live ? (liveLeaders ?? slotLeaders) : slotLeaders} animated={viewEndSlot !== null} dragging={isScrollingToLive} liveScrollOffset={live && viewEndSlot === null ? scrollOffset : 0} viewSlotCount={viewSlotCount} onHover={updateInfoBar} />
             </div>
             </div>{/* end mask wrapper */}
           </div>
         ))}
+        {/* Arrow navigation */}
+        <div className="flex items-center gap-1 pt-1 pl-[64px]">
+          <button
+            onClick={() => stepSlots(-1)}
+            className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="Back"
+          >
+            <ChevronLeft size={14} />
+          </button>
+          <button
+            onClick={() => stepSlots(1)}
+            disabled={viewEndSlot === null}
+            className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 transition-colors"
+            title="Forward"
+          >
+            <ChevronRight size={14} />
+          </button>
+        </div>
         </div>{/* end chart rows */}
         {/* Right info panel */}
         <div className="w-60 shrink-0 border-l border-border flex flex-col px-5 py-5">
@@ -2050,7 +1908,7 @@ export function EdgeScoreboardPage() {
                       onClick={() => scrollToLiveRef.current?.()}
                       className="text-[#0ea5e9] hover:text-[#0284c7] transition-colors"
                     >
-                      <ChevronsRight size={16} />
+                      <ChevronRight size={16} />
                     </button>
                   )}
                   <button

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -846,11 +846,15 @@ function RecentSlotsChart({
       }).catch(() => {})
     }
 
-    // Poll every 5s. The server cache refreshes every 30s (~75 new slots each time).
-    // At 400ms/slot drain rate, 75 slots take ~30s — matching the cache cycle. Polling
-    // at 5s means we catch a fresh cache within 5s of it arriving rather than up to 10s.
+    // Poll every 5s. Pass sinceSlot so the server bypasses its 30s page cache and
+    // runs a lightweight cursor query (recent_slots only, no expensive aggregations).
+    // Without sinceSlot every poll hits the cache and returns the same slots for ~30s,
+    // keeping newNums empty and stalling the animation queue until the cache refreshes.
     const poll = () => {
-      fetchEdgeScoreboard(window, leadersOnly).then(data => {
+      // Use liveMaxSlotRef at call time (not closure time) so concurrent polls don't
+      // redundantly re-queue the same range. Only pass sinceSlot once the buffer is seeded.
+      const sinceSlot = liveMaxSlotRef.current > 0 ? liveMaxSlotRef.current : undefined
+      fetchEdgeScoreboard(window, leadersOnly, { sinceSlot }).then(data => {
         if (cancelled) return
         loadSlots(data)
       }).catch(() => {})
@@ -1816,22 +1820,6 @@ export function EdgeScoreboardPage() {
                   </div>
                 ))}
               </div>
-              <div className="w-px h-4 bg-border" />
-              <div className="relative group">
-                <button
-                  type="button"
-                  onClick={() => setGranular(!granular)}
-                  className={cn(
-                    'p-1.5 rounded-md border border-border transition-colors',
-                    granular ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                  )}
-                >
-                  <Layers size={15} />
-                </button>
-                <span className="pointer-events-none absolute top-full right-0 mt-2 z-30 w-48 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
-                  {granular ? 'Showing DZ Edge, Jito, and Turbine separately — click to collapse to DZ vs Other' : 'Break out DZ Edge leaders and retransmits alongside Jito and Turbine'}
-                </span>
-              </div>
             </div>
           }
         />
@@ -1911,6 +1899,21 @@ export function EdgeScoreboardPage() {
                       <ChevronRight size={16} />
                     </button>
                   )}
+                  <div className="relative group">
+                    <button
+                      type="button"
+                      onClick={() => setGranular(!granular)}
+                      className={cn(
+                        'p-1.5 rounded-md border border-border transition-colors',
+                        granular ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      )}
+                    >
+                      <Layers size={15} />
+                    </button>
+                    <span className="pointer-events-none absolute top-full right-0 mt-2 z-30 w-48 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
+                      {granular ? 'Showing DZ Edge, Jito, and Turbine separately — click to collapse to DZ vs Other' : 'Break out DZ Edge leaders and retransmits alongside Jito and Turbine'}
+                    </span>
+                  </div>
                   <button
                     onClick={() => toggleLiveRef.current?.()}
                     className={cn(

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1850,7 +1850,7 @@ export function EdgeScoreboardPage() {
             {/* Left: description + publisher stats */}
             <div className="flex-1 p-6 flex flex-col justify-between min-w-0">
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Measures arrival time of shreds published from validators into DZ Edge multicast versus those delivered via Jito Shredstream and Turbine, showing how often DZ Edge shreds arrive first.
+                Scoreboard benchmarks shred delivery speed across DoubleZero Edge and other providers, using slot-level data to compare performance in real time.
               </p>
               <div className="border-t border-border pt-4 mt-4 flex items-center gap-6">
                 <div>

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -746,6 +746,8 @@ function RecentSlotsChart({
   // LIVE_BUFFER_SIZE so uPlot never re-initialises and the slide animation fires.
   const liveMaxSlotRef = useRef(0)
   const liveQueueRef = useRef<EdgeScoreboardSlotRace[][]>([])
+  // Ref to the latest poll function so scrollToLive can trigger an immediate refresh.
+  const pollRef = useRef<(() => void) | null>(null)
   // liveEdge: the slot number drain considers the right edge of the live window.
   // Only advances via drain, so computeViewByEnd(buf, null, liveEdge) and
   // scrollToLive both target the same value — eliminating the jump on transition.
@@ -854,6 +856,7 @@ function RecentSlotsChart({
         loadSlots(data)
       }).catch(() => {})
     }
+    pollRef.current = poll
     const pollInterval = setInterval(poll, 5_000)
 
     // Single rAF loop drives both the scroll animation and the drain.
@@ -925,6 +928,7 @@ function RecentSlotsChart({
       cancelled = true
       clearInterval(pollInterval)
       cancelAnimationFrame(drainRafId)
+      pollRef.current = null
       liveMaxSlotRef.current = 0
       liveQueueRef.current = []
       // Don't clear the buffer — non-live mode will overwrite it with slots next render.
@@ -1031,8 +1035,10 @@ function RecentSlotsChart({
   const isDraggingRef = useRef(isDragging)
   isDraggingRef.current = isDragging
   const [overscrollPx, setOverscrollPx] = useState(0)
-  // Sub-slot fractional offset applied as CSS translate during inertia so bars glide
-  // smoothly between slot boundaries without triggering activeSlots recomputation.
+  // Sub-slot fractional offsets applied as CSS translate so bars glide smoothly between
+  // slot boundaries without triggering activeSlots recomputation.
+  // dragFracPx: active during pointer drag (same pattern as inertiaFracPx during momentum).
+  const [dragFracPx, setDragFracPx] = useState(0)
   const [inertiaFracPx, setInertiaFracPx] = useState(0)
   const [isInertia, setIsInertia] = useState(false)
   const [isScrollingToLive, setIsScrollingToLive] = useState(false)
@@ -1095,6 +1101,10 @@ function RecentSlotsChart({
 
     // Start live mode (no-op if already live) so drain + SSE begin.
     if (!liveRef.current) setLive(true)
+
+    // Immediately poll to refill the queue without waiting for the next scheduled poll.
+    // This eliminates the potential freeze when the queue was drained while scrolled back.
+    pollRef.current?.()
 
     // If liveEdge is already known and we're already at it, snap and done.
     if (liveEdgeRef.current > 0 && effectiveStart >= liveEdgeRef.current) {
@@ -1215,16 +1225,22 @@ function RecentSlotsChart({
           setOverscrollPx(Math.min(350, rawOverflowPx * 0.35))
           viewEndSlotRef.current = minEnd
           setViewEndSlot(minEnd)
+          setDragFracPx(0)
         } else if (rawEnd > liveEdge) {
           // Past the right (live) edge: anchor at liveEdge, grow CSS transform leftward.
           const rawOverflowPx = (rawEnd - liveEdge) * px()
           setOverscrollPx(-Math.min(350, rawOverflowPx * 0.35))
           viewEndSlotRef.current = liveEdge
           setViewEndSlot(liveEdge)
+          setDragFracPx(0)
         } else {
           setOverscrollPx(0)
           viewEndSlotRef.current = rawEnd
-          setViewEndSlot(rawEnd)
+          // Only trigger re-render at slot boundaries (same pattern as inertia).
+          // dragFracPx provides smooth sub-slot positioning between boundaries.
+          const slotted = Math.floor(rawEnd)
+          setViewEndSlot(slotted)
+          setDragFracPx(-(rawEnd - slotted) * px())
         }
         setIsDragging(true)
       }
@@ -1232,6 +1248,7 @@ function RecentSlotsChart({
       if (last) {
         setIsDragging(false)
         setOverscrollPx(0)  // CSS transition snaps back
+        setDragFracPx(0)
 
         const nums = slotNums()
         const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
@@ -1339,7 +1356,17 @@ function RecentSlotsChart({
       // is unaffected by buffer growth — no offset adjustment needed.
       const existingSlots = new Set(slotBufferRef.current.map(r => r.slot))
       const newRaces = data.recent_slots.filter((r: EdgeScoreboardSlotRace) => !existingSlots.has(r.slot))
-      if (newRaces.length) slotBufferRef.current = [...newRaces, ...slotBufferRef.current]
+      if (!newRaces.length) return
+      slotBufferRef.current = [...newRaces, ...slotBufferRef.current]
+      // If the user is still pinned at the old left edge, shift the view to the new
+      // left edge so the loaded history becomes immediately visible without another drag.
+      const oldMinEnd = oldestSlot + viewSlotCountRef.current - 1
+      if (!isDraggingRef.current && viewEndSlotRef.current !== null && Math.abs(viewEndSlotRef.current - oldMinEnd) < 2) {
+        const newNums = [...new Set(slotBufferRef.current.map(r => r.slot))].sort((a, b) => a - b)
+        const newMinEnd = (newNums[0] ?? 0) + viewSlotCountRef.current - 1
+        viewEndSlotRef.current = newMinEnd
+        setViewEndSlot(newMinEnd)
+      }
     }).catch(() => {
       prefetchedBoundariesRef.current.delete(oldestSlot)
     }).finally(() => {
@@ -1584,7 +1611,7 @@ function RecentSlotsChart({
             <div
               className="flex"
               style={{
-                transform: `translateX(${overscrollPx + inertiaFracPx - (live && viewEndSlot === null && !isDragging ? scrollOffset : 0)}px)`,
+                transform: `translateX(${overscrollPx + dragFracPx + inertiaFracPx - (live && viewEndSlot === null && !isDragging ? scrollOffset : 0)}px)`,
                 transition: (isDragging || isInertia || (live && viewEndSlot === null)) ? undefined : 'transform 0.15s cubic-bezier(0.2, 0, 0, 1)',
                 willChange: 'transform',
               }}

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -875,7 +875,7 @@ function RecentSlotsChart({
       // burst of rapid drains on return (rAF is throttled in background tabs).
       const dt = lastTime === null ? 0 : Math.min(now - lastTime, 400)
       lastTime = now
-      const slotPx = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
+      const slotPx = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
       const inTail = !isDraggingRef.current && viewEndSlotRef.current === null
       if (inTail) {
         // Only advance when there's something to drain — prevents scroll from oscillating
@@ -1196,7 +1196,7 @@ function RecentSlotsChart({
   useDrag(
     ({ movement: [mx], velocity: [vx], direction: [dirX], first, last, active }) => {
       const slotNums = () => [...new Set(slotBufferRef.current.map(r => r.slot))].sort((a, b) => a - b)
-      const px = () => Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
+      const px = () => Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
 
       if (active) {
         // Cancel any running inertia — only when it's actually running to avoid no-op re-renders.
@@ -1244,7 +1244,7 @@ function RecentSlotsChart({
           // Sub-slot glide uses a CSS custom property set directly on the DOM — zero React
           // re-renders between slot boundaries, pointer events handled at native speed.
           setViewEndSlot(Math.floor(rawEnd))
-          const slotPxVal = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCount)
+          const slotPxVal = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCount)
           chartRowsRef.current?.style.setProperty('--drag-frac', `${-(rawEnd - Math.floor(rawEnd)) * slotPxVal}px`)
         }
       }
@@ -1290,7 +1290,7 @@ function RecentSlotsChart({
             const value = target + (from - target) * decay
             const clamped = Math.max(minEnd, Math.min(liveEdge, value))
 
-            const slotPxNow = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
+            const slotPxNow = Math.max(1, ((chartRowsRef.current?.offsetWidth ?? 260) - 64) / viewSlotCountRef.current)
             const committed = Math.floor(clamped)
             const fracPx = -(clamped - committed) * slotPxNow
 
@@ -1787,9 +1787,11 @@ export function EdgeScoreboardPage() {
       }
       nodeFeedRates.push(nodeRates)
 
+      const dzEdge = node.feeds['dz_edge']
       const dz = node.feeds['dz']
-      if (dz?.lead_times) {
-        for (const lt of dz.lead_times) {
+      const leadSource = dzEdge?.lead_times?.length ? dzEdge.lead_times : dz?.lead_times
+      if (leadSource) {
+        for (const lt of leadSource) {
           if (lt.loser_feed in weightedP50) {
             weightedP50[lt.loser_feed] += lt.p50_ms * node.slots_observed
             weightedP95[lt.loser_feed] += lt.p95_ms * node.slots_observed
@@ -2131,12 +2133,16 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
   const [fixedPos, setFixedPos] = useState<{ top: number; left: number } | null>(null)
   const cellRef = useRef<HTMLDivElement>(null)
   const dz = node.feeds['dz']
-  const edgeFirstArrival = node.feeds['dz_edge']?.win_rate_pct ?? 0
+  const dzEdge = node.feeds['dz_edge']
+  const edgeFirstArrival = dzEdge?.win_rate_pct ?? 0
 
-  // Build lead time lookup: loser_feed -> { p50, p95 }
+  // Build lead time lookup: loser_feed -> { p50, p95 }.
+  // Prefer dz_edge (dz + dz_rebop combined, matches the win-rate framing);
+  // fall back to dz-only for older API responses.
   const dzLeadByFeed: Record<string, { p50: number; p95: number }> = {}
-  if (dz?.lead_times) {
-    for (const lt of dz.lead_times) {
+  const leadSource = dzEdge?.lead_times?.length ? dzEdge.lead_times : dz?.lead_times
+  if (leadSource) {
+    for (const lt of leadSource) {
       dzLeadByFeed[lt.loser_feed] = { p50: lt.p50_ms, p95: lt.p95_ms }
     }
   }

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1037,8 +1037,8 @@ function RecentSlotsChart({
   const [overscrollPx, setOverscrollPx] = useState(0)
   // Sub-slot fractional offsets applied as CSS translate so bars glide smoothly between
   // slot boundaries without triggering activeSlots recomputation.
-  // dragFracPx: active during pointer drag (same pattern as inertiaFracPx during momentum).
-  const [dragFracPx, setDragFracPx] = useState(0)
+  // dragFracPx: set via CSS custom property (--drag-frac) on chartRowsRef so pointer
+  // events bypass React entirely between slot boundaries — zero re-renders during drag.
   const [inertiaFracPx, setInertiaFracPx] = useState(0)
   const [isInertia, setIsInertia] = useState(false)
   const [isScrollingToLive, setIsScrollingToLive] = useState(false)
@@ -1199,9 +1199,12 @@ function RecentSlotsChart({
       const px = () => Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
 
       if (active) {
-        momentumStopRef.current?.stop()
-        momentumStopRef.current = null
-        setInertiaFracPx(0)
+        // Cancel any running inertia — only when it's actually running to avoid no-op re-renders.
+        if (momentumStopRef.current) {
+          momentumStopRef.current.stop()
+          momentumStopRef.current = null
+          setInertiaFracPx(0)
+        }
 
         const nums = slotNums()
         const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
@@ -1213,6 +1216,7 @@ function RecentSlotsChart({
           // This makes overscroll accumulate correctly — delta-based math resets each frame
           // when viewEndSlotRef is frozen at minEnd during overscroll.
           dragStartSlotRef.current = viewEndSlotRef.current ?? liveEdge
+          setIsDragging(true)
         }
 
         // Use cumulative movement from gesture start, not incremental delta.
@@ -1225,30 +1229,30 @@ function RecentSlotsChart({
           setOverscrollPx(Math.min(350, rawOverflowPx * 0.35))
           viewEndSlotRef.current = minEnd
           setViewEndSlot(minEnd)
-          setDragFracPx(0)
+          chartRowsRef.current?.style.removeProperty('--drag-frac')
         } else if (rawEnd > liveEdge) {
           // Past the right (live) edge: anchor at liveEdge, grow CSS transform leftward.
           const rawOverflowPx = (rawEnd - liveEdge) * px()
           setOverscrollPx(-Math.min(350, rawOverflowPx * 0.35))
           viewEndSlotRef.current = liveEdge
           setViewEndSlot(liveEdge)
-          setDragFracPx(0)
+          chartRowsRef.current?.style.removeProperty('--drag-frac')
         } else {
           setOverscrollPx(0)
           viewEndSlotRef.current = rawEnd
           // Only trigger activeSlots recomputation at slot boundaries.
-          // Sub-slot CSS offset is driven by dragFracPx so bars glide smoothly between slots.
+          // Sub-slot glide uses a CSS custom property set directly on the DOM — zero React
+          // re-renders between slot boundaries, pointer events handled at native speed.
           setViewEndSlot(Math.floor(rawEnd))
           const slotPxVal = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCount)
-          setDragFracPx(-(rawEnd - Math.floor(rawEnd)) * slotPxVal)
+          chartRowsRef.current?.style.setProperty('--drag-frac', `${-(rawEnd - Math.floor(rawEnd)) * slotPxVal}px`)
         }
-        setIsDragging(true)
       }
 
       if (last) {
         setIsDragging(false)
         setOverscrollPx(0)  // CSS transition snaps back
-        setDragFracPx(0)
+        chartRowsRef.current?.style.removeProperty('--drag-frac')
 
         const nums = slotNums()
         const liveEdge = liveEdgeRef.current || (nums.at(-1) ?? 0)
@@ -1611,7 +1615,7 @@ function RecentSlotsChart({
             <div
               className="flex"
               style={{
-                transform: `translateX(${overscrollPx + dragFracPx + inertiaFracPx - (live && viewEndSlot === null && !isDragging ? scrollOffset : 0)}px)`,
+                transform: `translateX(calc(var(--drag-frac, 0px) + ${overscrollPx + inertiaFracPx - (live && viewEndSlot === null && !isDragging ? scrollOffset : 0)}px))`,
                 transition: (isDragging || isInertia || (live && viewEndSlot === null)) ? undefined : 'transform 0.15s cubic-bezier(0.2, 0, 0, 1)',
                 willChange: 'transform',
               }}

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -2060,7 +2060,7 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
         const lt = dzLeadByFeed[f]
         return (
           <td key={f} className="px-4 py-3 text-right tabular-nums text-sm">
-            {lt ? <>{formatMs(lt.p50)} <span className="text-muted-foreground">({formatMs(lt.p95)})</span></> : '—'}
+            {lt ? <><AnimatedStat value={lt.p50} fmt={formatMs} /> <span className="text-muted-foreground">(<AnimatedStat value={lt.p95} fmt={formatMs} />)</span></> : '—'}
           </td>
         )
       })}

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback } from 'react'
+import { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
 import { useDrag } from '@use-gesture/react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useSearchParams, Link } from 'react-router-dom'
@@ -334,7 +334,7 @@ type SlotHoverInfo = {
 // effect only fires for the owner, so moving to another row clears the previous one.
 let activeChartId: string | null = null
 
-function SlotRaceNodeChart({
+const SlotRaceNodeChart = memo(function SlotRaceNodeChart({
   slotData,
   feeds,
   slotLeaders,
@@ -677,7 +677,7 @@ function SlotRaceNodeChart({
       <div ref={containerRef} />
     </div>
   )
-}
+})
 
 const LIVE_BUFFER_SIZE = 200
 const MAX_BUFFER_SLOTS = 2000
@@ -918,14 +918,6 @@ function RecentSlotsChart({
             const slotNum = races[0]?.slot
             if (slotNum) { liveEdgeRef.current = slotNum }
           }
-        }
-        // Drive dragFracPx at rAF rate (60fps) rather than pointer-event rate (~120Hz+)
-        // so sub-slot CSS updates don't trigger React re-renders faster than the display.
-        if (isDraggingRef.current && viewEndSlotRef.current !== null) {
-          const slotPxVal = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCountRef.current)
-          const rawEnd = viewEndSlotRef.current
-          const frac = -(rawEnd - Math.floor(rawEnd)) * slotPxVal
-          setDragFracPx(frac)
         }
       }
       drainRafId = requestAnimationFrame(tick)
@@ -1244,9 +1236,11 @@ function RecentSlotsChart({
         } else {
           setOverscrollPx(0)
           viewEndSlotRef.current = rawEnd
-          // Only trigger re-render at slot boundaries — sub-slot CSS offset is driven
-          // by the rAF drain loop at 60fps rather than at pointer-event rate.
+          // Only trigger activeSlots recomputation at slot boundaries.
+          // Sub-slot CSS offset is driven by dragFracPx so bars glide smoothly between slots.
           setViewEndSlot(Math.floor(rawEnd))
+          const slotPxVal = Math.max(1, ((containerRef.current?.offsetWidth ?? 260) - 130) / viewSlotCount)
+          setDragFracPx(-(rawEnd - Math.floor(rawEnd)) * slotPxVal)
         }
         setIsDragging(true)
       }

--- a/web/src/components/publisher-check-page.tsx
+++ b/web/src/components/publisher-check-page.tsx
@@ -402,7 +402,7 @@ export function PublisherCheckPage() {
       <div className="mx-auto px-4 sm:px-8 py-8">
         <PageHeader
           icon={ShieldCheck}
-          title="Publisher Check"
+          title="Shred Publishers"
           subtitle={
             activeTab === 'slots'
               ? data?.max_slot

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -20,7 +20,6 @@ import {
   Map,
   Network,
   Shield,
-  ShieldCheck,
   Wrench,
   ShieldAlert,
   Gauge,
@@ -89,12 +88,12 @@ const { resolvedTheme, setTheme } = useTheme()
   const isUsersRoute = location.pathname.startsWith('/dz/users')
   const isMulticastGroupsRoute = location.pathname.startsWith('/dz/multicast-groups')
   const isScoreboardRoute = location.pathname === '/dz/shreds/scoreboard'
-  const isShredsRoute = location.pathname.startsWith('/dz/shreds') && !isScoreboardRoute
+  const isShredsPublishersRoute = location.pathname === '/dz/shreds/publishers' || location.pathname === '/dz/publisher-check'
   const isShredsSeatsRoute = location.pathname === '/dz/shreds/subscribers'
   const isShredsDevicesRoute = location.pathname === '/dz/shreds/devices'
   const isShredsEscrowEventsRoute = location.pathname === '/dz/shreds/activity'
-  const isPublisherCheckRoute = location.pathname === '/dz/publisher-check'
-  const isEdgeRoute = isShredsRoute || isScoreboardRoute || isPublisherCheckRoute
+  const isShredsRoute = location.pathname.startsWith('/dz/shreds') || isShredsPublishersRoute
+  const isEdgeRoute = isShredsRoute
   const isValidatorsRoute = location.pathname.startsWith('/solana/validators')
   const isGossipNodesRoute = location.pathname.startsWith('/solana/gossip-nodes')
   const isSolanaOverviewRoute = location.pathname === '/solana/overview'
@@ -458,20 +457,18 @@ const { resolvedTheme, setTheme } = useTheme()
             <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">Edge</span>
           </div>
           <div className="space-y-1">
-            <Link to="/dz/shreds/scoreboard" className={navItemClass(isScoreboardRoute)}>
-              <Trophy className="h-4 w-4" />
-              Scoreboard
-            </Link>
-            <Link to="/dz/publisher-check" className={navItemClass(isPublisherCheckRoute)}>
-              <ShieldCheck className="h-4 w-4" />
-              Publisher Check
-            </Link>
-            <Link to="/dz/shreds/subscribers" className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}>
+            <Link to="/dz/shreds/scoreboard" className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}>
               <Puzzle className="h-4 w-4" />
               Shreds
             </Link>
             {isShredsRoute && (
               <>
+                <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
+                  Scoreboard
+                </Link>
+                <Link to="/dz/shreds/publishers" className={subNavItemClass(isShredsPublishersRoute)}>
+                  Publishers
+                </Link>
                 <Link to="/dz/shreds/subscribers" className={subNavItemClass(isShredsSeatsRoute)}>
                   Subscribers
                 </Link>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5177,7 +5177,7 @@ export async function fetchEdgeScoreboard(
 ): Promise<EdgeScoreboardResponse> {
   const params = new URLSearchParams()
   params.set('window', window)
-  if (leadersOnly) params.set('leaders_only', 'true')
+  params.set('leaders_only', leadersOnly ? 'true' : 'false')
   if (opts?.sinceSlot) params.set('since_slot', String(opts.sinceSlot))
   if (opts?.beforeSlot) params.set('before_slot', String(opts.beforeSlot))
   if (opts?.limit) params.set('limit', String(opts.limit))


### PR DESCRIPTION
## Summary of Changes
- Removes drag-to-scroll from the edge scoreboard slot race chart, replacing it with `< >` arrow buttons that step through history in `viewSlotCount`-sized increments
- Wraps `SlotRaceNodeChart` in `React.memo` to prevent unnecessary canvas redraws across 25+ chart instances during scroll and live streaming
- Fixes `slotPx` measurement (was reading outer card width via `containerRef`, now reads the chart rows area via `chartRowsRef` — avoids 20–30% underestimate)
- Adds an immediate poll on `scrollToLive()` so the queue refills without waiting for the next 5s interval when returning from scrolled-back state
- Auto-advances view to the new left edge after prefetch completes, so loaded history becomes visible without a manual step
- Prefers `dz_edge.lead_times` over `dz.lead_times` for lead-time display (covers the combined dz + dz_rebop framing used by win-rate)

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +78 / -183  | -105 |
| **Total**    |     1 | +78 / -183  | -105 |

Net removal of ~105 lines — almost entirely drag/momentum/inertia code that was deleted.

## Testing Verification
- Manually verified arrow navigation steps back and forward through slot history at the expected pace
- Confirmed forward arrow disables correctly when at the live edge, and clicking it triggers `scrollToLive`
- Verified live streaming continues uninterrupted while navigated away and returns smoothly on live button click