### PR TITLE
docker: use azure ubuntu mirror for faster ci builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ RUN echo "$CACHE_BUSTER" > ${BIN_DIR}/.cache-buster && \
 # ----------------------------------------------------------------------------
 FROM ubuntu:24.04
 
+# Swap to the Azure-hosted Ubuntu mirror — GitHub-hosted runners are on Azure
+# and the default archive.ubuntu.com mirror is much slower from there.
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://azure.archive.ubuntu.com/ubuntu/|g; s|http://security.ubuntu.com/ubuntu/|http://azure.archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
+
 # Install build dependencies and other utilities
 RUN apt update -qq && \
     apt install --no-install-recommends -y \


### PR DESCRIPTION
## Summary
- Swap the default `archive.ubuntu.com` / `security.ubuntu.com` mirrors for `azure.archive.ubuntu.com` in the runtime image's apt sources, since GitHub-hosted runners are on Azure and the default mirror is noticeably slower from there.

## Testing Verification
- Local `docker build` succeeds against the modified `ubuntu:24.04` sources file (DEB822 format at `/etc/apt/sources.list.d/ubuntu.sources`).