### PR TITLE
api: fast page cache for edge scoreboard live-tail

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -168,6 +169,49 @@ func edgeScoreboardCacheKey(r *http.Request) string {
 	return "edge_scoreboard"
 }
 
+// edgeScoreboardLatestCacheKey returns the cache key for the fast-refreshed latest-slots
+// slice. Used by live-tail polls (since_slot set, no before_slot) to avoid hammering
+// ClickHouse every few seconds. Returns "" if the request isn't eligible.
+func edgeScoreboardLatestCacheKey(r *http.Request) string {
+	if r.URL.Query().Get("since_slot") == "" || r.URL.Query().Get("before_slot") != "" {
+		return ""
+	}
+	leadersOnly := strings.TrimSpace(r.URL.Query().Get("leaders_only")) != "false"
+	if leadersOnly {
+		return "edge_scoreboard:latest:leaders"
+	}
+	return "edge_scoreboard:latest"
+}
+
+// filterSlotsSince returns slots with slot > sinceSlot, in ASC order, capped at limit.
+// The cached payload is DESC (latest first) with multiple rows per slot (one per feed/host),
+// so we collect all matching rows, then sort ASC by slot, then cap by distinct slot count.
+func filterSlotsSince(slots []EdgeScoreboardSlotRace, sinceSlot uint64, limit int) []EdgeScoreboardSlotRace {
+	out := make([]EdgeScoreboardSlotRace, 0, len(slots))
+	for _, s := range slots {
+		if s.Slot > sinceSlot {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slot < out[j].Slot })
+	if limit <= 0 {
+		return out
+	}
+	// Cap by distinct slot count so N rows-per-slot don't truncate the feed groupings.
+	seen := make(map[uint64]struct{})
+	cut := len(out)
+	for i, s := range out {
+		if _, ok := seen[s.Slot]; !ok {
+			if len(seen) >= limit {
+				cut = i
+				break
+			}
+			seen[s.Slot] = struct{}{}
+		}
+	}
+	return out[:cut]
+}
+
 // GetEdgeScoreboard returns aggregated win rate / completeness data for DZ Edge nodes.
 func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 	// Try to serve from cache for default (window=1h) requests.
@@ -206,6 +250,24 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Sscanf(l, "%d", &slotLimit)
 		if slotLimit < 1 || slotLimit > 1000 {
 			slotLimit = 200
+		}
+	}
+
+	// Live-tail fast path: serve since_slot from the fast-refreshed latest cache when possible.
+	if isMainnet(r.Context()) && sinceSlot > 0 && beforeSlot == 0 {
+		if cacheKey := edgeScoreboardLatestCacheKey(r); cacheKey != "" {
+			if data, err := a.readPageCache(r.Context(), cacheKey); err == nil {
+				var cached EdgeScoreboardResponse
+				if err := json.Unmarshal(data, &cached); err == nil && cached.CurrentSlot >= sinceSlot {
+					trimmed := filterSlotsSince(cached.RecentSlots, sinceSlot, slotLimit)
+					resp := cached
+					resp.RecentSlots = trimmed
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("X-Cache", "HIT")
+					writeJSON(w, &resp)
+					return
+				}
+			}
 		}
 	}
 
@@ -1425,4 +1487,26 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		SlotBucketSize:     slotBucketSize,
 		SlotLeaders:        slotLeaders,
 	}, nil
