### PR TITLE
indexer: add geolocation ClickHouse tables, schema, store, and query

### DIFF
--- a/indexer/db/clickhouse/migrations/20260415000001_geolocation_tables.sql
+++ b/indexer/db/clickhouse/migrations/20260415000001_geolocation_tables.sql
@@ -1,0 +1,270 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- geoloc_probes
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_probes_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    exchange_pk String,
+    public_ip String,
+    location_offset_port UInt16,
+    metrics_publisher_pk String,
+    reference_count UInt32,
+    code String,
+    parent_devices String,
+    target_update_count UInt32
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_probes_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    exchange_pk String,
+    public_ip String,
+    location_offset_port UInt16,
+    metrics_publisher_pk String,
+    reference_count UInt32,
+    code String,
+    parent_devices String,
+    target_update_count UInt32
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_probes_current view
+CREATE OR REPLACE VIEW geoloc_probes_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_probes_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner,
+    exchange_pk,
+    public_ip,
+    location_offset_port,
+    metrics_publisher_pk,
+    reference_count,
+    code,
+    parent_devices,
+    target_update_count
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_users
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_users_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    code String,
+    token_account String,
+    payment_status String,
+    status String,
+    target_count UInt32,
+    billing_rate UInt64,
+    last_deduction_dz_epoch UInt64
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_users_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    owner String,
+    code String,
+    token_account String,
+    payment_status String,
+    status String,
+    target_count UInt32,
+    billing_rate UInt64,
+    last_deduction_dz_epoch UInt64
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_users_current view
+CREATE OR REPLACE VIEW geoloc_users_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_users_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner,
+    code,
+    token_account,
+    payment_status,
+    status,
+    target_count,
+    billing_rate,
+    last_deduction_dz_epoch
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_targets
+-- History table (immutable SCD2, single source of truth)
+CREATE TABLE IF NOT EXISTS dim_geoloc_targets_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    geoloc_user_pk String,
+    probe_pk String,
+    target_type String,
+    ip String,
+    location_offset_port UInt16,
+    target_pk String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Staging table (landing zone for snapshots, 7-day TTL)
+CREATE TABLE IF NOT EXISTS stg_dim_geoloc_targets_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    geoloc_user_pk String,
+    probe_pk String,
+    target_type String,
+    ip String,
+    location_offset_port UInt16,
+    target_pk String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- geoloc_targets_current view
+CREATE OR REPLACE VIEW geoloc_targets_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_geoloc_targets_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    geoloc_user_pk,
+    probe_pk,
+    target_type,
+    ip,
+    location_offset_port,
+    target_pk
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_targets_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_targets_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_targets_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_users_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_users_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_users_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS geoloc_probes_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_geoloc_probes_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_geoloc_probes_history;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/geolocation/main_test.go
+++ b/indexer/pkg/dz/geolocation/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
 	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 )
@@ -24,4 +25,8 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	sharedDB.Close()
 	os.Exit(code)
+}
+
+func testClient(t *testing.T) clickhouse.Client {
+	return laketesting.NewClient(t, sharedDB)
 }

--- a/indexer/pkg/dz/geolocation/main_test.go
+++ b/indexer/pkg/dz/geolocation/main_test.go
@@ -25,4 +25,3 @@ func TestMain(m *testing.M) {
 	sharedDB.Close()
 	os.Exit(code)
 }
-

--- a/indexer/pkg/dz/geolocation/main_test.go
+++ b/indexer/pkg/dz/geolocation/main_test.go
@@ -1,0 +1,33 @@
+package geolocation
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+var (
+	sharedDB *clickhousetesting.DB
+)
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("failed to create shared DB", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}
+
+func testClient(t *testing.T) clickhouse.Client {
+	client := laketesting.NewClient(t, sharedDB)
+	return client
+}

--- a/indexer/pkg/dz/geolocation/main_test.go
+++ b/indexer/pkg/dz/geolocation/main_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
 	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 )
@@ -27,7 +26,3 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func testClient(t *testing.T) clickhouse.Client {
-	client := laketesting.NewClient(t, sharedDB)
-	return client
-}

