### PR TITLE
web: remove user ratio on status page

### DIFF
--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -4282,7 +4282,6 @@ export function StatusPage() {
             label="Users"
             value={status.network.users}
             format="number"
-            max={status.network.max_users > 0 ? status.network.max_users : undefined}
             href="/dz/users"
           />
           <StatCard


### PR DESCRIPTION
## Summary
- Remove the `max` prop from the Users StatCard on the status page so it shows the raw user count instead of a `current/max` ratio (e.g. `1742/9936`).
- The ratio display was added for device detail pages but isn't appropriate for the network-level status stat.