+}
+
+// FetchEdgeScoreboardLatest fetches just the latest N slots (recent_slots + slot_leaders).
+// Skips the heavy aggregate queries. Intended for the fast page-cache refresher so live-tail
+// polls can be served from cache rather than hitting ClickHouse every few seconds.
+func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, slotLimit int) (*EdgeScoreboardResponse, error) {
+	if slotLimit <= 0 {
+		slotLimit = 1000
+	}
+	shredderDB := fmt.Sprintf("`%s`", a.ShredderDB)
+	var maxSlot uint64
+	start := time.Now()
+	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary`, shredderDB)).Scan(&maxSlot)
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+	if err != nil {
+		return nil, fmt.Errorf("max slot: %w", err)
+	}
+	if maxSlot == 0 {
+		return &EdgeScoreboardResponse{LeadersOnly: leadersOnly, GeneratedAt: time.Now().UTC()}, nil
+	}
+	// beforeSlot = maxSlot+1 triggers cursor mode and returns the latest slotLimit slots DESC.
+	return a.FetchEdgeScoreboardData(ctx, "", leadersOnly, 0, maxSlot+1, slotLimit)
 }

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -18,6 +18,7 @@ const (
 	WorkflowID = "api-page-cache"
 
 	refreshInterval        = 30 * time.Second
+	fastRefreshInterval    = 3 * time.Second
 	continueAsNewThreshold = 60 // ~30 min at 30s intervals
 	errorAfterFailures     = 3  // log WARN for transient failures, ERROR after this many consecutive failures
 )
@@ -155,6 +156,34 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 	return nil
 }
 
+// latestEntries are refreshed on the fast cadence (see fastRefreshInterval). They back
+// the edge scoreboard live-tail so client polls read cached latest slots instead of
+// hitting ClickHouse every few seconds.
+func (a *Activities) latestEntries() []cacheEntry {
+	api := a.API
+	return []cacheEntry{
+		{"edge scoreboard (latest)", "edge_scoreboard:latest", func(ctx context.Context) (any, error) {
+			return api.FetchEdgeScoreboardLatest(ctx, false, 1000)
+		}},
+		{"edge scoreboard (latest, leaders)", "edge_scoreboard:latest:leaders", func(ctx context.Context) (any, error) {
+			return api.FetchEdgeScoreboardLatest(ctx, true, 1000)
+		}},
+	}
+}
+
+// RefreshLatestCaches refreshes just the fast-cadence entries (latest slots slice).
+func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
+	g, gctx := errgroup.WithContext(ctx)
+	for _, entry := range a.latestEntries() {
+		g.Go(func() error {
+			a.refresh(gctx, entry.name, entry.key, entry.fn)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return nil
+}
+
 func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error)) {
 	const maxAttempts = 2
 	for attempt := range maxAttempts {
@@ -224,13 +253,35 @@ func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	}
 	ctx = temporalworkflow.WithActivityOptions(ctx, actOpts)
 
+	fastActOpts := temporalworkflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+	}
+	fastCtx := temporalworkflow.WithActivityOptions(ctx, fastActOpts)
+
 	for iteration < continueAsNewThreshold {
 		_ = temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshCaches).Get(ctx, nil)
 
 		iteration++
 		if iteration < continueAsNewThreshold {
-			if err := temporalworkflow.Sleep(ctx, refreshInterval); err != nil {
-				return err
+			// Tick the fast-cadence refresh repeatedly during the outer sleep window
+			// so latest-slots caches stay fresh for live-tail clients.
+			deadline := temporalworkflow.Now(ctx).Add(refreshInterval)
+			for temporalworkflow.Now(ctx).Before(deadline) {
+				_ = temporalworkflow.ExecuteActivity(fastCtx, (*Activities).RefreshLatestCaches).Get(fastCtx, nil)
+				remaining := deadline.Sub(temporalworkflow.Now(ctx))
+				if remaining <= 0 {
+					break
+				}
+				sleep := fastRefreshInterval
+				if remaining < sleep {
+					sleep = remaining
+				}
+				if err := temporalworkflow.Sleep(ctx, sleep); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds a 3s-cadence page cache (`edge_scoreboard:latest[:leaders]`) for the latest slots slice so live-tail polls serve from cache instead of querying ClickHouse every few seconds per client.
- New `FetchEdgeScoreboardLatest` reuses cursor mode (anchored at `max(slot)+1`) to return just recent_slots + slot_leaders without the heavy aggregate queries.
- Handler live-tail path (`since_slot` set, no `before_slot`) reads the fast cache, filters `slot > since_slot`, and returns `X-Cache: HIT`.
- `PageCacheWorkflow` now ticks the fast activity inside each 30s outer iteration; the 30s aggregate cache and historical drag-scroll (`before_slot`) are unchanged.