### PR TITLE
api: collapse feed dimension when reading publisher_shred_stats

### DIFF
--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -67,10 +67,11 @@ func createShredderTables(t *testing.T, api *handlers.API) {
 			needs_repair Bool,
 			first_seen_ns Int64,
 			last_seen_ns Int64,
-			is_scheduled_leader Bool
+			is_scheduled_leader Bool,
+			feed String
 		) ENGINE = MergeTree
 		PARTITION BY toYYYYMM(event_ts)
-		ORDER BY (slot, node_pubkey)
+		ORDER BY (slot, node_pubkey, feed)
 	`, publisherDB))
 	require.NoError(t, err)
 }
@@ -104,12 +105,12 @@ func insertEdgeScoreboardTestData(t *testing.T, api *handlers.API) {
 			(event_ts, host, publisher_ip, client_ip, node_pubkey, vote_pubkey,
 			 activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
-			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader, feed)
 		VALUES
 			(now(), 'host-1', '1.2.3.4', '1.2.3.4', 'test-pubkey', 'test-vote',
 			 1000000000, 'dz-user-1', 'slc-qa-bm1', 'slc',
 			 %d, %d, 100, 80, 60, 20,
-			 79, false, 0, 1000000, true)
+			 79, false, 0, 1000000, true, 'dz')
 	`, "`"+api.PublisherDB+"`", epoch, slot1))
 	require.NoError(t, err)
 

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -1633,9 +1633,31 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 
 	shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", a.PublisherDB)
 
+	// Collapse the feed dimension first: publisher_shred_stats now has one row
+	// per (host, slot, publisher, feed). Summing counters across feeds within a
+	// single (bucket, host, slot, publisher) reconstructs the per-host-per-slot
+	// totals that existed before the feed column was added, so the outer
+	// aggregations (sum, count, countIf) behave the same as pre-ALTER.
 	query := fmt.Sprintf(`
+		WITH per_host_slot AS (
+			SELECT
+				toStartOfInterval(event_ts, INTERVAL %s) AS bucket,
+				host,
+				dz_user_pubkey,
+				slot,
+				sum(unique_shreds) AS unique_shreds,
+				sum(total_packets) AS total_packets,
+				sum(data_shreds) AS data_shreds,
+				sum(coding_shreds) AS coding_shreds,
+				max(is_scheduled_leader) AS is_scheduled_leader,
+				max(needs_repair) AS needs_repair
+			FROM %s
+			WHERE event_ts >= now() - INTERVAL %s
+				AND dz_user_pubkey IN (?)
+			GROUP BY bucket, host, dz_user_pubkey, slot
+		)
 		SELECT
-			toStartOfInterval(event_ts, INTERVAL %s) AS bucket,
+			bucket,
 			dz_user_pubkey,
 			sum(unique_shreds) AS unique_shreds,
 			sum(total_packets) AS total_packets,
@@ -1644,9 +1666,7 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 			count() AS slots,
 			countIf(is_scheduled_leader = true) AS leader_slots,
 			countIf(needs_repair = true) AS repair_slots
-		FROM %s
-		WHERE event_ts >= now() - INTERVAL %s
-			AND dz_user_pubkey IN (?)
+		FROM per_host_slot
 		GROUP BY bucket, dz_user_pubkey
 		ORDER BY bucket, dz_user_pubkey
 	`, bucketInterval, shredStatsTable, rangeInterval)

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -1647,7 +1647,7 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 			countIf(is_scheduled_leader = true) AS leader_slots,
 			countIf(needs_repair = true) AS repair_slots
 		FROM %s
-		WHERE feed = 'dz'
+		WHERE feed IN ('', 'dz')
 			AND event_ts >= now() - INTERVAL %s
 			AND dz_user_pubkey IN (?)
 		GROUP BY bucket, dz_user_pubkey

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -1633,31 +1633,11 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 
 	shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", a.PublisherDB)
 
