### PR TITLE
api: increase edge scoreboard request timeout

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -227,7 +227,7 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("X-Cache", "MISS")
-	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
 	window := strings.TrimSpace(r.URL.Query().Get("window"))


### PR DESCRIPTION
## Summary of Changes
- Increases the per-request timeout for the edge scoreboard handler from 20s to 60s

The previous 20s budget was occasionally exhausted when ClickHouse was under load, causing `context deadline exceeded` errors surfacing as `EdgeScoreboard error: query6b rows`. The scoreboard runs several sequential queries; by the time the final validator-info lookup (query6b) starts iterating rows, the clock had already run out.