### PR TITLE
web: route non-internal users to publishers when clicking Shreds

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,11 +94,20 @@ const queryClient = new QueryClient({
 })
 
 // Redirect to latest or new query session
-function InternalOnly({ children }: { children: React.ReactNode }) {
+function InternalOnly({ children, redirectTo = '/' }: { children: React.ReactNode; redirectTo?: string }) {
   const { user, isLoading } = useAuth()
   if (isLoading) return null
-  if (!user?.is_internal_user) return <Navigate to="/" replace />
+  if (!user?.is_internal_user) return <Navigate to={redirectTo} replace />
   return <>{children}</>
+}
+
+// /dz/shreds lands on the scoreboard for internal users (the hero dashboard) and on the
+// public publishers page for everyone else. Without this, non-internal users hitting
+// /dz/shreds directly would bounce to the home page via the scoreboard's InternalOnly gate.
+function ShredsIndexRedirect() {
+  const { user, isLoading } = useAuth()
+  if (isLoading) return null
+  return <Navigate to={user?.is_internal_user ? '/dz/shreds/scoreboard' : '/dz/shreds/publishers'} replace />
 }
 
 function QueryRedirect() {
@@ -702,8 +711,8 @@ function AppContent() {
             <Route path="/dz/users/:pk" element={<UserDetailPage />} />
             <Route path="/dz/multicast-groups" element={<MulticastGroupsPage />} />
             <Route path="/dz/multicast-groups/:pk" element={<MulticastGroupDetailPage />} />
-            <Route path="/dz/shreds" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
-            <Route path="/dz/shreds/scoreboard" element={<InternalOnly><EdgeScoreboardPage /></InternalOnly>} />
+            <Route path="/dz/shreds" element={<ShredsIndexRedirect />} />
+            <Route path="/dz/shreds/scoreboard" element={<InternalOnly redirectTo="/dz/shreds/publishers"><EdgeScoreboardPage /></InternalOnly>} />
             <Route path="/dz/shreds/publishers" element={<PublisherCheckPage />} />
             <Route path="/dz/publisher-check" element={<Navigate to="/dz/shreds/publishers" replace />} />
             <Route path="/dz/shreds/subscribers" element={<ShredsSeatsPage />} />

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -43,7 +43,11 @@ export function Sidebar() {
   const location = useLocation()
   const navigate = useNavigate()
   const { features } = useEnv()
-  useAuth()
+  const { user } = useAuth()
+  // Non-internal users can't view the scoreboard (gated by InternalOnly), so the Shreds
+  // top-level link falls back to publishers — otherwise clicking Shreds bounces them to
+  // the home page and the Shreds sub-menu never opens.
+  const shredsDefaultPath = user?.is_internal_user ? '/dz/shreds/scoreboard' : '/dz/shreds/publishers'
   const hasNeo4j = features.neo4j !== false
   const hasSolana = features.solana !== false
 const { resolvedTheme, setTheme } = useTheme()
@@ -234,7 +238,7 @@ const { resolvedTheme, setTheme } = useTheme()
           <div className="w-6 border-t border-border/50 my-2" />
 
           {/* Entity sections */}
-          <Link to="/dz/shreds/scoreboard" className={collapsedIconClass(isEdgeRoute)} title="Edge">
+          <Link to={shredsDefaultPath} className={collapsedIconClass(isEdgeRoute)} title="Edge">
             <Trophy className="h-4 w-4" />
           </Link>
           <Link to="/dz/devices" className={collapsedIconClass(isDZRoute && !isEdgeRoute)} title="DoubleZero">
@@ -457,15 +461,17 @@ const { resolvedTheme, setTheme } = useTheme()
             <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">Edge</span>
           </div>
           <div className="space-y-1">
-            <Link to="/dz/shreds/scoreboard" className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}>
+            <Link to={shredsDefaultPath} className={isShredsRoute ? navItemExpandedClass : navItemClass(false)}>
               <Puzzle className="h-4 w-4" />
               Shreds
             </Link>
             {isShredsRoute && (
               <>
-                <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
-                  Scoreboard
-                </Link>
+                {user?.is_internal_user && (
+                  <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
+                    Scoreboard
+                  </Link>
+                )}
                 <Link to="/dz/shreds/publishers" className={subNavItemClass(isShredsPublishersRoute)}>
                   Publishers
                 </Link>


### PR DESCRIPTION
## Summary
- The sidebar Shreds link pointed to \`/dz/shreds/scoreboard\` for everyone, but the scoreboard is gated by \`InternalOnly\`. Non-internal users clicking Shreds were redirected to \`/\` and couldn't reach the Shreds sub-pages (publishers, subscribers, devices, activity) from the nav.
- Now the top-level link, the collapsed-sidebar icon, and the \`/dz/shreds\` index redirect all pick the default sub-page based on internal status — scoreboard for internal users, publishers for everyone else.
- Hides the Scoreboard sub-nav item for non-internal users.
- Scoreboard's \`InternalOnly\` gate now redirects to \`/dz/shreds/publishers\` (not \`/\`) if hit directly via URL.

## Testing Verification
- As a non-internal user: click Shreds in sidebar → lands on publishers (not bounced to home).
- As an internal user: click Shreds → lands on scoreboard (unchanged).
- Directly navigating to \`/dz/shreds/scoreboard\` as a non-internal user lands on publishers instead of home.