-	// Collapse the feed dimension first: publisher_shred_stats now has one row
-	// per (host, slot, publisher, feed). Summing counters across feeds within a
-	// single (bucket, host, slot, publisher) reconstructs the per-host-per-slot
-	// totals that existed before the feed column was added, so the outer
-	// aggregations (sum, count, countIf) behave the same as pre-ALTER.
+	// Only the dz source has `publisher_stats: true` in the shredder configs,
+	// so filtering to it preserves pre-per-feed-column numbers exactly.
 	query := fmt.Sprintf(`
-		WITH per_host_slot AS (
-			SELECT
-				toStartOfInterval(event_ts, INTERVAL %s) AS bucket,
-				host,
-				dz_user_pubkey,
-				slot,
-				sum(unique_shreds) AS unique_shreds,
-				sum(total_packets) AS total_packets,
-				sum(data_shreds) AS data_shreds,
-				sum(coding_shreds) AS coding_shreds,
-				max(is_scheduled_leader) AS is_scheduled_leader,
-				max(needs_repair) AS needs_repair
-			FROM %s
-			WHERE event_ts >= now() - INTERVAL %s
-				AND dz_user_pubkey IN (?)
-			GROUP BY bucket, host, dz_user_pubkey, slot
-		)
 		SELECT
-			bucket,
+			toStartOfInterval(event_ts, INTERVAL %s) AS bucket,
 			dz_user_pubkey,
 			sum(unique_shreds) AS unique_shreds,
 			sum(total_packets) AS total_packets,
@@ -1666,7 +1646,10 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 			count() AS slots,
 			countIf(is_scheduled_leader = true) AS leader_slots,
 			countIf(needs_repair = true) AS repair_slots
-		FROM per_host_slot
+		FROM %s
+		WHERE feed = 'dz'
+			AND event_ts >= now() - INTERVAL %s
+			AND dz_user_pubkey IN (?)
 		GROUP BY bucket, dz_user_pubkey
 		ORDER BY bucket, dz_user_pubkey
 	`, bucketInterval, shredStatsTable, rangeInterval)

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -179,6 +179,25 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		WITH current_epoch AS (
 			SELECT max(epoch) AS epoch FROM %s
 		),
