### PR TITLE
api: cast max_users sum to UInt64 in status query

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -422,7 +422,7 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 	})
 
 	g.Go(func() error {
-		query := `SELECT COALESCE(SUM(max_users), 0) FROM dz_devices_current WHERE max_users > 0 AND device_type != 'transit'`
+		query := `SELECT toUInt64(COALESCE(SUM(max_users), 0)) FROM dz_devices_current WHERE max_users > 0 AND device_type != 'transit'`
 		row := a.envDB(ctx).QueryRow(ctx, query)
 		return row.Scan(&resp.Network.MaxUsers)
 	})


### PR DESCRIPTION
## Summary

- Wrap `SUM(max_users)` in `toUInt64(...)` so the Int64 result from ClickHouse can be scanned into the `uint64` field on `NetworkSummary.MaxUsers`.
- Fixes the prod `page-cache` refresh failing with `converting Int64 to *uint64 is unsupported` and the cascading warn logs on the sibling ISIS queries that share the same errgroup.

## Why

`max_users` is `Int32` in ClickHouse, so `SUM(max_users)` returns `Int64` and `COALESCE(..., 0)` keeps it `Int64`. Introduced in #509 when the `MaxUsers uint64` field was added to the status response. The type mismatch caused the status page cache to fail every refresh (seen in prod logs with `consecutive_failures=53`).