### PR TITLE
web: smarter back link on detail pages + rename to Shreds Scoreboard

### DIFF
--- a/web/src/components/contributor-detail-page.tsx
+++ b/web/src/components/contributor-detail-page.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, Building2, AlertCircle, ArrowLeft } from 'lucide-react'
 import { fetchContributor } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -16,6 +17,7 @@ function formatBps(bps: number): string {
 export function ContributorDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/dz/contributors', label: 'contributors' })
 
   const { data: contributor, isLoading, error } = useQuery({
     queryKey: ['contributor', pk],
@@ -40,10 +42,10 @@ export function ContributorDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Contributor not found</div>
           <button
-            onClick={() => navigate('/dz/contributors')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to contributors
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -55,11 +57,11 @@ export function ContributorDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/dz/contributors')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to contributors
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -6,6 +6,7 @@ import { CopyableText } from '@/components/copyable-text'
 import { fetchDevice, fetchDeviceMetrics } from '@/lib/api'
 import { DeviceInfoContent } from '@/components/shared/DeviceInfoContent'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 import { deviceDetailToInfo } from '@/components/shared/device-info-converters'
 import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
@@ -32,6 +33,7 @@ const statusColors: Record<string, string> = {
 
 export function DeviceDetailPage() {
   const { pk } = useParams<{ pk: string }>()
+  const back = useBackLink({ to: '/dz/devices', label: 'devices' })
   const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<TimeRange>({ preset: '24h' })
   const [hoveredTimeRange, setHoveredTimeRange] = useState<{ start: number; end: number } | null>(null)
@@ -68,10 +70,10 @@ export function DeviceDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Device not found</div>
           <Link
-            to="/dz/devices"
+            to={back.to}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to devices
+            Back to {back.label}
           </Link>
         </div>
       </div>
@@ -86,11 +88,11 @@ export function DeviceDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-8">
         {/* Back button */}
         <Link
-          to="/dz/devices"
+          to={back.to}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to devices
+          Back to {back.label}
         </Link>
 
         {/* Header */}

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { useSearchParams, Link } from 'react-router-dom'
+import { useSearchParams, Link, useNavigate } from 'react-router-dom'
 import { Trophy, Loader2, ChevronLeft, ChevronRight, Play, Square, Layers, Info, ArrowRight } from 'lucide-react'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
@@ -754,6 +754,7 @@ function RecentSlotsChart({
   const containerRef = useRef<HTMLDivElement>(null)
   const viewSlotCountRef = useRef(viewSlotCount)
   viewSlotCountRef.current = viewSlotCount
+  const navigate = useNavigate()
 
   // Live mode: fetch 300 slots on activate (show first 100 immediately, queue
   // the rest for animation), then poll every 5s with a since_slot cursor so
@@ -1631,7 +1632,17 @@ function RecentSlotsChart({
           </div>
           <div className="mt-5 flex flex-col gap-0.5">
             <span className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">Slot Leader</span>
-            <a ref={infoLeaderNameRef} className="text-sm font-medium leading-snug truncate hover:text-emerald-400 transition-colors" />
+            <a
+              ref={infoLeaderNameRef}
+              onClick={(e) => {
+                const href = e.currentTarget.getAttribute('href')
+                if (!href) return
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+                e.preventDefault()
+                navigate(href, { state: { back: { to: '/dz/shreds/scoreboard', label: 'Shreds Scoreboard' } } })
+              }}
+              className="text-sm font-medium leading-snug truncate hover:text-emerald-400 transition-colors"
+            />
             <span ref={infoLeaderRef} className="text-xs text-muted-foreground leading-snug mt-0.5" />
           </div>
         </div>

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -298,7 +298,7 @@ function NodeLabel({ node, label }: { node: EdgeScoreboardNode; label: string })
       onMouseLeave={() => setFixedPos(null)}
     >
       {hasGossip ? (
-        <Link to={`/solana/gossip-nodes/${node.gossip_pubkey}`} className="hover:text-[#10b981] transition-colors">
+        <Link to={`/solana/gossip-nodes/${node.gossip_pubkey}`} state={{ back: { to: '/dz/shreds/scoreboard', label: 'Shreds Scoreboard' } }} className="hover:text-[#10b981] transition-colors">
           {label}
         </Link>
       ) : (
@@ -1910,7 +1910,7 @@ export function EdgeScoreboardPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-8 py-8">
         <PageHeader
           icon={Trophy}
-          title="Edge Scoreboard"
+          title="Shreds Scoreboard"
           subtitle={
             <span className="text-xs text-muted-foreground/50 flex items-center gap-2">
               <span>{windowLabel(activeWindow)}</span>
@@ -2195,7 +2195,7 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
           }
         }} onMouseLeave={() => setFixedPos(null)}>
           {hasGossip ? (
-            <Link to={`/solana/gossip-nodes/${node.gossip_pubkey}`} className="text-sm font-medium hover:text-[#10b981] transition-colors">
+            <Link to={`/solana/gossip-nodes/${node.gossip_pubkey}`} state={{ back: { to: '/dz/shreds/scoreboard', label: 'Shreds Scoreboard' } }} className="text-sm font-medium hover:text-[#10b981] transition-colors">
               {label}
             </Link>
           ) : (

--- a/web/src/components/gossip-node-detail-page.tsx
+++ b/web/src/components/gossip-node-detail-page.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, Radio, AlertCircle, ArrowLeft, Check } from 'lucide-react'
 import { fetchGossipNode } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 function formatStake(sol: number): string {
   if (sol === 0) return '—'
@@ -19,6 +20,7 @@ function truncatePubkey(pubkey: string): string {
 export function GossipNodeDetailPage() {
   const { pubkey } = useParams<{ pubkey: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/solana/gossip-nodes', label: 'gossip nodes' })
 
   const { data: node, isLoading, error } = useQuery({
     queryKey: ['gossip-node', pubkey],
@@ -43,10 +45,10 @@ export function GossipNodeDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Gossip node not found</div>
           <button
-            onClick={() => navigate('/solana/gossip-nodes')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to gossip nodes
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -58,11 +60,11 @@ export function GossipNodeDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/solana/gossip-nodes')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to gossip nodes
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -17,9 +17,11 @@ import { TimeRangeSelector, TrafficFilters } from '@/components/topology/TimeRan
 import type { TimeRange, BucketSize } from '@/components/topology/utils'
 import { bucketLabels, resolveAutoBucket, type TimeRangePreset } from '@/components/topology/utils'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 export function LinkDetailPage() {
   const { pk } = useParams<{ pk: string }>()
+  const back = useBackLink({ to: '/dz/links', label: 'links' })
   const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<TimeRange>({ preset: '24h' })
   const [bucket, setBucket] = useState<BucketSize>('auto')
@@ -61,10 +63,10 @@ export function LinkDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Link not found</div>
           <Link
-            to="/dz/links"
+            to={back.to}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to links
+            Back to {back.label}
           </Link>
         </div>
       </div>
@@ -77,11 +79,11 @@ export function LinkDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-8">
         {/* Back button */}
         <Link
-          to="/dz/links"
+          to={back.to}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to links
+          Back to {back.label}
         </Link>
 
         {/* Header */}

--- a/web/src/components/metro-detail-page.tsx
+++ b/web/src/components/metro-detail-page.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, MapPin, AlertCircle, ArrowLeft } from 'lucide-react'
 import { fetchMetro } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -23,6 +24,7 @@ function formatStake(sol: number): string {
 export function MetroDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/dz/metros', label: 'metros' })
 
   const { data: metro, isLoading, error } = useQuery({
     queryKey: ['metro', pk],
@@ -47,10 +49,10 @@ export function MetroDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Metro not found</div>
           <button
-            onClick={() => navigate('/dz/metros')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to metros
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -62,11 +64,11 @@ export function MetroDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/dz/metros')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to metros
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -8,6 +8,7 @@ import { useUPlotLegendSync } from '@/hooks/use-uplot-legend-sync'
 import { formatChartAxisRate, formatChartAxisPps } from '@/components/topology/utils'
 import { fetchMulticastGroup, fetchMulticastGroupMembers, fetchMulticastGroupTraffic, fetchMulticastGroupMemberCounts, fetchMulticastGroupShredStats, type MulticastMember } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 import { useChartLegend } from '@/hooks/use-chart-legend'
 import { InlineFilter } from '@/components/inline-filter'
 import { Pagination } from '@/components/pagination'
@@ -1238,6 +1239,7 @@ function toMemberFilterParam(filter: string): string {
 export function MulticastGroupDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/dz/multicast-groups', label: 'multicast groups' })
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = (searchParams.get('tab') === 'subscribers' ? 'subscribers' : 'publishers') as 'publishers' | 'subscribers'
   const sortField = (searchParams.get('sort') || 'stake_sol') as MemberSortField
@@ -1455,10 +1457,10 @@ export function MulticastGroupDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Multicast group not found</div>
           <button
-            onClick={() => navigate('/dz/multicast-groups')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to multicast groups
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -1528,11 +1530,11 @@ export function MulticastGroupDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/dz/multicast-groups')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to multicast groups
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/components/tenant-detail-page.tsx
+++ b/web/src/components/tenant-detail-page.tsx
@@ -3,10 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, Layers, AlertCircle, ArrowLeft } from 'lucide-react'
 import { fetchTenant } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 export function TenantDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/dz/tenants', label: 'tenants' })
 
   const { data: tenant, isLoading, error } = useQuery({
     queryKey: ['tenant', pk],
@@ -31,10 +33,10 @@ export function TenantDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Tenant not found</div>
           <button
-            onClick={() => navigate('/dz/tenants')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to tenants
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -45,11 +47,11 @@ export function TenantDetailPage() {
     <div className="flex-1 overflow-auto">
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         <button
-          onClick={() => navigate('/dz/tenants')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to tenants
+          Back to {back.label}
         </button>
 
         <div className="flex items-center gap-3 mb-8">

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -7,6 +7,7 @@ import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import { fetchUser, fetchUserTraffic, fetchUserMulticastGroups } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 import { useTheme } from '@/hooks/use-theme'
 
 function formatBps(bps: number): string {
@@ -371,6 +372,7 @@ const statusColors: Record<string, string> = {
 export function UserDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/dz/users', label: 'users' })
 
   const { data: user, isLoading, error } = useQuery({
     queryKey: ['user', pk],
@@ -401,10 +403,10 @@ export function UserDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">User not found</div>
           <button
-            onClick={() => navigate('/dz/users')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to users
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -416,11 +418,11 @@ export function UserDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/dz/users')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to users
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/components/validator-detail-page.tsx
+++ b/web/src/components/validator-detail-page.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, Landmark, AlertCircle, ArrowLeft, Check } from 'lucide-react'
 import { fetchValidator } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useBackLink } from '@/hooks/use-back-link'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -23,6 +24,7 @@ function formatStake(sol: number): string {
 export function ValidatorDetailPage() {
   const { vote_pubkey } = useParams<{ vote_pubkey: string }>()
   const navigate = useNavigate()
+  const back = useBackLink({ to: '/solana/validators', label: 'validators' })
 
   const { data: validator, isLoading, error } = useQuery({
     queryKey: ['validator', vote_pubkey],
@@ -47,10 +49,10 @@ export function ValidatorDetailPage() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <div className="text-lg font-medium mb-2">Validator not found</div>
           <button
-            onClick={() => navigate('/solana/validators')}
+            onClick={() => navigate(back.to)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            Back to validators
+            Back to {back.label}
           </button>
         </div>
       </div>
@@ -62,11 +64,11 @@ export function ValidatorDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">
         {/* Back button */}
         <button
-          onClick={() => navigate('/solana/validators')}
+          onClick={() => navigate(back.to)}
           className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-6"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to validators
+          Back to {back.label}
         </button>
 
         {/* Header */}

--- a/web/src/hooks/use-back-link.ts
+++ b/web/src/hooks/use-back-link.ts
@@ -1,0 +1,15 @@
+import { useLocation } from 'react-router-dom'
+
+export interface BackTarget {
+  to: string
+  label: string
+}
+
+export function useBackLink(defaultTarget: BackTarget): BackTarget {
+  const location = useLocation()
+  const back = (location.state as { back?: BackTarget } | null)?.back
+  if (back && typeof back.to === 'string' && typeof back.label === 'string') {
+    return back
+  }
+  return defaultTarget
+}


### PR DESCRIPTION
## Summary
- Entity detail pages (device, link, metro, contributor, tenant, user, gossip node, validator, multicast group) now accept an optional \`{ back: { to, label } }\` via router \`location.state\` so the "Back to …" link reflects where the user came from, not just the entity's default category.
- Wired this up on the Shreds Scoreboard: clicking a node now lands on the gossip-node page with "Back to Shreds Scoreboard" instead of "Back to gossip nodes".
- Renamed the scoreboard page title from "Edge Scoreboard" to "Shreds Scoreboard".
- New \`useBackLink\` hook centralizes the lookup with a sensible default fallback.

Other link sites can opt in by passing the same state shape — behavior is unchanged wherever state isn't provided.