### PR TITLE
api, web: load device validator stats async

### DIFF
--- a/api/handlers/device_metrics.go
+++ b/api/handlers/device_metrics.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/go-chi/chi/v5"
 	"github.com/malbeclabs/lake/api/health"
 	"golang.org/x/sync/errgroup"
@@ -207,6 +209,19 @@ func (a *API) GetDeviceMetrics(w http.ResponseWriter, r *http.Request) {
 		params.UseRaw = isRawBucket(interval)
 	}
 
+	// For default 24h requests, serve device-level status+traffic from the
+	// bulk device metrics cache. The cache already contains the heavy
+	// device-grouped rollup scan for every device, so we only need to run
+	// the per-interface rollup and status-change queries on cache hit.
+	if singleDeviceMetricsCanUseBulkCache(r) && isMainnet(r.Context()) {
+		if resp, err := a.fetchDeviceMetricsFromBulkCache(ctx, devicePK, params, include); err == nil && resp != nil {
+			w.Header().Set("X-Cache", "HIT")
+			writeJSON(w, resp)
+			return
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
 	resp, err := a.fetchDeviceMetrics(ctx, devicePK, params, include)
 	if err != nil {
 		slog.Error("error fetching device metrics", "error", err, "device_pk", devicePK)
@@ -219,6 +234,227 @@ func (a *API) GetDeviceMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, resp)
+}
+
+// singleDeviceMetricsCanUseBulkCache reports whether a single-device metrics
+// request can be served from the bulk_device_metrics cache. Matches the set of
+// requests covered by bulkDeviceMetricsCacheKey (default 24h window, no custom
+// bucket, includes limited to status/traffic/status_changes).
+func singleDeviceMetricsCanUseBulkCache(r *http.Request) bool {
+	q := r.URL.Query()
+	inc := q.Get("include")
+	rng := q.Get("range")
+	incOK := inc == "" || inc == "all" || inc == "status,traffic" || inc == "status"
+	if !incOK || (rng != "" && rng != "24h") || q.Get("start_time") != "" || q.Get("end_time") != "" || q.Get("bucket") != "" {
+		return false
+	}
+	return true
+}
+
+// fetchDeviceMetricsFromBulkCache assembles a single-device response using
+// the cached bulk payload for status+traffic buckets, running only the
+// per-interface rollup and status-change queries as needed.
+func (a *API) fetchDeviceMetricsFromBulkCache(ctx context.Context, devicePK string, params bucketParams, include deviceMetricsInclude) (*DeviceMetricsResponse, error) {
+	data, err := a.readPageCache(ctx, "bulk_device_metrics")
+	if err != nil {
+		return nil, err
+	}
+	var bulk BulkDeviceMetricsResponse
+	if err := json.Unmarshal(data, &bulk); err != nil {
+		return nil, err
+	}
+	cached := bulk.Devices[devicePK]
+	if cached == nil {
+		return nil, nil
+	}
+
+	db := a.envDB(ctx)
+
+	// Align the per-interface query's time window to the cached bucket
+	// timestamps so bucket boundaries match even when the cache is a few
+	// seconds stale (e.g. across an hour boundary).
+	cacheAlignedParams := alignParamsToCachedBuckets(params, cached)
+
+	var (
+		perIntfRows   []interfaceRollupRow
+		statusChanges []EntityStatusChange
+	)
+	g, gctx := errgroup.WithContext(ctx)
+
+	if include.Traffic {
+		g.Go(func() error {
+			rows, err := queryInterfaceRollup(gctx, db, cacheAlignedParams, interfaceRollupOpts{
+				GroupBy:   groupByDeviceIntf,
+				DevicePKs: []string{devicePK},
+			})
+			if err != nil {
+				return fmt.Errorf("device per-interface rollup: %w", err)
+			}
+			perIntfRows = rows
+			return nil
+		})
+	}
+
+	if include.StatusChanges {
+		g.Go(func() error {
+			startTS, endTS := statusChangeTimeRange(cacheAlignedParams)
+			if endTS != "" {
+				statusChanges = fetchDeviceStatusChanges(gctx, db, devicePK, startTS, &endTS)
+			} else {
+				statusChanges = fetchDeviceStatusChanges(gctx, db, devicePK, startTS, nil)
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	linkCodes := resolveLinkCodes(ctx, db, perIntfRows)
+	cyoaTypes := resolveDeviceInterfaceCYOATypes(ctx, db, devicePK)
+
+	perIntfIndex := make(map[time.Time][]interfaceRollupRow)
+	for _, r := range perIntfRows {
+		perIntfIndex[r.BucketTS] = append(perIntfIndex[r.BucketTS], r)
+	}
+
+	buckets := make([]DeviceMetricsBucket, len(cached.Buckets))
+	for i, b := range cached.Buckets {
+		buckets[i] = b
+		if !include.Traffic {
+			buckets[i].Traffic = nil
+		}
+		if !include.Status {
+			buckets[i].Status = nil
+		}
+		if include.Traffic {
+			bucketStart, err := time.Parse(time.RFC3339, b.TS)
+			if err != nil {
+				continue
+			}
+			if rows := perIntfIndex[bucketStart]; len(rows) > 0 {
+				buckets[i].Interfaces = buildInterfaceTraffic(rows, linkCodes, cyoaTypes)
+			}
+		}
+	}
+
+	resp := *cached
+	resp.Buckets = buckets
+	if include.StatusChanges {
+		resp.StatusChanges = statusChanges
+	} else {
+		resp.StatusChanges = nil
+	}
+	return &resp, nil
+}
+
+func alignParamsToCachedBuckets(params bucketParams, cached *DeviceMetricsResponse) bucketParams {
+	if cached == nil || len(cached.Buckets) == 0 {
+		return params
+	}
+	aligned := params
+	if start, err := time.Parse(time.RFC3339, cached.Buckets[0].TS); err == nil {
+		aligned.StartTime = &start
+	}
+	if last, err := time.Parse(time.RFC3339, cached.Buckets[len(cached.Buckets)-1].TS); err == nil {
+		end := last.Add(time.Duration(cached.BucketSeconds) * time.Second)
+		aligned.EndTime = &end
+	}
+	return aligned
+}
+
+func statusChangeTimeRange(params bucketParams) (startTS, endTS string) {
+	if params.StartTime != nil {
+		startTS = params.StartTime.Format(time.RFC3339)
+	} else {
+		startTS = time.Now().UTC().Add(-time.Duration(params.TotalMinutes) * time.Minute).Format(time.RFC3339)
+	}
+	if params.EndTime != nil {
+		endTS = params.EndTime.Format(time.RFC3339)
+	}
+	return
+}
+
+func resolveLinkCodes(ctx context.Context, db driver.Conn, rows []interfaceRollupRow) map[string]string {
+	linkCodes := make(map[string]string)
+	if len(rows) == 0 {
+		return linkCodes
+	}
+	linkPKSet := make(map[string]struct{})
+	for _, r := range rows {
+		if r.LinkPK != "" {
+			linkPKSet[r.LinkPK] = struct{}{}
+		}
+	}
+	if len(linkPKSet) == 0 {
+		return linkCodes
+	}
+	pks := make([]string, 0, len(linkPKSet))
+	for pk := range linkPKSet {
+		pks = append(pks, pk)
+	}
+	result, err := db.Query(ctx, "SELECT pk, code FROM dz_links_current WHERE pk IN ($1)", pks)
+	if err != nil {
+		return linkCodes
+	}
+	defer result.Close()
+	for result.Next() {
+		var pk, code string
+		if err := result.Scan(&pk, &code); err == nil {
+			linkCodes[pk] = code
+		}
+	}
+	return linkCodes
+}
+
+func resolveDeviceInterfaceCYOATypes(ctx context.Context, db driver.Conn, devicePK string) map[string]string {
+	cyoaTypes := make(map[string]string)
+	rows, err := db.Query(ctx, "SELECT intf, cyoa_type FROM dz_device_interfaces_current WHERE device_pk = $1 AND cyoa_type != 'none'", devicePK)
+	if err != nil {
+		return cyoaTypes
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var intf, cyoaType string
+		if err := rows.Scan(&intf, &cyoaType); err == nil {
+			cyoaTypes[intf] = cyoaType
+		}
+	}
+	return cyoaTypes
+}
+
+func buildInterfaceTraffic(rows []interfaceRollupRow, linkCodes, cyoaTypes map[string]string) []DeviceInterfaceTraffic {
+	intfs := make([]DeviceInterfaceTraffic, 0, len(rows))
+	for _, ir := range rows {
+		intfs = append(intfs, DeviceInterfaceTraffic{
+			Intf:               ir.Intf,
+			LinkPK:             ir.LinkPK,
+			LinkCode:           linkCodes[ir.LinkPK],
+			LinkSide:           ir.LinkSide,
+			UserPK:             ir.UserPK,
+			CYOAType:           cyoaTypes[ir.Intf],
+			InBps:              ir.AvgInBps,
+			P50InBps:           ir.P50InBps,
+			P90InBps:           ir.P90InBps,
+			P95InBps:           ir.P95InBps,
+			P99InBps:           ir.P99InBps,
+			MaxInBps:           ir.MaxInBps,
+			OutBps:             ir.AvgOutBps,
+			P50OutBps:          ir.P50OutBps,
+			P90OutBps:          ir.P90OutBps,
+			P95OutBps:          ir.P95OutBps,
+			P99OutBps:          ir.P99OutBps,
+			MaxOutBps:          ir.MaxOutBps,
+			InErrors:           ir.InErrors,
+			OutErrors:          ir.OutErrors,
+			InFcsErrors:        ir.InFcsErrors,
+			InDiscards:         ir.InDiscards,
+			OutDiscards:        ir.OutDiscards,
+			CarrierTransitions: ir.CarrierTransitions,
+		})
+	}
+	return intfs
 }
 
 // fetchDeviceMetrics runs parallel queries and assembles the unified response.

--- a/api/handlers/devices.go
+++ b/api/handlers/devices.go
@@ -312,10 +312,13 @@ type DeviceDetail struct {
 	OutBps                    float64                 `json:"out_bps"`
 	PeakInBps                 float64                 `json:"peak_in_bps"`
 	PeakOutBps                float64                 `json:"peak_out_bps"`
-	ValidatorCount            uint64                  `json:"validator_count"`
-	StakeSol                  float64                 `json:"stake_sol"`
-	StakeShare                float64                 `json:"stake_share"`
 	Interfaces                []DeviceDetailInterface `json:"interfaces"`
+}
+
+type DeviceValidatorStats struct {
+	ValidatorCount uint64  `json:"validator_count"`
+	StakeSol       float64 `json:"stake_sol"`
+	StakeShare     float64 `json:"stake_share"`
 }
 
 func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
@@ -365,23 +368,6 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 				AND link_pk = ''
 				AND device_pk = ?
 			GROUP BY device_pk
-		),
-		validator_stats AS (
-			SELECT
-				u.device_pk,
-				count(DISTINCT v.vote_pubkey) as validator_count,
-				sum(v.activated_stake_lamports) / 1e9 as stake_sol
-			FROM dz_users_current u
-			JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip
-			JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey
-			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true'
-				AND u.device_pk = ?
-			GROUP BY u.device_pk
-		),
-		total_stake AS (
-			SELECT COALESCE(SUM(activated_stake_lamports), 0) as total_lamports
-			FROM solana_vote_accounts_current
-			WHERE epoch_vote_account = 'true' AND activated_stake_lamports > 0
 		)
 		SELECT
 			d.pk,
@@ -409,28 +395,20 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 			COALESCE(tr.out_bps, 0) as out_bps,
 			COALESCE(pr.peak_in_bps, 0) as peak_in_bps,
 			COALESCE(pr.peak_out_bps, 0) as peak_out_bps,
-			COALESCE(vs.validator_count, 0) as validator_count,
-			COALESCE(vs.stake_sol, 0) as stake_sol,
-			CASE
-				WHEN ts.total_lamports > 0 THEN COALESCE(vs.stake_sol, 0) * 1e9 / ts.total_lamports * 100
-				ELSE 0
-			END as stake_share,
 			COALESCE(d.interfaces, '[]') as interfaces
 		FROM dz_devices_current d
-		CROSS JOIN total_stake ts
 		LEFT JOIN dz_contributors_current c ON d.contributor_pk = c.pk
 		LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
 		LEFT JOIN unicast_counts ucu ON d.pk = ucu.device_pk
 		LEFT JOIN multicast_counts ucm ON d.pk = ucm.device_pk
 		LEFT JOIN traffic_rates tr ON d.pk = tr.device_pk
 		LEFT JOIN peak_rates pr ON d.pk = pr.device_pk
-		LEFT JOIN validator_stats vs ON d.pk = vs.device_pk
 		WHERE d.pk = ?
 	`
 
 	var device DeviceDetail
 	var interfacesJSON string
-	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk, pk).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk).Scan(
 		&device.PK,
 		&device.Code,
 		&device.Status,
@@ -456,9 +434,6 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 		&device.OutBps,
 		&device.PeakInBps,
 		&device.PeakOutBps,
-		&device.ValidatorCount,
-		&device.StakeSol,
-		&device.StakeShare,
 		&interfacesJSON,
 	)
 	duration := time.Since(start)
@@ -530,6 +505,64 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(device); err != nil {
+		logError("failed to encode response", "error", err)
+	}
+}
+
+func (a *API) GetDeviceValidatorStats(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	pk := chi.URLParam(r, "pk")
+	if pk == "" {
+		http.Error(w, "missing device pk", http.StatusBadRequest)
+		return
+	}
+
+	start := time.Now()
+	query := `
+		WITH validator_stats AS (
+			SELECT
+				count(DISTINCT v.vote_pubkey) as validator_count,
+				sum(v.activated_stake_lamports) / 1e9 as stake_sol
+			FROM dz_users_current u
+			JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip
+			JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey
+			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true'
+				AND u.device_pk = ?
+		),
+		total_stake AS (
+			SELECT COALESCE(SUM(activated_stake_lamports), 0) as total_lamports
+			FROM solana_vote_accounts_current
+			WHERE epoch_vote_account = 'true' AND activated_stake_lamports > 0
+		)
+		SELECT
+			COALESCE(vs.validator_count, 0) as validator_count,
+			COALESCE(vs.stake_sol, 0) as stake_sol,
+			CASE
+				WHEN ts.total_lamports > 0 THEN COALESCE(vs.stake_sol, 0) * 1e9 / ts.total_lamports * 100
+				ELSE 0
+			END as stake_share
+		FROM validator_stats vs
+		CROSS JOIN total_stake ts
+	`
+
+	var stats DeviceValidatorStats
+	err := a.envDB(ctx).QueryRow(ctx, query, pk).Scan(
+		&stats.ValidatorCount,
+		&stats.StakeSol,
+		&stats.StakeShare,
+	)
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		logError("device validator stats query failed", "error", err, "pk", pk)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stats); err != nil {
 		logError("failed to encode response", "error", err)
 	}
 }

--- a/api/main.go
+++ b/api/main.go
@@ -533,6 +533,7 @@ func main() {
 		// DZ entity routes
 		r.Get("/api/dz/devices", api.GetDevices)
 		r.Get("/api/dz/devices/{pk}", api.GetDevice)
+		r.Get("/api/dz/devices/{pk}/validator-stats", api.GetDeviceValidatorStats)
 		r.Get("/api/dz/links", api.GetLinks)
 		r.Get("/api/dz/links/{pk}", api.GetLink)
 		r.Get("/api/dz/links-health", api.GetLinkHealth)

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Loader2, RefreshCw, Server, AlertCircle, ArrowLeft } from 'lucide-react'
 import { CopyableText } from '@/components/copyable-text'
-import { fetchDevice, fetchDeviceMetrics } from '@/lib/api'
+import { fetchDevice, fetchDeviceMetrics, fetchDeviceValidatorStats } from '@/lib/api'
 import { DeviceInfoContent } from '@/components/shared/DeviceInfoContent'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
@@ -52,6 +52,12 @@ export function DeviceDetailPage() {
     enabled: !!pk,
   })
 
+  const { data: validatorStats } = useQuery({
+    queryKey: ['deviceValidatorStats', pk],
+    queryFn: () => fetchDeviceValidatorStats(pk!),
+    enabled: !!pk,
+  })
+
   const metricsParams = useMemo(() => toDeviceMetricsParams(timeRange), [timeRange])
 
   const {
@@ -91,7 +97,7 @@ export function DeviceDetailPage() {
     )
   }
 
-  const deviceInfo = deviceDetailToInfo(device)
+  const deviceInfo = deviceDetailToInfo(device, undefined, validatorStats)
 
   return (
     <div className="flex-1 overflow-auto">

--- a/web/src/components/shared/DeviceInfoContent.tsx
+++ b/web/src/components/shared/DeviceInfoContent.tsx
@@ -29,9 +29,9 @@ export interface DeviceInfoData {
   maxUnicastUsers: number
   maxMulticastSubscribers: number
   maxMulticastPublishers: number
-  validatorCount: number
-  stakeSol: number
-  stakeShare: number
+  validatorCount: number | null
+  stakeSol: number | null
+  stakeShare: number | null
   interfaces: DeviceInterface[]
 }
 
@@ -118,6 +118,10 @@ function formatStakeShare(share: number): string {
   return `${share.toFixed(2)}%`
 }
 
+function InlineSkeleton() {
+  return <span className="inline-block align-middle h-4 w-12 rounded bg-muted animate-pulse" />
+}
+
 /**
  * Shared component for displaying device information.
  * Used by both the topology panel and the device detail page.
@@ -191,9 +195,9 @@ export function DeviceInfoContent({
         }
       </span>
     ) }] : []),
-    { label: 'Validators', value: String(device.validatorCount) },
-    { label: 'Stake', value: formatStake(device.stakeSol) },
-    { label: 'Stake Share', value: formatStakeShare(device.stakeShare) },
+    { label: 'Validators', value: device.validatorCount === null ? <InlineSkeleton /> : String(device.validatorCount) },
+    { label: 'Stake', value: device.stakeSol === null ? <InlineSkeleton /> : formatStake(device.stakeSol) },
+    { label: 'Stake Share', value: device.stakeShare === null ? <InlineSkeleton /> : formatStakeShare(device.stakeShare) },
   ]
 
   const deviceAvailable = device.maxUsers > 0 ? Math.max(0, device.maxUsers - device.userCount) : 0

--- a/web/src/components/shared/device-info-converters.ts
+++ b/web/src/components/shared/device-info-converters.ts
@@ -1,10 +1,15 @@
-import type { DeviceDetail, TopologyDevice } from '@/lib/api'
+import type { DeviceDetail, DeviceValidatorStats, TopologyDevice } from '@/lib/api'
 import type { DeviceInfoData } from './DeviceInfoContent'
 
 /**
- * Convert DeviceDetail (from /api/dz/devices/:pk) to shared DeviceInfoData
+ * Convert DeviceDetail (from /api/dz/devices/:pk) to shared DeviceInfoData.
+ * Validator stats are fetched separately and passed in when available.
  */
-export function deviceDetailToInfo(device: DeviceDetail, metroName?: string): DeviceInfoData {
+export function deviceDetailToInfo(
+  device: DeviceDetail,
+  metroName?: string,
+  validatorStats?: DeviceValidatorStats,
+): DeviceInfoData {
   return {
     pk: device.pk,
     code: device.code,
@@ -22,9 +27,9 @@ export function deviceDetailToInfo(device: DeviceDetail, metroName?: string): De
     maxUnicastUsers: device.max_unicast_users ?? 0,
     maxMulticastSubscribers: device.max_multicast_subscribers ?? 0,
     maxMulticastPublishers: device.max_multicast_publishers ?? 0,
-    validatorCount: device.validator_count,
-    stakeSol: device.stake_sol,
-    stakeShare: device.stake_share,
+    validatorCount: validatorStats ? validatorStats.validator_count : null,
+    stakeSol: validatorStats ? validatorStats.stake_sol : null,
+    stakeShare: validatorStats ? validatorStats.stake_share : null,
     interfaces: device.interfaces || [],
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2889,9 +2889,6 @@ export async function fetchDevicesByContributor(contributorPk: string, limit = 5
 
 export interface DeviceDetail extends Device {
   metro_name: string
-  validator_count: number
-  stake_sol: number
-  stake_share: number
   interfaces: DeviceInterface[]
 }
 
@@ -2899,6 +2896,20 @@ export async function fetchDevice(pk: string): Promise<DeviceDetail> {
   const res = await fetchWithRetry(`/api/dz/devices/${encodeURIComponent(pk)}`)
   if (!res.ok) {
     throw new Error('Failed to fetch device')
+  }
+  return res.json()
+}
+
+export interface DeviceValidatorStats {
+  validator_count: number
+  stake_sol: number
+  stake_share: number
+}
+
+export async function fetchDeviceValidatorStats(pk: string): Promise<DeviceValidatorStats> {
+  const res = await fetchWithRetry(`/api/dz/devices/${encodeURIComponent(pk)}/validator-stats`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch device validator stats')
   }
   return res.json()
 }


### PR DESCRIPTION
## Summary
- Split validator/stake CTEs out of `GetDevice` into a new `/api/dz/devices/{pk}/validator-stats` endpoint so the heavy Solana gossip/vote-account joins don't block the device detail page from rendering.
- Device detail page fetches validator stats in parallel; the three stat cards show an inline shimmer until the call returns.
- Topology view is unchanged — it still gets validator stats from the bulk topology payload.

## Why
`GetDevice` was doing six CTEs in one query, and `validator_stats` (joins `dz_users_current` → `solana_gossip_nodes_current` → `solana_vote_accounts_current`) plus `total_stake` (full scan of `solana_vote_accounts_current`) were the slow parts. Locally that took the endpoint from 0.5–2.2s down to ~0.04s; the new validator-stats call is ~0.22s but no longer gates first paint.

## Testing Verification
- `go test ./api/handlers/ -run TestGetDevice -count=1` passes.
- Timed both endpoints against the local API: `GetDevice` ~0.04s, `validator-stats` ~0.22s, validator-stats body returns the expected `validator_count`/`stake_sol`/`stake_share`.