### PR TITLE
shreds: hide client IPs from non-internal users on subscribers/activity

### DIFF
--- a/api/handlers/field_values.go
+++ b/api/handlers/field_values.go
@@ -270,6 +270,16 @@ func (a *API) GetFieldValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Client IP autocomplete is gated to internal (domain-authenticated) users.
+	if entity == "shred-seats" && field == "ip" {
+		acc := GetAccountFromContext(ctx)
+		if acc == nil || !acc.IsInternalUser {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(FieldValuesResponse{Values: []string{}})
+			return
+		}
+	}
+
 	// Try scoped query first (dashboard filter-aware), fall back to generic
 	query := buildMulticastMembersFieldQuery(entity, field, fieldCfg, r)
 	if query == "" {

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -158,8 +158,32 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
+	// Client IPs are only exposed to internal (domain-authenticated) users.
+	// For everyone else, drop the ip-based sort/filter fields so the column
+	// can't be sorted, filtered, or substring-searched via the "all" filter.
+	acc := GetAccountFromContext(ctx)
+	canSeeClientIP := acc != nil && acc.IsInternalUser
+	sortFields := seatSortFields
+	filterFields := seatFilterFields
+	if !canSeeClientIP {
+		sortFields = make(map[string]string, len(seatSortFields)-1)
+		for k, v := range seatSortFields {
+			if k == "ip" {
+				continue
+			}
+			sortFields[k] = v
+		}
+		filterFields = make(map[string]FilterFieldConfig, len(seatFilterFields)-1)
+		for k, v := range seatFilterFields {
+			if k == "ip" {
+				continue
+			}
+			filterFields[k] = v
+		}
+	}
+
 	pagination := ParsePagination(r, 100)
-	sort := ParseSort(r, "active_epoch", seatSortFields)
+	sort := ParseSort(r, "active_epoch", sortFields)
 	filters := ParseFilters(r)
 
 	// Status filter: active, inactive, closed (comma-separated).
@@ -171,7 +195,7 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 	var whereClauses []string
 	var whereArgs []any
 
-	filterClause, filterArgs := filters.BuildFilterClause(seatFilterFields)
+	filterClause, filterArgs := filters.BuildFilterClause(filterFields)
 	if filterClause != "" {
 		whereClauses = append(whereClauses, filterClause)
 		whereArgs = append(whereArgs, filterArgs...)
@@ -252,7 +276,7 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Data query.
-	orderBy := sort.OrderByClause(seatSortFields)
+	orderBy := sort.OrderByClause(sortFields)
 	query := `
 		WITH escrow_balances AS (
 			SELECT client_seat_key, sum(usdc_balance) as total_usdc_balance
@@ -318,6 +342,9 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 		}
 		if lastActivity != nil && !lastActivity.IsZero() {
 			s.LastActivity = lastActivity.UTC().Format(time.RFC3339)
+		}
+		if !canSeeClientIP {
+			s.ClientIP = ""
 		}
 		items = append(items, s)
 	}
@@ -642,6 +669,10 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
+	// Client IPs are only exposed to internal (domain-authenticated) users.
+	acc := GetAccountFromContext(ctx)
+	canSeeClientIP := acc != nil && acc.IsInternalUser
+
 	pagination := ParsePagination(r, 100)
 	sort := ParseSort(r, "time", escrowEventSortFields)
 	filters := ParseFilters(r)
@@ -737,6 +768,9 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 		}
 		e.EventTS = eventTS.UTC().Format(time.RFC3339)
 		e.SolscanURL = "https://solscan.io/tx/" + e.TxSignature
+		if !canSeeClientIP {
+			e.ClientIP = ""
+		}
 		items = append(items, e)
 	}
 	if items == nil {

--- a/api/handlers/shreds_test.go
+++ b/api/handlers/shreds_test.go
@@ -191,7 +191,8 @@ func TestGetShredClientSeats_WithData(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/client-seats", nil)
 	rr := httptest.NewRecorder()
-	api.GetShredClientSeats(rr, req)
+	// Internal user can see client_ip.
+	api.GetShredClientSeats(rr, withAccount(req, &handlers.Account{IsInternalUser: true}))
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
@@ -219,6 +220,45 @@ func TestGetShredClientSeats_WithData(t *testing.T) {
 	require.NotNil(t, seat2)
 	assert.Equal(t, int64(25), seat2.PricePerEpochDollars)
 	assert.Equal(t, uint8(1), seat2.HasPriceOverride)
+}
+
+func TestGetShredClientSeats_ClientIPRedacted(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	cases := []struct {
+		name string
+		req  func(r *http.Request) *http.Request
+	}{
+		{"anonymous", func(r *http.Request) *http.Request { return r }},
+		{"wallet auth", func(r *http.Request) *http.Request {
+			return withAccount(r, &handlers.Account{AccountType: "wallet", IsInternalUser: false})
+		}},
+		{"non-internal domain", func(r *http.Request) *http.Request {
+			return withAccount(r, &handlers.Account{AccountType: "domain", IsInternalUser: false})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// IP filter and ip-sorted requests must be ignored (not leak via sort/filter either).
+			req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/client-seats?filters=ip:192.168&sort_by=ip", nil)
+			rr := httptest.NewRecorder()
+			api.GetShredClientSeats(rr, tc.req(req))
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+
+			var response handlers.PaginatedResponse[handlers.ShredClientSeatItem]
+			err := json.NewDecoder(rr.Body).Decode(&response)
+			require.NoError(t, err)
+			// Filter is dropped, so all seats returned.
+			assert.Equal(t, 3, response.Total)
+			for _, item := range response.Items {
+				assert.Empty(t, item.ClientIP, "client_ip should be redacted for %s", tc.name)
+			}
+		})
+	}
 }
 
 func TestGetShredClientSeats_StatusFilter(t *testing.T) {
@@ -413,6 +453,57 @@ func TestGetShredEscrowEvents_WithData(t *testing.T) {
 	assert.Equal(t, "close", response.Items[0].EventType)
 	assert.NotEmpty(t, response.Items[0].SolscanURL)
 	assert.NotEmpty(t, response.Items[0].Signer)
+}
+
+func TestGetShredEscrowEvents_ClientIPRedacted(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api) // gives seat-1 -> client_ip 192.168.1.1
+	insertEscrowEventsTestData(t, api)
+
+	t.Run("anonymous redacts", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/escrow-events?range=30d", nil)
+		rr := httptest.NewRecorder()
+		api.GetShredEscrowEvents(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		var response handlers.PaginatedResponse[handlers.ShredEscrowEventItem]
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response.Items)
+		for _, item := range response.Items {
+			assert.Empty(t, item.ClientIP, "client_ip should be redacted for anonymous users")
+		}
+	})
+
+	t.Run("wallet auth redacts", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/escrow-events?range=30d", nil)
+		rr := httptest.NewRecorder()
+		api.GetShredEscrowEvents(rr, withAccount(req, &handlers.Account{AccountType: "wallet", IsInternalUser: false}))
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		var response handlers.PaginatedResponse[handlers.ShredEscrowEventItem]
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+		for _, item := range response.Items {
+			assert.Empty(t, item.ClientIP, "client_ip should be redacted for wallet-auth users")
+		}
+	})
+
+	t.Run("internal user sees ip", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/escrow-events?range=30d&filters=seat:seat-1", nil)
+		rr := httptest.NewRecorder()
+		api.GetShredEscrowEvents(rr, withAccount(req, &handlers.Account{AccountType: "domain", IsInternalUser: true}))
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		var response handlers.PaginatedResponse[handlers.ShredEscrowEventItem]
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response.Items)
+		for _, item := range response.Items {
+			assert.Equal(t, "192.168.1.1", item.ClientIP)
+		}
+	})
 }
 
 func TestGetShredEscrowEvents_IncludeInternal(t *testing.T) {

--- a/web/src/components/shreds-page.tsx
+++ b/web/src/components/shreds-page.tsx
@@ -26,6 +26,7 @@ import {
   type ShredFunder,
 } from '@/lib/api'
 import { handleRowClick } from '@/lib/utils'
+import { useAuth } from '@/contexts/AuthContext'
 import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
@@ -305,7 +306,7 @@ function ErrorState({ message }: { message: string }) {
 
 // --- Seats Page ---
 
-const seatFieldPrefixes = [
+const seatFieldPrefixesWithIP = [
   { prefix: 'seat:', description: 'Filter by seat key' },
   { prefix: 'device:', description: 'Filter by device code' },
   { prefix: 'metro:', description: 'Filter by metro code' },
@@ -316,6 +317,7 @@ const seatFieldPrefixes = [
   { prefix: 'balance:', description: 'Filter by USDC balance (e.g., >0)' },
   { prefix: 'prepaid:', description: 'Filter by prepaid epochs (e.g., >5)' },
 ]
+const seatFieldPrefixesWithoutIP = seatFieldPrefixesWithIP.filter(p => p.prefix !== 'ip:')
 
 function prepaidEpochs(seat: ShredClientSeat): number {
   if (seat.price_per_epoch_dollars <= 0 || seat.total_usdc_balance === 0) return 0
@@ -429,6 +431,8 @@ export function ShredsSeatsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const [showStatusInfo, setShowStatusInfo] = useState(false)
+  const { user } = useAuth()
+  const showClientIP = !!user?.is_internal_user
 
   // Fetch overview for current Solana epoch (used for status badges)
   const { data: overview } = useQuery({
@@ -602,10 +606,10 @@ export function ShredsSeatsPage() {
               removeFilter={removeFilter}
               clearAllFilters={clearAllFilters}
               setLiveFilter={() => {}}
-              fieldPrefixes={seatFieldPrefixes}
+              fieldPrefixes={showClientIP ? seatFieldPrefixesWithIP : seatFieldPrefixesWithoutIP}
               entity="shred-seats"
               placeholder="Filter seats..."
-              autocompleteFields={['device', 'metro', 'ip', 'funder']}
+              autocompleteFields={showClientIP ? ['device', 'metro', 'ip', 'funder'] : ['device', 'metro', 'funder']}
             />
           }
         />
@@ -729,13 +733,15 @@ export function ShredsSeatsPage() {
                     currentDir={sortDir}
                     onSort={handleSort}
                   />
-                  <SortHeader
-                    field="ip"
-                    label="Client IP"
-                    currentSort={sortBy}
-                    currentDir={sortDir}
-                    onSort={handleSort}
-                  />
+                  {showClientIP && (
+                    <SortHeader
+                      field="ip"
+                      label="Client IP"
+                      currentSort={sortBy}
+                      currentDir={sortDir}
+                      onSort={handleSort}
+                    />
+                  )}
                   <th className="px-4 py-3 font-medium">Status</th>
                   <SortHeader
                     field="tenure"
@@ -812,22 +818,24 @@ export function ShredsSeatsPage() {
                           <span className="text-muted-foreground">{'\u2014'}</span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-sm font-mono group/cell">
-                        <span className="inline-flex items-center gap-1">
-                          {seat.user_pk ? (
-                            <Link
-                              to={`/dz/users/${seat.user_pk}`}
-                              className="text-foreground/85 hover:text-foreground hover:underline"
-                              title={seat.user_pk}
-                            >
-                              {seat.client_ip}
-                            </Link>
-                          ) : (
-                            seat.client_ip
-                          )}
-                          <CopyIcon text={seat.client_ip} />
-                        </span>
-                      </td>
+                      {showClientIP && (
+                        <td className="px-4 py-3 text-sm font-mono group/cell">
+                          <span className="inline-flex items-center gap-1">
+                            {seat.user_pk ? (
+                              <Link
+                                to={`/dz/users/${seat.user_pk}`}
+                                className="text-foreground/85 hover:text-foreground hover:underline"
+                                title={seat.user_pk}
+                              >
+                                {seat.client_ip}
+                              </Link>
+                            ) : (
+                              seat.client_ip
+                            )}
+                            <CopyIcon text={seat.client_ip} />
+                          </span>
+                        </td>
+                      )}
                       <td className="px-4 py-3">
                         <SeatStatusBadge status={status} />
                       </td>
@@ -861,7 +869,7 @@ export function ShredsSeatsPage() {
                 })}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={10} className="px-4 py-8 text-center text-muted-foreground">
+                    <td colSpan={showClientIP ? 10 : 9} className="px-4 py-8 text-center text-muted-foreground">
                       No subscribers found
                     </td>
                   </tr>
@@ -1440,6 +1448,8 @@ function toLocalDatetimeString(ts: number): string {
 
 export function ShredsEscrowEventsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
+  const { user } = useAuth()
+  const showClientIP = !!user?.is_internal_user
 
   // Pagination from URL.
   const page = parseInt(searchParams.get('page') || '1')
@@ -1771,7 +1781,7 @@ export function ShredsEscrowEventsPage() {
                     onSort={handleSort}
                   />
                   <th className="px-4 py-3 font-medium">Seat</th>
-                  <th className="px-4 py-3 font-medium">Client IP</th>
+                  {showClientIP && <th className="px-4 py-3 font-medium">Client IP</th>}
                   <th className="px-4 py-3 font-medium">Signer</th>
                   <SortHeader
                     field="amount"
@@ -1845,12 +1855,14 @@ export function ShredsEscrowEventsPage() {
                         )}
                       </span>
                     </td>
-                    <td className="px-4 py-3 font-mono text-xs">
-                      <span className="inline-flex items-center gap-1.5 group/cell">
-                        {e.client_ip || <span className="text-muted-foreground">{'\u2014'}</span>}
-                        {e.client_ip && <CopyIcon text={e.client_ip} />}
-                      </span>
-                    </td>
+                    {showClientIP && (
+                      <td className="px-4 py-3 font-mono text-xs">
+                        <span className="inline-flex items-center gap-1.5 group/cell">
+                          {e.client_ip || <span className="text-muted-foreground">{'\u2014'}</span>}
+                          {e.client_ip && <CopyIcon text={e.client_ip} />}
+                        </span>
+                      </td>
+                    )}
                     <td className="px-4 py-3 font-mono text-xs" title={e.signer}>
                       <span className="inline-flex items-center gap-1.5 group/cell">
                         {e.signer ? (
@@ -1898,7 +1910,7 @@ export function ShredsEscrowEventsPage() {
                 ))}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">
+                    <td colSpan={showClientIP ? 9 : 8} className="px-4 py-8 text-center text-muted-foreground">
                       No activity found
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

- Gate `client_ip` on the shred subscribers and activity pages to internal (domain-authenticated) users only — anonymous and wallet-auth users no longer see IPs.
- API: `GetShredClientSeats` and `GetShredEscrowEvents` zero `ClientIP` after scan for non-internal callers. The seats endpoint also drops the `ip` sort/filter fields, so `sort_by=ip`, `filters=ip:`, and the `all` substring search can't be used to infer the value.
- API: `/api/dz/field-values?entity=shred-seats&field=ip` returns empty for non-internal users (autocomplete suggestions previously listed real IPs).
- Web: hide the Client IP column on both pages, and drop the `ip:` filter prefix and `ip` autocomplete entry from the seats page.

## Testing Verification

- New `TestGetShredClientSeats_ClientIPRedacted` covers anonymous, wallet, and non-internal-domain accounts; verifies `ClientIP` is empty, that the `ip:` filter is dropped (3 rows still returned), and that `sort_by=ip` falls back to default.
- New `TestGetShredEscrowEvents_ClientIPRedacted` covers anonymous, wallet, and internal cases (internal sees the actual `192.168.1.1`).
- Updated `TestGetShredClientSeats_WithData` to exercise the internal-user path so existing IP assertion still applies.