--- a/indexer/pkg/dz/geolocation/query.go
+++ b/indexer/pkg/dz/geolocation/query.go
@@ -1,0 +1,157 @@
+package geolocation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+type probeRow struct {
+	PK                 string `ch:"pk"`
+	Owner              string `ch:"owner"`
+	ExchangePK         string `ch:"exchange_pk"`
+	PublicIP           string `ch:"public_ip"`
+	LocationOffsetPort uint16 `ch:"location_offset_port"`
+	MetricsPublisherPK string `ch:"metrics_publisher_pk"`
+	ReferenceCount     uint32 `ch:"reference_count"`
+	Code               string `ch:"code"`
+	ParentDevices      string `ch:"parent_devices"`
+	TargetUpdateCount  uint32 `ch:"target_update_count"`
+}
+
+type userRow struct {
+	PK                   string `ch:"pk"`
+	Owner                string `ch:"owner"`
+	Code                 string `ch:"code"`
+	TokenAccount         string `ch:"token_account"`
+	PaymentStatus        string `ch:"payment_status"`
+	Status               string `ch:"status"`
+	TargetCount          uint32 `ch:"target_count"`
+	BillingRate          uint64 `ch:"billing_rate"`
+	LastDeductionDzEpoch uint64 `ch:"last_deduction_dz_epoch"`
+}
+
+type targetRow struct {
+	GeolocUserPK       string `ch:"geoloc_user_pk"`
+	ProbePK            string `ch:"probe_pk"`
+	TargetType         string `ch:"target_type"`
+	IP                 string `ch:"ip"`
+	LocationOffsetPort uint16 `ch:"location_offset_port"`
+	TargetPK           string `ch:"target_pk"`
+}
+
+func QueryCurrentProbes(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]Probe, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewProbeDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[probeRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query probes: %w", err)
+	}
+
+	probes := make([]Probe, len(rows))
+	for i, row := range rows {
+		var parentDevices []string
+		if row.ParentDevices != "" {
+			if err := json.Unmarshal([]byte(row.ParentDevices), &parentDevices); err != nil {
+				log.Debug("geolocation: failed to unmarshal parent_devices", "pk", row.PK, "error", err)
+			}
+		}
+		probes[i] = Probe{
+			PK:                 row.PK,
+			Owner:              row.Owner,
+			ExchangePK:         row.ExchangePK,
+			PublicIP:           row.PublicIP,
+			LocationOffsetPort: row.LocationOffsetPort,
+			MetricsPublisherPK: row.MetricsPublisherPK,
+			ReferenceCount:     row.ReferenceCount,
+			Code:               row.Code,
+			ParentDevices:      parentDevices,
+			TargetUpdateCount:  row.TargetUpdateCount,
+		}
+	}
+
+	return probes, nil
+}
+
+func QueryCurrentUsers(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]User, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewUserDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[userRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query users: %w", err)
+	}
+
+	users := make([]User, len(rows))
+	for i, row := range rows {
+		users[i] = User{
+			PK:                   row.PK,
+			Owner:                row.Owner,
+			Code:                 row.Code,
+			TokenAccount:         row.TokenAccount,
+			PaymentStatus:        row.PaymentStatus,
+			Status:               row.Status,
+			TargetCount:          row.TargetCount,
+			BillingRate:          row.BillingRate,
+			LastDeductionDzEpoch: row.LastDeductionDzEpoch,
+		}
+	}
+
+	return users, nil
+}
+
+func QueryCurrentTargets(ctx context.Context, log *slog.Logger, db clickhouse.Client) ([]Target, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+	defer conn.Close()
+
+	d, err := NewTargetDataset(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	typed := dataset.NewTypedDimensionType2Dataset[targetRow](d)
+	rows, err := typed.GetCurrentRows(ctx, conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query targets: %w", err)
+	}
+
+	targets := make([]Target, len(rows))
+	for i, row := range rows {
+		targets[i] = Target{
+			GeolocUserPK:       row.GeolocUserPK,
+			ProbePK:            row.ProbePK,
+			TargetType:         row.TargetType,
+			IP:                 row.IP,
+			LocationOffsetPort: row.LocationOffsetPort,
+			TargetPK:           row.TargetPK,
+		}
+	}
+
+	return targets, nil
+}

--- a/indexer/pkg/dz/geolocation/schema.go
+++ b/indexer/pkg/dz/geolocation/schema.go
@@ -1,0 +1,150 @@
+package geolocation
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// ProbeSchema defines the schema for geolocation probes.
+type ProbeSchema struct{}
+
+func (s *ProbeSchema) Name() string {
+	return "geoloc_probes"
+}
+
+func (s *ProbeSchema) PrimaryKeyColumns() []string {
+	return []string{"pk:VARCHAR"}
+}
+
+func (s *ProbeSchema) PayloadColumns() []string {
+	return []string{
+		"owner:VARCHAR",
+		"exchange_pk:VARCHAR",
+		"public_ip:VARCHAR",
+		"location_offset_port:INTEGER",
+		"metrics_publisher_pk:VARCHAR",
+		"reference_count:INTEGER",
+		"code:VARCHAR",
+		"parent_devices:VARCHAR",
+		"target_update_count:INTEGER",
+	}
+}
+
+func (s *ProbeSchema) ToRow(p Probe) []any {
+	parentDevicesJSON, _ := json.Marshal(p.ParentDevices)
+	return []any{
+		p.PK,
+		p.Owner,
+		p.ExchangePK,
+		p.PublicIP,
+		p.LocationOffsetPort,
+		p.MetricsPublisherPK,
+		p.ReferenceCount,
+		p.Code,
+		string(parentDevicesJSON),
+		p.TargetUpdateCount,
+	}
+}
+
+func (s *ProbeSchema) GetPrimaryKey(p Probe) string {
+	return p.PK
+}
+
+// UserSchema defines the schema for geolocation users.
+type UserSchema struct{}
+
+func (s *UserSchema) Name() string {
+	return "geoloc_users"
+}
+
+func (s *UserSchema) PrimaryKeyColumns() []string {
+	return []string{"pk:VARCHAR"}
+}
+
+func (s *UserSchema) PayloadColumns() []string {
+	return []string{
+		"owner:VARCHAR",
+		"code:VARCHAR",
+		"token_account:VARCHAR",
+		"payment_status:VARCHAR",
+		"status:VARCHAR",
+		"target_count:INTEGER",
+		"billing_rate:BIGINT",
+		"last_deduction_dz_epoch:BIGINT",
+	}
+}
+
+func (s *UserSchema) ToRow(u User) []any {
+	return []any{
+		u.PK,
+		u.Owner,
+		u.Code,
+		u.TokenAccount,
+		u.PaymentStatus,
+		u.Status,
+		u.TargetCount,
+		u.BillingRate,
+		u.LastDeductionDzEpoch,
+	}
+}
+
+func (s *UserSchema) GetPrimaryKey(u User) string {
+	return u.PK
+}
+
+// TargetSchema defines the schema for geolocation targets.
+type TargetSchema struct{}
+
+func (s *TargetSchema) Name() string {
+	return "geoloc_targets"
+}
+
+func (s *TargetSchema) PrimaryKeyColumns() []string {
+	return []string{
+		"geoloc_user_pk:VARCHAR",
+		"probe_pk:VARCHAR",
+		"target_type:VARCHAR",
+		"ip:VARCHAR",
+		"location_offset_port:INTEGER",
+		"target_pk:VARCHAR",
+	}
+}
+
+func (s *TargetSchema) PayloadColumns() []string {
+	return nil
+}
+
+func (s *TargetSchema) ToRow(t Target) []any {
+	return []any{
+		t.GeolocUserPK,
+		t.ProbePK,
+		t.TargetType,
+		t.IP,
+		t.LocationOffsetPort,
+		t.TargetPK,
+	}
+}
+
+func (s *TargetSchema) GetPrimaryKey(t Target) string {
+	return t.EntityID()
+}
+
+var (
+	probeSchema  = &ProbeSchema{}
+	userSchema   = &UserSchema{}
+	targetSchema = &TargetSchema{}
+)
+
+func NewProbeDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, probeSchema)
+}
+
+func NewUserDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, userSchema)
+}
+
+func NewTargetDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, targetSchema)
+}

