### PR TITLE
api: default shredder db to shredder_qa

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -26,8 +26,8 @@ var HealthDB driver.Conn
 // Falls back to DB (main user) if those env vars are not set.
 var PublicQueryDB driver.Conn
 
-// shredderDB is the ClickHouse database name for shredder tables (default: "shredder").
-var shredderDB = "shredder"
+// shredderDB is the ClickHouse database name for shredder tables (default: "shredder_qa").
+var shredderDB = "shredder_qa"
 
 // publisherDB is the ClickHouse database name for publisher tables e.g. publisher_shred_stats (default: "shredder").
 var publisherDB = "shredder"


### PR DESCRIPTION
## Summary of Changes
- Changes the default `shredderDB` from `shredder` to `shredder_qa` so the API points at the QA shredder dataset out of the box

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic | 1     | +2 / -2     | 0   |

## Testing Verification
- Verified locally against ClickHouse Cloud — shreds scoreboard loads correctly with `shredder_qa` as the default database