### PR TITLE
web/api: gate scoreboard time indicator behind debug, default shredder db back to shredder

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -19,7 +19,7 @@ var externalRemoteTables = []struct {
 }{
 	{"shredder", "publisher_shred_stats"},
 	{"shredder", "slot_feed_races"},
-	// {"shredder", "slot_feed_race_summary"}, // not yet created in shredder proper
+	{"shredder", "slot_feed_race_summary"},
 	{"shredder_qa", "publisher_shred_stats"},
 	{"shredder_qa", "slot_feed_races"},
 	{"shredder_qa", "slot_feed_race_summary"},

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -26,8 +26,8 @@ var HealthDB driver.Conn
 // Falls back to DB (main user) if those env vars are not set.
 var PublicQueryDB driver.Conn
 
-// shredderDB is the ClickHouse database name for shredder tables (default: "shredder_qa").
-var shredderDB = "shredder_qa"
+// shredderDB is the ClickHouse database name for shredder tables (default: "shredder").
+var shredderDB = "shredder"
 
 // publisherDB is the ClickHouse database name for publisher tables e.g. publisher_shred_stats (default: "shredder").
 var publisherDB = "shredder"

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1511,7 +1511,7 @@ function RecentSlotsChart({
             })()}
           </h3>}
           <div className="flex items-center gap-2 -mt-2">
-            {live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
+            {debugEnabled && live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
               <div className="group relative">
                 <span className="text-[10px] uppercase tracking-wide text-muted-foreground border border-border rounded px-1.5 py-0.5 flex items-center gap-1 cursor-help">
                   <Info className="w-2.5 h-2.5" />
@@ -2031,7 +2031,7 @@ export function EdgeScoreboardPage() {
               <div className="flex items-center px-4 py-3">
                 <h2 className="text-sm font-semibold flex-1">Win Rate by Slot</h2>
                 <div className="flex items-center gap-2">
-                  {live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
+                  {debugEnabled && live && viewEndSlot === null && liveTailStatus && liveTailStatus.delayMin > 0 && (
                     <div className="group relative">
                       <span className="text-[10px] uppercase tracking-wide text-muted-foreground border border-border rounded px-1.5 py-0.5 flex items-center gap-1 cursor-help">
                         <Info className="w-2.5 h-2.5" />


### PR DESCRIPTION
## Summary
- Gate the edge scoreboard `timeLabel · ~Nm ago` indicator (hero h3 and Win Rate card) behind `?debug=1`, matching the other live-tail debug overlays added in #460.
- Revert the default `shredderDB` value in `api/config/config.go` from `shredder_qa` back to `shredder`.