### PR TITLE
indexer: add geolocation probes, users, and targets (#462)

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -23,6 +23,7 @@ import (
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/config"
 	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
+	geolocsdk "github.com/malbeclabs/doublezero/sdk/geolocation/go"
 	shreds "github.com/malbeclabs/doublezero/sdk/shreds/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
@@ -296,6 +297,7 @@ func run() error {
 	defer dzRPCClient.Close()
 	serviceabilityClient := serviceability.New(dzRPCClient, networkConfig.ServiceabilityProgramID)
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
+	geolocationClient := geolocsdk.New(log, dzRPCClient, networkConfig.GeolocationProgramID)
 
 	// Shreds subscription client (mainnet-beta and testnet only, not devnet).
 	// Mainnet uses Solana proper RPC; testnet uses the DZ ledger RPC.
@@ -531,6 +533,9 @@ func run() error {
 		// Serviceability configuration
 		ServiceabilityRPC: serviceabilityClient,
 
+		// Geolocation configuration
+		GeolocationRPC: geolocationClient,
+
 		// Telemetry configuration
 		TelemetryRPC:           telemetryClient,
 		DZEpochRPC:             dzRPCClient,
@@ -620,6 +625,7 @@ func run() error {
 				IngestionLog:   ingestionLogWriter,
 				Network:        *dzEnvFlag,
 				Serviceability: idx.Serviceability(),
+				Geolocation:    idx.Geolocation(),
 				Shreds:         idx.Shreds(),
 				EscrowEvents:   idx.EscrowEvents(),
 				TelemLatency:   idx.TelemLatency(),
@@ -869,6 +875,7 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	defer dzRPCClient.Close()
 	serviceabilityClient := serviceability.New(dzRPCClient, networkConfig.ServiceabilityProgramID)
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
+	geolocationClient := geolocsdk.New(log, dzRPCClient, networkConfig.GeolocationProgramID)
 
 	// Shreds subscription client (testnet only, not devnet).
 	var shredsClient *shreds.Client
@@ -906,6 +913,7 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		RefreshInterval:        cfg.refreshInterval,
 		MaxConcurrency:         cfg.maxConcurrency,
 		ServiceabilityRPC:      serviceabilityClient,
+		GeolocationRPC:         geolocationClient,
 		TelemetryRPC:           telemetryClient,
 		DZEpochRPC:             dzRPCClient,
 		InternetLatencyAgentPK: networkConfig.InternetLatencyCollectorPK,
@@ -955,6 +963,7 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		IngestionLog:   secondaryIngestionLog,
 		Network:        env,
 		Serviceability: idx.Serviceability(),
+		Geolocation:    idx.Geolocation(),
 		Shreds:         idx.Shreds(),
 		EscrowEvents:   idx.EscrowEvents(),
 		TelemLatency:   idx.TelemLatency(),

--- a/indexer/db/clickhouse/migrations/20260415000001_geolocation_tables.sql
+++ b/indexer/db/clickhouse/migrations/20260415000001_geolocation_tables.sql
@@ -1,0 +1,270 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- geoloc_probes
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_probes_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    exchange_pk String,
+    public_ip String,
+    location_offset_port UInt16,
+    metrics_publisher_pk String,
+    reference_count UInt32,
+    code String,
+    parent_devices String,
+    target_update_count UInt32
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_probes_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    exchange_pk String,
+    public_ip String,
+    location_offset_port UInt16,
+    metrics_publisher_pk String,
+    reference_count UInt32,
+    code String,
+    parent_devices String,
+    target_update_count UInt32
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_probes_current view
+CREATE OR REPLACE VIEW geoloc_probes_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_probes_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner,
+    exchange_pk,
+    public_ip,
+    location_offset_port,
+    metrics_publisher_pk,
+    reference_count,
+    code,
+    parent_devices,
+    target_update_count
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_users
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_users_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    code String,
+    token_account String,
+    payment_status String,
+    status String,
+    target_count UInt32,
+    billing_rate UInt64,
+    last_deduction_dz_epoch UInt64
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_users_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    code String,
+    token_account String,
+    payment_status String,
+    status String,
+    target_count UInt32,
+    billing_rate UInt64,
+    last_deduction_dz_epoch UInt64
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_users_current view
+CREATE OR REPLACE VIEW geoloc_users_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_users_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner,
+    code,
+    token_account,
+    payment_status,
+    status,
+    target_count,
+    billing_rate,
+    last_deduction_dz_epoch
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_targets
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_targets_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    geoloc_user_pk String,
+    probe_pk String,
+    target_type String,
+    ip String,
+    location_offset_port UInt16,
+    target_pk String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_targets_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    geoloc_user_pk String,
+    probe_pk String,
+    target_type String,
+    ip String,
+    location_offset_port UInt16,
+    target_pk String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_targets_current view
+CREATE OR REPLACE VIEW geoloc_targets_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_targets_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    geoloc_user_pk,
+    probe_pk,
+    target_type,
+    ip,
+    location_offset_port,
+    target_pk
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_targets_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_targets_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_targets_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_users_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_users_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_users_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_probes_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_probes_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_probes_history;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/geolocation/main_test.go
+++ b/indexer/pkg/dz/geolocation/main_test.go
@@ -1,0 +1,33 @@
+package geolocation
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+var (
+	sharedDB *clickhousetesting.DB
+)
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("failed to create shared DB", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}
+
+func testClient(t *testing.T) clickhouse.Client {
+	client := laketesting.NewClient(t, sharedDB)
+	return client
+}

--- a/indexer/pkg/dz/geolocation/query.go
+++ b/indexer/pkg/dz/geolocation/query.go
@@ -1,0 +1,155 @@
+package geolocation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+type probeRow struct {
+	PK                 string `ch:"pk"`
+	Owner              string `ch:"owner"`
+	ExchangePK         string `ch:"exchange_pk"`
+	PublicIP           string `ch:"public_ip"`
+	LocationOffsetPort uint16 `ch:"location_offset_port"`
+	MetricsPublisherPK string `ch:"metrics_publisher_pk"`
+	ReferenceCount     uint32 `ch:"reference_count"`
+	Code               string `ch:"code"`
+	ParentDevices      string `ch:"parent_devices"`
+	TargetUpdateCount  uint32 `ch:"target_update_count"`
+}
+
+type userRow struct {
+	PK                   string `ch:"pk"`
+	Owner                string `ch:"owner"`
+	Code                 string `ch:"code"`
+	TokenAccount         string `ch:"token_account"`
+	PaymentStatus        string `ch:"payment_status"`
+	Status               string `ch:"status"`
+	TargetCount          uint32 `ch:"target_count"`
+	BillingRate          uint64 `ch:"billing_rate"`
+	LastDeductionDzEpoch uint64 `ch:"last_deduction_dz_epoch"`
+}
+
+type targetRow struct {
+	GeolocUserPK       string `ch:"geoloc_user_pk"`
+	ProbePK            string `ch:"probe_pk"`
+	TargetType         string `ch:"target_type"`
+	IP                 string `ch:"ip"`
+	LocationOffsetPort uint16 `ch:"location_offset_port"`
+	TargetPK           string `ch:"target_pk"`
+}
+
+func QueryCurrentProbes(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]Probe, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewProbeDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[probeRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query probes: %w", err)
+	}
+
+	probes := make([]Probe, len(rows))
+	for i, row := range rows {
+		var parentDevices []string
+		if row.ParentDevices != "" {
+			_ = json.Unmarshal([]byte(row.ParentDevices), &parentDevices)
+		}
+		probes[i] = Probe{
+			PK:                 row.PK,
+			Owner:              row.Owner,
+			ExchangePK:         row.ExchangePK,
+			PublicIP:           row.PublicIP,
+			LocationOffsetPort: row.LocationOffsetPort,
+			MetricsPublisherPK: row.MetricsPublisherPK,
+			ReferenceCount:     row.ReferenceCount,
+			Code:               row.Code,
+			ParentDevices:      parentDevices,
+			TargetUpdateCount:  row.TargetUpdateCount,
+		}
+	}
+
+	return probes, nil
+}
+
+func QueryCurrentUsers(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]User, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewUserDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[userRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query users: %w", err)
+	}
+
+	users := make([]User, len(rows))
+	for i, row := range rows {
+		users[i] = User{
+			PK:                   row.PK,
+			Owner:                row.Owner,
+			Code:                 row.Code,
+			TokenAccount:         row.TokenAccount,
+			PaymentStatus:        row.PaymentStatus,
+			Status:               row.Status,
+			TargetCount:          row.TargetCount,
+			BillingRate:          row.BillingRate,
+			LastDeductionDzEpoch: row.LastDeductionDzEpoch,
+		}
+	}
+
+	return users, nil
+}
+
+func QueryCurrentTargets(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]Target, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewTargetDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[targetRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query targets: %w", err)
+	}
+
+	targets := make([]Target, len(rows))
+	for i, row := range rows {
+		targets[i] = Target{
+			GeolocUserPK:       row.GeolocUserPK,
+			ProbePK:            row.ProbePK,
+			TargetType:         row.TargetType,
+			IP:                 row.IP,
+			LocationOffsetPort: row.LocationOffsetPort,
+			TargetPK:           row.TargetPK,
+		}
+	}
+
+	return targets, nil
+}

--- a/indexer/pkg/dz/geolocation/query.go
+++ b/indexer/pkg/dz/geolocation/query.go
@@ -66,7 +66,9 @@ func QueryCurrentProbes(ctx context.Context, log *slog.Logger, db clickhouse.Cli
 	for i, row := range rows {
 		var parentDevices []string
 		if row.ParentDevices != "" {
-			_ = json.Unmarshal([]byte(row.ParentDevices), &parentDevices)
+			if err := json.Unmarshal([]byte(row.ParentDevices), &parentDevices); err != nil {
+				log.Debug("geolocation: failed to unmarshal parent_devices", "pk", row.PK, "error", err)
+			}
 		}
 		probes[i] = Probe{
 			PK:                 row.PK,

--- a/indexer/pkg/dz/geolocation/schema.go
+++ b/indexer/pkg/dz/geolocation/schema.go
@@ -1,0 +1,150 @@
+package geolocation
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// ProbeSchema defines the schema for geolocation probes.
+type ProbeSchema struct{}
+
+func (s *ProbeSchema) Name() string {
+	return "geoloc_probes"
+}
+
+func (s *ProbeSchema) PrimaryKeyColumns() []string {
+	return []string{"pk:VARCHAR"}
+}
+
+func (s *ProbeSchema) PayloadColumns() []string {
+	return []string{
+		"owner:VARCHAR",
+		"exchange_pk:VARCHAR",
+		"public_ip:VARCHAR",
+		"location_offset_port:INTEGER",
+		"metrics_publisher_pk:VARCHAR",
+		"reference_count:INTEGER",
+		"code:VARCHAR",
+		"parent_devices:VARCHAR",
+		"target_update_count:INTEGER",
+	}
+}
+
+func (s *ProbeSchema) ToRow(p Probe) []any {
+	parentDevicesJSON, _ := json.Marshal(p.ParentDevices)
+	return []any{
+		p.PK,
+		p.Owner,
+		p.ExchangePK,
+		p.PublicIP,
+		p.LocationOffsetPort,
+		p.MetricsPublisherPK,
+		p.ReferenceCount,
+		p.Code,
+		string(parentDevicesJSON),
+		p.TargetUpdateCount,
+	}
+}
+
+func (s *ProbeSchema) GetPrimaryKey(p Probe) string {
+	return p.PK
+}
+
+// UserSchema defines the schema for geolocation users.
+type UserSchema struct{}
+
+func (s *UserSchema) Name() string {
+	return "geoloc_users"
+}
+
+func (s *UserSchema) PrimaryKeyColumns() []string {
+	return []string{"pk:VARCHAR"}
+}
+
+func (s *UserSchema) PayloadColumns() []string {
+	return []string{
+		"owner:VARCHAR",
+		"code:VARCHAR",
+		"token_account:VARCHAR",
+		"payment_status:VARCHAR",
+		"status:VARCHAR",
+		"target_count:INTEGER",
+		"billing_rate:BIGINT",
+		"last_deduction_dz_epoch:BIGINT",
+	}
+}
+
+func (s *UserSchema) ToRow(u User) []any {
+	return []any{
+		u.PK,
+		u.Owner,
+		u.Code,
+		u.TokenAccount,
+		u.PaymentStatus,
+		u.Status,
+		u.TargetCount,
+		u.BillingRate,
+		u.LastDeductionDzEpoch,
+	}
+}
+
+func (s *UserSchema) GetPrimaryKey(u User) string {
+	return u.PK
+}
+
+// TargetSchema defines the schema for geolocation targets.
+type TargetSchema struct{}
+
+func (s *TargetSchema) Name() string {
+	return "geoloc_targets"
+}
+
+func (s *TargetSchema) PrimaryKeyColumns() []string {
+	return []string{
+		"geoloc_user_pk:VARCHAR",
+		"probe_pk:VARCHAR",
+		"target_type:VARCHAR",
+		"ip:VARCHAR",
+		"location_offset_port:INTEGER",
+		"target_pk:VARCHAR",
+	}
+}
+
+func (s *TargetSchema) PayloadColumns() []string {
+	return nil
+}
+
+func (s *TargetSchema) ToRow(t Target) []any {
+	return []any{
+		t.GeolocUserPK,
+		t.ProbePK,
+		t.TargetType,
+		t.IP,
+		t.LocationOffsetPort,
+		t.TargetPK,
+	}
+}
+
+func (s *TargetSchema) GetPrimaryKey(t Target) string {
+	return t.EntityID()
+}
+
+var (
+	probeSchema  = &ProbeSchema{}
+	userSchema   = &UserSchema{}
+	targetSchema = &TargetSchema{}
+)
+
+func NewProbeDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, probeSchema)
+}
+
+func NewUserDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, userSchema)
+}
+
+func NewTargetDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, targetSchema)
+}

