### PR TITLE
geoloc: add explorer map page

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -164,7 +164,9 @@ func Setup(log *slog.Logger, cfg Config) error {
 			t.RemoteDB, t.RemoteTable, remoteAddr, t.RemoteDB, t.RemoteTable, cfg.RemoteUser, cfg.RemotePassword,
 		)
 		if err := localConn.Exec(ctx, query); err != nil {
-			return fmt.Errorf("failed to create proxy for %s.%s: %w", t.RemoteDB, t.RemoteTable, err)
+			log.Warn("skipping external proxy table (remote table may not exist)", "table", fmt.Sprintf("%s.%s", t.RemoteDB, t.RemoteTable), "error", err)
+			extSkipped++
+			continue
 		}
 		log.Info("created external proxy table", "table", fmt.Sprintf("%s.%s", t.RemoteDB, t.RemoteTable))
 		extCreated++

--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -27,6 +27,9 @@ var externalRemoteTables = []struct {
 	{"shredder_qa", "slot_feed_races"},
 	{"shredder_qa", "slot_feed_race_summary"},
 	{"shredder_qa", "slot_feed_race_summary_v2"},
+	{"mainnet-beta", "location_offsets"},
+	{"devnet", "location_offsets"},
+	{"testnet", "location_offsets"},
 }
 
 // Config holds configuration for creating remote proxy tables.

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -14,6 +14,7 @@ import (
 
 type GeolocExplorerResponse struct {
 	Devices []GeolocExplorerDevice `json:"devices"`
+	Probes  []GeolocExplorerProbe  `json:"probes"`
 	Targets []GeolocExplorerTarget `json:"targets"`
 }
 
@@ -23,6 +24,13 @@ type GeolocExplorerDevice struct {
 	Lat                 float64 `json:"lat"`
 	Lng                 float64 `json:"lng"`
 	MinRefMeasuredRttNs uint64  `json:"min_ref_measured_rtt_ns"`
+}
+
+type GeolocExplorerProbe struct {
+	PK   string  `json:"pk"`
+	Code string  `json:"code"`
+	Lat  float64 `json:"lat"`
+	Lng  float64 `json:"lng"`
 }
 
 type GeolocExplorerTarget struct {
@@ -59,10 +67,9 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 			sender_pubkey,
 			any(lat) AS lat,
 			any(lng) AS lng,
-			min(ref_measured_rtt_ns[1]) AS min_ref_measured_rtt_ns
+			minIf(ref_measured_rtt_ns[1], length(ref_measured_rtt_ns) > 0) AS min_ref_measured_rtt_ns
 		FROM `+"`%s`"+`.location_offsets
 		WHERE received_at >= now() - INTERVAL %d HOUR
-		  AND length(ref_measured_rtt_ns) > 0
 		GROUP BY sender_pubkey
 	`, envDB, hours)
 
@@ -135,30 +142,55 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enrich devices with probe codes from the lake database via a separate query.
-	// geoloc_probes_current lives in the lake DB (a.DB), not behind remoteSecure().
-	if len(pubkeys) > 0 {
-		pks := make([]string, 0, len(pubkeys))
-		for pk := range pubkeys {
-			pks = append(pks, pk)
-		}
-		probeRows, err := a.DB.Query(ctx, "SELECT pk, code FROM geoloc_probes_current WHERE pk IN (?)", pks)
-		if err != nil {
-			logError("geoloc explorer probe query error", "error", err)
-			// Non-fatal: return devices without probe codes
-		} else {
-			defer probeRows.Close()
-			codeMap := make(map[string]string)
-			for probeRows.Next() {
-				var pk, code string
-				if err := probeRows.Scan(&pk, &code); err == nil {
-					codeMap[pk] = code
-				}
+	// Query 3: All geoprobes with metro coordinates from dimension tables.
+	// This ensures probes appear on the map even without recent measurements.
+	// Resolves coordinates via: probe → first parent device → metro.
+	// Falls back to matching the metro code prefix from the probe code.
+	var probes []GeolocExplorerProbe
+	probeRows, err := a.DB.Query(ctx, `
+		SELECT
+			gp.pk,
+			gp.code,
+			coalesce(
+				nullIf(m1.latitude, 0),
+				nullIf(m2.latitude, 0),
+				0
+			) AS lat,
+			coalesce(
+				nullIf(m1.longitude, 0),
+				nullIf(m2.longitude, 0),
+				0
+			) AS lng
+		FROM geoloc_probes_current gp
+		LEFT JOIN dz_devices_current d
+			ON d.pk = JSONExtractString(gp.parent_devices, 1)
+		LEFT JOIN dz_metros_current m1
+			ON m1.pk = d.metro_pk
+		LEFT JOIN dz_metros_current m2
+			ON m2.code = substring(gp.code, 1, 3)
+	`)
+	if err != nil {
+		logError("geoloc explorer probe location query error", "error", err)
+		// Non-fatal: proceed without probe locations
+	} else {
+		defer probeRows.Close()
+		for probeRows.Next() {
+			var p GeolocExplorerProbe
+			if err := probeRows.Scan(&p.PK, &p.Code, &p.Lat, &p.Lng); err == nil && p.Lat != 0 && p.Lng != 0 {
+				probes = append(probes, p)
 			}
-			for i := range devices {
-				if code, ok := codeMap[devices[i].SenderPubkey]; ok {
-					devices[i].ProbeCode = code
-				}
+		}
+	}
+
+	// Enrich devices with probe codes from the probes we already fetched.
+	if len(pubkeys) > 0 && len(probes) > 0 {
+		codeMap := make(map[string]string, len(probes))
+		for _, p := range probes {
+			codeMap[p.PK] = p.Code
+		}
+		for i := range devices {
+			if code, ok := codeMap[devices[i].SenderPubkey]; ok {
+				devices[i].ProbeCode = code
 			}
 		}
 	}
@@ -166,12 +198,19 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	if devices == nil {
 		devices = []GeolocExplorerDevice{}
 	}
+	if probes == nil {
+		probes = []GeolocExplorerProbe{}
+	}
 	if targets == nil {
 		targets = []GeolocExplorerTarget{}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(GeolocExplorerResponse{Devices: devices, Targets: targets}); err != nil {
+	if err := json.NewEncoder(w).Encode(GeolocExplorerResponse{
+		Devices: devices,
+		Probes:  probes,
+		Targets: targets,
+	}); err != nil {
 		logError("failed to encode response", "error", err)
 	}
 }

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+type GeolocExplorerResponse struct {
+	Offsets []GeolocExplorerOffset `json:"offsets"`
+}
+
+type GeolocExplorerOffset struct {
+	SenderPubkey     string   `json:"sender_pubkey"`
+	ProbeCode        string   `json:"probe_code"`
+	Lat              float64  `json:"lat"`
+	Lng              float64  `json:"lng"`
+	RttNs            uint64   `json:"rtt_ns"`
+	MeasuredRttNs    uint64   `json:"measured_rtt_ns"`
+	TargetIP         string   `json:"target_ip"`
+	NumReferences    uint8    `json:"num_references"`
+	RefMeasuredRttNs []uint64 `json:"ref_measured_rtt_ns"`
+	RefRttNs         []uint64 `json:"ref_rtt_ns"`
+}
+
+func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	hours := 1
+	if hoursStr := r.URL.Query().Get("hours"); hoursStr != "" {
+		if v, err := strconv.Atoi(hoursStr); err == nil {
+			hours = v
+		}
+	}
+	if hours < 1 {
+		hours = 1
+	}
+	if hours > 24 {
+		hours = 24
+	}
+
+	envDB := string(EnvFromContext(r.Context()))
+	lakeDB := a.DatabaseForEnvFromContext(r.Context())
+
+	query := fmt.Sprintf(`
+		SELECT
+			lo.sender_pubkey,
+			coalesce(gp.code, '') AS probe_code,
+			lo.lat,
+			lo.lng,
+			lo.rtt_ns,
+			lo.measured_rtt_ns,
+			lo.target_ip,
+			lo.num_references,
+			lo.ref_measured_rtt_ns,
+			lo.ref_rtt_ns
+		FROM `+"`%s`"+`.location_offsets lo
+		LEFT JOIN `+"`%s`"+`.geoloc_probes_current gp ON lo.sender_pubkey = gp.pk
+		WHERE lo.received_at >= now() - INTERVAL %d HOUR
+		ORDER BY lo.received_at DESC
+		LIMIT 10000
+	`, envDB, lakeDB, hours)
+
+	start := time.Now()
+	rows, err := a.envDB(ctx).Query(ctx, query)
+	duration := time.Since(start)
+	metrics.RecordClickHouseQuery(duration, err)
+
+	if err != nil {
+		logError("geoloc explorer query error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	var offsets []GeolocExplorerOffset
+	for rows.Next() {
+		var o GeolocExplorerOffset
+		if err := rows.Scan(
+			&o.SenderPubkey,
+			&o.ProbeCode,
+			&o.Lat,
+			&o.Lng,
+			&o.RttNs,
+			&o.MeasuredRttNs,
+			&o.TargetIP,
+			&o.NumReferences,
+			&o.RefMeasuredRttNs,
+			&o.RefRttNs,
+		); err != nil {
+			logError("geoloc explorer scan error", "error", err)
+			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+			return
+		}
+		offsets = append(offsets, o)
+	}
+
+	if err := rows.Err(); err != nil {
+		logError("geoloc explorer rows error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	// Return empty array instead of null
+	if offsets == nil {
+		offsets = []GeolocExplorerOffset{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(GeolocExplorerResponse{Offsets: offsets}); err != nil {
+		logError("failed to encode response", "error", err)
+	}
+}

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -147,6 +147,7 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	// Resolves coordinates via: probe → first parent device → metro.
 	// Falls back to matching the metro code prefix from the probe code.
 	var probes []GeolocExplorerProbe
+	codeMap := make(map[string]string)
 	probeRows, err := a.DB.Query(ctx, `
 		SELECT
 			gp.pk,
@@ -176,22 +177,19 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 		defer probeRows.Close()
 		for probeRows.Next() {
 			var p GeolocExplorerProbe
-			if err := probeRows.Scan(&p.PK, &p.Code, &p.Lat, &p.Lng); err == nil && p.Lat != 0 && p.Lng != 0 {
-				probes = append(probes, p)
+			if err := probeRows.Scan(&p.PK, &p.Code, &p.Lat, &p.Lng); err == nil {
+				codeMap[p.PK] = p.Code
+				if p.Lat != 0 && p.Lng != 0 {
+					probes = append(probes, p)
+				}
 			}
 		}
 	}
 
-	// Enrich devices with probe codes from the probes we already fetched.
-	if len(pubkeys) > 0 && len(probes) > 0 {
-		codeMap := make(map[string]string, len(probes))
-		for _, p := range probes {
-			codeMap[p.PK] = p.Code
-		}
-		for i := range devices {
-			if code, ok := codeMap[devices[i].SenderPubkey]; ok {
-				devices[i].ProbeCode = code
-			}
+	// Enrich devices with probe codes from all probes (including those without coordinates).
+	for i := range devices {
+		if code, ok := codeMap[devices[i].SenderPubkey]; ok {
+			devices[i].ProbeCode = code
 		}
 	}
 

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -13,27 +13,31 @@ import (
 )
 
 type GeolocExplorerResponse struct {
-	Offsets []GeolocExplorerOffset `json:"offsets"`
+	Devices []GeolocExplorerDevice `json:"devices"`
+	Targets []GeolocExplorerTarget `json:"targets"`
 }
 
-type GeolocExplorerOffset struct {
-	SenderPubkey     string   `json:"sender_pubkey"`
-	ProbeCode        string   `json:"probe_code"`
-	Lat              float64  `json:"lat"`
-	Lng              float64  `json:"lng"`
-	RttNs            uint64   `json:"rtt_ns"`
-	MeasuredRttNs    uint64   `json:"measured_rtt_ns"`
-	TargetIP         string   `json:"target_ip"`
-	NumReferences    uint8    `json:"num_references"`
-	RefMeasuredRttNs []uint64 `json:"ref_measured_rtt_ns"`
-	RefRttNs         []uint64 `json:"ref_rtt_ns"`
+type GeolocExplorerDevice struct {
+	SenderPubkey        string  `json:"sender_pubkey"`
+	ProbeCode           string  `json:"probe_code"`
+	Lat                 float64 `json:"lat"`
+	Lng                 float64 `json:"lng"`
+	MinRefMeasuredRttNs uint64  `json:"min_ref_measured_rtt_ns"`
+}
+
+type GeolocExplorerTarget struct {
+	SenderPubkey     string  `json:"sender_pubkey"`
+	TargetIP         string  `json:"target_ip"`
+	Lat              float64 `json:"lat"`
+	Lng              float64 `json:"lng"`
+	MinMeasuredRttNs uint64  `json:"min_measured_rtt_ns"`
 }
 
 func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	hours := 1
+	hours := 24
 	if hoursStr := r.URL.Query().Get("hours"); hoursStr != "" {
 		if v, err := strconv.Atoi(hoursStr); err == nil {
 			hours = v
@@ -42,68 +46,96 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	if hours < 1 {
 		hours = 1
 	}
-	if hours > 24 {
-		hours = 24
+	if hours > 168 {
+		hours = 168
 	}
 
 	envDB := string(EnvFromContext(r.Context()))
 
-	// Query location_offsets from the env-named database. This table is a
-	// remoteSecure() proxy, so the entire query is pushed to ClickHouse Cloud.
-	// We must NOT cross-database JOIN here because the local DB name ("default")
-	// doesn't exist on Cloud.
-	offsetQuery := fmt.Sprintf(`
+	// Query 1: Devices — one row per sender_pubkey with min geoprobe RTT.
+	// ClickHouse arrays are 1-indexed, so ref_measured_rtt_ns[1] is the first element.
+	deviceQuery := fmt.Sprintf(`
 		SELECT
-			sender_pubkey, lat, lng, rtt_ns, measured_rtt_ns, target_ip,
-			num_references, ref_measured_rtt_ns, ref_rtt_ns
+			sender_pubkey,
+			any(lat) AS lat,
+			any(lng) AS lng,
+			min(ref_measured_rtt_ns[1]) AS min_ref_measured_rtt_ns
 		FROM `+"`%s`"+`.location_offsets
 		WHERE received_at >= now() - INTERVAL %d HOUR
-		ORDER BY received_at DESC
-		LIMIT 10000
+		  AND length(ref_measured_rtt_ns) > 0
+		GROUP BY sender_pubkey
 	`, envDB, hours)
 
 	start := time.Now()
-	rows, err := a.envDB(ctx).Query(ctx, offsetQuery)
+	deviceRows, err := a.envDB(ctx).Query(ctx, deviceQuery)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
-
 	if err != nil {
-		logError("geoloc explorer query error", "error", err)
+		logError("geoloc explorer device query error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 		return
 	}
-	defer rows.Close()
+	defer deviceRows.Close()
 
-	var offsets []GeolocExplorerOffset
+	var devices []GeolocExplorerDevice
 	pubkeys := make(map[string]struct{})
-	for rows.Next() {
-		var o GeolocExplorerOffset
-		if err := rows.Scan(
-			&o.SenderPubkey,
-			&o.Lat,
-			&o.Lng,
-			&o.RttNs,
-			&o.MeasuredRttNs,
-			&o.TargetIP,
-			&o.NumReferences,
-			&o.RefMeasuredRttNs,
-			&o.RefRttNs,
-		); err != nil {
-			logError("geoloc explorer scan error", "error", err)
+	for deviceRows.Next() {
+		var d GeolocExplorerDevice
+		if err := deviceRows.Scan(&d.SenderPubkey, &d.Lat, &d.Lng, &d.MinRefMeasuredRttNs); err != nil {
+			logError("geoloc explorer device scan error", "error", err)
 			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 			return
 		}
-		pubkeys[o.SenderPubkey] = struct{}{}
-		offsets = append(offsets, o)
+		pubkeys[d.SenderPubkey] = struct{}{}
+		devices = append(devices, d)
 	}
-
-	if err := rows.Err(); err != nil {
-		logError("geoloc explorer rows error", "error", err)
+	if err := deviceRows.Err(); err != nil {
+		logError("geoloc explorer device rows error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 		return
 	}
 
-	// Enrich with probe codes from the lake database via a separate query.
+	// Query 2: Targets — one row per (sender_pubkey, target_ip) with min measured RTT.
+	targetQuery := fmt.Sprintf(`
+		SELECT
+			sender_pubkey,
+			target_ip,
+			any(lat) AS lat,
+			any(lng) AS lng,
+			min(measured_rtt_ns) AS min_measured_rtt_ns
+		FROM `+"`%s`"+`.location_offsets
+		WHERE received_at >= now() - INTERVAL %d HOUR
+		GROUP BY sender_pubkey, target_ip
+	`, envDB, hours)
+
+	start = time.Now()
+	targetRows, err := a.envDB(ctx).Query(ctx, targetQuery)
+	duration = time.Since(start)
+	metrics.RecordClickHouseQuery(duration, err)
+	if err != nil {
+		logError("geoloc explorer target query error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+	defer targetRows.Close()
+
+	var targets []GeolocExplorerTarget
+	for targetRows.Next() {
+		var t GeolocExplorerTarget
+		if err := targetRows.Scan(&t.SenderPubkey, &t.TargetIP, &t.Lat, &t.Lng, &t.MinMeasuredRttNs); err != nil {
+			logError("geoloc explorer target scan error", "error", err)
+			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+			return
+		}
+		targets = append(targets, t)
+	}
+	if err := targetRows.Err(); err != nil {
+		logError("geoloc explorer target rows error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	// Enrich devices with probe codes from the lake database via a separate query.
 	// geoloc_probes_current lives in the lake DB (a.DB), not behind remoteSecure().
 	if len(pubkeys) > 0 {
 		pks := make([]string, 0, len(pubkeys))
@@ -113,7 +145,7 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 		probeRows, err := a.DB.Query(ctx, "SELECT pk, code FROM geoloc_probes_current WHERE pk IN (?)", pks)
 		if err != nil {
 			logError("geoloc explorer probe query error", "error", err)
-			// Non-fatal: return offsets without probe codes
+			// Non-fatal: return devices without probe codes
 		} else {
 			defer probeRows.Close()
 			codeMap := make(map[string]string)
@@ -123,21 +155,23 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 					codeMap[pk] = code
 				}
 			}
-			for i := range offsets {
-				if code, ok := codeMap[offsets[i].SenderPubkey]; ok {
-					offsets[i].ProbeCode = code
+			for i := range devices {
+				if code, ok := codeMap[devices[i].SenderPubkey]; ok {
+					devices[i].ProbeCode = code
 				}
 			}
 		}
 	}
 
-	// Return empty array instead of null
-	if offsets == nil {
-		offsets = []GeolocExplorerOffset{}
+	if devices == nil {
+		devices = []GeolocExplorerDevice{}
+	}
+	if targets == nil {
+		targets = []GeolocExplorerTarget{}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(GeolocExplorerResponse{Offsets: offsets}); err != nil {
+	if err := json.NewEncoder(w).Encode(GeolocExplorerResponse{Devices: devices, Targets: targets}); err != nil {
 		logError("failed to encode response", "error", err)
 	}
 }

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -47,29 +47,23 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	envDB := string(EnvFromContext(r.Context()))
-	lakeDB := a.DatabaseForEnvFromContext(r.Context())
 
-	query := fmt.Sprintf(`
+	// Query location_offsets from the env-named database. This table is a
+	// remoteSecure() proxy, so the entire query is pushed to ClickHouse Cloud.
+	// We must NOT cross-database JOIN here because the local DB name ("default")
+	// doesn't exist on Cloud.
+	offsetQuery := fmt.Sprintf(`
 		SELECT
-			lo.sender_pubkey,
-			coalesce(gp.code, '') AS probe_code,
-			lo.lat,
-			lo.lng,
-			lo.rtt_ns,
-			lo.measured_rtt_ns,
-			lo.target_ip,
-			lo.num_references,
-			lo.ref_measured_rtt_ns,
-			lo.ref_rtt_ns
-		FROM `+"`%s`"+`.location_offsets lo
-		LEFT JOIN `+"`%s`"+`.geoloc_probes_current gp ON lo.sender_pubkey = gp.pk
-		WHERE lo.received_at >= now() - INTERVAL %d HOUR
-		ORDER BY lo.received_at DESC
+			sender_pubkey, lat, lng, rtt_ns, measured_rtt_ns, target_ip,
+			num_references, ref_measured_rtt_ns, ref_rtt_ns
+		FROM `+"`%s`"+`.location_offsets
+		WHERE received_at >= now() - INTERVAL %d HOUR
+		ORDER BY received_at DESC
 		LIMIT 10000
-	`, envDB, lakeDB, hours)
+	`, envDB, hours)
 
 	start := time.Now()
-	rows, err := a.envDB(ctx).Query(ctx, query)
+	rows, err := a.envDB(ctx).Query(ctx, offsetQuery)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 
@@ -81,11 +75,11 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	var offsets []GeolocExplorerOffset
+	pubkeys := make(map[string]struct{})
 	for rows.Next() {
 		var o GeolocExplorerOffset
 		if err := rows.Scan(
 			&o.SenderPubkey,
-			&o.ProbeCode,
 			&o.Lat,
 			&o.Lng,
 			&o.RttNs,
@@ -99,6 +93,7 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 			return
 		}
+		pubkeys[o.SenderPubkey] = struct{}{}
 		offsets = append(offsets, o)
 	}
 
@@ -106,6 +101,34 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 		logError("geoloc explorer rows error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 		return
+	}
+
+	// Enrich with probe codes from the lake database via a separate query.
+	// geoloc_probes_current lives in the lake DB (a.DB), not behind remoteSecure().
+	if len(pubkeys) > 0 {
+		pks := make([]string, 0, len(pubkeys))
+		for pk := range pubkeys {
+			pks = append(pks, pk)
+		}
+		probeRows, err := a.DB.Query(ctx, "SELECT pk, code FROM geoloc_probes_current WHERE pk IN (?)", pks)
+		if err != nil {
+			logError("geoloc explorer probe query error", "error", err)
+			// Non-fatal: return offsets without probe codes
+		} else {
+			defer probeRows.Close()
+			codeMap := make(map[string]string)
+			for probeRows.Next() {
+				var pk, code string
+				if err := probeRows.Scan(&pk, &code); err == nil {
+					codeMap[pk] = code
+				}
+			}
+			for i := range offsets {
+				if code, ok := codeMap[offsets[i].SenderPubkey]; ok {
+					offsets[i].ProbeCode = code
+				}
+			}
+		}
 	}
 
 	// Return empty array instead of null

--- a/api/handlers/geoloc_explorer_test.go
+++ b/api/handlers/geoloc_explorer_test.go
@@ -1,0 +1,141 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createLocationOffsetsTable creates the location_offsets table in the
+// mainnet-beta database, matching the env-named database the handler queries.
+func createLocationOffsetsTable(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	err := api.DB.Exec(ctx, "CREATE DATABASE IF NOT EXISTS `mainnet-beta`")
+	require.NoError(t, err)
+	err = api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.location_offsets (
+			received_at DateTime64(3),
+			source_addr String,
+			authority_pubkey String,
+			sender_pubkey String,
+			measurement_slot UInt64,
+			lat Float64,
+			lng Float64,
+			measured_rtt_ns UInt64,
+			rtt_ns UInt64,
+			target_ip String,
+			num_references UInt8,
+			signature_valid Bool,
+			signature_error String,
+			raw_offset String,
+			ref_authority_pubkeys Array(String),
+			ref_sender_pubkeys Array(String),
+			ref_measured_rtt_ns Array(UInt64),
+			ref_rtt_ns Array(UInt64)
+		) ENGINE = MergeTree
+		PARTITION BY toYYYYMM(received_at)
+		ORDER BY (received_at, sender_pubkey)
+	`, "`mainnet-beta`"))
+	require.NoError(t, err)
+}
+
+func setupGeolocExplorerTestData(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+
+	// Insert probe dimension data (backs the geoloc_probes_current view)
+	err := api.DB.Exec(ctx, `
+		INSERT INTO dim_geoloc_probes_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner, exchange_pk, public_ip, location_offset_port, metrics_publisher_pk,
+			 reference_count, code, parent_devices, target_update_count)
+		VALUES
+			('probe-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'sender-pk-1', 'owner1', '', '1.2.3.4', 9100, '', 3, 'probe-ams', '', 5)
+	`)
+	require.NoError(t, err)
+
+	// Insert location_offsets data in the env-named database
+	err = api.DB.Exec(ctx, "INSERT INTO `mainnet-beta`.location_offsets"+`
+		(received_at, source_addr, authority_pubkey, sender_pubkey, measurement_slot,
+		 lat, lng, measured_rtt_ns, rtt_ns, target_ip, num_references,
+		 signature_valid, signature_error, raw_offset,
+		 ref_authority_pubkeys, ref_sender_pubkeys, ref_measured_rtt_ns, ref_rtt_ns)
+		VALUES
+			(now(), '10.0.0.1', 'auth1', 'sender-pk-1', 100,
+			 52.37, 4.89, 5000000, 6000000, '8.8.8.8', 3,
+			 true, '', '{}',
+			 ['auth-ref-1', 'auth-ref-2'], ['sender-ref-1', 'sender-ref-2'], [4000000, 4500000], [5000000, 5500000]),
+			(now(), '10.0.0.2', 'auth2', 'sender-pk-2', 101,
+			 40.71, -74.01, 8000000, 9000000, '1.1.1.1', 2,
+			 true, '', '{}',
+			 ['auth-ref-3'], ['sender-ref-3'], [7000000], [8000000])
+	`)
+	require.NoError(t, err)
+}
+
+func TestGetGeolocExplorer(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	// Map the default env to the test database so joins resolve correctly
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	createLocationOffsetsTable(t, api)
+
+	t.Run("empty response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer", nil)
+		w := httptest.NewRecorder()
+		api.GetGeolocExplorer(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp handlers.GeolocExplorerResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Offsets)
+	})
+
+	setupGeolocExplorerTestData(t, api)
+
+	t.Run("returns offsets with probe code", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer", nil)
+		w := httptest.NewRecorder()
+		api.GetGeolocExplorer(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp handlers.GeolocExplorerResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Offsets)
+		found := false
+		for _, o := range resp.Offsets {
+			if o.SenderPubkey == "sender-pk-1" {
+				found = true
+				assert.Equal(t, "probe-ams", o.ProbeCode)
+				assert.InDelta(t, 52.37, o.Lat, 0.01)
+				assert.InDelta(t, 4.89, o.Lng, 0.01)
+				assert.NotEmpty(t, o.RefMeasuredRttNs)
+				assert.NotEmpty(t, o.RefRttNs)
+			}
+		}
+		assert.True(t, found, "expected to find offset with sender-pk-1")
+	})
+
+	t.Run("custom hours param", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer?hours=24", nil)
+		w := httptest.NewRecorder()
+		api.GetGeolocExplorer(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp handlers.GeolocExplorerResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Offsets)
+	})
+}

--- a/api/handlers/geoloc_explorer_test.go
+++ b/api/handlers/geoloc_explorer_test.go
@@ -63,7 +63,8 @@ func setupGeolocExplorerTestData(t *testing.T, api *handlers.API) {
 	`)
 	require.NoError(t, err)
 
-	// Insert location_offsets data in the env-named database
+	// Insert location_offsets data in the env-named database.
+	// Two rows for sender-pk-1 to test min aggregation.
 	err = api.DB.Exec(ctx, "INSERT INTO `mainnet-beta`.location_offsets"+`
 		(received_at, source_addr, authority_pubkey, sender_pubkey, measurement_slot,
 		 lat, lng, measured_rtt_ns, rtt_ns, target_ip, num_references,
@@ -71,11 +72,15 @@ func setupGeolocExplorerTestData(t *testing.T, api *handlers.API) {
 		 ref_authority_pubkeys, ref_sender_pubkeys, ref_measured_rtt_ns, ref_rtt_ns)
 		VALUES
 			(now(), '10.0.0.1', 'auth1', 'sender-pk-1', 100,
-			 52.37, 4.89, 5000000, 6000000, '8.8.8.8', 3,
+			 52.37, 4.89, 8000000, 6000000, '8.8.8.8', 3,
 			 true, '', '{}',
-			 ['auth-ref-1', 'auth-ref-2'], ['sender-ref-1', 'sender-ref-2'], [4000000, 4500000], [5000000, 5500000]),
-			(now(), '10.0.0.2', 'auth2', 'sender-pk-2', 101,
-			 40.71, -74.01, 8000000, 9000000, '1.1.1.1', 2,
+			 ['auth-ref-1'], ['sender-ref-1'], [5000000], [5500000]),
+			(now(), '10.0.0.1', 'auth1', 'sender-pk-1', 101,
+			 52.37, 4.89, 6000000, 5000000, '8.8.8.8', 3,
+			 true, '', '{}',
+			 ['auth-ref-1'], ['sender-ref-1'], [4000000], [4500000]),
+			(now(), '10.0.0.2', 'auth2', 'sender-pk-2', 102,
+			 40.71, -74.01, 9000000, 8000000, '1.1.1.1', 2,
 			 true, '', '{}',
 			 ['auth-ref-3'], ['sender-ref-3'], [7000000], [8000000])
 	`)
@@ -100,12 +105,13 @@ func TestGetGeolocExplorer(t *testing.T) {
 		var resp handlers.GeolocExplorerResponse
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
-		assert.Empty(t, resp.Offsets)
+		assert.Empty(t, resp.Devices)
+		assert.Empty(t, resp.Targets)
 	})
 
 	setupGeolocExplorerTestData(t, api)
 
-	t.Run("returns offsets with probe code", func(t *testing.T) {
+	t.Run("returns aggregated devices and targets", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer", nil)
 		w := httptest.NewRecorder()
 		api.GetGeolocExplorer(w, req)
@@ -113,29 +119,48 @@ func TestGetGeolocExplorer(t *testing.T) {
 		var resp handlers.GeolocExplorerResponse
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
-		assert.NotEmpty(t, resp.Offsets)
-		found := false
-		for _, o := range resp.Offsets {
-			if o.SenderPubkey == "sender-pk-1" {
-				found = true
-				assert.Equal(t, "probe-ams", o.ProbeCode)
-				assert.InDelta(t, 52.37, o.Lat, 0.01)
-				assert.InDelta(t, 4.89, o.Lng, 0.01)
-				assert.NotEmpty(t, o.RefMeasuredRttNs)
-				assert.NotEmpty(t, o.RefRttNs)
+
+		// Should have 2 devices (sender-pk-1 and sender-pk-2)
+		assert.Len(t, resp.Devices, 2)
+
+		// Find sender-pk-1 and verify aggregation
+		var dev1 *handlers.GeolocExplorerDevice
+		for i := range resp.Devices {
+			if resp.Devices[i].SenderPubkey == "sender-pk-1" {
+				dev1 = &resp.Devices[i]
 			}
 		}
-		assert.True(t, found, "expected to find offset with sender-pk-1")
+		require.NotNil(t, dev1, "expected to find device with sender-pk-1")
+		assert.Equal(t, "probe-ams", dev1.ProbeCode)
+		assert.InDelta(t, 52.37, dev1.Lat, 0.01)
+		assert.InDelta(t, 4.89, dev1.Lng, 0.01)
+		// min of 5000000 and 4000000 = 4000000
+		assert.Equal(t, uint64(4000000), dev1.MinRefMeasuredRttNs)
+
+		// Should have 2 targets (sender-pk-1/8.8.8.8 and sender-pk-2/1.1.1.1)
+		assert.Len(t, resp.Targets, 2)
+
+		// Find the target for sender-pk-1
+		var tgt1 *handlers.GeolocExplorerTarget
+		for i := range resp.Targets {
+			if resp.Targets[i].SenderPubkey == "sender-pk-1" {
+				tgt1 = &resp.Targets[i]
+			}
+		}
+		require.NotNil(t, tgt1, "expected to find target for sender-pk-1")
+		assert.Equal(t, "8.8.8.8", tgt1.TargetIP)
+		// min of 8000000 and 6000000 = 6000000
+		assert.Equal(t, uint64(6000000), tgt1.MinMeasuredRttNs)
 	})
 
 	t.Run("custom hours param", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer?hours=24", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/explorer?hours=1", nil)
 		w := httptest.NewRecorder()
 		api.GetGeolocExplorer(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp handlers.GeolocExplorerResponse
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
-		assert.NotEmpty(t, resp.Offsets)
+		assert.NotEmpty(t, resp.Devices)
 	})
 }

--- a/api/handlers/geoloc_explorer_test.go
+++ b/api/handlers/geoloc_explorer_test.go
@@ -106,6 +106,7 @@ func TestGetGeolocExplorer(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Empty(t, resp.Devices)
+		assert.Empty(t, resp.Probes)
 		assert.Empty(t, resp.Targets)
 	})
 

--- a/api/main.go
+++ b/api/main.go
@@ -575,6 +575,7 @@ func main() {
 			r.Use(handlers.RequireInternalDomain)
 			r.Get("/api/dz/geoloc/probes", api.GetGeolocProbes)
 			r.Get("/api/dz/geoloc/users", api.GetGeolocUsers)
+			r.Get("/api/dz/geoloc/explorer", api.GetGeolocExplorer)
 		})
 
 		// Solana entity routes

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -57,6 +57,7 @@ import { UserDetailPage } from '@/components/user-detail-page'
 import { MulticastGroupsPage } from '@/components/multicast-groups-page'
 import { GeolocProbesPage } from '@/components/geoloc-probes-page'
 import { GeolocUsersPage } from '@/components/geoloc-users-page'
+import { GeolocExplorerPage } from '@/components/geoloc-explorer-page'
 import { ShredsSeatsPage, ShredsFundersPage, ShredsDevicesPage, ShredsEscrowEventsPage } from '@/components/shreds-page'
 import { ShredsEconomicsPage } from '@/components/shreds-economics-page'
 import { PublisherCheckPage } from './components/publisher-check-page'
@@ -717,6 +718,7 @@ function AppContent() {
             {/* Geolocation routes */}
             <Route path="/dz/geoloc/probes" element={<GeolocProbesPage />} />
             <Route path="/dz/geoloc/users" element={<GeolocUsersPage />} />
+            <Route path="/dz/geoloc/explorer" element={<GeolocExplorerPage />} />
 
             {/* Solana entity routes */}
             <Route path="/solana/overview" element={<SolanaOverviewPage />} />

--- a/web/src/components/geoloc-explorer-page.tsx
+++ b/web/src/components/geoloc-explorer-page.tsx
@@ -102,10 +102,11 @@ export function GeolocExplorerPage() {
   })
 
   const devices = data?.devices ?? []
+  const probes = data?.probes ?? []
   const targets = data?.targets ?? []
   const mapStyle = useMemo(() => createMapStyle(isDark), [isDark])
 
-  // Device dots — one per sender_pubkey
+  // Device dots — one per sender_pubkey from location_offsets
   const devicePointsGeoJSON = useMemo(() => ({
     type: 'FeatureCollection' as const,
     features: devices.map((d) => ({
@@ -118,7 +119,25 @@ export function GeolocExplorerPage() {
     })),
   }), [devices])
 
-  // Geoprobe circles — one per device, radius from min ref_measured_rtt_ns
+  // Probe dots — all geoprobes at their metro coordinates.
+  // Probes that also appear as devices (with measurement data) are excluded
+  // to avoid duplicate dots at slightly different positions.
+  const probePointsGeoJSON = useMemo(() => {
+    const devicePKs = new Set(devices.map((d) => d.sender_pubkey))
+    return {
+      type: 'FeatureCollection' as const,
+      features: probes
+        .filter((p) => !devicePKs.has(p.pk))
+        .map((p) => ({
+          type: 'Feature' as const,
+          properties: { label: p.code, sender_pubkey: p.pk },
+          geometry: { type: 'Point' as const, coordinates: [p.lng, p.lat] },
+        })),
+    }
+  }, [probes, devices])
+
+  // Geoprobe circles — one per probe with measurement data,
+  // using the device's lat/lng and min ref_measured_rtt_ns for the radius.
   const geoProbeCirclesGeoJSON = useMemo(() => {
     const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
     for (const d of devices) {
@@ -221,7 +240,30 @@ export function GeolocExplorerPage() {
             paint={{ 'line-color': '#3b82f6', 'line-width': 1, 'line-opacity': 0.5 }} />
         </Source>
 
-        {/* Device point markers */}
+        {/* Probe point markers (probes without measurement data) */}
+        <Source id="probe-points" type="geojson" data={probePointsGeoJSON}>
+          <Layer id="probe-points-circle" type="circle"
+            paint={{
+              'circle-radius': 5,
+              'circle-color': '#22c55e',
+              'circle-stroke-width': 2,
+              'circle-stroke-color': isDark ? '#1a1a2e' : '#ffffff',
+            }} />
+          <Layer id="probe-points-label" type="symbol"
+            layout={{
+              'text-field': ['get', 'label'],
+              'text-size': 11,
+              'text-offset': [0, 1.5],
+              'text-anchor': 'top',
+            }}
+            paint={{
+              'text-color': isDark ? '#e2e8f0' : '#1e293b',
+              'text-halo-color': isDark ? '#0f172a' : '#ffffff',
+              'text-halo-width': 1,
+            }} />
+        </Source>
+
+        {/* Device point markers (devices with measurement data) */}
         <Source id="device-points" type="geojson" data={devicePointsGeoJSON}>
           <Layer id="device-points-circle" type="circle"
             paint={{
@@ -246,7 +288,7 @@ export function GeolocExplorerPage() {
       </MapGL>
 
       {/* Empty state overlay */}
-      {devices.length === 0 && targets.length === 0 && (
+      {devices.length === 0 && probes.length === 0 && targets.length === 0 && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <div className="bg-card/90 backdrop-blur-sm border border-border rounded-lg px-6 py-4 text-center">
             <div className="text-sm text-muted-foreground">No location offset data available</div>

--- a/web/src/components/geoloc-explorer-page.tsx
+++ b/web/src/components/geoloc-explorer-page.tsx
@@ -7,7 +7,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useTheme } from '@/hooks/use-theme'
 import { Loader2, AlertCircle } from 'lucide-react'
 import { fetchGeolocExplorer } from '@/lib/api'
-import type { GeolocExplorerOffset } from '@/lib/api'
 
 /* ------------------------------------------------------------------ */
 /*  Map style                                                         */
@@ -92,81 +91,72 @@ export function GeolocExplorerPage() {
   const isDark = resolvedTheme === 'dark'
 
   const [hoverInfo, setHoverInfo] = useState<{
-    x: number; y: number; probeCode: string
-    targetIP: string; rttNs: number; measuredRttNs: number
+    x: number; y: number; label: string
+    detail: string; rttNs: number
   } | null>(null)
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['geoloc-explorer'],
-    queryFn: () => fetchGeolocExplorer(),
+    queryFn: () => fetchGeolocExplorer(24),
     refetchInterval: 30_000,
   })
 
-  const offsets = data?.offsets ?? []
+  const devices = data?.devices ?? []
+  const targets = data?.targets ?? []
   const mapStyle = useMemo(() => createMapStyle(isDark), [isDark])
 
-  // Probe points (deduplicated by sender_pubkey)
-  const probePointsGeoJSON = useMemo(() => {
-    const seen = new Map<string, GeolocExplorerOffset>()
-    for (const o of offsets) {
-      if (!seen.has(o.sender_pubkey)) seen.set(o.sender_pubkey, o)
-    }
-    return {
-      type: 'FeatureCollection' as const,
-      features: Array.from(seen.values()).map((o) => ({
-        type: 'Feature' as const,
-        properties: {
-          probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
-          sender_pubkey: o.sender_pubkey,
-        },
-        geometry: { type: 'Point' as const, coordinates: [o.lng, o.lat] },
-      })),
-    }
-  }, [offsets])
+  // Device dots — one per sender_pubkey
+  const devicePointsGeoJSON = useMemo(() => ({
+    type: 'FeatureCollection' as const,
+    features: devices.map((d) => ({
+      type: 'Feature' as const,
+      properties: {
+        label: d.probe_code || d.sender_pubkey.slice(0, 8),
+        sender_pubkey: d.sender_pubkey,
+      },
+      geometry: { type: 'Point' as const, coordinates: [d.lng, d.lat] },
+    })),
+  }), [devices])
 
-  // Geoprobe RTT circles (from ref_measured_rtt_ns[0])
+  // Geoprobe circles — one per device, radius from min ref_measured_rtt_ns
   const geoProbeCirclesGeoJSON = useMemo(() => {
     const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
-    for (const o of offsets) {
-      if (o.ref_measured_rtt_ns && o.ref_measured_rtt_ns.length > 0) {
-        const radius = rttToRadiusMeters(o.ref_measured_rtt_ns[0])
+    for (const d of devices) {
+      if (d.min_ref_measured_rtt_ns > 0) {
+        const radius = rttToRadiusMeters(d.min_ref_measured_rtt_ns)
         if (radius > 0 && radius < 5_000_000) {
-          const circle = createCirclePolygon(o.lng, o.lat, radius)
+          const circle = createCirclePolygon(d.lng, d.lat, radius)
           circle.properties = {
-            probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
-            target_ip: o.target_ip,
-            rtt_ns: o.ref_measured_rtt_ns[0],
-            measured_rtt_ns: o.measured_rtt_ns,
-            type: 'geoprobe',
+            label: d.probe_code || d.sender_pubkey.slice(0, 8),
+            detail: 'geoprobe',
+            rtt_ns: d.min_ref_measured_rtt_ns,
           }
           features.push(circle)
         }
       }
     }
     return { type: 'FeatureCollection' as const, features }
-  }, [offsets])
+  }, [devices])
 
-  // Target RTT circles (from rtt_ns)
+  // Target circles — one per (device, target_ip), radius from min measured_rtt_ns
   const targetCirclesGeoJSON = useMemo(() => {
     const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
-    for (const o of offsets) {
-      if (o.rtt_ns > 0) {
-        const radius = rttToRadiusMeters(o.rtt_ns)
+    for (const t of targets) {
+      if (t.min_measured_rtt_ns > 0) {
+        const radius = rttToRadiusMeters(t.min_measured_rtt_ns)
         if (radius > 0 && radius < 5_000_000) {
-          const circle = createCirclePolygon(o.lng, o.lat, radius)
+          const circle = createCirclePolygon(t.lng, t.lat, radius)
           circle.properties = {
-            probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
-            target_ip: o.target_ip,
-            rtt_ns: o.rtt_ns,
-            measured_rtt_ns: o.measured_rtt_ns,
-            type: 'target',
+            label: t.target_ip,
+            detail: `from ${t.sender_pubkey.slice(0, 8)}`,
+            rtt_ns: t.min_measured_rtt_ns,
           }
           features.push(circle)
         }
       }
     }
     return { type: 'FeatureCollection' as const, features }
-  }, [offsets])
+  }, [targets])
 
   const onHover = useCallback((event: MapLayerMouseEvent) => {
     const feature = event.features?.[0]
@@ -174,10 +164,9 @@ export function GeolocExplorerPage() {
       setHoverInfo({
         x: event.point.x,
         y: event.point.y,
-        probeCode: (feature.properties?.probe_code as string) ?? '',
-        targetIP: (feature.properties?.target_ip as string) ?? '',
+        label: (feature.properties?.label as string) ?? '',
+        detail: (feature.properties?.detail as string) ?? '',
         rttNs: Number(feature.properties?.rtt_ns ?? 0),
-        measuredRttNs: Number(feature.properties?.measured_rtt_ns ?? 0),
       })
     } else {
       setHoverInfo(null)
@@ -232,18 +221,18 @@ export function GeolocExplorerPage() {
             paint={{ 'line-color': '#3b82f6', 'line-width': 1, 'line-opacity': 0.5 }} />
         </Source>
 
-        {/* Probe point markers */}
-        <Source id="probe-points" type="geojson" data={probePointsGeoJSON}>
-          <Layer id="probe-points-circle" type="circle"
+        {/* Device point markers */}
+        <Source id="device-points" type="geojson" data={devicePointsGeoJSON}>
+          <Layer id="device-points-circle" type="circle"
             paint={{
               'circle-radius': 5,
               'circle-color': '#22c55e',
               'circle-stroke-width': 2,
               'circle-stroke-color': isDark ? '#1a1a2e' : '#ffffff',
             }} />
-          <Layer id="probe-points-label" type="symbol"
+          <Layer id="device-points-label" type="symbol"
             layout={{
-              'text-field': ['get', 'probe_code'],
+              'text-field': ['get', 'label'],
               'text-size': 11,
               'text-offset': [0, 1.5],
               'text-anchor': 'top',
@@ -257,7 +246,7 @@ export function GeolocExplorerPage() {
       </MapGL>
 
       {/* Empty state overlay */}
-      {offsets.length === 0 && (
+      {devices.length === 0 && targets.length === 0 && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <div className="bg-card/90 backdrop-blur-sm border border-border rounded-lg px-6 py-4 text-center">
             <div className="text-sm text-muted-foreground">No location offset data available</div>
@@ -271,15 +260,17 @@ export function GeolocExplorerPage() {
           className="absolute z-10 pointer-events-none bg-popover border border-border rounded-lg px-3 py-2 shadow-lg text-sm"
           style={{ left: hoverInfo.x + 12, top: hoverInfo.y - 12 }}
         >
-          <div className="font-medium">{hoverInfo.probeCode}</div>
-          {hoverInfo.targetIP && (
-            <div className="text-muted-foreground">Target: {hoverInfo.targetIP}</div>
+          <div className="font-medium">{hoverInfo.label}</div>
+          {hoverInfo.detail && (
+            <div className="text-muted-foreground">{hoverInfo.detail}</div>
           )}
-          <div className="text-muted-foreground">
-            RTT: {(hoverInfo.rttNs / 1000).toFixed(1)} us
-            {' · '}
-            Radius: {(rttToRadiusMeters(hoverInfo.rttNs) / 1000).toFixed(1)} km
-          </div>
+          {hoverInfo.rttNs > 0 && (
+            <div className="text-muted-foreground">
+              RTT: {(hoverInfo.rttNs / 1000).toFixed(1)} us
+              {' · '}
+              Radius: {(rttToRadiusMeters(hoverInfo.rttNs) / 1000).toFixed(1)} km
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/geoloc-explorer-page.tsx
+++ b/web/src/components/geoloc-explorer-page.tsx
@@ -1,0 +1,287 @@
+import { useMemo, useState, useCallback } from 'react'
+import MapGL, { Source, Layer } from 'react-map-gl/maplibre'
+import type { MapLayerMouseEvent } from 'react-map-gl/maplibre'
+import type { StyleSpecification } from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
+import { useQuery } from '@tanstack/react-query'
+import { useTheme } from '@/hooks/use-theme'
+import { Loader2, AlertCircle } from 'lucide-react'
+import { fetchGeolocExplorer } from '@/lib/api'
+import type { GeolocExplorerOffset } from '@/lib/api'
+
+/* ------------------------------------------------------------------ */
+/*  Map style                                                         */
+/* ------------------------------------------------------------------ */
+
+function createMapStyle(isDark: boolean): StyleSpecification {
+  const tileUrl = isDark
+    ? 'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
+    : 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+  return {
+    version: 8,
+    sources: {
+      carto: {
+        type: 'raster',
+        tiles: [tileUrl],
+        tileSize: 256,
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      },
+    },
+    layers: [
+      { id: 'carto-tiles', type: 'raster', source: 'carto', minzoom: 0, maxzoom: 22 },
+    ],
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  RTT helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+const SPEED_OF_LIGHT = 299_792_458
+const FIBER_FACTOR = 0.6
+
+function rttToRadiusMeters(rttNs: number): number {
+  return (FIBER_FACTOR * SPEED_OF_LIGHT * rttNs) / (2 * 1e9)
+}
+
+/* ------------------------------------------------------------------ */
+/*  Great-circle polygon                                              */
+/* ------------------------------------------------------------------ */
+
+function createCirclePolygon(
+  centerLng: number,
+  centerLat: number,
+  radiusMeters: number,
+  points = 32,
+): GeoJSON.Feature<GeoJSON.Polygon> {
+  const coords: [number, number][] = []
+  const earthRadius = 6_371_000
+  const angularRadius = radiusMeters / earthRadius
+  const centerLatRad = (centerLat * Math.PI) / 180
+  const centerLngRad = (centerLng * Math.PI) / 180
+
+  for (let i = 0; i <= points; i++) {
+    const bearing = (2 * Math.PI * i) / points
+    const lat = Math.asin(
+      Math.sin(centerLatRad) * Math.cos(angularRadius) +
+        Math.cos(centerLatRad) * Math.sin(angularRadius) * Math.cos(bearing),
+    )
+    const lng =
+      centerLngRad +
+      Math.atan2(
+        Math.sin(bearing) * Math.sin(angularRadius) * Math.cos(centerLatRad),
+        Math.cos(angularRadius) - Math.sin(centerLatRad) * Math.sin(lat),
+      )
+    coords.push([(lng * 180) / Math.PI, (lat * 180) / Math.PI])
+  }
+
+  return {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'Polygon', coordinates: [coords] },
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                         */
+/* ------------------------------------------------------------------ */
+
+export function GeolocExplorerPage() {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
+
+  const [hoverInfo, setHoverInfo] = useState<{
+    x: number; y: number; probeCode: string
+    targetIP: string; rttNs: number; measuredRttNs: number
+  } | null>(null)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['geoloc-explorer'],
+    queryFn: () => fetchGeolocExplorer(),
+    refetchInterval: 30_000,
+  })
+
+  const offsets = data?.offsets ?? []
+  const mapStyle = useMemo(() => createMapStyle(isDark), [isDark])
+
+  // Probe points (deduplicated by sender_pubkey)
+  const probePointsGeoJSON = useMemo(() => {
+    const seen = new Map<string, GeolocExplorerOffset>()
+    for (const o of offsets) {
+      if (!seen.has(o.sender_pubkey)) seen.set(o.sender_pubkey, o)
+    }
+    return {
+      type: 'FeatureCollection' as const,
+      features: Array.from(seen.values()).map((o) => ({
+        type: 'Feature' as const,
+        properties: {
+          probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
+          sender_pubkey: o.sender_pubkey,
+        },
+        geometry: { type: 'Point' as const, coordinates: [o.lng, o.lat] },
+      })),
+    }
+  }, [offsets])
+
+  // Geoprobe RTT circles (from ref_measured_rtt_ns[0])
+  const geoProbeCirclesGeoJSON = useMemo(() => {
+    const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
+    for (const o of offsets) {
+      if (o.ref_measured_rtt_ns && o.ref_measured_rtt_ns.length > 0) {
+        const radius = rttToRadiusMeters(o.ref_measured_rtt_ns[0])
+        if (radius > 0 && radius < 5_000_000) {
+          const circle = createCirclePolygon(o.lng, o.lat, radius)
+          circle.properties = {
+            probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
+            target_ip: o.target_ip,
+            rtt_ns: o.ref_measured_rtt_ns[0],
+            measured_rtt_ns: o.measured_rtt_ns,
+            type: 'geoprobe',
+          }
+          features.push(circle)
+        }
+      }
+    }
+    return { type: 'FeatureCollection' as const, features }
+  }, [offsets])
+
+  // Target RTT circles (from rtt_ns)
+  const targetCirclesGeoJSON = useMemo(() => {
+    const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
+    for (const o of offsets) {
+      if (o.rtt_ns > 0) {
+        const radius = rttToRadiusMeters(o.rtt_ns)
+        if (radius > 0 && radius < 5_000_000) {
+          const circle = createCirclePolygon(o.lng, o.lat, radius)
+          circle.properties = {
+            probe_code: o.probe_code || o.sender_pubkey.slice(0, 8),
+            target_ip: o.target_ip,
+            rtt_ns: o.rtt_ns,
+            measured_rtt_ns: o.measured_rtt_ns,
+            type: 'target',
+          }
+          features.push(circle)
+        }
+      }
+    }
+    return { type: 'FeatureCollection' as const, features }
+  }, [offsets])
+
+  const onHover = useCallback((event: MapLayerMouseEvent) => {
+    const feature = event.features?.[0]
+    if (feature) {
+      setHoverInfo({
+        x: event.point.x,
+        y: event.point.y,
+        probeCode: (feature.properties?.probe_code as string) ?? '',
+        targetIP: (feature.properties?.target_ip as string) ?? '',
+        rttNs: Number(feature.properties?.rtt_ns ?? 0),
+        measuredRttNs: Number(feature.properties?.measured_rtt_ns ?? 0),
+      })
+    } else {
+      setHoverInfo(null)
+    }
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center">
+          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <div className="text-lg font-medium mb-2">Unable to load explorer data</div>
+          <div className="text-sm text-muted-foreground">
+            {(error as Error)?.message || 'Unknown error'}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 relative">
+      <MapGL
+        initialViewState={{ longitude: 0, latitude: 20, zoom: 2 }}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle={mapStyle}
+        interactiveLayerIds={['geoprobe-circles-fill', 'target-circles-fill']}
+        onMouseMove={onHover}
+        onMouseLeave={() => setHoverInfo(null)}
+      >
+        {/* Target RTT circles (rendered first, behind geoprobe circles) */}
+        <Source id="target-circles" type="geojson" data={targetCirclesGeoJSON}>
+          <Layer id="target-circles-fill" type="fill"
+            paint={{ 'fill-color': '#f97316', 'fill-opacity': 0.08 }} />
+          <Layer id="target-circles-line" type="line"
+            paint={{ 'line-color': '#f97316', 'line-width': 1, 'line-opacity': 0.4 }} />
+        </Source>
+
+        {/* Geoprobe RTT circles */}
+        <Source id="geoprobe-circles" type="geojson" data={geoProbeCirclesGeoJSON}>
+          <Layer id="geoprobe-circles-fill" type="fill"
+            paint={{ 'fill-color': '#3b82f6', 'fill-opacity': 0.1 }} />
+          <Layer id="geoprobe-circles-line" type="line"
+            paint={{ 'line-color': '#3b82f6', 'line-width': 1, 'line-opacity': 0.5 }} />
+        </Source>
+
+        {/* Probe point markers */}
+        <Source id="probe-points" type="geojson" data={probePointsGeoJSON}>
+          <Layer id="probe-points-circle" type="circle"
+            paint={{
+              'circle-radius': 5,
+              'circle-color': '#22c55e',
+              'circle-stroke-width': 2,
+              'circle-stroke-color': isDark ? '#1a1a2e' : '#ffffff',
+            }} />
+          <Layer id="probe-points-label" type="symbol"
+            layout={{
+              'text-field': ['get', 'probe_code'],
+              'text-size': 11,
+              'text-offset': [0, 1.5],
+              'text-anchor': 'top',
+            }}
+            paint={{
+              'text-color': isDark ? '#e2e8f0' : '#1e293b',
+              'text-halo-color': isDark ? '#0f172a' : '#ffffff',
+              'text-halo-width': 1,
+            }} />
+        </Source>
+      </MapGL>
+
+      {/* Empty state overlay */}
+      {offsets.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="bg-card/90 backdrop-blur-sm border border-border rounded-lg px-6 py-4 text-center">
+            <div className="text-sm text-muted-foreground">No location offset data available</div>
+          </div>
+        </div>
+      )}
+
+      {/* Hover tooltip */}
+      {hoverInfo && (
+        <div
+          className="absolute z-10 pointer-events-none bg-popover border border-border rounded-lg px-3 py-2 shadow-lg text-sm"
+          style={{ left: hoverInfo.x + 12, top: hoverInfo.y - 12 }}
+        >
+          <div className="font-medium">{hoverInfo.probeCode}</div>
+          {hoverInfo.targetIP && (
+            <div className="text-muted-foreground">Target: {hoverInfo.targetIP}</div>
+          )}
+          <div className="text-muted-foreground">
+            RTT: {(hoverInfo.rttNs / 1000).toFixed(1)} us
+            {' · '}
+            Radius: {(rttToRadiusMeters(hoverInfo.rttNs) / 1000).toFixed(1)} km
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/geoloc-explorer-page.tsx
+++ b/web/src/components/geoloc-explorer-page.tsx
@@ -106,22 +106,26 @@ export function GeolocExplorerPage() {
   const targets = data?.targets ?? []
   const mapStyle = useMemo(() => createMapStyle(isDark), [isDark])
 
-  // Device dots — one per sender_pubkey from location_offsets
+  // Set of probe PKs for distinguishing devices from geoprobes
+  const probePKs = useMemo(() => new Set(probes.map((p) => p.pk)), [probes])
+
+  // Device dots (green) — only non-probe devices
   const devicePointsGeoJSON = useMemo(() => ({
     type: 'FeatureCollection' as const,
-    features: devices.map((d) => ({
-      type: 'Feature' as const,
-      properties: {
-        label: d.probe_code || d.sender_pubkey.slice(0, 8),
-        sender_pubkey: d.sender_pubkey,
-      },
-      geometry: { type: 'Point' as const, coordinates: [d.lng, d.lat] },
-    })),
-  }), [devices])
+    features: devices
+      .filter((d) => !probePKs.has(d.sender_pubkey))
+      .map((d) => ({
+        type: 'Feature' as const,
+        properties: {
+          label: d.probe_code || d.sender_pubkey.slice(0, 8),
+          sender_pubkey: d.sender_pubkey,
+        },
+        geometry: { type: 'Point' as const, coordinates: [d.lng, d.lat] },
+      })),
+  }), [devices, probePKs])
 
-  // Probe dots — all geoprobes at their metro coordinates.
-  // Probes that also appear as devices (with measurement data) are excluded
-  // to avoid duplicate dots at slightly different positions.
+  // Geoprobe dots (blue) — probes without measurement data, at metro coordinates.
+  // Probes WITH measurement data get a blue circle instead (below).
   const probePointsGeoJSON = useMemo(() => {
     const devicePKs = new Set(devices.map((d) => d.sender_pubkey))
     return {
@@ -136,11 +140,12 @@ export function GeolocExplorerPage() {
     }
   }, [probes, devices])
 
-  // Geoprobe circles — one per probe with measurement data,
+  // Geoprobe circles (blue) — probes with measurement data,
   // using the device's lat/lng and min ref_measured_rtt_ns for the radius.
   const geoProbeCirclesGeoJSON = useMemo(() => {
     const features: GeoJSON.Feature<GeoJSON.Polygon>[] = []
     for (const d of devices) {
+      if (!probePKs.has(d.sender_pubkey)) continue
       if (d.min_ref_measured_rtt_ns > 0) {
         const radius = rttToRadiusMeters(d.min_ref_measured_rtt_ns)
         if (radius > 0 && radius < 5_000_000) {
@@ -155,7 +160,7 @@ export function GeolocExplorerPage() {
       }
     }
     return { type: 'FeatureCollection' as const, features }
-  }, [devices])
+  }, [devices, probePKs])
 
   // Target circles — one per (device, target_ip), radius from min measured_rtt_ns
   const targetCirclesGeoJSON = useMemo(() => {
@@ -245,7 +250,7 @@ export function GeolocExplorerPage() {
           <Layer id="probe-points-circle" type="circle"
             paint={{
               'circle-radius': 5,
-              'circle-color': '#22c55e',
+              'circle-color': '#3b82f6',
               'circle-stroke-width': 2,
               'circle-stroke-color': isDark ? '#1a1a2e' : '#ffffff',
             }} />

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -102,6 +102,7 @@ const { resolvedTheme, setTheme } = useTheme()
   const isGeolocRoute = location.pathname.startsWith('/dz/geoloc/')
   const isGeolocProbesRoute = location.pathname.startsWith('/dz/geoloc/probes')
   const isGeolocUsersRoute = location.pathname.startsWith('/dz/geoloc/users')
+  const isGeolocExplorerRoute = location.pathname === '/dz/geoloc/explorer'
   const isValidatorsRoute = location.pathname.startsWith('/solana/validators')
   const isGossipNodesRoute = location.pathname.startsWith('/solana/gossip-nodes')
   const isSolanaOverviewRoute = location.pathname === '/solana/overview'
@@ -588,6 +589,10 @@ const { resolvedTheme, setTheme } = useTheme()
               <Link to="/dz/geoloc/users" className={navItemClass(isGeolocUsersRoute)}>
                 <Users className="h-4 w-4" />
                 Users
+              </Link>
+              <Link to="/dz/geoloc/explorer" className={navItemClass(isGeolocExplorerRoute)}>
+                <Map className="h-4 w-4" />
+                Explorer
               </Link>
             </div>
           </div>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -582,6 +582,10 @@ const { resolvedTheme, setTheme } = useTheme()
               <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">Geolocation</span>
             </div>
             <div className="space-y-1">
+              <Link to="/dz/geoloc/explorer" className={navItemClass(isGeolocExplorerRoute)}>
+                <Map className="h-4 w-4" />
+                Explorer
+              </Link>
               <Link to="/dz/geoloc/probes" className={navItemClass(isGeolocProbesRoute)}>
                 <MapPin className="h-4 w-4" />
                 Probes
@@ -589,10 +593,6 @@ const { resolvedTheme, setTheme } = useTheme()
               <Link to="/dz/geoloc/users" className={navItemClass(isGeolocUsersRoute)}>
                 <Users className="h-4 w-4" />
                 Users
-              </Link>
-              <Link to="/dz/geoloc/explorer" className={navItemClass(isGeolocExplorerRoute)}>
-                <Map className="h-4 w-4" />
-                Explorer
               </Link>
             </div>
           </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5817,21 +5817,25 @@ export async function fetchGeolocUsers(
   return res.json()
 }
 
-export interface GeolocExplorerOffset {
+export interface GeolocExplorerDevice {
   sender_pubkey: string
   probe_code: string
   lat: number
   lng: number
-  rtt_ns: number
-  measured_rtt_ns: number
+  min_ref_measured_rtt_ns: number
+}
+
+export interface GeolocExplorerTarget {
+  sender_pubkey: string
   target_ip: string
-  num_references: number
-  ref_measured_rtt_ns: number[]
-  ref_rtt_ns: number[]
+  lat: number
+  lng: number
+  min_measured_rtt_ns: number
 }
 
 export interface GeolocExplorerResponse {
-  offsets: GeolocExplorerOffset[]
+  devices: GeolocExplorerDevice[]
+  targets: GeolocExplorerTarget[]
 }
 
 export async function fetchGeolocExplorer(hours?: number): Promise<GeolocExplorerResponse> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5825,6 +5825,13 @@ export interface GeolocExplorerDevice {
   min_ref_measured_rtt_ns: number
 }
 
+export interface GeolocExplorerProbe {
+  pk: string
+  code: string
+  lat: number
+  lng: number
+}
+
 export interface GeolocExplorerTarget {
   sender_pubkey: string
   target_ip: string
@@ -5835,6 +5842,7 @@ export interface GeolocExplorerTarget {
 
 export interface GeolocExplorerResponse {
   devices: GeolocExplorerDevice[]
+  probes: GeolocExplorerProbe[]
   targets: GeolocExplorerTarget[]
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5834,8 +5834,11 @@ export interface GeolocExplorerResponse {
   offsets: GeolocExplorerOffset[]
 }
 
-export async function fetchGeolocExplorer(): Promise<GeolocExplorerResponse> {
-  const res = await apiFetch('/api/dz/geoloc/explorer')
+export async function fetchGeolocExplorer(hours?: number): Promise<GeolocExplorerResponse> {
+  const params = new URLSearchParams()
+  if (hours) params.set('hours', String(hours))
+  const query = params.toString()
+  const res = await apiFetch(`/api/dz/geoloc/explorer${query ? `?${query}` : ''}`)
   if (!res.ok) {
     throw new Error('Failed to fetch geolocation explorer data')
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5816,3 +5816,28 @@ export async function fetchGeolocUsers(
   }
   return res.json()
 }
+
+export interface GeolocExplorerOffset {
+  sender_pubkey: string
+  probe_code: string
+  lat: number
+  lng: number
+  rtt_ns: number
+  measured_rtt_ns: number
+  target_ip: string
+  num_references: number
+  ref_measured_rtt_ns: number[]
+  ref_rtt_ns: number[]
+}
+
+export interface GeolocExplorerResponse {
+  offsets: GeolocExplorerOffset[]
+}
+
+export async function fetchGeolocExplorer(): Promise<GeolocExplorerResponse> {
+  const res = await apiFetch('/api/dz/geoloc/explorer')
+  if (!res.ok) {
+    throw new Error('Failed to fetch geolocation explorer data')
+  }
+  return res.json()
+}


### PR DESCRIPTION
Resolves: #494

## Summary of Changes
- Add a geolocation explorer page that visualizes geoprobe devices and measurement targets on an interactive map, with RTT data and probe code enrichment
- New API endpoint `GET /api/dz/geoloc/explorer` aggregates `location_offsets` data by sender and target, joins with probe dimension tables for metadata
- Register `location_offsets` as external remote table proxies for mainnet-beta, devnet, and testnet environments
- Make external remote table proxy creation non-fatal so the indexer init container doesn't crash when remote tables haven't been provisioned yet

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +579 / -0   | +579 |
| Scaffolding  |     5 | +15 / -2    |  +13 |
| Tests        |     1 | +167 / -0   | +167 |
| **Total**    |     9 | +761 / -2   | +759 |

New feature — mostly core logic (handler + frontend page) with full test coverage for the API endpoint.

<details>
<summary>Key files (click to expand)</summary>

- [`web/src/components/geoloc-explorer-page.tsx`](https://github.com/malbeclabs/lake/pull/500/files#diff-9caa38e170dacfb6edaa5db1036df07a677a271358fc18e51dd03cfaa7de41a8) — New React page with interactive map showing geoprobe devices (green dots), measurement targets, and RTT data
- [`api/handlers/geoloc_explorer.go`](https://github.com/malbeclabs/lake/pull/500/files#diff-57b1c3bae4ccf462d783796780b481af784e88f2f4f13f98d27fd4d7d2e8ab23) — API handler with three ClickHouse queries: devices by sender, targets by sender+IP, and probe metadata enrichment
- [`web/src/lib/api.ts`](https://github.com/malbeclabs/lake/pull/500/files#diff-af490ef10b2e4da7f8055bd843c240828a9e8bcd6e6244b55888fe13f8ce8f7a) — API client types and fetch function for the explorer endpoint
- [`admin/remotetables/setup.go`](https://github.com/malbeclabs/lake/pull/500/files#diff-abea27beeb63c339ca583784b0e13eed99070b407e80b7a0bf8f9c15b3584668) — Register location_offsets proxy tables; make external proxy creation non-fatal

</details>

## Testing Verification
- Added `TestGetGeolocExplorer` covering empty response, aggregated device/target data with probe code enrichment, and custom hours parameter
- Verified probe code enrichment works correctly when probes lack metro coordinates (the enrichment map is built from all probes, not just those with valid lat/lng)