### PR TITLE
api: add slot range to query5 outer scan

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -1061,10 +1061,11 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				FROM %s.slot_feed_race_summary AS r
 				INNER JOIN common_slots cs ON r.slot = cs.slot
 				WHERE r.feed_type = 'shred' AND r.loser_feed = '' AND r.feed IN (%s)
+					AND r.slot BETWEEN %d AND %d
 					AND r.host IN (SELECT host FROM active_hosts)
 				ORDER BY r.host, r.slot, r.feed
 			SETTINGS final=1
-`, dzLeaderCTEForRecent, shredderDB, slotWindowMin, slotWindowMax, slotWindowMin, slotWindowMax, shredderDB, slotFilter, orderDir, slotLimit, shredderDB, scoreboardFeeds)
+`, dzLeaderCTEForRecent, shredderDB, slotWindowMin, slotWindowMax, slotWindowMin, slotWindowMax, shredderDB, slotFilter, orderDir, slotLimit, shredderDB, scoreboardFeeds, slotWindowMin, slotWindowMax)
 		} else {
 			query5 = fmt.Sprintf(`
 				WITH active_hosts AS (
@@ -1095,10 +1096,11 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				FROM %s.slot_feed_race_summary AS r
 				INNER JOIN common_slots cs ON r.slot = cs.slot
 				WHERE r.feed_type = 'shred' AND r.loser_feed = '' AND r.feed IN (%s)
+					AND r.slot BETWEEN %d AND %d
 					AND r.host IN (SELECT host FROM active_hosts)
 				ORDER BY r.host, r.slot, r.feed
 			SETTINGS final=1
-`, shredderDB, slotWindowMin, slotWindowMax, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, shredderDB, scoreboardFeeds)
+`, shredderDB, slotWindowMin, slotWindowMax, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, shredderDB, scoreboardFeeds, slotWindowMin, slotWindowMax)
 		}
 		t := time.Now()
 		rows5, err := a.envDB(gctx).Query(gctx, query5)


### PR DESCRIPTION
## Summary
- \`query5\` (recent slot races) had an explicit slot range on its CTE subqueries but not on the outer \`r\` scan — it relied on the \`INNER JOIN common_slots\` to restrict slots.
- ClickHouse doesn't reliably push the join's slot set down to prune granules on the outer scan, so the query was reading the full current partition's matching-feed rows and filtering via hash join.
- Adding explicit \`r.slot BETWEEN slotWindowMin AND slotWindowMax\` lets the primary index prune granules the same way it already does for the CTEs.