### PR TITLE
add aggressive vacuum to help with page cache

### DIFF
--- a/api/config/migrations/00015_page_cache_autovacuum.sql
+++ b/api/config/migrations/00015_page_cache_autovacuum.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Aggressive autovacuum on page_cache to reclaim dead tuples from frequent upserts.
+-- With ~4MB payloads upserted every 30s, dead tuple bloat fills disk quickly without this.
+ALTER TABLE page_cache SET (
+    autovacuum_vacuum_scale_factor = 0,
+    autovacuum_vacuum_threshold = 10,
+    autovacuum_analyze_scale_factor = 0,
+    autovacuum_analyze_threshold = 10
+);
+
+-- +goose Down
+ALTER TABLE page_cache RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_scale_factor,
+    autovacuum_analyze_threshold
+);


### PR DESCRIPTION
## Summary of Changes
PSQL was having trouble staying up with the regional feeds. This vacuum helps improve the page cache handling by aggressively clearing out dead tuples. 

## Testing Verification
* Tested in https://pr-467.data.malbeclabs.com/dz/shreds/publishers and DB issues went away