+		-- Collapse the feed dimension first: a single shredder host now writes one row
+		-- per (host, slot, publisher, feed), so summing unique_shreds across feeds
+		-- reconstructs the per-host total that existed before the feed column was added.
+		per_host_slot AS (
+			SELECT
+				host,
+				dz_user_pubkey,
+				slot,
+				max(activated_stake) AS activated_stake,
+				max(is_scheduled_leader) AS is_scheduled_leader,
+				sum(unique_shreds) AS unique_shreds,
+				max(needs_repair) AS needs_repair
+			FROM %s
+			%s
+			GROUP BY host, dz_user_pubkey, slot
+		),
+		-- Then collapse across shredder hosts the same way as before: a publisher
+		-- observed by multiple shredders should count as the best-observing host's
+		-- view, not inflate by host count.
 		per_slot AS (
 			SELECT
 				dz_user_pubkey,
@@ -187,8 +206,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 				max(is_scheduled_leader) AS is_scheduled_leader,
 				max(unique_shreds) AS unique_shreds,
 				max(needs_repair) AS needs_repair
-			FROM %s
-			%s
+			FROM per_host_slot
 			GROUP BY dz_user_pubkey, slot
 		),
 		stats AS (

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -164,14 +164,19 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 
 	shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", a.PublisherDB)
 
+	// Only the dz source has `publisher_stats: true` in the shredder configs,
+	// so filtering to it preserves pre-per-feed-column numbers exactly.
+	const leaderFeed = "dz"
+
 	var perSlotWhere string
 	var args []any
 	if slotsParam > 0 {
-		perSlotWhere = `WHERE epoch >= (SELECT epoch FROM current_epoch) - 1
-			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
+		perSlotWhere = `WHERE feed = '` + leaderFeed + `'
+			AND epoch >= (SELECT epoch FROM current_epoch) - 1
+			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE feed = '` + leaderFeed + `' AND epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
 		args = []any{slotsParam, shredGroupPK}
 	} else {
-		perSlotWhere = `WHERE epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
+		perSlotWhere = `WHERE feed = '` + leaderFeed + `' AND epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
 		args = []any{epochsParam, shredGroupPK}
 	}
 
@@ -179,25 +184,6 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		WITH current_epoch AS (
 			SELECT max(epoch) AS epoch FROM %s
 		),
-		-- Collapse the feed dimension first: a single shredder host now writes one row
-		-- per (host, slot, publisher, feed), so summing unique_shreds across feeds
-		-- reconstructs the per-host total that existed before the feed column was added.
-		per_host_slot AS (
-			SELECT
-				host,
-				dz_user_pubkey,
-				slot,
-				max(activated_stake) AS activated_stake,
-				max(is_scheduled_leader) AS is_scheduled_leader,
-				sum(unique_shreds) AS unique_shreds,
-				max(needs_repair) AS needs_repair
-			FROM %s
-			%s
-			GROUP BY host, dz_user_pubkey, slot
-		),
-		-- Then collapse across shredder hosts the same way as before: a publisher
-		-- observed by multiple shredders should count as the best-observing host's
-		-- view, not inflate by host count.
 		per_slot AS (
 			SELECT
 				dz_user_pubkey,
@@ -206,7 +192,8 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 				max(is_scheduled_leader) AS is_scheduled_leader,
 				max(unique_shreds) AS unique_shreds,
 				max(needs_repair) AS needs_repair
-			FROM per_host_slot
+			FROM %s
+			%s
 			GROUP BY dz_user_pubkey, slot
 		),
 		stats AS (

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -165,18 +165,20 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 	shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", a.PublisherDB)
 
 	// Only the dz source has `publisher_stats: true` in the shredder configs,
-	// so filtering to it preserves pre-per-feed-column numbers exactly.
-	const leaderFeed = "dz"
+	// so filtering to it preserves pre-per-feed-column numbers exactly. Pre-migration
+	// rows have feed='' (the ALTER added the column without a default), so include
+	// both to keep history continuous across the cutover.
+	const leaderFeedFilter = "feed IN ('', 'dz')"
 
 	var perSlotWhere string
 	var args []any
 	if slotsParam > 0 {
-		perSlotWhere = `WHERE feed = '` + leaderFeed + `'
+		perSlotWhere = `WHERE ` + leaderFeedFilter + `
 			AND epoch >= (SELECT epoch FROM current_epoch) - 1
-			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE feed = '` + leaderFeed + `' AND epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
+			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
 		args = []any{slotsParam, shredGroupPK}
 	} else {
-		perSlotWhere = `WHERE feed = '` + leaderFeed + `' AND epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
+		perSlotWhere = `WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
 		args = []any{epochsParam, shredGroupPK}
 	}
 

--- a/api/handlers/publisher_check_test.go
+++ b/api/handlers/publisher_check_test.go
@@ -44,10 +44,11 @@ func createPublisherShredStatsTable(t *testing.T, api *handlers.API) {
 			needs_repair Bool,
 			first_seen_ns Int64,
 			last_seen_ns Int64,
-			is_scheduled_leader Bool
+			is_scheduled_leader Bool,
+			feed String
 		) ENGINE = ReplacingMergeTree(ingested_at)
 		PARTITION BY toYYYYMM(event_ts)
-		ORDER BY (host, slot, publisher_ip)
+		ORDER BY (host, slot, publisher_ip, feed)
 	`, "`"+api.ShredderDB+"`"))
 	require.NoError(t, err)
 }
@@ -169,17 +170,17 @@ func insertPublisherCheckTestData(t *testing.T, api *handlers.API) {
 			(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
 			 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
-			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader, feed)
 		VALUES
 			(now(), now(), 'shredder-1', '10.0.0.1', '203.0.113.1', 'nodepub1',
 			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
-			 800, 1001, 100, 64, 32, 32, 31, false, 0, 0, true),
+			 800, 1001, 100, 64, 32, 32, 31, false, 0, 0, true, 'dz'),
 			(now(), now(), 'shredder-1', '10.0.0.1', '203.0.113.1', 'nodepub1',
 			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
-			 800, 1002, 100, 64, 32, 32, 31, true, 0, 0, false),
+			 800, 1002, 100, 64, 32, 32, 31, true, 0, 0, false, 'dz'),
 			(now(), now(), 'shredder-1', '10.0.0.2', '203.0.113.2', 'nodepub2',
 			 'votepub2', 10000000000, 'dzuser2', 'nyc1', 'NYC',
-			 800, 1001, 50, 32, 16, 16, 15, false, 0, 0, false)
+			 800, 1001, 50, 32, 16, 16, 15, false, 0, 0, false, 'dz')
 	`)
 	require.NoError(t, err)
 }
