### PR TITLE
web: stabilize shreds economics shimmer loader

### DIFF
--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -33,28 +33,51 @@ import { SmallDropdown } from "./topology/TimeRangeSelector";
 
 // Helpers
 
-function useMinVisibleDuration(active: boolean, minMs = 500): boolean {
-  const [visible, setVisible] = useState(active);
+function useDebouncedShimmer(
+  active: boolean,
+  delayMs = 250,
+  minMs = 500,
+): boolean {
+  const [visible, setVisible] = useState(false);
   const shownAt = useRef<number>(0);
+  const showTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
     if (active) {
       clearTimeout(hideTimer.current);
-      if (shownAt.current === 0) shownAt.current = Date.now();
-      if (!visible) setVisible(true);
-    } else if (visible) {
-      const remaining = minMs - (Date.now() - shownAt.current);
-      const finish = () => {
-        shownAt.current = 0;
-        setVisible(false);
-      };
-      if (remaining <= 0) finish();
-      else hideTimer.current = setTimeout(finish, remaining);
+      if (!visible && !showTimer.current) {
+        showTimer.current = setTimeout(() => {
+          showTimer.current = undefined;
+          shownAt.current = Date.now();
+          setVisible(true);
+        }, delayMs);
+      }
+    } else {
+      if (showTimer.current) {
+        clearTimeout(showTimer.current);
+        showTimer.current = undefined;
+      }
+      if (visible) {
+        const remaining = minMs - (Date.now() - shownAt.current);
+        const finish = () => {
+          shownAt.current = 0;
+          setVisible(false);
+        };
+        if (remaining <= 0) finish();
+        else hideTimer.current = setTimeout(finish, remaining);
+      }
     }
-  }, [active, visible, minMs]);
+  }, [active, visible, delayMs, minMs]);
 
-  useEffect(() => () => clearTimeout(hideTimer.current), []);
+  useEffect(
+    () => () => {
+      clearTimeout(showTimer.current);
+      clearTimeout(hideTimer.current);
+    },
+    [],
+  );
+
   return visible;
 }
 
@@ -462,7 +485,7 @@ export function ShredsEconomicsPage() {
   const [revenueRange, setRevenueRange] = useState<1 | 5 | 10 | "all">("all");
 
   const refresh = useRefreshButton(refetch, rawFetching);
-  const shimmerVisible = useMinVisibleDuration(rawFetching, 800);
+  const shimmerVisible = useDebouncedShimmer(rawFetching, 250, 800);
 
   const seats = seatsData?.items ?? [];
   const econ = useMemo(

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -33,6 +33,29 @@ import { SmallDropdown } from "./topology/TimeRangeSelector";
 
 // Helpers
 
+function useMinVisibleDuration(active: boolean, minMs = 500): boolean {
+  const [visible, setVisible] = useState(active);
+  const shownAt = useRef<number>(active ? Date.now() : 0);
+  const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    if (active) {
+      clearTimeout(hideTimer.current);
+      if (!visible) {
+        shownAt.current = Date.now();
+        setVisible(true);
+      }
+    } else if (visible) {
+      const remaining = minMs - (Date.now() - shownAt.current);
+      if (remaining <= 0) setVisible(false);
+      else hideTimer.current = setTimeout(() => setVisible(false), remaining);
+    }
+  }, [active, visible, minMs]);
+
+  useEffect(() => () => clearTimeout(hideTimer.current), []);
+  return visible;
+}
+
 function useRefreshButton(
   refetch: () => void,
   isFetching: boolean,
@@ -437,6 +460,7 @@ export function ShredsEconomicsPage() {
   const [revenueRange, setRevenueRange] = useState<1 | 5 | 10 | "all">("all");
 
   const refresh = useRefreshButton(refetch, rawFetching);
+  const shimmerVisible = useMinVisibleDuration(rawFetching, 800);
 
   const seats = seatsData?.items ?? [];
   const econ = useMemo(
@@ -489,11 +513,11 @@ export function ShredsEconomicsPage() {
           }
         />
 
-        {rawFetching && (
-          <div className="h-0.5 w-full overflow-hidden rounded-full mb-6">
-            <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
-          </div>
-        )}
+        <div className="h-0.5 w-full overflow-hidden rounded-full mb-6">
+          {shimmerVisible && (
+            <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_0.9s_ease-in-out_infinite] rounded-full" />
+          )}
+        </div>
 
         <div className="space-y-8">
           {/* Revenue Overview */}
@@ -1415,9 +1439,9 @@ export function ShredsEconomicsPage() {
           <section>
             <SectionTitle>Metro Breakdown</SectionTitle>
             <div className="relative border border-border rounded-lg overflow-hidden bg-card">
-              {rawFetching && seatsData && (
+              {shimmerVisible && seatsData && (
                 <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden z-10">
-                  <div className="h-full w-1/3 bg-primary/60 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
+                  <div className="h-full w-1/3 bg-primary/60 animate-[shimmer_0.9s_ease-in-out_infinite] rounded-full" />
                 </div>
               )}
               <div className="overflow-x-auto">
@@ -1625,9 +1649,9 @@ export function ShredsEconomicsPage() {
               )}
             </div>
             <div className="relative border border-border rounded-lg overflow-hidden bg-card">
-              {rawFetching && seatsData && (
+              {shimmerVisible && seatsData && (
                 <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden z-10">
-                  <div className="h-full w-1/3 bg-primary/60 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
+                  <div className="h-full w-1/3 bg-primary/60 animate-[shimmer_0.9s_ease-in-out_infinite] rounded-full" />
                 </div>
               )}
               <div className="overflow-x-auto">

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -35,20 +35,22 @@ import { SmallDropdown } from "./topology/TimeRangeSelector";
 
 function useMinVisibleDuration(active: boolean, minMs = 500): boolean {
   const [visible, setVisible] = useState(active);
-  const shownAt = useRef<number>(active ? Date.now() : 0);
+  const shownAt = useRef<number>(0);
   const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
     if (active) {
       clearTimeout(hideTimer.current);
-      if (!visible) {
-        shownAt.current = Date.now();
-        setVisible(true);
-      }
+      if (shownAt.current === 0) shownAt.current = Date.now();
+      if (!visible) setVisible(true);
     } else if (visible) {
       const remaining = minMs - (Date.now() - shownAt.current);
-      if (remaining <= 0) setVisible(false);
-      else hideTimer.current = setTimeout(() => setVisible(false), remaining);
+      const finish = () => {
+        shownAt.current = 0;
+        setVisible(false);
+      };
+      if (remaining <= 0) finish();
+      else hideTimer.current = setTimeout(finish, remaining);
     }
   }, [active, visible, minMs]);
 


### PR DESCRIPTION
## Summary

- Reserve the top shimmer bar's vertical space so it no longer pushes content down when toggling
- Enforce a minimum visible duration (800ms) so fast refetches don't produce a sub-frame flash
- Speed the shimmer animation to 0.9s so at least ~90% of one pass is visible whenever it appears

Applies to all three shimmer bars on the Shreds Economics page (header, Metro Breakdown, Top Funders).