--- a/indexer/pkg/dz/geolocation/store.go
+++ b/indexer/pkg/dz/geolocation/store.go
@@ -1,0 +1,120 @@
+package geolocation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+type StoreConfig struct {
+	Logger     *slog.Logger
+	ClickHouse clickhouse.Client
+}
+
+func (cfg *StoreConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	return nil
+}
+
+type Store struct {
+	log *slog.Logger
+	cfg StoreConfig
+}
+
+func NewStore(cfg StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Store{
+		log: cfg.Logger,
+		cfg: cfg,
+	}, nil
+}
+
+func (s *Store) GetClickHouse() clickhouse.Client {
+	return s.cfg.ClickHouse
+}
+
+func (s *Store) ReplaceProbes(ctx context.Context, probes []Probe) error {
+	s.log.Debug("geolocation/store: replacing probes", "count", len(probes))
+
+	d, err := NewProbeDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(probes), func(i int) ([]any, error) {
+		return probeSchema.ToRow(probes[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write probes to ClickHouse: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) ReplaceUsers(ctx context.Context, users []User) error {
+	s.log.Debug("geolocation/store: replacing users", "count", len(users))
+
+	d, err := NewUserDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(users), func(i int) ([]any, error) {
+		return userSchema.ToRow(users[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write users to ClickHouse: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) ReplaceTargets(ctx context.Context, targets []Target) error {
+	s.log.Debug("geolocation/store: replacing targets", "count", len(targets))
+
+	d, err := NewTargetDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(targets), func(i int) ([]any, error) {
+		return targetSchema.ToRow(targets[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("failed to write targets to ClickHouse: %w", err)
+	}
+
+	return nil
+}

--- a/indexer/pkg/dz/geolocation/store_test.go
+++ b/indexer/pkg/dz/geolocation/store_test.go
@@ -1,0 +1,165 @@
+package geolocation
+
+import (
+	"context"
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_Geolocation_Store_ReplaceProbes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes and reads back probes", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		log := laketesting.NewLogger()
+
+		store, err := NewStore(StoreConfig{Logger: log, ClickHouse: db})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		probes := []Probe{
+			{
+				PK:                 "probe-pk-1",
+				Owner:              "owner-1",
+				ExchangePK:         "exchange-1",
+				PublicIP:           "10.0.1.1",
+				LocationOffsetPort: 9000,
+				MetricsPublisherPK: "metrics-1",
+				ReferenceCount:     5,
+				Code:               "probe-1",
+				ParentDevices:      []string{"device-a", "device-b"},
+				TargetUpdateCount:  3,
+			},
+		}
+
+		err = store.ReplaceProbes(ctx, probes)
+		require.NoError(t, err)
+
+		got, err := QueryCurrentProbes(ctx, log, db)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "probe-pk-1", got[0].PK)
+		require.Equal(t, "owner-1", got[0].Owner)
+		require.Equal(t, "10.0.1.1", got[0].PublicIP)
+		require.Equal(t, uint16(9000), got[0].LocationOffsetPort)
+		require.Equal(t, uint32(5), got[0].ReferenceCount)
+		require.Equal(t, "probe-1", got[0].Code)
+		require.Equal(t, []string{"device-a", "device-b"}, got[0].ParentDevices)
+		require.Equal(t, uint32(3), got[0].TargetUpdateCount)
+	})
+
+	t.Run("tombstones removed probes on replace", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		log := laketesting.NewLogger()
+
+		store, err := NewStore(StoreConfig{Logger: log, ClickHouse: db})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		err = store.ReplaceProbes(ctx, []Probe{
+			{PK: "probe-a", Code: "a"},
+			{PK: "probe-b", Code: "b"},
+		})
+		require.NoError(t, err)
+
+		err = store.ReplaceProbes(ctx, []Probe{
+			{PK: "probe-a", Code: "a-updated"},
+		})
+		require.NoError(t, err)
+
+		got, err := QueryCurrentProbes(ctx, log, db)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "probe-a", got[0].PK)
+		require.Equal(t, "a-updated", got[0].Code)
+	})
+}
+
+func TestLake_Geolocation_Store_ReplaceUsers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes and reads back users", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		log := laketesting.NewLogger()
+
+		store, err := NewStore(StoreConfig{Logger: log, ClickHouse: db})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		users := []User{
+			{
+				PK:                   "user-pk-1",
+				Owner:                "owner-1",
+				Code:                 "user-1",
+				TokenAccount:         "token-1",
+				PaymentStatus:        "paid",
+				Status:               "activated",
+				TargetCount:          3,
+				BillingRate:          1000,
+				LastDeductionDzEpoch: 42,
+			},
+		}
+
+		err = store.ReplaceUsers(ctx, users)
+		require.NoError(t, err)
+
+		got, err := QueryCurrentUsers(ctx, log, db)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "user-pk-1", got[0].PK)
+		require.Equal(t, "user-1", got[0].Code)
+		require.Equal(t, "paid", got[0].PaymentStatus)
+		require.Equal(t, "activated", got[0].Status)
+		require.Equal(t, uint32(3), got[0].TargetCount)
+		require.Equal(t, uint64(1000), got[0].BillingRate)
+		require.Equal(t, uint64(42), got[0].LastDeductionDzEpoch)
+	})
+}
+
+func TestLake_Geolocation_Store_ReplaceTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes and reads back targets", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		log := laketesting.NewLogger()
+
+		store, err := NewStore(StoreConfig{Logger: log, ClickHouse: db})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		targets := []Target{
+			{
+				GeolocUserPK:       "user-1",
+				ProbePK:            "probe-1",
+				TargetType:         "outbound",
+				IP:                 "192.168.1.1",
+				LocationOffsetPort: 8080,
+				TargetPK:           "target-1",
+			},
+		}
+
+		err = store.ReplaceTargets(ctx, targets)
+		require.NoError(t, err)
+
+		got, err := QueryCurrentTargets(ctx, log, db)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "user-1", got[0].GeolocUserPK)
+		require.Equal(t, "probe-1", got[0].ProbePK)
+		require.Equal(t, "outbound", got[0].TargetType)
+		require.Equal(t, "192.168.1.1", got[0].IP)
+		require.Equal(t, uint16(8080), got[0].LocationOffsetPort)
+		require.Equal(t, "target-1", got[0].TargetPK)
+	})
+}