--- a/indexer/pkg/dz/geolocation/store.go
+++ b/indexer/pkg/dz/geolocation/store.go
@@ -1,0 +1,120 @@
+package geolocation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+type StoreConfig struct {
+	Logger     *slog.Logger
+	ClickHouse clickhouse.Client
+}
+
+func (cfg *StoreConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	return nil
+}
+
+type Store struct {
+	log *slog.Logger
+	cfg StoreConfig
+}
+
+func NewStore(cfg StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Store{
+		log: cfg.Logger,
+		cfg: cfg,
+	}, nil
+}
+
+func (s *Store) GetClickHouse() clickhouse.Client {
+	return s.cfg.ClickHouse
+}
+
+func (s *Store) ReplaceProbes(ctx context.Context, probes []Probe) error {
+	s.log.Debug("geolocation/store: replacing probes", "count", len(probes))
+
+	d, err := NewProbeDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(probes), func(i int) ([]any, error) {
+		return probeSchema.ToRow(probes[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write probes to ClickHouse: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) ReplaceUsers(ctx context.Context, users []User) error {
+	s.log.Debug("geolocation/store: replacing users", "count", len(users))
+
+	d, err := NewUserDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(users), func(i int) ([]any, error) {
+		return userSchema.ToRow(users[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write users to ClickHouse: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) ReplaceTargets(ctx context.Context, targets []Target) error {
+	s.log.Debug("geolocation/store: replacing targets", "count", len(targets))
+
+	d, err := NewTargetDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(targets), func(i int) ([]any, error) {
+		return targetSchema.ToRow(targets[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write targets to ClickHouse: %w", err)
+	}
+
+	return nil
+}

--- a/indexer/pkg/dz/geolocation/view.go
+++ b/indexer/pkg/dz/geolocation/view.go
@@ -58,10 +58,15 @@ type Target struct {
 func (t Target) EntityID() string {
 	h := sha256.New()
 	h.Write([]byte(t.GeolocUserPK))
+	h.Write([]byte{0})
 	h.Write([]byte(t.ProbePK))
+	h.Write([]byte{0})
 	h.Write([]byte(t.TargetType))
+	h.Write([]byte{0})
 	h.Write([]byte(t.IP))
+	h.Write([]byte{0})
 	h.Write([]byte{byte(t.LocationOffsetPort >> 8), byte(t.LocationOffsetPort)})
+	h.Write([]byte{0})
 	h.Write([]byte(t.TargetPK))
 	return fmt.Sprintf("%x", h.Sum(nil))[:32]
 }
@@ -228,6 +233,16 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 	v.log.Debug("geolocation: fetched program data",
 		"probes", len(onchainProbes),
 		"users", len(onchainUsers))
+
+	// Validate that we received data — empty responses would tombstone all existing entities.
+	if len(onchainProbes) == 0 {
+		metrics.ViewRefreshTotal.WithLabelValues("geolocation", "error").Inc()
+		return result, fmt.Errorf("refusing to write snapshot: RPC returned no probes (possible RPC issue)")
+	}
+	if len(onchainUsers) == 0 {
+		metrics.ViewRefreshTotal.WithLabelValues("geolocation", "error").Inc()
+		return result, fmt.Errorf("refusing to write snapshot: RPC returned no users (possible RPC issue)")
+	}
 
 	probes := convertProbes(onchainProbes)
 	users := convertUsers(onchainUsers)

--- a/indexer/pkg/dz/geolocation/view.go
+++ b/indexer/pkg/dz/geolocation/view.go
@@ -1,0 +1,322 @@
+package geolocation
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/jonboulle/clockwork"
+	geolocsdk "github.com/malbeclabs/doublezero/sdk/geolocation/go"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
+	"golang.org/x/sync/errgroup"
+)
+
+type Probe struct {
+	PK                 string
+	Owner              string
+	ExchangePK         string
+	PublicIP           string
+	LocationOffsetPort uint16
+	MetricsPublisherPK string
+	ReferenceCount     uint32
+	Code               string
+	ParentDevices      []string
+	TargetUpdateCount  uint32
+}
+
+type User struct {
+	PK                   string
+	Owner                string
+	Code                 string
+	TokenAccount         string
+	PaymentStatus        string
+	Status               string
+	TargetCount          uint32
+	BillingRate          uint64
+	LastDeductionDzEpoch uint64
+}
+
+type Target struct {
+	GeolocUserPK       string
+	ProbePK            string
+	TargetType         string
+	IP                 string
+	LocationOffsetPort uint16
+	TargetPK           string
+}
+
+// EntityID returns a stable composite key for a target (targets don't have
+// their own on-chain account, so we derive an ID from their fields).
+func (t Target) EntityID() string {
+	h := sha256.New()
+	h.Write([]byte(t.GeolocUserPK))
+	h.Write([]byte(t.ProbePK))
+	h.Write([]byte(t.TargetType))
+	h.Write([]byte(t.IP))
+	h.Write([]byte{byte(t.LocationOffsetPort >> 8), byte(t.LocationOffsetPort)})
+	h.Write([]byte(t.TargetPK))
+	return fmt.Sprintf("%x", h.Sum(nil))[:32]
+}
+
+type GeolocationRPC interface {
+	GetGeoProbes(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error)
+	GetGeolocationUsers(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error)
+}
+
+type ViewConfig struct {
+	Logger          *slog.Logger
+	Clock           clockwork.Clock
+	GeolocationRPC  GeolocationRPC
+	RefreshInterval time.Duration
+	ClickHouse      clickhouse.Client
+}
+
+func (cfg *ViewConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.GeolocationRPC == nil {
+		return errors.New("geolocation rpc is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	if cfg.RefreshInterval <= 0 {
+		return errors.New("refresh interval must be greater than 0")
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+type View struct {
+	log       *slog.Logger
+	cfg       ViewConfig
+	store     *Store
+	refreshMu sync.Mutex
+
+	fetchedAt time.Time
+	readyOnce sync.Once
+	readyCh   chan struct{}
+}
+
+func NewView(cfg ViewConfig) (*View, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	store, err := NewStore(StoreConfig{
+		Logger:     cfg.Logger,
+		ClickHouse: cfg.ClickHouse,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create store: %w", err)
+	}
+
+	v := &View{
+		log:     cfg.Logger,
+		cfg:     cfg,
+		store:   store,
+		readyCh: make(chan struct{}),
+	}
+
+	return v, nil
+}
+
+func (v *View) Store() *Store {
+	return v.store
+}
+
+func (v *View) Ready() bool {
+	select {
+	case <-v.readyCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v *View) WaitReady(ctx context.Context) error {
+	select {
+	case <-v.readyCh:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context cancelled while waiting for geolocation view: %w", ctx.Err())
+	}
+}
+
+func (v *View) Start(ctx context.Context) {
+	go func() {
+		v.log.Info("geolocation: starting refresh loop", "interval", v.cfg.RefreshInterval)
+
+		v.safeRefresh(ctx)
+
+		ticker := v.cfg.Clock.NewTicker(v.cfg.RefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.Chan():
+				v.safeRefresh(ctx)
+			}
+		}
+	}()
+}
+
+func (v *View) safeRefresh(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			v.log.Error("geolocation: refresh panicked", "panic", r)
+			metrics.ViewRefreshTotal.WithLabelValues("geolocation", "panic").Inc()
+		}
+	}()
+
+	if _, err := v.Refresh(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		v.log.Error("geolocation: refresh failed", "error", err)
+	}
+}
+
+func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	v.refreshMu.Lock()
+	defer v.refreshMu.Unlock()
+
+	var result ingestionlog.RefreshResult
+
+	refreshStart := time.Now()
+	v.log.Debug("geolocation: refresh started", "start_time", refreshStart)
+	defer func() {
+		duration := time.Since(refreshStart)
+		v.log.Info("geolocation: refresh completed", "duration", duration.String())
+		metrics.ViewRefreshDuration.WithLabelValues("geolocation").Observe(duration.Seconds())
+	}()
+
+	// Fetch probes and users concurrently.
+	var (
+		onchainProbes []geolocsdk.KeyedGeoProbe
+		onchainUsers  []geolocsdk.KeyedGeolocationUser
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		onchainProbes, err = v.cfg.GeolocationRPC.GetGeoProbes(gctx)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		onchainUsers, err = v.cfg.GeolocationRPC.GetGeolocationUsers(gctx)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues("geolocation", "error").Inc()
+		return result, err
+	}
+
+	v.log.Debug("geolocation: fetched program data",
+		"probes", len(onchainProbes),
+		"users", len(onchainUsers))
+
+	probes := convertProbes(onchainProbes)
+	users := convertUsers(onchainUsers)
+	targets := convertTargets(onchainUsers)
+
+	fetchedAt := time.Now().UTC()
+
+	if err := v.store.ReplaceProbes(ctx, probes); err != nil {
+		return result, fmt.Errorf("failed to replace probes: %w", err)
+	}
+
+	if err := v.store.ReplaceUsers(ctx, users); err != nil {
+		return result, fmt.Errorf("failed to replace users: %w", err)
+	}
+
+	if err := v.store.ReplaceTargets(ctx, targets); err != nil {
+		return result, fmt.Errorf("failed to replace targets: %w", err)
+	}
+
+	result.RowsAffected = int64(len(probes) + len(users) + len(targets))
+	result.SourceMaxEventTS = &fetchedAt
+
+	v.fetchedAt = fetchedAt
+	v.readyOnce.Do(func() {
+		close(v.readyCh)
+		v.log.Info("geolocation: view is now ready")
+	})
+
+	v.log.Debug("geolocation: refresh completed", "fetched_at", fetchedAt)
+	metrics.ViewRefreshTotal.WithLabelValues("geolocation", "success").Inc()
+	return result, nil
+}
+
+func convertProbes(onchain []geolocsdk.KeyedGeoProbe) []Probe {
+	result := make([]Probe, len(onchain))
+	for i, p := range onchain {
+		parentDevices := make([]string, len(p.ParentDevices))
+		for j, pd := range p.ParentDevices {
+			parentDevices[j] = pd.String()
+		}
+
+		result[i] = Probe{
+			PK:                 p.Pubkey.String(),
+			Owner:              solana.PublicKeyFromBytes(p.Owner[:]).String(),
+			ExchangePK:         solana.PublicKeyFromBytes(p.ExchangePK[:]).String(),
+			PublicIP:           net.IP(p.PublicIP[:]).String(),
+			LocationOffsetPort: p.LocationOffsetPort,
+			MetricsPublisherPK: solana.PublicKeyFromBytes(p.MetricsPublisherPK[:]).String(),
+			ReferenceCount:     p.ReferenceCount,
+			Code:               p.Code,
+			ParentDevices:      parentDevices,
+			TargetUpdateCount:  p.TargetUpdateCount,
+		}
+	}
+	return result
+}
+
+func convertUsers(onchain []geolocsdk.KeyedGeolocationUser) []User {
+	result := make([]User, len(onchain))
+	for i, u := range onchain {
+		result[i] = User{
+			PK:                   u.Pubkey.String(),
+			Owner:                solana.PublicKeyFromBytes(u.Owner[:]).String(),
+			Code:                 u.Code,
+			TokenAccount:         solana.PublicKeyFromBytes(u.TokenAccount[:]).String(),
+			PaymentStatus:        u.PaymentStatus.String(),
+			Status:               u.Status.String(),
+			TargetCount:          uint32(len(u.Targets)),
+			BillingRate:          u.Billing.FlatPerEpoch.Rate,
+			LastDeductionDzEpoch: u.Billing.FlatPerEpoch.LastDeductionDzEpoch,
+		}
+	}
+	return result
+}
+
+func convertTargets(onchain []geolocsdk.KeyedGeolocationUser) []Target {
+	var result []Target
+	for _, u := range onchain {
+		userPK := u.Pubkey.String()
+		for _, t := range u.Targets {
+			result = append(result, Target{
+				GeolocUserPK:       userPK,
+				ProbePK:            solana.PublicKeyFromBytes(t.GeoProbePK[:]).String(),
+				TargetType:         t.TargetType.String(),
+				IP:                 net.IP(t.IPAddress[:]).String(),
+				LocationOffsetPort: t.LocationOffsetPort,
+				TargetPK:           solana.PublicKeyFromBytes(t.TargetPK[:]).String(),
+			})
+		}
+	}
+	return result
+}

--- a/indexer/pkg/dz/geolocation/view_test.go
+++ b/indexer/pkg/dz/geolocation/view_test.go
@@ -31,6 +31,17 @@ func (m *MockGeolocationRPC) GetGeolocationUsers(ctx context.Context) ([]geolocs
 	return nil, nil
 }
 
+func nonEmptyGeolocationRPC() *MockGeolocationRPC {
+	return &MockGeolocationRPC{
+		getGeoProbesFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error) {
+			return []geolocsdk.KeyedGeoProbe{{Pubkey: solana.MustPublicKeyFromBase58("11111111111111111111111111111111")}}, nil
+		},
+		getGeolocationUsersFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error) {
+			return []geolocsdk.KeyedGeolocationUser{{Pubkey: solana.MustPublicKeyFromBase58("11111111111111111111111111111111")}}, nil
+		},
+	}
+}
+
 func testPubkeyBytes(seed byte) [32]byte {
 	var pk [32]byte
 	for i := range pk {
@@ -66,7 +77,7 @@ func TestLake_Geolocation_View_Ready(t *testing.T) {
 		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),
 			Clock:           clockwork.NewFakeClock(),
-			GeolocationRPC:  &MockGeolocationRPC{},
+			GeolocationRPC:  nonEmptyGeolocationRPC(),
 			RefreshInterval: time.Second,
 			ClickHouse:      mockDB,
 		})
@@ -90,7 +101,7 @@ func TestLake_Geolocation_View_WaitReady(t *testing.T) {
 		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),
 			Clock:           clockwork.NewFakeClock(),
-			GeolocationRPC:  &MockGeolocationRPC{},
+			GeolocationRPC:  nonEmptyGeolocationRPC(),
 			RefreshInterval: time.Second,
 			ClickHouse:      mockDB,
 		})
@@ -435,12 +446,16 @@ func TestLake_Geolocation_View_Refresh(t *testing.T) {
 		require.Equal(t, uint16(8080), targets[0].LocationOffsetPort)
 	})
 
-	t.Run("handles empty RPC response", func(t *testing.T) {
+	t.Run("rejects empty probes response", func(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testClient(t)
 
-		rpc := &MockGeolocationRPC{}
+		rpc := &MockGeolocationRPC{
+			getGeolocationUsersFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error) {
+				return []geolocsdk.KeyedGeolocationUser{{Pubkey: solana.MustPublicKeyFromBase58("11111111111111111111111111111111")}}, nil
+			},
+		}
 
 		view, err := NewView(ViewConfig{
 			Logger:          laketesting.NewLogger(),
@@ -453,6 +468,33 @@ func TestLake_Geolocation_View_Refresh(t *testing.T) {
 
 		ctx := context.Background()
 		_, err = view.Refresh(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no probes")
+	})
+
+	t.Run("rejects empty users response", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		rpc := &MockGeolocationRPC{
+			getGeoProbesFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error) {
+				return []geolocsdk.KeyedGeoProbe{{Pubkey: solana.MustPublicKeyFromBase58("11111111111111111111111111111111")}}, nil
+			},
+		}
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  rpc,
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
 		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = view.Refresh(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no users")
 	})
 }

--- a/indexer/pkg/dz/geolocation/view_test.go
+++ b/indexer/pkg/dz/geolocation/view_test.go
@@ -333,12 +333,14 @@ func TestLake_Geolocation_View_Refresh(t *testing.T) {
 
 		mockDB := testClient(t)
 
-		probePK := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		probePKBytes := testPubkeyBytes(10)
+		probePK := solana.PublicKeyFromBytes(probePKBytes[:])
 		ownerBytes := testPubkeyBytes(1)
 		exchangeBytes := testPubkeyBytes(2)
 		metricsBytes := testPubkeyBytes(3)
 
-		userPK := solana.MustPublicKeyFromBase58("22222222222222222222222222222222")
+		userPKBytes := testPubkeyBytes(20)
+		userPK := solana.PublicKeyFromBytes(userPKBytes[:])
 		userOwnerBytes := testPubkeyBytes(4)
 		tokenAcctBytes := testPubkeyBytes(5)
 		targetPKBytes := testPubkeyBytes(6)

--- a/indexer/pkg/dz/geolocation/view_test.go
+++ b/indexer/pkg/dz/geolocation/view_test.go
@@ -1,0 +1,456 @@
+package geolocation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/jonboulle/clockwork"
+	geolocsdk "github.com/malbeclabs/doublezero/sdk/geolocation/go"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+type MockGeolocationRPC struct {
+	getGeoProbesFunc        func(context.Context) ([]geolocsdk.KeyedGeoProbe, error)
+	getGeolocationUsersFunc func(context.Context) ([]geolocsdk.KeyedGeolocationUser, error)
+}
+
+func (m *MockGeolocationRPC) GetGeoProbes(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error) {
+	if m.getGeoProbesFunc != nil {
+		return m.getGeoProbesFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockGeolocationRPC) GetGeolocationUsers(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error) {
+	if m.getGeolocationUsersFunc != nil {
+		return m.getGeolocationUsersFunc(ctx)
+	}
+	return nil, nil
+}
+
+func testPubkeyBytes(seed byte) [32]byte {
+	var pk [32]byte
+	for i := range pk {
+		pk[i] = seed
+	}
+	return pk
+}
+
+func TestLake_Geolocation_View_Ready(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns false when not ready", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  &MockGeolocationRPC{},
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+		require.False(t, view.Ready(), "view should not be ready before first refresh")
+	})
+
+	t.Run("returns true after successful refresh", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  &MockGeolocationRPC{},
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = view.Refresh(ctx)
+		require.NoError(t, err)
+		require.True(t, view.Ready(), "view should be ready after successful refresh")
+	})
+}
+
+func TestLake_Geolocation_View_WaitReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns immediately when already ready", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  &MockGeolocationRPC{},
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = view.Refresh(ctx)
+		require.NoError(t, err)
+
+		err = view.WaitReady(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when context is cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  &MockGeolocationRPC{},
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = view.WaitReady(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context cancelled")
+	})
+}
+
+func TestLake_Geolocation_View_ConvertProbes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts onchain probes to domain types", func(t *testing.T) {
+		t.Parallel()
+
+		pk := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		ownerBytes := testPubkeyBytes(1)
+		exchangeBytes := testPubkeyBytes(2)
+		metricsBytes := testPubkeyBytes(3)
+		parentDevice := testPubkeyBytes(4)
+
+		onchain := []geolocsdk.KeyedGeoProbe{
+			{
+				Pubkey: pk,
+				GeoProbe: geolocsdk.GeoProbe{
+					Owner:              ownerBytes,
+					ExchangePK:         exchangeBytes,
+					PublicIP:           [4]uint8{10, 0, 1, 1},
+					LocationOffsetPort: 9000,
+					MetricsPublisherPK: metricsBytes,
+					ReferenceCount:     5,
+					Code:               "probe-1",
+					ParentDevices:      []solana.PublicKey{solana.PublicKeyFromBytes(parentDevice[:])},
+					TargetUpdateCount:  3,
+				},
+			},
+		}
+
+		result := convertProbes(onchain)
+
+		require.Len(t, result, 1)
+		require.Equal(t, pk.String(), result[0].PK)
+		require.Equal(t, solana.PublicKeyFromBytes(ownerBytes[:]).String(), result[0].Owner)
+		require.Equal(t, solana.PublicKeyFromBytes(exchangeBytes[:]).String(), result[0].ExchangePK)
+		require.Equal(t, "10.0.1.1", result[0].PublicIP)
+		require.Equal(t, uint16(9000), result[0].LocationOffsetPort)
+		require.Equal(t, solana.PublicKeyFromBytes(metricsBytes[:]).String(), result[0].MetricsPublisherPK)
+		require.Equal(t, uint32(5), result[0].ReferenceCount)
+		require.Equal(t, "probe-1", result[0].Code)
+		require.Len(t, result[0].ParentDevices, 1)
+		require.Equal(t, uint32(3), result[0].TargetUpdateCount)
+	})
+
+	t.Run("handles empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		result := convertProbes(nil)
+		require.Empty(t, result)
+	})
+}
+
+func TestLake_Geolocation_View_ConvertUsers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts onchain users to domain types", func(t *testing.T) {
+		t.Parallel()
+
+		pk := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		ownerBytes := testPubkeyBytes(1)
+		tokenAcctBytes := testPubkeyBytes(2)
+
+		onchain := []geolocsdk.KeyedGeolocationUser{
+			{
+				Pubkey: pk,
+				GeolocationUser: geolocsdk.GeolocationUser{
+					Owner:         ownerBytes,
+					Code:          "user-1",
+					TokenAccount:  tokenAcctBytes,
+					PaymentStatus: geolocsdk.GeolocationPaymentStatusPaid,
+					Status:        geolocsdk.GeolocationUserStatusActivated,
+					Billing: geolocsdk.GeolocationBillingConfig{
+						FlatPerEpoch: geolocsdk.FlatPerEpochConfig{
+							Rate:                 1000,
+							LastDeductionDzEpoch: 42,
+						},
+					},
+					Targets: []geolocsdk.GeolocationTarget{
+						{}, {}, {},
+					},
+				},
+			},
+		}
+
+		result := convertUsers(onchain)
+
+		require.Len(t, result, 1)
+		require.Equal(t, pk.String(), result[0].PK)
+		require.Equal(t, solana.PublicKeyFromBytes(ownerBytes[:]).String(), result[0].Owner)
+		require.Equal(t, "user-1", result[0].Code)
+		require.Equal(t, solana.PublicKeyFromBytes(tokenAcctBytes[:]).String(), result[0].TokenAccount)
+		require.Equal(t, "paid", result[0].PaymentStatus)
+		require.Equal(t, "activated", result[0].Status)
+		require.Equal(t, uint32(3), result[0].TargetCount)
+		require.Equal(t, uint64(1000), result[0].BillingRate)
+		require.Equal(t, uint64(42), result[0].LastDeductionDzEpoch)
+	})
+}
+
+func TestLake_Geolocation_View_ConvertTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fans out targets from users", func(t *testing.T) {
+		t.Parallel()
+
+		userPK := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		probeBytes := testPubkeyBytes(1)
+		targetBytes := testPubkeyBytes(2)
+
+		onchain := []geolocsdk.KeyedGeolocationUser{
+			{
+				Pubkey: userPK,
+				GeolocationUser: geolocsdk.GeolocationUser{
+					Targets: []geolocsdk.GeolocationTarget{
+						{
+							TargetType:         geolocsdk.GeoLocationTargetTypeOutbound,
+							IPAddress:          [4]uint8{192, 168, 1, 1},
+							LocationOffsetPort: 8080,
+							TargetPK:           targetBytes,
+							GeoProbePK:         probeBytes,
+						},
+						{
+							TargetType:         geolocsdk.GeoLocationTargetTypeInbound,
+							IPAddress:          [4]uint8{0, 0, 0, 0},
+							LocationOffsetPort: 0,
+							TargetPK:           targetBytes,
+							GeoProbePK:         probeBytes,
+						},
+					},
+				},
+			},
+		}
+
+		result := convertTargets(onchain)
+
+		require.Len(t, result, 2)
+		require.Equal(t, userPK.String(), result[0].GeolocUserPK)
+		require.Equal(t, solana.PublicKeyFromBytes(probeBytes[:]).String(), result[0].ProbePK)
+		require.Equal(t, "outbound", result[0].TargetType)
+		require.Equal(t, "192.168.1.1", result[0].IP)
+		require.Equal(t, uint16(8080), result[0].LocationOffsetPort)
+		require.Equal(t, solana.PublicKeyFromBytes(targetBytes[:]).String(), result[0].TargetPK)
+
+		require.Equal(t, "inbound", result[1].TargetType)
+	})
+
+	t.Run("handles users with no targets", func(t *testing.T) {
+		t.Parallel()
+
+		userPK := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		onchain := []geolocsdk.KeyedGeolocationUser{
+			{
+				Pubkey:          userPK,
+				GeolocationUser: geolocsdk.GeolocationUser{},
+			},
+		}
+
+		result := convertTargets(onchain)
+		require.Empty(t, result)
+	})
+}
+
+func TestLake_Geolocation_View_TargetEntityID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces stable IDs for same fields", func(t *testing.T) {
+		t.Parallel()
+
+		t1 := Target{
+			GeolocUserPK:       "user1",
+			ProbePK:            "probe1",
+			TargetType:         "outbound",
+			IP:                 "1.2.3.4",
+			LocationOffsetPort: 8080,
+			TargetPK:           "target1",
+		}
+		t2 := Target{
+			GeolocUserPK:       "user1",
+			ProbePK:            "probe1",
+			TargetType:         "outbound",
+			IP:                 "1.2.3.4",
+			LocationOffsetPort: 8080,
+			TargetPK:           "target1",
+		}
+
+		require.Equal(t, t1.EntityID(), t2.EntityID())
+	})
+
+	t.Run("produces different IDs for different fields", func(t *testing.T) {
+		t.Parallel()
+
+		t1 := Target{GeolocUserPK: "user1", ProbePK: "probe1", TargetType: "outbound", IP: "1.2.3.4", LocationOffsetPort: 8080, TargetPK: "target1"}
+		t2 := Target{GeolocUserPK: "user2", ProbePK: "probe1", TargetType: "outbound", IP: "1.2.3.4", LocationOffsetPort: 8080, TargetPK: "target1"}
+
+		require.NotEqual(t, t1.EntityID(), t2.EntityID())
+	})
+}
+
+func TestLake_Geolocation_View_Refresh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stores probes, users, and targets on refresh", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		probePK := solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		ownerBytes := testPubkeyBytes(1)
+		exchangeBytes := testPubkeyBytes(2)
+		metricsBytes := testPubkeyBytes(3)
+
+		userPK := solana.MustPublicKeyFromBase58("22222222222222222222222222222222")
+		userOwnerBytes := testPubkeyBytes(4)
+		tokenAcctBytes := testPubkeyBytes(5)
+		targetPKBytes := testPubkeyBytes(6)
+
+		rpc := &MockGeolocationRPC{
+			getGeoProbesFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error) {
+				return []geolocsdk.KeyedGeoProbe{
+					{
+						Pubkey: probePK,
+						GeoProbe: geolocsdk.GeoProbe{
+							Owner:              ownerBytes,
+							ExchangePK:         exchangeBytes,
+							PublicIP:           [4]uint8{10, 0, 1, 1},
+							LocationOffsetPort: 9000,
+							MetricsPublisherPK: metricsBytes,
+							ReferenceCount:     1,
+							Code:               "probe-1",
+						},
+					},
+				}, nil
+			},
+			getGeolocationUsersFunc: func(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error) {
+				return []geolocsdk.KeyedGeolocationUser{
+					{
+						Pubkey: userPK,
+						GeolocationUser: geolocsdk.GeolocationUser{
+							Owner:         userOwnerBytes,
+							Code:          "user-1",
+							TokenAccount:  tokenAcctBytes,
+							PaymentStatus: geolocsdk.GeolocationPaymentStatusPaid,
+							Status:        geolocsdk.GeolocationUserStatusActivated,
+							Billing: geolocsdk.GeolocationBillingConfig{
+								FlatPerEpoch: geolocsdk.FlatPerEpochConfig{
+									Rate:                 500,
+									LastDeductionDzEpoch: 10,
+								},
+							},
+							Targets: []geolocsdk.GeolocationTarget{
+								{
+									TargetType:         geolocsdk.GeoLocationTargetTypeOutbound,
+									IPAddress:          [4]uint8{192, 168, 1, 1},
+									LocationOffsetPort: 8080,
+									TargetPK:           targetPKBytes,
+									GeoProbePK:         testPubkeyBytes(7),
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  rpc,
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		result, err := view.Refresh(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int64(3), result.RowsAffected) // 1 probe + 1 user + 1 target
+
+		// Verify data via query functions.
+		probes, err := QueryCurrentProbes(ctx, laketesting.NewLogger(), mockDB)
+		require.NoError(t, err)
+		require.Len(t, probes, 1)
+		require.Equal(t, probePK.String(), probes[0].PK)
+		require.Equal(t, "10.0.1.1", probes[0].PublicIP)
+		require.Equal(t, "probe-1", probes[0].Code)
+
+		users, err := QueryCurrentUsers(ctx, laketesting.NewLogger(), mockDB)
+		require.NoError(t, err)
+		require.Len(t, users, 1)
+		require.Equal(t, userPK.String(), users[0].PK)
+		require.Equal(t, "user-1", users[0].Code)
+		require.Equal(t, "paid", users[0].PaymentStatus)
+		require.Equal(t, "activated", users[0].Status)
+		require.Equal(t, uint32(1), users[0].TargetCount)
+		require.Equal(t, uint64(500), users[0].BillingRate)
+		require.Equal(t, uint64(10), users[0].LastDeductionDzEpoch)
+
+		targets, err := QueryCurrentTargets(ctx, laketesting.NewLogger(), mockDB)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		require.Equal(t, userPK.String(), targets[0].GeolocUserPK)
+		require.Equal(t, "outbound", targets[0].TargetType)
+		require.Equal(t, "192.168.1.1", targets[0].IP)
+		require.Equal(t, uint16(8080), targets[0].LocationOffsetPort)
+	})
+
+	t.Run("handles empty RPC response", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testClient(t)
+
+		rpc := &MockGeolocationRPC{}
+
+		view, err := NewView(ViewConfig{
+			Logger:          laketesting.NewLogger(),
+			Clock:           clockwork.NewFakeClock(),
+			GeolocationRPC:  rpc,
+			RefreshInterval: time.Second,
+			ClickHouse:      mockDB,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = view.Refresh(ctx)
+		require.NoError(t, err)
+	})
+}

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
@@ -24,6 +25,7 @@ type Activities struct {
 	IngestionLog   *ingestionlog.Writer
 	Network        string
 	Serviceability *dzsvc.View
+	Geolocation    *dzgeoloc.View     // nil when geolocation is not configured
 	Shreds         *dzshreds.View     // nil when shreds is not configured
 	EscrowEvents   *escrowevents.View // nil when shreds is not configured
 	TelemLatency   *dztelemlatency.View
@@ -40,6 +42,22 @@ func (a *Activities) RefreshServiceability(ctx context.Context) error {
 		result, err := a.Serviceability.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("serviceability refresh: %w", err)
+		}
+		return result, nil
+	})
+}
+
+// RefreshGeolocation fetches geolocation program state from RPC
+// and writes it to ClickHouse dimension tables. No-op if geolocation is not configured.
+func (a *Activities) RefreshGeolocation(ctx context.Context) error {
+	if a.Geolocation == nil {
+		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshGeolocation", a.Network)
+		return nil
+	}
+	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshGeolocation", a.Network, func() (ingestionlog.RefreshResult, error) {
+		result, err := a.Geolocation.Refresh(ctx)
+		if err != nil {
+			return result, fmt.Errorf("geolocation refresh: %w", err)
 		}
 		return result, nil
 	})

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -14,6 +14,7 @@ import (
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 
+	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
@@ -35,6 +36,7 @@ type Config struct {
 
 	// Views and stores for activity execution.
 	Serviceability *dzsvc.View
+	Geolocation    *dzgeoloc.View     // optional
 	Shreds         *dzshreds.View     // optional
 	EscrowEvents   *escrowevents.View // optional
 	TelemLatency   *dztelemlatency.View
@@ -79,6 +81,7 @@ func Start(ctx context.Context, cfg Config) error {
 		IngestionLog:   cfg.IngestionLog,
 		Network:        cfg.Network,
 		Serviceability: cfg.Serviceability,
+		Geolocation:    cfg.Geolocation,
 		Shreds:         cfg.Shreds,
 		EscrowEvents:   cfg.EscrowEvents,
 		TelemLatency:   cfg.TelemLatency,

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -54,8 +54,9 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 			logger.Error("serviceability refresh failed", "error", err)
 		}
 
-		// Run telemetry latency, shreds, escrow events, ISIS sync, and graph sync in parallel.
+		// Run telemetry latency, geolocation, shreds, escrow events, ISIS sync, and graph sync in parallel.
 		telemLatencyFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshTelemetryLatency)
+		geolocationFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshGeolocation)
 		shredsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShreds)
 		escrowEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShredEscrowEvents)
 		isisSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncISIS)
