### PR TITLE
web: fix win rate label to show normalized share on shreds scoreboard

### DIFF
--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -2168,7 +2168,6 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
   const cellRef = useRef<HTMLDivElement>(null)
   const dz = node.feeds['dz']
   const dzEdge = node.feeds['dz_edge']
-  const edgeFirstArrival = dzEdge?.win_rate_pct ?? 0
 
   // Build lead time lookup: loser_feed -> { p50, p95 }.
   // Prefer dz_edge (dz + dz_rebop combined, matches the win-rate framing);

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1752,9 +1752,6 @@ export function EdgeScoreboardPage() {
   const globalStats = useMemo(() => {
     if (!data?.nodes) return null
 
-    let dzShredsWon = 0
-    let dzTotalShreds = 0
-
     // Per-competitor weighted lead times
     const competitors = ['jito', 'turbine'] as const
     const weightedP50: Record<string, number> = {}
@@ -1772,9 +1769,6 @@ export function EdgeScoreboardPage() {
     const nodeFeedRates: Record<string, number>[] = []
 
     for (const node of data.nodes) {
-      dzShredsWon += node.feeds['dz_edge']?.win_rate_pct ?? 0
-      dzTotalShreds++
-
       const nodeRates: Record<string, number> = {}
       const hasDzEdge = 'dz_edge' in node.feeds
       for (const [feedName, stats] of Object.entries(node.feeds)) {

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -1852,8 +1852,12 @@ export function EdgeScoreboardPage() {
       for (const key of Object.keys(feedRatesGranular)) feedRatesGranular[key] *= scale
     }
 
+    const winRate = Object.entries(feedRatesGranular)
+      .filter(([key]) => DZ_FEED_KEYS.has(key))
+      .reduce((sum, [, pct]) => sum + pct, 0)
+
     return {
-      winRate: dzTotalShreds > 0 ? dzShredsWon / dzTotalShreds : 0,
+      winRate,
       leads,
       avgCompleteness: data.completeness_pct,
       feedRates,
@@ -2177,7 +2181,7 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
     }
   }
 
-  // Per-feed-key win rates for the stacked bar (normalized to 100%)
+  // Per-feed-key win rates for the stacked bar, normalized so displayed feeds sum to 100%.
   const feedBarSegments = useMemo(() => {
     const accumulated: Record<string, number> = {}
     const hasDzEdge = 'dz_edge' in node.feeds
@@ -2193,6 +2197,14 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
       .sort(([a], [b]) => feedSortPriority(a) - feedSortPriority(b))
       .map(([key, pct]) => ({ key, pct: pct * scale, color: FEED_COLORS[key] ?? '#6b7280' }))
   }, [node.feeds, granular])
+
+  // Always derive from dz_edge.win_rate_pct (the canonical DZ metric) normalized
+  // against the non-granular total so the label is stable across the granular toggle.
+  const dzEdgeRaw = dzEdge?.win_rate_pct ?? 0
+  const dzNonGranularTotal = dzEdgeRaw
+    + (node.feeds['jito']?.win_rate_pct ?? 0)
+    + (node.feeds['turbine']?.win_rate_pct ?? 0)
+  const dzNormalizedPct = dzNonGranularTotal > 0 ? (dzEdgeRaw / dzNonGranularTotal) * 100 : 0
 
   const hasGossip = !!node.gossip_pubkey
 
@@ -2223,8 +2235,8 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
       </td>
       <td className="px-4 py-3 text-right tabular-nums text-sm">
         {dz ? (
-          <StackedBar segments={feedBarSegments} popoverSide="right" dzTotalPct={edgeFirstArrival}>
-            <div className="mb-1.5">{formatPct(edgeFirstArrival)}</div>
+          <StackedBar segments={feedBarSegments} popoverSide="right" dzTotalPct={dzNormalizedPct}>
+            <div className="mb-1.5">{formatPct(dzNormalizedPct)}</div>
           </StackedBar>
         ) : '—'}
       </td>


### PR DESCRIPTION
## Summary of Changes
- The win rate percentage displayed above each row's bar and in the hero card was showing the raw \`dz_edge.win_rate_pct\` value from the API, which uses a different denominator than the bar segments (which are normalized so DZ Edge + Jito + Turbine sum to 100%). This caused the label to show a significantly lower number (e.g. 56%) than what the bar and tooltip were displaying (e.g. 87%).
- Per-row label and tooltip header now use \`dz_edge.win_rate_pct\` normalized against the non-granular total (DZ Edge + Jito + Turbine), making label, bar, and tooltip consistent. The label is also stable across the granular toggle since it always uses the same non-granular basis.
- Hero bar \`winRate\` (label and gauge) is now derived from the already-normalized \`feedRatesGranular\` DZ keys instead of a simple raw average, so the hero and row figures are computed on the same basis. The now-unused raw accumulator variables (\`dzShredsWon\`, \`dzTotalShreds\`, \`edgeFirstArrival\`) are removed.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic | 1     | +16 / -11   |  +5 |

Pure display fix — no data, API, or test changes.

## Testing Verification
- Verified label, bar fill, and tooltip hover all show the same percentage for a given row
- Confirmed the label value is stable when toggling the granular layers button