### PR TITLE
api, admin: switch edge scoreboard to slot_feed_race_summary_v2

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -18,11 +18,15 @@ var externalRemoteTables = []struct {
 	RemoteTable string
 }{
 	{"shredder", "publisher_shred_stats"},
+	{"shredder", "shred_timing_events"},
 	{"shredder", "slot_feed_races"},
 	{"shredder", "slot_feed_race_summary"},
+	{"shredder", "slot_feed_race_summary_v2"},
 	{"shredder_qa", "publisher_shred_stats"},
+	{"shredder_qa", "shred_timing_events"},
 	{"shredder_qa", "slot_feed_races"},
 	{"shredder_qa", "slot_feed_race_summary"},
+	{"shredder_qa", "slot_feed_race_summary_v2"},
 }
 
 // Config holds configuration for creating remote proxy tables.

--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -120,7 +120,7 @@ type EdgeScoreboardResponse struct {
 	SlotBuckets        []EdgeScoreboardSlotBucket       `json:"slot_buckets,omitempty"`
 	SlotBucketSize     uint64                           `json:"slot_bucket_size,omitempty"`
 	SlotLeaders        map[string]*EdgeScoreboardLeader `json:"slot_leaders,omitempty"`
-	// DataLagMs is how far behind wall clock the latest row in slot_feed_race_summary is
+	// DataLagMs is how far behind wall clock the latest row in slot_feed_race_summary_v2 is
 	// (server now − max(event_ts)). The client adds this to its own queue depth to show a
 	// pill reflecting actual on-chain time.
 	DataLagMs uint64 `json:"data_lag_ms,omitempty"`
@@ -150,7 +150,7 @@ var validWindows = map[string]string{
 }
 
 // slotsPerWindow bounds how many Solana slots fit in each window. Used to derive
-// a slot-range filter on slot_feed_race_summary, which is ORDER BY (host, slot, …)
+// a slot-range filter on slot_feed_race_summary_v2, which is ORDER BY (host, slot, …)
 // — so a slot range lets the primary index prune, whereas event_ts alone forces
 // a full monthly-partition scan. A small over-estimate is fine (the event_ts
 // filter still enforces exact window semantics).
@@ -337,7 +337,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		var lagSec float64
 		start := time.Now()
 		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(
-			`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary WHERE slot < %d`,
+			`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary_v2 WHERE slot < %d`,
 			shredderDB, maxValidSlot,
 		)).Scan(&maxSlot, &lagSec)
 		metrics.RecordClickHouseQuery(time.Since(start), err)
@@ -404,7 +404,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			max(slot) AS max_slot,
 			max(event_ts) AS last_updated,
 			uniqExact(feed) AS feed_count
-		FROM %s.slot_feed_race_summary
+		FROM %s.slot_feed_race_summary_v2
 		WHERE feed_type = 'shred' AND loser_feed = '' %s
 		GROUP BY host
 	SETTINGS final=1
@@ -499,7 +499,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			query1b := fmt.Sprintf(`
 			WITH %s
 			SELECT host, uniqExact(slot) AS dz_leader_slots
-			FROM %s.slot_feed_race_summary
+			FROM %s.slot_feed_race_summary_v2
 			WHERE feed_type = 'shred' AND (feed = 'dz' OR loser_feed = 'dz')
 				AND slot IN (SELECT slot FROM dz_leader_slots)
 				%s
@@ -544,7 +544,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		// Query 1c: DZ-leader slot count and total slot count.
 		// dz_leader_slots comes directly from publisher_shred_stats (is_scheduled_leader=true) —
 		// the authoritative count of slots where the scheduled leader published via DZ.
-		// total_slots is the distinct slot count from slot_feed_race_summary aggregate rows.
+		// total_slots is the distinct slot count from slot_feed_race_summary_v2 aggregate rows.
 		// completeness_pct = dz_leader_slots / total_slots — fraction of slots with a DZ leader.
 		{
 			query1c := fmt.Sprintf(`
@@ -552,7 +552,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			SELECT
 				(SELECT count() FROM dz_leader_slots) AS dz_leader_slots,
 				uniqExact(slot) AS total_slots
-			FROM %s.slot_feed_race_summary
+			FROM %s.slot_feed_race_summary_v2
 			WHERE feed_type = 'shred' AND loser_feed = '' %s
 		SETTINGS final=1
 `, dzLeaderCTE, shredderDB, rangeFilter)
@@ -704,7 +704,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				WITH %[1]s,
 				feed_totals AS (
 					SELECT host, feed, sum(shreds_won) AS shreds_won
-					FROM %[2]s.slot_feed_race_summary
+					FROM %[2]s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%[3]s)
 						AND slot IN (SELECT slot FROM dz_leader_slots)
 						%[4]s
@@ -726,7 +726,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				q2 = fmt.Sprintf(`
 				WITH feed_totals AS (
 					SELECT host, feed, sum(shreds_won) AS shreds_won
-					FROM %[1]s.slot_feed_race_summary
+					FROM %[1]s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%[2]s) %[3]s
 					GROUP BY host, feed
 				),
