### PR TITLE
api: align shreds seat expiring filter threshold with frontend

### DIFF
--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -220,13 +220,13 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 
 		var statusOr []string
 		if statuses["active"] {
-			// Active but NOT expiring (prepaid >= 2).
-			statusOr = append(statusOr, "(s.active_epoch >= ? AND s.escrow_count > 0 AND "+prepaidExpr+" >= 2)")
+			// Active but NOT expiring (prepaid >= 1).
+			statusOr = append(statusOr, "(s.active_epoch >= ? AND s.escrow_count > 0 AND "+prepaidExpr+" >= 1)")
 			whereArgs = append(whereArgs, solanaEpoch)
 		}
 		if statuses["expiring"] {
-			// Active but expiring soon (prepaid < 2).
-			statusOr = append(statusOr, "(s.active_epoch >= ? AND s.escrow_count > 0 AND "+prepaidExpr+" < 2)")
+			// Active but expiring soon (prepaid < 1).
+			statusOr = append(statusOr, "(s.active_epoch >= ? AND s.escrow_count > 0 AND "+prepaidExpr+" < 1)")
 			whereArgs = append(whereArgs, solanaEpoch)
 		}
 		if statuses["pending"] {


### PR DESCRIPTION
## Summary
- Backend status filter on the shred subscribers endpoint used `>= 2` / `< 2` prepaid epochs to split active vs expiring, but the frontend was tightened to `>= 1` / `< 1` in #401. Filtering by `status=expiring` returned seats with exactly 1 prepaid epoch, which the frontend then rendered with the Active badge.
- Updated the backend thresholds in `api/handlers/shreds.go` to match the frontend so the Expiring-only view no longer includes Active rows.