### PR TITLE
indexer: ignore "Check CLI version" escrow instruction

### DIFF
--- a/indexer/pkg/dz/shreds/escrowevents/parser.go
+++ b/indexer/pkg/dz/shreds/escrowevents/parser.go
@@ -142,6 +142,8 @@ func parseInstructionGroup(action string, details []string, clientSeatPK string)
 		return &parsedEvent{EventType: EventTypeAckWithdraw}
 	case "Set client seat price override":
 		return &parsedEvent{EventType: EventTypeSetPriceOverride}
+	case "Check CLI version":
+		return nil
 	default:
 		return &parsedEvent{EventType: EventTypeUnknown}
 	}


### PR DESCRIPTION
## Summary
- Skip the "Check CLI version" instruction in the escrow events parser instead of logging it as an unknown action
- This instruction is not relevant to escrow event tracking and was producing noisy error logs

## Testing Verification
- Existing parser unit tests pass
- Verified the instruction returns `nil` (no event row created, no error logged)