### PR TITLE
shreds: remove auth gate from scoreboard page and nav

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -553,7 +553,7 @@ func main() {
 		r.Get("/api/dz/multicast-groups/{pk}/member-counts", api.GetMulticastGroupMemberCounts)
 		r.Get("/api/dz/multicast-groups/{pk}/shred-stats", api.GetMulticastGroupShredStats)
 		r.Get("/api/dz/publisher-check", api.GetPublisherCheck)
-		r.With(handlers.RequireInternalDomain).Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
+		r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
 		r.Get("/api/dz/tenants", api.GetTenants)
 		r.Get("/api/dz/tenants/{pk}", api.GetTenant)
 		r.Get("/api/dz/shreds/overview", api.GetShredsOverview)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -93,23 +93,6 @@ const queryClient = new QueryClient({
   },
 })
 
-// Redirect to latest or new query session
-function InternalOnly({ children, redirectTo = '/' }: { children: React.ReactNode; redirectTo?: string }) {
-  const { user, isLoading } = useAuth()
-  if (isLoading) return null
-  if (!user?.is_internal_user) return <Navigate to={redirectTo} replace />
-  return <>{children}</>
-}
-
-// /dz/shreds lands on the scoreboard for internal users (the hero dashboard) and on the
-// public publishers page for everyone else. Without this, non-internal users hitting
-// /dz/shreds directly would bounce to the home page via the scoreboard's InternalOnly gate.
-function ShredsIndexRedirect() {
-  const { user, isLoading } = useAuth()
-  if (isLoading) return null
-  return <Navigate to={user?.is_internal_user ? '/dz/shreds/scoreboard' : '/dz/shreds/publishers'} replace />
-}
-
 function QueryRedirect() {
   const navigate = useNavigate()
   const { data: sessions, isLoading, isError } = useQuerySessions()
@@ -711,8 +694,8 @@ function AppContent() {
             <Route path="/dz/users/:pk" element={<UserDetailPage />} />
             <Route path="/dz/multicast-groups" element={<MulticastGroupsPage />} />
             <Route path="/dz/multicast-groups/:pk" element={<MulticastGroupDetailPage />} />
-            <Route path="/dz/shreds" element={<ShredsIndexRedirect />} />
-            <Route path="/dz/shreds/scoreboard" element={<InternalOnly redirectTo="/dz/shreds/publishers"><EdgeScoreboardPage /></InternalOnly>} />
+            <Route path="/dz/shreds" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
+            <Route path="/dz/shreds/scoreboard" element={<EdgeScoreboardPage />} />
             <Route path="/dz/shreds/publishers" element={<PublisherCheckPage />} />
             <Route path="/dz/publisher-check" element={<Navigate to="/dz/shreds/publishers" replace />} />
             <Route path="/dz/shreds/subscribers" element={<ShredsSeatsPage />} />

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -36,18 +36,13 @@ import {
 import { cn } from '@/lib/utils'
 import { useTheme } from '@/hooks/use-theme'
 import { useVersionCheck } from '@/hooks/use-version-check'
-import { useAuth } from '@/contexts/AuthContext'
 import { UserPopover } from './auth/UserPopover'
 
 export function Sidebar() {
   const location = useLocation()
   const navigate = useNavigate()
   const { features } = useEnv()
-  const { user } = useAuth()
-  // Non-internal users can't view the scoreboard (gated by InternalOnly), so the Shreds
-  // top-level link falls back to publishers — otherwise clicking Shreds bounces them to
-  // the home page and the Shreds sub-menu never opens.
-  const shredsDefaultPath = user?.is_internal_user ? '/dz/shreds/scoreboard' : '/dz/shreds/publishers'
+  const shredsDefaultPath = '/dz/shreds/scoreboard'
   const hasNeo4j = features.neo4j !== false
   const hasSolana = features.solana !== false
 const { resolvedTheme, setTheme } = useTheme()
@@ -467,11 +462,9 @@ const { resolvedTheme, setTheme } = useTheme()
             </Link>
             {isShredsRoute && (
               <>
-                {user?.is_internal_user && (
-                  <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
-                    Scoreboard
-                  </Link>
-                )}
+                <Link to="/dz/shreds/scoreboard" className={subNavItemClass(isScoreboardRoute)}>
+                  Scoreboard
+                </Link>
                 <Link to="/dz/shreds/publishers" className={subNavItemClass(isShredsPublishersRoute)}>
                   Publishers
                 </Link>


### PR DESCRIPTION
## Summary
- Drop the `InternalOnly` route wrapper from `/dz/shreds/scoreboard` and make `/dz/shreds` redirect there unconditionally.
- Show the Scoreboard sub-nav to all users and default the Shreds top-level link to the scoreboard.
- Remove the `RequireInternalDomain` middleware from the `/api/dz/edge/scoreboard` endpoint so the page's data fetch succeeds for non-internal users.