### PR TITLE
web: revert status page active tab underline to foreground color

### DIFF
--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -752,7 +752,7 @@ function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros
           onClick={() => navigateWithParams('/status/links')}
           className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
             activeTab === 'links'
-              ? 'border-primary text-foreground'
+              ? 'border-foreground text-foreground'
               : 'border-transparent text-muted-foreground hover:text-foreground'
           }`}
         >
@@ -762,7 +762,7 @@ function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros
           onClick={() => navigateWithParams('/status/devices')}
           className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
             activeTab === 'devices'
-              ? 'border-primary text-foreground'
+              ? 'border-foreground text-foreground'
               : 'border-transparent text-muted-foreground hover:text-foreground'
           }`}
         >
@@ -772,7 +772,7 @@ function TabNavigation({ activeTab }: { activeTab: 'links' | 'devices' | 'metros
           onClick={() => navigateWithParams('/status/metros')}
           className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
             activeTab === 'metros'
-              ? 'border-primary text-foreground'
+              ? 'border-foreground text-foreground'
               : 'border-transparent text-muted-foreground hover:text-foreground'
           }`}
         >


### PR DESCRIPTION
## Summary

- The status page's active tab underline (Links / Devices / Metros) was using `border-primary`, which turned blue after commit e911623 repurposed `--primary` to `#16B5F4`.
- Switch just this underline to `border-foreground` so the tab indicator matches the tab's text color again, without reverting the global primary token.