@@ -823,7 +823,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					count() AS slot_count,
 					quantile(0.5)(lead_time_p50_ms) AS p50_ms,
 					quantile(0.95)(lead_time_p95_ms) AS p95_ms
-				FROM %s.slot_feed_race_summary
+				FROM %s.slot_feed_race_summary_v2
 				WHERE feed_type = 'shred' AND feed = 'dz' AND loser_feed IN (%s)
 					AND slot IN (SELECT slot FROM dz_leader_slots)
 					AND lead_time_p50_ms <= 500
@@ -838,7 +838,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					count() AS slot_count,
 					quantile(0.5)(lead_time_p50_ms) AS p50_ms,
 					quantile(0.95)(lead_time_p95_ms) AS p95_ms
-				FROM %s.slot_feed_race_summary
+				FROM %s.slot_feed_race_summary_v2
 				WHERE feed_type = 'shred' AND feed IN ('dz', 'dz_rebop') AND loser_feed IN (%s)
 					AND lead_time_p50_ms <= 500
 					%s
@@ -980,7 +980,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 
 		// For recent slots, dz_leader_slots must NOT use the time window filter.
 		// The time filter is based on event_ts in publisher_shred_stats, which has much
-		// longer history than slot_feed_race_summary. A wide window (e.g. 7d) would pull
+		// longer history than slot_feed_race_summary_v2. A wide window (e.g. 7d) would pull
 		// in old leader slots that don't exist in the recent slot range, shrinking results.
 		// Instead, scope to the recent slot range directly so the intersection is correct.
 		dzLeaderCTEForRecent := fmt.Sprintf(`dz_leader_slots AS (
@@ -1009,7 +1009,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				WITH %s,
 				active_hosts AS (
 					SELECT host
-					FROM %s.slot_feed_race_summary
+					FROM %s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = ''
 						AND slot BETWEEN %d AND %d
 					GROUP BY host
@@ -1024,7 +1024,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					SELECT slot
 					FROM (
 						SELECT DISTINCT host, slot
-						FROM %s.slot_feed_race_summary
+						FROM %s.slot_feed_race_summary_v2
 						WHERE feed_type = 'shred' AND loser_feed = ''
 							AND host IN (SELECT host FROM active_hosts)
 							AND slot IN (SELECT slot FROM dz_slots)
@@ -1037,7 +1037,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				)
 				SELECT r.host, r.slot, r.feed, r.shreds_won,
 					round(r.shreds_won / greatest(r.total_shreds, 1) * 100, 1) AS win_pct
-				FROM %s.slot_feed_race_summary AS r
+				FROM %s.slot_feed_race_summary_v2 AS r
 				INNER JOIN common_slots cs ON r.slot = cs.slot
 				WHERE r.feed_type = 'shred' AND r.loser_feed = '' AND r.feed IN (%s)
 					AND r.slot BETWEEN %d AND %d
@@ -1049,7 +1049,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			query5 = fmt.Sprintf(`
 				WITH active_hosts AS (
 					SELECT host
-					FROM %s.slot_feed_race_summary
+					FROM %s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = ''
 						AND slot BETWEEN %d AND %d
 					GROUP BY host
@@ -1059,7 +1059,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					SELECT slot
 					FROM (
 						SELECT DISTINCT host, slot
-						FROM %s.slot_feed_race_summary
+						FROM %s.slot_feed_race_summary_v2
 						WHERE feed_type = 'shred' AND loser_feed = ''
 							AND host IN (SELECT host FROM active_hosts)
 							AND slot BETWEEN %d AND %d
@@ -1072,7 +1072,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				)
 				SELECT r.host, r.slot, r.feed, r.shreds_won,
 					round(r.shreds_won / greatest(r.total_shreds, 1) * 100, 1) AS win_pct
-				FROM %s.slot_feed_race_summary AS r
+				FROM %s.slot_feed_race_summary_v2 AS r
 				INNER JOIN common_slots cs ON r.slot = cs.slot
 				WHERE r.feed_type = 'shred' AND r.loser_feed = '' AND r.feed IN (%s)
 					AND r.slot BETWEEN %d AND %d
@@ -1273,7 +1273,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 						intDiv(slot, %d) * %d AS slot_bucket,
 						feed,
 						sum(shreds_won) AS feed_won
-					FROM %s.slot_feed_race_summary
+					FROM %s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%s)
 						AND host IN (%s)
 						AND slot IN (SELECT slot FROM dz_leader_slots)
@@ -1300,7 +1300,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 						intDiv(slot, %d) * %d AS slot_bucket,
 						feed,
 						sum(shreds_won) AS feed_won
-					FROM %s.slot_feed_race_summary
+					FROM %s.slot_feed_race_summary_v2
 					WHERE feed_type = 'shred' AND loser_feed = '' AND feed IN (%s)
 						AND host IN (%s)
 						AND slot <= %d
@@ -1507,7 +1507,7 @@ func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, s
 	var lagSec float64
 	start := time.Now()
 	err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(
-		`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary WHERE slot < %d`,
+		`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary_v2 WHERE slot < %d`,
 		shredderDB, maxValidSlot,
 	)).Scan(&maxSlot, &lagSec)
 	metrics.RecordClickHouseQuery(time.Since(start), err)