--- a/indexer/pkg/dz/geolocation/types.go
+++ b/indexer/pkg/dz/geolocation/types.go
@@ -1,0 +1,66 @@
+package geolocation
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	geolocsdk "github.com/malbeclabs/doublezero/sdk/geolocation/go"
+)
+
+type Probe struct {
+	PK                 string
+	Owner              string
+	ExchangePK         string
+	PublicIP           string
+	LocationOffsetPort uint16
+	MetricsPublisherPK string
+	ReferenceCount     uint32
+	Code               string
+	ParentDevices      []string
+	TargetUpdateCount  uint32
+}
+
+type User struct {
+	PK                   string
+	Owner                string
+	Code                 string
+	TokenAccount         string
+	PaymentStatus        string
+	Status               string
+	TargetCount          uint32
+	BillingRate          uint64
+	LastDeductionDzEpoch uint64
+}
+
+type Target struct {
+	GeolocUserPK       string
+	ProbePK            string
+	TargetType         string
+	IP                 string
+	LocationOffsetPort uint16
+	TargetPK           string
+}
+
+// EntityID returns a stable composite key for a target (targets don't have
+// their own on-chain account, so we derive an ID from their fields).
+func (t Target) EntityID() string {
+	h := sha256.New()
+	h.Write([]byte(t.GeolocUserPK))
+	h.Write([]byte{0})
+	h.Write([]byte(t.ProbePK))
+	h.Write([]byte{0})
+	h.Write([]byte(t.TargetType))
+	h.Write([]byte{0})
+	h.Write([]byte(t.IP))
+	h.Write([]byte{0})
+	h.Write([]byte{byte(t.LocationOffsetPort >> 8), byte(t.LocationOffsetPort)})
+	h.Write([]byte{0})
+	h.Write([]byte(t.TargetPK))
+	return fmt.Sprintf("%x", h.Sum(nil))[:32]
+}
+
+type GeolocationRPC interface {
+	GetGeoProbes(ctx context.Context) ([]geolocsdk.KeyedGeoProbe, error)
+	GetGeolocationUsers(ctx context.Context) ([]geolocsdk.KeyedGeolocationUser, error)
+}


