### PR TITLE
api: cap max(slot) preamble to exclude corrupted rows

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -122,6 +122,13 @@ type EdgeScoreboardResponse struct {
 	SlotLeaders        map[string]*EdgeScoreboardLeader `json:"slot_leaders,omitempty"`
 }
 
+// maxValidSlot caps max(slot) queries against shredder tables to exclude corrupted rows.
+// Occasional bad inserts produce slot values near 2^64; any of those poison the preamble
+// `SELECT max(slot)` so the derived slot-range filter excludes all real data. Valid Solana
+// slots are currently ~4e8 and advance ~80M/year, so 1e12 is a generous cap with centuries
+// of headroom.
+const maxValidSlot = 1_000_000_000_000
+
 // scoreboardFeeds is the whitelist of feed names included in edge scoreboard results.
 const scoreboardFeeds = `'dz', 'dz_rebop', 'jito', 'turbine'`
 
@@ -323,7 +330,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 	if slotWindow, ok := slotsPerWindow[window]; ok {
 		var maxSlot uint64
 		start := time.Now()
-		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary`, shredderDB)).Scan(&maxSlot)
+		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary WHERE slot < %d`, shredderDB, maxValidSlot)).Scan(&maxSlot)
 		metrics.RecordClickHouseQuery(time.Since(start), err)
 		if err != nil {
 			return nil, fmt.Errorf("max slot: %w", err)
@@ -1523,7 +1530,7 @@ func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, s
 	shredderDB := fmt.Sprintf("`%s`", a.ShredderDB)
 	var maxSlot uint64
 	start := time.Now()
-	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary`, shredderDB)).Scan(&maxSlot)
+	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary WHERE slot < %d`, shredderDB, maxValidSlot)).Scan(&maxSlot)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("max slot: %w", err)


### PR DESCRIPTION
## Summary
Occasional bad inserts leave rows in \`slot_feed_race_summary\` with slot values near 2^64. The edge scoreboard preamble's \`SELECT max(slot)\` has no cap, so a single corrupted row returns e.g. 4.3e18. That value is then used to derive \`slot >= maxSlot - window\` for every subsequent query — which matches zero real slots, so **all charts show no data**.

Caps the preamble to \`slot < 1e12\` (valid Solana slots are ~4e8, advancing ~80M/year, so 1e12 is centuries of headroom). Query1's per-host median-filter already handles its own outlier detection, so this is the only unguarded spot.

## Impact
Currently reproducible in prod — every edge scoreboard chart is empty because of one bad row. This unblocks the UI immediately.

## Testing Verification
- \`SELECT max(slot) FROM shredder_qa.slot_feed_race_summary\` returns 4344924272058607121 today (visible via the local proxy).
- With the cap, \`SELECT max(slot) FROM shredder_qa.slot_feed_race_summary WHERE slot < 1e12\` returns a real slot value in the ~4e8 range.
- After deploy, hero stats and charts should populate again.