@@ -72,6 +73,12 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 				return ctx.Err()
 			}
 			logger.Error("telemetry latency refresh failed", "error", err)
+		}
+		if err := geolocationFuture.Get(ctx, nil); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			logger.Error("geolocation refresh failed", "error", err)
 		}
 		if err := shredsFuture.Get(ctx, nil); err != nil {
 			if ctx.Err() != nil {

--- a/indexer/pkg/indexer/config.go
+++ b/indexer/pkg/indexer/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/malbeclabs/doublezero/tools/maxmind/pkg/geoip"
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -39,6 +40,9 @@ type Config struct {
 
 	// Serviceability RPC configuration.
 	ServiceabilityRPC dzsvc.ServiceabilityRPC
+
+	// Geolocation RPC configuration (optional).
+	GeolocationRPC dzgeoloc.GeolocationRPC
 
 	// Telemetry RPC configuration.
 	TelemetryRPC           dztelemlatency.TelemetryRPC

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
@@ -25,6 +26,7 @@ type Indexer struct {
 	cfg Config
 
 	svc           *dzsvc.View
+	geoloc        *dzgeoloc.View
 	shreds        *dzshreds.View
 	escrowEvents  *escrowevents.View
 	graphStore    *dzgraph.Store
@@ -81,6 +83,21 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create serviceability view: %w", err)
+	}
+
+	// Initialize geolocation view (optional)
+	var geolocView *dzgeoloc.View
+	if cfg.GeolocationRPC != nil {
+		geolocView, err = dzgeoloc.NewView(dzgeoloc.ViewConfig{
+			Logger:          cfg.Logger,
+			Clock:           cfg.Clock,
+			GeolocationRPC:  cfg.GeolocationRPC,
+			RefreshInterval: cfg.RefreshInterval,
+			ClickHouse:      cfg.ClickHouse,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create geolocation view: %w", err)
+		}
 	}
 
 	// Initialize shreds subscription view (optional, mainnet-beta + testnet only)
@@ -250,6 +267,7 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 		cfg: cfg,
 
 		svc:           svcView,
+		geoloc:        geolocView,
 		shreds:        shredsView,
 		escrowEvents:  escrowEventsView,
 		graphStore:    graphStore,
@@ -332,6 +350,11 @@ func (i *Indexer) ISISSource() isis.Source {
 // ISISStore returns the ISIS ClickHouse store, or nil if not configured.
 func (i *Indexer) ISISStore() *isis.Store {
 	return i.isisStore
+}
+
+// Geolocation returns the geolocation view, or nil if not configured.
+func (i *Indexer) Geolocation() *dzgeoloc.View {
+	return i.geoloc
 }
 
 // Shreds returns the shreds subscription view, or nil if not configured.


### PR DESCRIPTION
## Summary

- Add three new ClickHouse SCD2 dimension tables (`dim_geoloc_probes_history`, `dim_geoloc_users_history`, `dim_geoloc_targets_history`) with staging tables and current-state views
- Create `indexer/pkg/dz/geolocation` package (schema, store, query, view) following the existing serviceability view pattern, with concurrent RPC calls via errgroup
- Wire geolocation view into indexer config, main.go (primary + secondary networks), and the Temporal dzingest workflow as a parallel activity

## Diff Breakdown (origin/main...HEAD)

| Category          | Files | Lines (+/-)     | Net    |
|-------------------|-------|-----------------|--------|
| Core logic        |     3 | +614   / -0     |   +614 |
| Migration         |     1 | +270   / -0     |   +270 |
| Scaffolding       |     7 | +215   / -1     |   +214 |
| Tests             |     2 | +533   / -0     |   +533 |
| **Total**         |    13 | +1632  / -1     |  +1631 |

### Core changes
- `indexer/pkg/dz/geolocation/view.go` — +337/-0 (refresh loop with concurrent RPC fetches, empty-response validation, on-chain to domain type conversions, target entity ID derivation via SHA-256)
- `indexer/pkg/dz/geolocation/query.go` — +157/-0 (typed ClickHouse queries for current probes/users/targets with row-to-domain mapping)
- `indexer/pkg/dz/geolocation/store.go` — +120/-0 (SCD2 batch writes with MissingMeansDeleted semantics for probes, users, and targets)

Summary: ~610 lines of core logic across 3 files, supported by ~215 lines of scaffolding (schema definitions, config wiring, workflow registration), ~530 lines of tests, and 1 migration.

## Testing Verification

- Integration tests cover probe/user/target conversion, target entity ID derivation (SHA-256 of composite fields), view readiness signaling, and full round-trip refresh with ClickHouse reads via testcontainers
- Empty-response validation prevents accidental tombstoning of all entities when RPC returns no data

Fixes #462