### PR DESCRIPTION
## Summary

- Add ClickHouse SCD2 dimension tables for geolocation probes, users, and targets (history + staging + current-state views)
- Create `indexer/pkg/dz/geolocation` package with domain types, schema definitions, store (batch writes with SCD2 semantics), and query functions
- Test infrastructure (`TestMain` + ClickHouse testcontainer setup) and store round-trip tests

This is part 1 of 2 for #462. Lays the data layer foundation — tables exist but are not yet populated by the indexer. Part 2 (view + wiring) will follow in #481.

## Diff Breakdown

| Category          | Files | Lines (+/-)     | Net    |
|-------------------|-------|-----------------|--------|
| Core logic        |     3 | +347   / -0     |   +347 |
| Migration         |     1 | +270   / -0     |   +270 |
| Scaffolding       |     1 | +150   / -0     |   +150 |
| Tests             |     2 | +197   / -0     |   +197 |
| **Total**         |     7 | +964   / -0     |   +964 |

### Core changes
- `indexer/pkg/dz/geolocation/query.go` — +157 (typed ClickHouse queries for current probes/users/targets)
- `indexer/pkg/dz/geolocation/store.go` — +120 (SCD2 batch writes with MissingMeansDeleted semantics)
- `indexer/pkg/dz/geolocation/types.go` — +66 (domain types, Target.EntityID via SHA-256, GeolocationRPC interface)

Summary: ~350 lines of core logic across 3 files, supported by ~150 lines of schema scaffolding, ~200 lines of tests, and 1 migration.

## Testing Verification

- Store round-trip tests verify write-then-read for all three entity types (probes, users, targets)
- Tombstone test confirms MissingMeansDeleted: replacing a two-probe set with one probe correctly removes the missing probe from current view

Fixes #462