### PR TITLE
web: add rx/tx toggle to device drill-down traffic charts

### DIFF
--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -396,16 +396,9 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
       </select>
       <button
         onClick={() => setBidirectional(!bidirectional)}
-        className={`px-3 py-1.5 text-sm border rounded-md transition-colors inline-flex items-center gap-1.5 ${
-          bidirectional
-            ? 'border-foreground/30 text-foreground bg-muted'
-            : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
-        }`}
-        title={bidirectional
-          ? 'Rx and Tx are shown separately (Rx up, Tx down). Click to combine into a single line per interface.'
-          : 'Rx and Tx are combined into a single line per interface. Click to split into separate Rx (up) and Tx (down).'}
+        className="text-[10px] text-muted-foreground hover:text-foreground border border-border rounded px-1.5 py-0.5 transition-colors"
       >
-        {bidirectional ? 'Rx / Tx' : 'Rx+Tx'}
+        {bidirectional ? 'Rx/Tx ±' : 'All +'}
       </button>
     </div>
   )

--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -65,6 +65,7 @@ interface CategoryChartProps {
   /** Interface type metadata for badges */
   interfaceTypes?: Map<string, { cyoa_type?: string; link_pk?: string }>
   aggMode: AggMode
+  bidirectional: boolean
   loading?: boolean
   className?: string
   bucketSeconds: number
@@ -72,7 +73,7 @@ interface CategoryChartProps {
   onCursorTime?: (time: number | null) => void
 }
 
-function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interfaceLabels, interfaceTypes, aggMode, loading, className, bucketSeconds, highlightTimeRange, onCursorTime }: CategoryChartProps) {
+function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interfaceLabels, interfaceTypes, aggMode, bidirectional, loading, className, bucketSeconds, highlightTimeRange, onCursorTime }: CategoryChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
   const chartRef = useRef<HTMLDivElement>(null)
@@ -122,7 +123,7 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
           const inVal = (d as unknown as Record<string, number>)[inKey]
           const outVal = (d as unknown as Record<string, number>)[outKey]
           inVals.push(inVal || null)
-          outVals.push(outVal ? -outVal : null)
+          outVals.push(outVal ? (bidirectional ? -outVal : outVal) : null)
         } else {
           inVals.push(null)
           outVals.push(null)
@@ -137,7 +138,7 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
     }
 
     return { uPlotData: arrays as uPlot.AlignedData, uPlotSeries: series, seriesKeys: keys }
-  }, [bucketTimestamps, interfaces, dataMap, aggMode])
+  }, [bucketTimestamps, interfaces, dataMap, aggMode, bidirectional])
 
   uPlotDataRef.current = uPlotData
 
@@ -319,6 +320,7 @@ function CategoryChart({ title, interfaces, bucketTimestamps, dataMap, interface
 
 export function DeviceTrafficChart({ data, className, loading, highlightTimeRange, onCursorTime }: DeviceTrafficChartProps) {
   const [aggMode, setAggMode] = useState<AggMode>('avg')
+  const [bidirectional, setBidirectional] = useState(true)
 
   // Collect all interface data across buckets, classify, and build lookup
   const { categories, bucketTimestamps, dataMap, interfaceLabels, interfaceTypes } = useMemo(() => {
@@ -392,6 +394,19 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
         <option value="p99">P99</option>
         <option value="max">Max</option>
       </select>
+      <button
+        onClick={() => setBidirectional(!bidirectional)}
+        className={`px-3 py-1.5 text-sm border rounded-md transition-colors inline-flex items-center gap-1.5 ${
+          bidirectional
+            ? 'border-foreground/30 text-foreground bg-muted'
+            : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+        }`}
+        title={bidirectional
+          ? 'Rx and Tx are shown separately (Rx up, Tx down). Click to combine into a single line per interface.'
+          : 'Rx and Tx are combined into a single line per interface. Click to split into separate Rx (up) and Tx (down).'}
+      >
+        {bidirectional ? 'Rx / Tx' : 'Rx+Tx'}
+      </button>
     </div>
   )
 
@@ -410,6 +425,7 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
           interfaceLabels={interfaceLabels}
           interfaceTypes={interfaceTypes}
           aggMode={aggMode}
+          bidirectional={bidirectional}
           loading={loading}
           className={className}
           bucketSeconds={data.bucket_seconds}

--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -398,7 +398,7 @@ export function DeviceTrafficChart({ data, className, loading, highlightTimeRang
         onClick={() => setBidirectional(!bidirectional)}
         className="text-[10px] text-muted-foreground hover:text-foreground border border-border rounded px-1.5 py-0.5 transition-colors"
       >
-        {bidirectional ? 'Rx/Tx ±' : 'All +'}
+        {bidirectional ? 'Rx / Tx' : 'Rx+Tx'}
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds a `Rx / Tx` ↔ `Rx+Tx` toggle to the device drill-down page (`/dz/devices/<pk>`) so Tx traffic can be drawn above the x-axis instead of mirrored below it. The current default visualization makes a real *increase* in Tx look like a *drop* toward the bottom of the chart, which has confused users.
- Mirrors the toggle that already exists on `/traffic/interfaces` — same button styling, label logic, and tooltip copy — for consistency between the two pages. Default remains `Rx / Tx` (mirrored), so behavior for existing users is unchanged until they click.
- Tx series stays dashed in both modes so users can still distinguish Rx from Tx when they overlap above the x-axis (the device-page convention is one color per interface, not per direction, so the dash is the only differentiator).

## Implementation notes

- All changes are contained to `web/src/components/device-charts/DeviceTrafficChart.tsx`. No backend or shared-component changes were needed — the device metrics API already returns `in_bps`/`out_bps` separately, so the toggle is a pure presentation flip on the existing data path.
- Did not refactor to share with the traffic page's `TrafficChart` component. The two implementations diverge in non-trivial ways (color convention, category grouping, legend layout) and unifying them is outside the scope of this PR.
- No persistence (URL param / localStorage). Matches the traffic page, which is also session-only.

## Testing Verification

- [ ] Loaded a device drill-down page and confirmed default `Rx / Tx` mode renders identically to before — Rx solid above, Tx dashed below, y-axis ticks unchanged.
- [ ] Clicked the toggle to `Rx+Tx` and confirmed Tx dashed lines flip above the x-axis, the y-axis auto-rescales with no negative tick labels, and the legend's Max / current-value columns continue to show the correct absolute numbers.
- [ ] Toggled back and forth several times; confirmed hover, legend filtering, and the highlight time-range overlay still work in both modes.
- [ ] Verified the toggle on `/traffic/interfaces` still works (sanity check that no shared code was touched).