### PR TITLE
api, web: scoreboard win rate as share of tracked-feed wins

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -691,50 +691,55 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		g.Go(func() error {
 			localFeedStats := make(map[feedKey]*EdgeScoreboardFeedStats)
 
+			// q2: per-host share-of-wins across the scoreboard feeds.
+			// denom = sum(shreds_won) across all scoreboard feeds for in-scope slots —
+			// only races one of the tracked feeds won first. Every feed's win_rate_pct is
+			// its share of those races, so dz + dz_rebop + jito + turbine sum to 100%
+			// and dz_edge (synthesized below from dz + dz_rebop) is additive.
+			// This excludes shreds won first by untracked feeds (regional retransmits,
+			// provider_one, etc.) so the scoreboard isn't diluted by new feeds we don't track.
 			var q2 string
 			if leadersOnly {
 				q2 = fmt.Sprintf(`
-				WITH %s
-				SELECT
-					host, feed, shreds_won, total_shreds,
-					round(shreds_won / max_total * 100, 1) AS win_rate_pct
-				FROM (
-					SELECT
-						host, feed, shreds_won, total_shreds,
-						MAX(total_shreds) OVER (PARTITION BY host) AS max_total
-					FROM (
-						SELECT
-							host, feed,
-							SUM(shreds_won) AS shreds_won,
-							SUM(total_shreds) AS total_shreds
-						FROM %s.slot_feed_race_summary
-						WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%s)
-							AND slot IN (SELECT slot FROM dz_leader_slots)
-							%s
-						GROUP BY host, feed
-					)
+				WITH %[1]s,
+				feed_totals AS (
+					SELECT host, feed, sum(shreds_won) AS shreds_won
+					FROM %[2]s.slot_feed_race_summary
+					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%[3]s)
+						AND slot IN (SELECT slot FROM dz_leader_slots)
+						%[4]s
+					GROUP BY host, feed
+				),
+				host_denom AS (
+					SELECT host, sum(shreds_won) AS denom
+					FROM feed_totals
+					GROUP BY host
 				)
+				SELECT
+					ft.host, ft.feed, ft.shreds_won, hd.denom AS total_shreds,
+					if(hd.denom > 0, round(ft.shreds_won / hd.denom * 100, 1), 0) AS win_rate_pct
+				FROM feed_totals ft
+				INNER JOIN host_denom hd ON ft.host = hd.host
 			SETTINGS final=1
 `, dzLeaderCTE, shredderDB, scoreboardFeeds, rangeFilter)
 			} else {
 				q2 = fmt.Sprintf(`
-				SELECT
-					host, feed, shreds_won, total_shreds,
-					round(shreds_won / max_total * 100, 1) AS win_rate_pct
-				FROM (
-					SELECT
-						host, feed, shreds_won, total_shreds,
-						MAX(total_shreds) OVER (PARTITION BY host) AS max_total
-					FROM (
-						SELECT
-							host, feed,
-							SUM(shreds_won) AS shreds_won,
-							SUM(total_shreds) AS total_shreds
-						FROM %s.slot_feed_race_summary
-						WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%s) %s
-						GROUP BY host, feed
-					)
+				WITH feed_totals AS (
+					SELECT host, feed, sum(shreds_won) AS shreds_won
+					FROM %[1]s.slot_feed_race_summary
+					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%[2]s) %[3]s
+					GROUP BY host, feed
+				),
+				host_denom AS (
+					SELECT host, sum(shreds_won) AS denom
+					FROM feed_totals
+					GROUP BY host
 				)
+				SELECT
+					ft.host, ft.feed, ft.shreds_won, hd.denom AS total_shreds,
+					if(hd.denom > 0, round(ft.shreds_won / hd.denom * 100, 1), 0) AS win_rate_pct
+				FROM feed_totals ft
+				INNER JOIN host_denom hd ON ft.host = hd.host
 			SETTINGS final=1
 `, shredderDB, scoreboardFeeds, rangeFilter)
 			}
@@ -763,84 +768,39 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				return fmt.Errorf("query2 rows: %w", err)
 			}
 
-			// q2c: dz_edge combined win rate with correct per-slot denominator.
-			// Groups by (host, slot) first so overlapping slot totals aren't double-counted
-			// when dz and dz_rebop cover different sets of slots.
-			var q2c string
-			if leadersOnly {
-				q2c = fmt.Sprintf(`
-				WITH %s
-				SELECT
-					host,
-					sum(dz_won + rebop_won) AS shreds_won,
-					sum(slot_total) AS total_shreds,
-					if(sum(slot_total) > 0, round(sum(dz_won + rebop_won) / sum(slot_total) * 100, 1), 0) AS win_rate_pct
-				FROM (
-					SELECT
-						host, slot,
-						sumIf(shreds_won, feed = 'dz') AS dz_won,
-						sumIf(shreds_won, feed = 'dz_rebop') AS rebop_won,
-						greatest(
-							maxIf(total_shreds, feed = 'dz'),
-							maxIf(total_shreds, feed = 'dz_rebop')
-						) AS slot_total
-					FROM %s.slot_feed_race_summary
-					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN ('dz', 'dz_rebop')
-						AND slot IN (SELECT slot FROM dz_leader_slots)
-						%s
-					GROUP BY host, slot
-					HAVING slot_total > 0
-				)
-				GROUP BY host
-				SETTINGS final=1
-`, dzLeaderCTE, shredderDB, rangeFilter)
-			} else {
-				q2c = fmt.Sprintf(`
-				SELECT
-					host,
-					sum(dz_won + rebop_won) AS shreds_won,
-					sum(slot_total) AS total_shreds,
-					if(sum(slot_total) > 0, round(sum(dz_won + rebop_won) / sum(slot_total) * 100, 1), 0) AS win_rate_pct
-				FROM (
-					SELECT
-						host, slot,
-						sumIf(shreds_won, feed = 'dz') AS dz_won,
-						sumIf(shreds_won, feed = 'dz_rebop') AS rebop_won,
-						greatest(
-							maxIf(total_shreds, feed = 'dz'),
-							maxIf(total_shreds, feed = 'dz_rebop')
-						) AS slot_total
-					FROM %s.slot_feed_race_summary
-					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN ('dz', 'dz_rebop') %s
-					GROUP BY host, slot
-					HAVING slot_total > 0
-				)
-				GROUP BY host
-				SETTINGS final=1
-`, shredderDB, rangeFilter)
+			// Synthesize dz_edge = dz + dz_rebop on the shared per-host denominator.
+			// Because both dz and dz_rebop carry the same host_denom as TotalShreds,
+			// dz_edge.win_rate_pct == dz.win_rate_pct + dz_rebop.win_rate_pct exactly.
+			hosts := make(map[string]struct{})
+			for k := range localFeedStats {
+				hosts[k.nodeID] = struct{}{}
 			}
-			t = time.Now()
-			rows2c, err := a.envDB(gctx).Query(gctx, q2c)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
-			if err != nil {
-				return fmt.Errorf("query2c: %w", err)
-			}
-			defer rows2c.Close()
-			for rows2c.Next() {
-				var nodeID string
-				var shredsWon, totalShreds uint64
-				var winRatePct float64
-				if err := rows2c.Scan(&nodeID, &shredsWon, &totalShreds, &winRatePct); err != nil {
-					return fmt.Errorf("query2c scan: %w", err)
+			for nodeID := range hosts {
+				dz := localFeedStats[feedKey{nodeID, "dz"}]
+				rebop := localFeedStats[feedKey{nodeID, "dz_rebop"}]
+				if dz == nil && rebop == nil {
+					continue
+				}
+				var denom, won uint64
+				if dz != nil {
+					denom = dz.TotalShreds
+					won += dz.ShredsWon
+				}
+				if rebop != nil {
+					if denom == 0 {
+						denom = rebop.TotalShreds
+					}
+					won += rebop.ShredsWon
+				}
+				var rate float64
+				if denom > 0 {
+					rate = float64(int(float64(won)/float64(denom)*1000+0.5)) / 10
 				}
 				localFeedStats[feedKey{nodeID, "dz_edge"}] = &EdgeScoreboardFeedStats{
-					ShredsWon:   shredsWon,
-					TotalShreds: totalShreds,
-					WinRatePct:  winRatePct,
+					ShredsWon:   won,
+					TotalShreds: denom,
+					WinRatePct:  rate,
 				}
-			}
-			if err := rows2c.Err(); err != nil {
-				return fmt.Errorf("query2c rows: %w", err)
 			}
 
 			feedStats = localFeedStats

--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -206,7 +206,8 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 	assert.Equal(t, uint64(2), slc.TotalSlots)
 	assert.Equal(t, uint64(1), slc.SlotsObserved)
 
-	// Check DZ feed win rate for SLC (only slot 100 is DZ-participating)
+	// Check DZ feed win rate for SLC. leaders_only=true by default, so only slot1
+	// (DZ-leader slot) is in scope. Shared denom = slot1 max(total_shreds)=100. dz won 80.
 	dzFeed, ok := slc.Feeds["dz"]
 	require.True(t, ok, "dz feed should exist for slc")
 	assert.Equal(t, uint64(80), dzFeed.ShredsWon)

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -151,7 +151,7 @@ const FEED_LABELS: Record<string, string> = {
   other: 'Other',
 }
 
-type FeedSegment = { key: string; pct: number; color: string }
+type FeedSegment = { key: string; pct: number; rawPct: number; color: string }
 
 function StackedBar({ segments, children, popoverSide = 'top', dzTotalPct }: { segments: FeedSegment[]; children?: React.ReactNode; popoverSide?: 'top' | 'bottom' | 'right'; dzTotalPct?: number }) {
   const [hover, setHover] = useState(false)
@@ -182,23 +182,23 @@ function StackedBar({ segments, children, popoverSide = 'top', dzTotalPct }: { s
               <>
                 <div className="flex items-center gap-2 py-0.5 font-medium">
                   <span>DZ Edge</span>
-                  <span className="ml-auto pl-4 tabular-nums">{(dzTotalPct ?? dzSegs.reduce((s, seg) => s + seg.pct, 0)).toFixed(1)}%</span>
+                  <span className="ml-auto pl-4 tabular-nums">{(dzTotalPct ?? dzSegs.reduce((s, seg) => s + seg.rawPct, 0)).toFixed(1)}%</span>
                 </div>
-                {dzSegs.map(({ key, pct, color }) => (
+                {dzSegs.map(({ key, rawPct, color }) => (
                   <div key={key} className="flex items-center gap-2 py-0.5 pl-3">
                     <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: color }} />
                     <span className="text-muted-foreground">{dzSubLabels[key] ?? key}</span>
-                    <span className="ml-auto pl-4 tabular-nums">{pct.toFixed(1)}%</span>
+                    <span className="ml-auto pl-4 tabular-nums">{rawPct.toFixed(1)}%</span>
                   </div>
                 ))}
                 {otherSegs.length > 0 && <div className="border-t border-border my-1.5" />}
               </>
             )}
-            {flatSegs.map(({ key, pct, color }) => (
+            {flatSegs.map(({ key, rawPct, color }) => (
               <div key={key} className="flex items-center gap-2 py-0.5">
                 <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
                 <span className="text-muted-foreground">{FEED_LABELS[key] ?? key}</span>
-                <span className="ml-auto pl-4 tabular-nums font-medium">{pct.toFixed(1)}%</span>
+                <span className="ml-auto pl-4 tabular-nums font-medium">{rawPct.toFixed(1)}%</span>
               </div>
             ))}
           </div>
@@ -1829,7 +1829,9 @@ export function EdgeScoreboardPage() {
       for (const key of Object.keys(feedRates)) feedRates[key] *= scale
     }
 
-    // Always-granular version for the hero bar (ignores the toggle)
+    // Always-granular version for the hero bar (ignores the toggle).
+    // Server returns all feed win_rate_pct on a shared per-host denominator, so
+    // dz + dz_rebop = dz_edge by construction and feed rates are already comparable.
     const granularAccum: Record<string, number> = {}
     for (const node of data.nodes) {
       const nodeRates: Record<string, number> = {}
@@ -1843,8 +1845,11 @@ export function EdgeScoreboardPage() {
       }
     }
     const feedRatesGranular: Record<string, number> = {}
+    const feedRatesGranularRaw: Record<string, number> = {}
     for (const [key, sum] of Object.entries(granularAccum)) {
-      feedRatesGranular[key] = nodeCount > 0 ? sum / nodeCount : 0
+      const avg = nodeCount > 0 ? sum / nodeCount : 0
+      feedRatesGranular[key] = avg
+      feedRatesGranularRaw[key] = avg
     }
     const granularTotal = Object.values(feedRatesGranular).reduce((s, v) => s + v, 0)
     if (granularTotal > 0) {
@@ -1858,6 +1863,7 @@ export function EdgeScoreboardPage() {
       avgCompleteness: data.completeness_pct,
       feedRates,
       feedRatesGranular,
+      feedRatesGranularRaw,
     }
   }, [data?.nodes, granular])
 
@@ -2015,7 +2021,7 @@ export function EdgeScoreboardPage() {
                   dzTotalPct={globalStats.winRate}
                   segments={Object.keys(globalStats.feedRatesGranular)
                     .sort((a, b) => feedSortPriority(a) - feedSortPriority(b))
-                    .map(key => ({ key, pct: globalStats.feedRatesGranular[key] ?? 0, color: FEED_COLORS[key] ?? '#6b7280' }))}
+                    .map(key => ({ key, pct: globalStats.feedRatesGranular[key] ?? 0, rawPct: globalStats.feedRatesGranularRaw[key] ?? 0, color: FEED_COLORS[key] ?? '#6b7280' }))}
                 >
                   <div className="flex items-center justify-between mb-1.5">
                     <span className="text-sm text-muted-foreground">DZ Edge Win Rate</span>
@@ -2177,7 +2183,9 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
     }
   }
 
-  // Per-feed-key win rates for the stacked bar (normalized to 100%)
+  // Per-feed-key segments for the stacked bar.
+  // `rawPct` = server-provided win_rate_pct on the shared per-host denominator.
+  // `pct` = visual width, normalized so the bar always fills 100%.
   const feedBarSegments = useMemo(() => {
     const accumulated: Record<string, number> = {}
     const hasDzEdge = 'dz_edge' in node.feeds
@@ -2191,7 +2199,7 @@ function NodeRow({ node, label, granular }: { node: EdgeScoreboardNode; label: s
     const scale = total > 0 ? 100 / total : 1
     return Object.entries(accumulated)
       .sort(([a], [b]) => feedSortPriority(a) - feedSortPriority(b))
-      .map(([key, pct]) => ({ key, pct: pct * scale, color: FEED_COLORS[key] ?? '#6b7280' }))
+      .map(([key, pct]) => ({ key, pct: pct * scale, rawPct: pct, color: FEED_COLORS[key] ?? '#6b7280' }))
   }, [node.feeds, granular])
 
   const hasGossip = !!node.gossip_pubkey


### PR DESCRIPTION
## Summary

- Replace the per-feed win_rate_pct formula (mismatched denominators across queries, could be diluted by untracked feeds like \`edge-solana-retrans-*\` and \`provider_one\`) with a share-of-wins formula: each feed's \`win_rate_pct = feed.shreds_won / sum(shreds_won across dz, dz_rebop, jito, turbine)\`, scoped to the selected time window (and DZ-leader slots in leaders-only mode).
- Synthesize \`dz_edge\` server-side from \`dz + dz_rebop\` on the same denominator so \`dz + dz_rebop = dz_edge\` exactly and \`dz + dz_rebop + jito + turbine\` sums to 100% per host. Drops the separate \`q2c\` query.
- Untracked feeds never enter numerator or denominator, so regional retransmit / provider_one rows no longer depress the displayed rates.
- Frontend tooltip now displays server \`win_rate_pct\` directly — removed the client-side contribution math that tried to reconstruct consistent segments from inconsistent server values. Bar segment widths still normalize to fill 100%.

## Why

DZ Edge win rate in the leaders view dropped into the 30–55% range after regional retransmit feeds started recording — because the old \`q2c\` included them in \`slot_total = greatest(total_shreds across DZ feeds)\` per slot, inflating the denominator. Under the new formula the same hosts land at 85–95% in leaders-only mode:
- fra-mn-bm1: 92%
- fra-mn-bm2: 92%
- tyo-mn-bm1: 95%
- tyo-mn-bm2: 92%
- sin-mn-bm1: 91%
- nyc-mn-bm1 / slc-qa-bm1: 86%

## Testing Verification

- \`TestGetEdgeScoreboard_WithData\` still passes (same expected values — the test's single DZ-leader slot already has dz + turbine + jito summing to 100% of observed wins).
- Verified against prod \`shredder.slot_feed_race_summary\` over the last 6h that per-host feed rates sum to exactly 100% and that dz_edge lands in the expected 85–95% range for leaders-only mode.