### PR TITLE
web: anchor edge scoreboard live tail with a deep seed queue

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -120,6 +120,10 @@ type EdgeScoreboardResponse struct {
 	SlotBuckets        []EdgeScoreboardSlotBucket       `json:"slot_buckets,omitempty"`
 	SlotBucketSize     uint64                           `json:"slot_bucket_size,omitempty"`
 	SlotLeaders        map[string]*EdgeScoreboardLeader `json:"slot_leaders,omitempty"`
+	// DataLagMs is how far behind wall clock the latest row in slot_feed_race_summary is
+	// (server now − max(event_ts)). The client adds this to its own queue depth to show a
+	// pill reflecting actual on-chain time.
+	DataLagMs uint64 `json:"data_lag_ms,omitempty"`
 }
 
 // maxValidSlot caps max(slot) queries against shredder tables to exclude corrupted rows.
@@ -255,7 +259,7 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 	slotLimit := 200
 	if l := r.URL.Query().Get("limit"); l != "" {
 		_, _ = fmt.Sscanf(l, "%d", &slotLimit)
-		if slotLimit < 1 || slotLimit > 1000 {
+		if slotLimit < 1 || slotLimit > 3000 {
 			slotLimit = 200
 		}
 	}
@@ -327,13 +331,21 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 	// lets the index seek directly to the ~24h range. max(slot) is O(1) against
 	// the primary key so the preamble is effectively free.
 	rangeFilter := timeFilter
+	var dataLagMs uint64
 	if slotWindow, ok := slotsPerWindow[window]; ok {
 		var maxSlot uint64
+		var lagSec float64
 		start := time.Now()
-		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary WHERE slot < %d`, shredderDB, maxValidSlot)).Scan(&maxSlot)
+		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(
+			`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary WHERE slot < %d`,
+			shredderDB, maxValidSlot,
+		)).Scan(&maxSlot, &lagSec)
 		metrics.RecordClickHouseQuery(time.Since(start), err)
 		if err != nil {
 			return nil, fmt.Errorf("max slot: %w", err)
+		}
+		if lagSec > 0 {
+			dataLagMs = uint64(lagSec * 1000)
 		}
 		if maxSlot > slotWindow {
 			rangeFilter = fmt.Sprintf("%s AND slot >= %d", timeFilter, maxSlot-slotWindow)
@@ -1517,6 +1529,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		SlotBuckets:        slotBuckets,
 		SlotBucketSize:     slotBucketSize,
 		SlotLeaders:        slotLeaders,
+		DataLagMs:          dataLagMs,
 	}, nil
 }
 
@@ -1529,8 +1542,12 @@ func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, s
 	}
 	shredderDB := fmt.Sprintf("`%s`", a.ShredderDB)
 	var maxSlot uint64
+	var lagSec float64
 	start := time.Now()
-	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`SELECT max(slot) FROM %s.slot_feed_race_summary WHERE slot < %d`, shredderDB, maxValidSlot)).Scan(&maxSlot)
+	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(
+		`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary WHERE slot < %d`,
+		shredderDB, maxValidSlot,
+	)).Scan(&maxSlot, &lagSec)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("max slot: %w", err)
@@ -1539,5 +1556,12 @@ func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, s
 		return &EdgeScoreboardResponse{LeadersOnly: leadersOnly, GeneratedAt: time.Now().UTC()}, nil
 	}
 	// beforeSlot = maxSlot+1 triggers cursor mode and returns the latest slotLimit slots DESC.
-	return a.FetchEdgeScoreboardData(ctx, "", leadersOnly, 0, maxSlot+1, slotLimit)
+	resp, err := a.FetchEdgeScoreboardData(ctx, "", leadersOnly, 0, maxSlot+1, slotLimit)
+	if err != nil {
+		return nil, err
+	}
+	if lagSec > 0 {
+		resp.DataLagMs = uint64(lagSec * 1000)
+	}
+	return resp, nil
 }

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -682,7 +682,16 @@ const SlotRaceNodeChart = memo(function SlotRaceNodeChart({
 })
 
 const LIVE_BUFFER_SIZE = 200
-const MAX_BUFFER_SLOTS = 2000
+const MAX_BUFFER_SLOTS = 3500
+
+// formatLag renders a millisecond duration as "Xm Ys" or "Ys" (no leading zeros).
+// Used by the scoreboard debug overlay so the queue/server lag read like "1m 5s".
+function formatLag(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000))
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return m > 0 ? `${m}m ${s}s` : `${s}s`
+}
 
 // Returns the windowSize slots whose right edge is at `endSlot`.
 // When endSlot is null, uses `liveEdge` as the anchor (the drain-controlled live edge).
@@ -722,6 +731,8 @@ function RecentSlotsChart({
   scrollToLiveRef,
   toggleLiveRef,
   onViewEndSlotChange,
+  onLiveTailStatusChange,
+  dataLagMs,
 }: {
   slots: EdgeScoreboardSlotRace[]
   nodes: EdgeScoreboardNode[]
@@ -737,6 +748,8 @@ function RecentSlotsChart({
   scrollToLiveRef?: React.RefObject<(() => void) | null>
   toggleLiveRef?: React.RefObject<(() => void) | null>
   onViewEndSlotChange?: (slot: number | null) => void
+  onLiveTailStatusChange?: (status: { queueLen: number; queueLagMs: number; serverLagMs: number; totalLagMs: number; delayMin: number; timeLabel: string; edge: number } | null) => void
+  dataLagMs?: number
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewSlotCountRef = useRef(viewSlotCount)
@@ -767,6 +780,29 @@ function RecentSlotsChart({
   // stable when the buffer grows on either end — no offset math needed.
   const [viewEndSlot, setViewEndSlotRaw] = useState<number | null>(null)
   const viewEndSlotRef = useRef<number | null>(null)
+  // liveTailStatus: what slot the chart is currently rendering and the derived wall-clock
+  // time that slot represents. Queue depth = wall-clock delta between the displayed slot and
+  // the server's latest. Wall-clock-as-of is reconstructed by subtracting that delta from now.
+  // Recomputed on liveEdge/bufferVersion changes, which track the drain/merge cycle.
+  const liveTailStatus = useMemo(() => {
+    if (!live || viewEndSlot !== null) return null
+    const queueLen = liveQueueRef.current.length
+    const queueLagMs = queueLen * 400
+    const serverLagMs = dataLagMs ?? 0
+    const totalLagMs = queueLagMs + serverLagMs
+    const delayMin = totalLagMs >= 60_000 ? Math.round(totalLagMs / 60_000) : 0
+    const asOf = new Date(Date.now() - totalLagMs)
+    const timeLabel = asOf.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    return { queueLen, queueLagMs, serverLagMs, totalLagMs, delayMin, timeLabel, edge: liveEdge }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [live, viewEndSlot, liveEdge, bufferVersion, dataLagMs])
+  // Bubble the status to the parent so it can render the indicator in its own header
+  // (when bare, this component's internal header isn't rendered).
+  useEffect(() => { onLiveTailStatusChange?.(liveTailStatus) }, [liveTailStatus, onLiveTailStatusChange])
+  // Debug overlay — enabled with ?debug=1. Never shown to end users.
+  // Note: `window` is a prop name in this component (TimeWindow), so we reach the global
+  // via globalThis.
+  const debugEnabled = typeof globalThis.window !== 'undefined' && new URLSearchParams(globalThis.window.location.search).has('debug')
   const setViewEndSlot = (slot: number | null) => {
     setViewEndSlotRaw(slot)
     onViewEndSlotChange?.(slot)
@@ -812,11 +848,19 @@ function RecentSlotsChart({
     // Seed the live buffer from a set of slot races (initial load path).
     // Puts the vast majority of slots into the immediate buffer (chart starts near live edge)
     // and queues only a small tail so the animation is visually active right away.
-    const INITIAL_QUEUE_SLOTS = 75 // ~30s of animation at 400ms/slot, matching server cache refresh cycle
+    // With a 2500-slot seed and 2250 slots in the queue, we get ~15 min of animation runway
+    // at 400ms/slot — enough to span the upstream MV's 5-min batch cadence many times over
+    // even if polls briefly hiccup. The immediate buffer (first 250 slots) gives the chart
+    // something to render instantly while the queue starts draining.
+    const INITIAL_QUEUE_SLOTS = 2250
     const seedBuffer = (races: EdgeScoreboardSlotRace[], leaders?: Record<string, EdgeScoreboardLeader>) => {
       const { map, nums } = bySlotOrdered(races)
       liveMaxSlotRef.current = nums.at(-1) ?? 0
-      const splitIdx = Math.max(0, nums.length - INITIAL_QUEUE_SLOTS)
+      // Keep at least LIVE_BUFFER_SIZE slots in the immediate buffer so the chart always has
+      // data to render. Only the slots beyond that go to the queue for animation. If the fetch
+      // returned fewer slots than LIVE_BUFFER_SIZE, put them all in immediate (empty queue).
+      const minImmediate = Math.min(nums.length, LIVE_BUFFER_SIZE)
+      const splitIdx = Math.max(minImmediate, nums.length - INITIAL_QUEUE_SLOTS)
       const immediate = nums.slice(0, splitIdx)
       const toQueue = nums.slice(splitIdx)
       const immediateSlot = immediate.at(-1) ?? nums.at(-1) ?? 0
@@ -887,20 +931,16 @@ function RecentSlotsChart({
       if (data.slot_leaders) setLiveLeaders(prev => ({ ...prev, ...data.slot_leaders }))
     }
 
-    // Seed immediately from the React Query data if already available, otherwise fetch.
-    // This eliminates a duplicate network round-trip on initial load and when re-entering live mode.
-    // If leadersOnly or window changed, slotsRef.current holds stale data (wrong filter),
-    // so we must fetch fresh to avoid seeding the buffer with mismatched slots.
-    const liveParamsChanged = prevLiveParamsRef.current.leadersOnly !== leadersOnly || prevLiveParamsRef.current.window !== window
+    // Fetch a deep seed (~15 min at 2.5 slots/sec) so the queue holds enough slots to span
+    // the upstream MV's ~5-min batch cadence without stalling. When live enters, the queue
+    // drains at a constant 400ms/slot; we want at least one MV batch cycle of runway so the
+    // animation never runs dry between polls.
+    const LIVE_SEED_LIMIT = 2500
     prevLiveParamsRef.current = { leadersOnly, window }
-    if (!liveParamsChanged && slotsRef.current.length > 0) {
-      seedBuffer(slotsRef.current, slotLeadersRef.current)
-    } else {
-      fetchEdgeScoreboard(window, leadersOnly).then(data => {
-        if (cancelled) return
-        seedBuffer(data.recent_slots, data.slot_leaders ?? undefined)
-      }).catch(() => {})
-    }
+    fetchEdgeScoreboard(window, leadersOnly, { limit: LIVE_SEED_LIMIT }).then(data => {
+      if (cancelled) return
+      seedBuffer(data.recent_slots, data.slot_leaders ?? undefined)
+    }).catch(() => {})
 
     // Poll every 5s. Pass sinceSlot with an OVERLAP_SLOTS rewind so lagging hosts
     // can fill in cells for already-admitted slots. The server returns rows for
@@ -1471,6 +1511,22 @@ function RecentSlotsChart({
             })()}
           </h3>}
           <div className="flex items-center gap-2 -mt-2">
+            {live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
+              <div className="group relative">
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground border border-border rounded px-1.5 py-0.5 flex items-center gap-1 cursor-help">
+                  <Info className="w-2.5 h-2.5" />
+                  {liveTailStatus.timeLabel} · ~{liveTailStatus.delayMin}m ago
+                </span>
+                <span className="pointer-events-none absolute top-full right-0 mt-2 z-30 w-72 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
+                  The upstream aggregation pipeline batches data every ~5 minutes. The live tail runs ~{liveTailStatus.delayMin}m behind real time so every slot shown is complete and the scroll stays smooth.
+                </span>
+              </div>
+            )}
+            {debugEnabled && live && viewEndSlot === null && liveTailStatus && (
+              <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/60 border border-border/50 rounded px-1.5 py-0.5">
+                queue={liveTailStatus.queueLen} · edge={liveEdge}
+              </span>
+            )}
             {live && viewEndSlot !== null && (
               <button
                 onClick={scrollToLive}
@@ -1632,6 +1688,8 @@ export function EdgeScoreboardPage() {
 
   const [live, setLive] = useState(true)
   const [viewEndSlot, setViewEndSlot] = useState<number | null>(null)
+  const [liveTailStatus, setLiveTailStatus] = useState<{ queueLen: number; queueLagMs: number; serverLagMs: number; totalLagMs: number; delayMin: number; timeLabel: string; edge: number } | null>(null)
+  const debugEnabled = typeof globalThis.window !== 'undefined' && new URLSearchParams(globalThis.window.location.search).has('debug')
   const scrollToLiveRef = useRef<(() => void) | null>(null)
   const toggleLiveRef = useRef<(() => void) | null>(null)
 
@@ -1973,6 +2031,22 @@ export function EdgeScoreboardPage() {
               <div className="flex items-center px-4 py-3">
                 <h2 className="text-sm font-semibold flex-1">Win Rate by Slot</h2>
                 <div className="flex items-center gap-2">
+                  {live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
+                    <div className="group relative">
+                      <span className="text-[10px] uppercase tracking-wide text-muted-foreground border border-border rounded px-1.5 py-0.5 flex items-center gap-1 cursor-help">
+                        <Info className="w-2.5 h-2.5" />
+                        {liveTailStatus.timeLabel} · ~{liveTailStatus.delayMin}m ago
+                      </span>
+                      <span className="pointer-events-none absolute top-full right-0 mt-2 z-30 w-72 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
+                        The upstream aggregation pipeline batches data every ~5 minutes. The live tail runs ~{liveTailStatus.delayMin}m behind real time so every slot shown is complete and the scroll stays smooth.
+                      </span>
+                    </div>
+                  )}
+                  {debugEnabled && live && viewEndSlot === null && liveTailStatus && (
+                    <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/60 border border-border/50 rounded px-1.5 py-0.5">
+                      queue={liveTailStatus.queueLen} ({formatLag(liveTailStatus.queueLagMs)}) · server={formatLag(liveTailStatus.serverLagMs)} · slot={liveTailStatus.edge}
+                    </span>
+                  )}
                   <div className="relative group">
                     <button
                       type="button"
@@ -2025,6 +2099,8 @@ export function EdgeScoreboardPage() {
                   scrollToLiveRef={scrollToLiveRef}
                   toggleLiveRef={toggleLiveRef}
                   onViewEndSlotChange={setViewEndSlot}
+                  onLiveTailStatusChange={setLiveTailStatus}
+                  dataLagMs={data.data_lag_ms}
                 />
               </div>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5143,6 +5143,7 @@ export interface EdgeScoreboardResponse {
   slot_buckets?: EdgeScoreboardSlotBucket[]
   slot_bucket_size?: number
   slot_leaders?: Record<string, EdgeScoreboardLeader>
+  data_lag_ms?: number
 }
 
 export interface EdgeScoreboardLeader {


### PR DESCRIPTION
## Summary
- The upstream MV that populates \`slot_feed_race_summary\` refreshes every ~5 min and takes ~4 min to run, so the true tip of the live tail is chronically 5–10 min stale. Before this change, the chart chased that edge and stalled between MV refreshes.
- On live entry the client now fetches a deep seed (2500 slots, ~15 min at 2.5 slots/sec) and places most of it in the animation queue. The existing rAF loop drains the queue at 400ms/slot (wall-clock rate), so with a 15-min runway the scroll stays continuous even when the MV is between batches. Polls continue to extend the queue as slots arrive.
- API \`limit\` cap raised from 1000 to 3000 to accommodate the 2500-slot seed.
- A "HH:MM · ~Xm ago" pill appears next to the Live button when the queue is more than a minute deep, with a tooltip explaining the delay. The time value tracks the queue as it drains and refills.
- A dev-only debug counter \`queue=N · slot=M\` is shown next to the pill when \`?debug=1\` is in the URL.

## Behavior
- Whole-slot gaps are invisible (no empty columns, just jump in slot number between adjacent columns).
- Per-host gaps still fill in via the overlap-refresh path from #453.
- If the queue fully drains (server tip truly stops advancing for 15+ min), the chart freezes on the last slot until a poll returns new data. No error state.

## Follow-ups
- Once the shredder MV cadence is tightened (see [shredder#73](https://github.com/malbeclabs/shredder/pull/73)), the 2500-slot seed can be reduced.