--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// createShredderTables creates the slot_feed_race_summary and publisher_shred_stats tables in the shredder/publisher DBs.
+// createShredderTables creates the slot_feed_race_summary_v2 and publisher_shred_stats tables in the shredder/publisher DBs.
 func createShredderTables(t *testing.T, api *handlers.API) {
 	t.Helper()
 	ctx := t.Context()
@@ -26,7 +26,7 @@ func createShredderTables(t *testing.T, api *handlers.API) {
 		require.NoError(t, err)
 	}
 	err = api.DB.Exec(ctx, fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.slot_feed_race_summary (
+		CREATE TABLE IF NOT EXISTS %s.slot_feed_race_summary_v2 (
 			event_ts DateTime64(3),
 			ingested_at DateTime64(3) DEFAULT now(),
 			host String,
@@ -39,8 +39,8 @@ func createShredderTables(t *testing.T, api *handlers.API) {
 			shreds_won UInt64,
 			lead_time_p50_ms Float64 DEFAULT 0,
 			lead_time_p95_ms Float64 DEFAULT 0
-		) ENGINE = MergeTree
-		PARTITION BY toYYYYMM(event_ts)
+		) ENGINE = ReplacingMergeTree(ingested_at)
+		PARTITION BY toYYYYMMDD(event_ts)
 		ORDER BY (host, slot, feed, loser_feed)
 	`, db))
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func insertEdgeScoreboardTestData(t *testing.T, api *handlers.API) {
 	// slot1: all 3 feeds (dz, turbine, jito) for both nodes — DZ wins most shreds (DZ-leader slot)
 	// slot2: only turbine + jito (no DZ) — tests completeness calculation
 	err = api.DB.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO %s.slot_feed_race_summary
+		INSERT INTO %s.slot_feed_race_summary_v2
 			(event_ts, host, feed_type, epoch, slot, feed, loser_feed, total_shreds, shreds_won)
 		VALUES
 			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'dz',      '', 100, 80),
@@ -136,7 +136,7 @@ func insertEdgeScoreboardTestData(t *testing.T, api *handlers.API) {
 	// Insert lead-time rows (loser_feed != '') — pairwise: winner vs specific loser
 	// For slot1 on slc-qa-bm1: dz beat turbine and jito
 	err = api.DB.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO %s.slot_feed_race_summary
+		INSERT INTO %s.slot_feed_race_summary_v2
 			(event_ts, host, feed_type, epoch, slot, feed, loser_feed, lead_time_p50_ms, lead_time_p95_ms)
 		VALUES
 			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'dz', 'turbine', 1.5, 3.0),


### PR DESCRIPTION
## Summary

- Points the edge scoreboard handler at `slot_feed_race_summary_v2`, the new MV target shipping in [malbeclabs/shredder#77](https://github.com/malbeclabs/shredder/pull/77). Same column shape as v1 — every query is a straight rename, no logic changes.
- Adds v2 to the remote-table proxy list so lake's local CH can query it.
- Adds `shred_timing_events` to the proxy list for ad-hoc shred-level queries from lake.
- Updates test DDL to match v2 (`ReplacingMergeTree(ingested_at)`, daily partitions). Test data and assertions are unchanged.

## Why v2

shredder#77 introduces v2 with three improvements over the v1 MV:
- Single-pass aggregation (1 source scan vs 4) — fewer expensive refresh cycles.
- Structural corrupt-slot filter (`HAVING total_shreds >= 32`) on top of the absolute `slot < 1e12` cap — corrupt slots no longer dominate `max(slot)` and shift the slot-tail predicate past every real slot.
- 3-day TTL with daily partitions so expired data drops on schedule.

## Validation

Ran v1 vs v2 side-by-side over a 4-hour window after deploy. Numbers tracked v1 within noise as v2 filled out:

| v2 window | headline Δ | per-host max Δ | per-row drift | p95 quantile Δ |
|---|---|---|---|---|
| 47 min | +0.30pp | 1.11pp | 0.10% | <0.1ms |
| 117 min | +0.09pp | 0.03pp | 0.20% | <0.1ms |
| 237 min | -0.05pp | 0.13pp | 0.19% | <0.1ms |

After the 85-min mark, headline DZ Edge Win Rate stayed within ±0.1pp of v1, per-host within ±0.15pp, and loser-pair p50/p95 medians within 0.1ms.

## Cutover ordering

This PR depends on shredder#77 being merged and the migration applied first — otherwise the scoreboard endpoint hits a missing table. The lake change is a hard cutover (no feature flag).

## Testing Verification

- `TestGetEdgeScoreboard*` pass against the v2 schema (test DDL updated to match).
- v1 vs v2 row-by-row comparison query (per-slot `INNER JOIN` on `(host, feed, loser_feed)`) shows shreds_won drift well under 0.5% on the same time window.