### PR TITLE
api: filter detail page CTEs by pk to avoid full table scans

### DIFF
--- a/api/handlers/contributors.go
+++ b/api/handlers/contributors.go
@@ -192,34 +192,34 @@ func (a *API) GetContributor(w http.ResponseWriter, r *http.Request) {
 		WITH device_counts AS (
 			SELECT contributor_pk, count(*) as cnt
 			FROM dz_devices_current
-			WHERE contributor_pk IS NOT NULL
+			WHERE contributor_pk = ?
 			GROUP BY contributor_pk
 		),
 		side_a_counts AS (
 			SELECT d.contributor_pk as cpk, count(DISTINCT l.pk) as cnt
 			FROM dz_links_current l
 			JOIN dz_devices_current d ON l.side_a_pk = d.pk
-			WHERE d.contributor_pk IS NOT NULL
+			WHERE d.contributor_pk = ?
 			GROUP BY d.contributor_pk
 		),
 		side_z_counts AS (
 			SELECT d.contributor_pk as cpk, count(DISTINCT l.pk) as cnt
 			FROM dz_links_current l
 			JOIN dz_devices_current d ON l.side_z_pk = d.pk
-			WHERE d.contributor_pk IS NOT NULL
+			WHERE d.contributor_pk = ?
 			GROUP BY d.contributor_pk
 		),
 		link_counts AS (
 			SELECT contributor_pk, count(*) as cnt
 			FROM dz_links_current
-			WHERE contributor_pk IS NOT NULL
+			WHERE contributor_pk = ?
 			GROUP BY contributor_pk
 		),
 		user_counts AS (
 			SELECT d.contributor_pk, count(*) as cnt
 			FROM dz_users_current u
 			JOIN dz_devices_current d ON u.device_pk = d.pk
-			WHERE u.status = 'activated' AND d.contributor_pk IS NOT NULL
+			WHERE u.status = 'activated' AND d.contributor_pk = ?
 			GROUP BY d.contributor_pk
 		),
 		traffic_rates AS (
@@ -232,7 +232,7 @@ func (a *API) GetContributor(w http.ResponseWriter, r *http.Request) {
 			WHERE f.bucket_ts >= now() - INTERVAL 15 MINUTE
 				AND f.user_tunnel_id IS NULL
 				AND f.link_pk = ''
-				AND d.contributor_pk IS NOT NULL
+				AND d.contributor_pk = ?
 			GROUP BY d.contributor_pk
 		)
 		SELECT
@@ -257,7 +257,7 @@ func (a *API) GetContributor(w http.ResponseWriter, r *http.Request) {
 	`
 
 	var contributor ContributorDetail
-	err := a.envDB(ctx).QueryRow(ctx, query, pk).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk, pk, pk).Scan(
 		&contributor.PK,
 		&contributor.Code,
 		&contributor.Name,

--- a/api/handlers/gossip_nodes.go
+++ b/api/handlers/gossip_nodes.go
@@ -239,6 +239,7 @@ func (a *API) GetGossipNode(w http.ResponseWriter, r *http.Request) {
 			WHERE u.status = 'activated'
 				AND u.client_ip IS NOT NULL
 				AND u.client_ip != ''
+				AND u.client_ip = (SELECT gossip_ip FROM solana_gossip_nodes_current WHERE pubkey = ?)
 			GROUP BY u.client_ip
 		),
 		validator_stake AS (
@@ -248,6 +249,7 @@ func (a *API) GetGossipNode(w http.ResponseWriter, r *http.Request) {
 				activated_stake_lamports / 1e9 as stake_sol
 			FROM solana_vote_accounts_current
 			WHERE epoch_vote_account = 'true'
+				AND node_pubkey = ?
 		)
 		SELECT
 			g.pubkey,
@@ -274,7 +276,7 @@ func (a *API) GetGossipNode(w http.ResponseWriter, r *http.Request) {
 	`
 
 	var node GossipNodeDetail
-	err := a.envDB(ctx).QueryRow(ctx, query, pubkey).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, pubkey, pubkey, pubkey).Scan(
 		&node.Pubkey,
 		&node.GossipIP,
 		&node.GossipPort,

--- a/api/handlers/metros.go
+++ b/api/handlers/metros.go
@@ -177,14 +177,14 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 		WITH device_counts AS (
 			SELECT metro_pk, count(*) as device_count
 			FROM dz_devices_current
-			WHERE metro_pk IS NOT NULL
+			WHERE metro_pk = ?
 			GROUP BY metro_pk
 		),
 		user_counts AS (
 			SELECT d.metro_pk, count(*) as user_count
 			FROM dz_users_current u
 			JOIN dz_devices_current d ON u.device_pk = d.pk
-			WHERE u.status = 'activated' AND d.metro_pk IS NOT NULL
+			WHERE u.status = 'activated' AND d.metro_pk = ?
 			GROUP BY d.metro_pk
 		),
 		validator_stats AS (
@@ -196,7 +196,8 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 			JOIN dz_devices_current d ON u.device_pk = d.pk
 			JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip
 			JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey
-			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true' AND d.metro_pk IS NOT NULL
+			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true'
+				AND d.metro_pk = ?
 			GROUP BY d.metro_pk
 		),
 		traffic_rates AS (
@@ -209,7 +210,7 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 			WHERE f.bucket_ts >= now() - INTERVAL 15 MINUTE
 				AND f.user_tunnel_id IS NULL
 				AND f.link_pk = ''
-				AND d.metro_pk IS NOT NULL
+				AND d.metro_pk = ?
 			GROUP BY d.metro_pk
 		)
 		SELECT
@@ -233,7 +234,7 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 	`
 
 	var metro MetroDetail
-	err := a.envDB(ctx).QueryRow(ctx, query, pk).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk).Scan(
 		&metro.PK,
 		&metro.Code,
 		&metro.Name,

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -606,6 +606,7 @@ func (a *API) GetUserMulticastGroups(w http.ResponseWriter, r *http.Request) {
 				FROM dz_users_current u
 				WHERE u.status = 'activated' AND u.kind = 'multicast' AND JSONLength(u.subscribers) > 0
 			)
+			WHERE group_pk IN (SELECT group_pk FROM user_groups)
 			GROUP BY group_pk
 		)
 		SELECT

--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -407,6 +407,10 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 			WHERE u.status = 'activated'
 				AND u.client_ip IS NOT NULL
 				AND u.client_ip != ''
+				AND u.client_ip = (
+					SELECT gossip_ip FROM solana_gossip_nodes_current
+					WHERE pubkey = (SELECT node_pubkey FROM solana_vote_accounts_current WHERE vote_pubkey = ?)
+				)
 			GROUP BY u.client_ip
 		),
 		traffic_rates AS (
@@ -416,7 +420,7 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 				SUM(avg_out_bps) as out_bps
 			FROM device_interface_rollup_5m
 			WHERE bucket_ts = (SELECT max(bucket_ts) FROM device_interface_rollup_5m)
-				AND user_pk != ''
+				AND user_pk IN (SELECT user_pk FROM dz_ip_info)
 			GROUP BY user_pk
 		),
 		skip_rates AS (
@@ -429,6 +433,7 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 				) as skip_rate
 			FROM fact_solana_block_production
 			WHERE event_ts > now() - INTERVAL 24 HOUR
+				AND leader_identity_pubkey = (SELECT node_pubkey FROM solana_vote_accounts_current WHERE vote_pubkey = ?)
 			GROUP BY leader_identity_pubkey
 			HAVING MAX(leader_slots_assigned_cum) > 0
 		),
@@ -438,6 +443,7 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 				software_client,
 				software_version
 			FROM validatorsapp_validators_current
+			WHERE vote_account = ?
 		)
 		SELECT
 			v.vote_pubkey,
@@ -475,7 +481,7 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 	`
 
 	var validator ValidatorDetail
-	err := a.envDB(ctx).QueryRow(ctx, query, votePubkey).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, votePubkey, votePubkey, votePubkey, votePubkey).Scan(
 		&validator.VotePubkey,
 		&validator.NodePubkey,
 		&validator.StakeSol,


### PR DESCRIPTION
## Summary of Changes
- Detail page handlers for gossip node, metro, contributor, validator, and user multicast groups had the same pattern as #456: CTEs aggregated across all rows before the pk filter was applied in the final WHERE clause
- Each handler now pushes its pk filter into the relevant CTEs so ClickHouse only scans the rows needed for the requested entity
- `GetValidator` uses subquery lookups to resolve the validator's gossip IP and node pubkey, since the vote pubkey can't be directly used to filter the user/traffic/skip-rate tables

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic |     5 | +25 / -15   | +10 |

All changes are query filter additions; no structural changes.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/validators.go` — `dz_ip_info` scoped to validator's gossip IP via subquery; `traffic_rates` scoped to matching user_pk; `skip_rates` and `validatorsapp_data` filtered by node/vote pubkey
- `api/handlers/contributors.go` — all 6 CTEs (`device_counts`, `side_a_counts`, `side_z_counts`, `link_counts`, `user_counts`, `traffic_rates`) now filter by `contributor_pk = ?`
- `api/handlers/metros.go` — 4 CTEs filter by `metro_pk = ?`
- `api/handlers/gossip_nodes.go` — `dz_nodes` scoped to gossip node's IP via subquery; `validator_stake` filtered by `node_pubkey = ?`
- `api/handlers/users.go` — `group_counts` in `GetUserMulticastGroups` scoped to the user's own groups via `IN (SELECT group_pk FROM user_groups)`

</details>

## Testing Verification
- All five handlers follow the same pattern fixed in #456, which has integration tests covering correctness and data isolation
- Builds cleanly