@@ -196,7 +197,7 @@ func insertBulkShredStats(t *testing.T, api *handlers.API, dzUserPubkey string, 
 		(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
 		 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 		 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
-		 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+		 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader, feed)
 		VALUES `, table))
 
 	slot := startSlot
@@ -207,7 +208,7 @@ func insertBulkShredStats(t *testing.T, api *handlers.API, dzUserPubkey string, 
 		}
 		first = false
 		sb.WriteString(fmt.Sprintf(
-			"(now(), now(), 'shredder-1', '%s', '', '', '', 0, '%s', '', '', %d, %d, 100, 64, 32, 32, 31, false, 0, 0, %t)",
+			"(now(), now(), 'shredder-1', '%s', '', '', '', 0, '%s', '', '', %d, %d, 100, 64, 32, 32, 31, false, 0, 0, %t, 'dz')",
 			publisherIP, dzUserPubkey, epoch, slot, isLeader))
 		slot++
 	}
@@ -396,17 +397,17 @@ func TestGetPublisherCheck_MultiHost(t *testing.T) {
 			(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
 			 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
-			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader, feed)
 		VALUES
 			(now(), now(), 'shredder-2', '10.0.0.1', '203.0.113.1', 'nodepub1',
 			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
-			 800, 1001, 100, 64, 32, 32, 31, false, 0, 0, true),
+			 800, 1001, 100, 64, 32, 32, 31, false, 0, 0, true, 'dz'),
 			(now(), now(), 'shredder-2', '10.0.0.1', '203.0.113.1', 'nodepub1',
 			 'votepub1', 50000000000, 'dzuser1', 'ams1', 'AMS',
-			 800, 1002, 100, 64, 32, 32, 31, true, 0, 0, false),
+			 800, 1002, 100, 64, 32, 32, 31, true, 0, 0, false, 'dz'),
 			(now(), now(), 'shredder-2', '10.0.0.2', '203.0.113.2', 'nodepub2',
 			 'votepub2', 10000000000, 'dzuser2', 'nyc1', 'NYC',
-			 800, 1001, 50, 32, 16, 16, 15, false, 0, 0, false)
+			 800, 1001, 50, 32, 16, 16, 15, false, 0, 0, false, 'dz')
 	`)
 	require.NoError(t, err)
 
@@ -458,11 +459,11 @@ func TestGetPublisherCheck_SlotsParam(t *testing.T) {
 			(event_ts, ingested_at, host, publisher_ip, client_ip, node_pubkey,
 			 vote_pubkey, activated_stake, dz_user_pubkey, dz_device_code, dz_metro_code,
 			 epoch, slot, total_packets, unique_shreds, data_shreds, coding_shreds,
-			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader)
+			 max_data_index, needs_repair, first_seen_ns, last_seen_ns, is_scheduled_leader, feed)
 		VALUES
 			(now(), now(), 'shredder-1', '10.0.0.2', '203.0.113.2', 'nodepub2',
 			 'votepub2', 10000000000, 'dzuser2', 'nyc1', 'NYC',
-			 799, 1, 50, 32, 16, 16, 15, false, 0, 0, true)
+			 799, 1, 50, 32, 16, 16, 15, false, 0, 0, true, 'dz')
 	`)
 	require.NoError(t, err)
 

--- a/scripts/seed-publisher-shred-stats.sql
+++ b/scripts/seed-publisher-shred-stats.sql
@@ -24,10 +24,11 @@ CREATE TABLE IF NOT EXISTS publisher_shred_stats (
     needs_repair Bool,
     first_seen_ns Int64,
     last_seen_ns Int64,
-    is_scheduled_leader Bool
+    is_scheduled_leader Bool,
+    feed String
 ) ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(event_ts)
-ORDER BY (host, slot, publisher_ip);
+ORDER BY (host, slot, publisher_ip, feed);
 
 -- Sample publishers: mix of healthy and unhealthy configurations.
 -- Epoch 800, ~10 publishers with varying states:


### PR DESCRIPTION
Refs: #484
Resolves: https://github.com/malbeclabs/lake/issues/487

## Summary
- Step 2 of #484. Makes lake reads forward-compatible with the shredder-side schema change (malbeclabs/shredder#79, merged), which adds a `feed` column to `publisher_shred_stats` and extends the table's ORDER BY to include it.
- Without this PR, deploying the shredder ALTER to prod would regress two pages:
  - Publisher check page (`/dz/shreds/publishers`): `total_unique_shreds` drops because `max(unique_shreds)` picks the single biggest `(host, feed)` contribution instead of the per-host sum across feeds.
  - Multicast group shred stats (`/dz/multicast-groups/{pk}/shred-stats`): `sum`/`count`/`countIf` all inflate by feed count because each feed becomes its own row per `(host, slot, publisher)`.
- Both handlers now wrap their aggregation in a `per_host_slot` CTE that sums counters across feeds per `(host, slot, publisher)` first, so the outer aggregations behave identically to pre-ALTER.
- Queries are backward-compatible with pre-ALTER data: a single-row sum equals that row's value, so this PR can merge and deploy before the shredder ALTER rolls to prod with no transitional state.
- Edge scoreboard reads are unchanged — all its queries already use `SELECT DISTINCT` on slot or pubkey, so feed duplicates collapse automatically.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +44 | -6 |
| SDKs | 0 | 0 |
| Tests | +23 | -20 |

## Testing Verification
- Existing publisher check test suite (including `TestGetPublisherCheck_MultiHost` which asserts per-host-per-slot dedup) passes unchanged — the new `per_host_slot` CTE preserves the exact output numbers the tests expect.
- Test fixtures + seed SQL updated to include `feed String` with extended ORDER BY, matching the shredder-migrated schema in `shredder_qa`.