### PR TITLE
web, api: ops management integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,13 @@ SLACK_ALLOWED_TEAM_IDS=
 
 
 # -----------------------------------------------------------------------------
+# Ops Management (required for incident/maintenance ticket integration)
+# -----------------------------------------------------------------------------
+# API key for the DoubleZero Ops Management service.
+# Used to create and fetch incident/maintenance tickets via the proxy endpoints.
+OPS_MANAGEMENT_API_KEY=
+
+# -----------------------------------------------------------------------------
 # Anthropic (required for AI agent)
 # -----------------------------------------------------------------------------
 # Powers the natural language SQL generation agent.

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,6 +1,9 @@
 # Anthropic API key (optional - uses Ollama if not set)
 ANTHROPIC_API_KEY=
 
+# Ops Management API key (required for incident/maintenance ticket integration)
+OPS_MANAGEMENT_API_KEY=
+
 # ClickHouse configuration
 CLICKHOUSE_ADDR_TCP=localhost:9000
 CLICKHOUSE_DATABASE=default

--- a/api/handlers/device_metrics.go
+++ b/api/handlers/device_metrics.go
@@ -24,6 +24,7 @@ type DeviceMetricsResponse struct {
 	DeviceCode      string                `json:"device_code"`
 	DeviceType      string                `json:"device_type"`
 	ContributorCode string                `json:"contributor_code"`
+	ContributorPK   string                `json:"contributor_pk"`
 	Metro           string                `json:"metro"`
 	MaxUsers        int32                 `json:"max_users"`
 	TimeRange       string                `json:"time_range"`
@@ -743,6 +744,7 @@ func (a *API) fetchDeviceMetrics(ctx context.Context, devicePK string, params bu
 		DeviceCode:      meta.Code,
 		DeviceType:      meta.DeviceType,
 		ContributorCode: meta.Contributor,
+		ContributorPK:   meta.ContributorPK,
 		Metro:           meta.Metro,
 		MaxUsers:        meta.MaxUsers,
 		TimeRange:       params.TimeRange,
@@ -1052,6 +1054,7 @@ func (a *API) fetchBulkDeviceMetrics(ctx context.Context, params bucketParams, i
 			DeviceCode:      meta.Code,
 			DeviceType:      meta.DeviceType,
 			ContributorCode: meta.Contributor,
+			ContributorPK:   meta.ContributorPK,
 			Metro:           meta.Metro,
 			MaxUsers:        meta.MaxUsers,
 			TimeRange:       params.TimeRange,

--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -22,6 +22,7 @@ type LinkMetricsResponse struct {
 	LinkCode           string               `json:"link_code"`
 	LinkType           string               `json:"link_type"`
 	ContributorCode    string               `json:"contributor_code"`
+	ContributorPK      string               `json:"contributor_pk"`
 	SideAMetro         string               `json:"side_a_metro"`
 	SideZMetro         string               `json:"side_z_metro"`
 	SideADevice        string               `json:"side_a_device"`
@@ -524,6 +525,7 @@ func (a *API) fetchLinkMetrics(ctx context.Context, linkPK string, params bucket
 		LinkCode:           meta.Code,
 		LinkType:           meta.LinkType,
 		ContributorCode:    meta.Contributor,
+		ContributorPK:      meta.ContributorPK,
 		SideAMetro:         meta.SideAMetro,
 		SideZMetro:         meta.SideZMetro,
 		SideADevice:        meta.SideADevice,
@@ -1290,6 +1292,7 @@ func (a *API) fetchBulkLinkMetrics(ctx context.Context, params bucketParams, inc
 			LinkCode:           meta.Code,
 			LinkType:           meta.LinkType,
 			ContributorCode:    meta.Contributor,
+			ContributorPK:      meta.ContributorPK,
 			SideAMetro:         meta.SideAMetro,
 			SideZMetro:         meta.SideZMetro,
 			SideADevice:        meta.SideADevice,

--- a/api/handlers/ops_tickets.go
+++ b/api/handlers/ops_tickets.go
@@ -1,0 +1,336 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+var opsMgmtBaseURL = "https://doublezero.xyz/api/network_incidents/v1"
+
+// activeStatuses are the ticket statuses that the upstream API considers "active".
+var activeStatuses = []string{
+	"open", "acknowledged", "investigating", "mitigating",
+	"monitoring", "planned", "in-progress",
+}
+
+// OpsTicketType is either "incident" or "maintenance".
+type OpsTicketType string
+
+const (
+	OpsTicketTypeIncident    OpsTicketType = "incident"
+	OpsTicketTypeMaintenance OpsTicketType = "maintenance"
+)
+
+// OpsTicketEntity is an enriched link or device reference returned by the Ops API.
+type OpsTicketEntity struct {
+	Code   string `json:"code"`
+	Pubkey string `json:"pubkey"`
+}
+
+// OpsTicket is a ticket from the Ops Management API.
+type OpsTicket struct {
+	ID                  string            `json:"id"`                // UUID
+	HumanReadableID     string            `json:"human_readable_id"` // e.g. "I20250413-a7b2"
+	Type                OpsTicketType     `json:"type"`
+	Title               string            `json:"title"`
+	Description         string            `json:"description"`
+	Severity            *string           `json:"severity,omitempty"` // "sev1"|"sev2"|"sev3"|nil
+	Status              string            `json:"status"`             // "open"|"acknowledged"|"investigating"|...
+	AffectedLinkPubkeys []string          `json:"affected_link_pubkey"`
+	DevicePubkeys       []string          `json:"device_pubkey"`
+	AffectedLinks       []OpsTicketEntity `json:"affected_links,omitempty"`
+	AffectedDevices     []OpsTicketEntity `json:"affected_devices,omitempty"`
+	ReporterName        string            `json:"reporter_name"`
+	ReporterEmail       string            `json:"reporter_email"`
+	StartAt             *string           `json:"start_at,omitempty"`
+	EndAt               *string           `json:"end_at,omitempty"`
+	SlackMessageURL     *string           `json:"slack_message_url,omitempty"`
+	CreatedAt           string            `json:"created_at"`
+	UpdatedAt           string            `json:"updated_at"`
+}
+
+// OpsTicketsListResponse wraps a paginated list of tickets.
+type OpsTicketsListResponse struct {
+	Tickets []OpsTicket `json:"tickets"`
+	Total   int         `json:"total"`
+}
+
+// CreateOpsTicketRequest is the body for POST /api/ops-tickets.
+type CreateOpsTicketRequest struct {
+	Type                OpsTicketType `json:"type"`
+	Title               string        `json:"title"`
+	Description         string        `json:"description"`
+	Severity            *string       `json:"severity,omitempty"`
+	Status              string        `json:"status"`
+	AffectedLinkPubkeys []string      `json:"affected_link_pubkey,omitempty"`
+	DevicePubkeys       []string      `json:"device_pubkey,omitempty"`
+	StartAt             *string       `json:"start_at,omitempty"`
+	EndAt               *string       `json:"end_at,omitempty"`
+	ContributorPubkey   *string       `json:"contributor_pubkey"`
+	ReporterName        string        `json:"reporter_name"`
+	ReporterEmail       string        `json:"reporter_email"`
+}
+
+// opsClient performs authenticated requests to the Ops Management API.
+type opsClient struct {
+	httpClient *http.Client
+	apiKey     string
+	baseURL    string
+}
+
+func newOpsClient() *opsClient {
+	return &opsClient{
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		apiKey:     os.Getenv("OPS_MANAGEMENT_API_KEY"),
+		baseURL:    opsMgmtBaseURL,
+	}
+}
+
+func (c *opsClient) get(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ops management request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ops management returned %d: %s", resp.StatusCode, body)
+	}
+	return body, nil
+}
+
+func (c *opsClient) post(ctx context.Context, path string, payload any) ([]byte, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ops management request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("ops management returned %d: %s", resp.StatusCode, body)
+	}
+	return body, nil
+}
+
+// GetOpsTickets proxies GET /api/ops-tickets
+// Query param: status=active (default) or any single status value.
+// The upstream API understands "active" and "not_active" as presets.
+// No auth required.
+func (a *API) GetOpsTickets(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	client := newOpsClient()
+
+	// Pass status param directly to the upstream API; default to "active".
+	status := r.URL.Query().Get("status")
+	if status == "" {
+		status = "active"
+	}
+
+	body, err := client.get(ctx, "/tickets?status="+url.QueryEscape(status))
+	if err != nil {
+		http.Error(w, "failed to fetch ops tickets", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// CreateOpsTicket proxies POST /api/ops-tickets.
+// Requires an internal-domain authenticated user.
+// Sets reporter_name and reporter_email from the authenticated session.
+func (a *API) CreateOpsTicket(w http.ResponseWriter, r *http.Request) {
+	account := GetAccountFromContext(r.Context())
+	if account == nil || !account.IsInternalUser {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	var req CreateOpsTicketRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, "title is required", http.StatusBadRequest)
+		return
+	}
+	if req.Type == "" {
+		req.Type = OpsTicketTypeIncident
+	}
+	if req.Status == "" {
+		req.Status = "open"
+	}
+
+	// Override reporter fields from authenticated session — never trust client input.
+	if account.DisplayName != nil {
+		req.ReporterName = firstName(*account.DisplayName)
+	}
+	if account.Email != nil {
+		req.ReporterEmail = *account.Email
+	}
+
+	client := newOpsClient()
+	body, err := client.post(r.Context(), "/tickets", req)
+	if err != nil {
+		log.Printf("CreateOpsTicket: upstream error: %v", err)
+		http.Error(w, "failed to create ops ticket", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_, _ = w.Write(body)
+}
+
+// firstName returns the first word of a display name, e.g. "Thijs van Dijk" → "Thijs".
+func firstName(displayName string) string {
+	for i, c := range displayName {
+		if c == ' ' {
+			return displayName[:i]
+		}
+	}
+	return displayName
+}
+
+// buildHistoryQuery constructs the query string for the history endpoint.
+// entityType should be "link" or "device" to select the correct API filter param.
+// Sending the same PK for both params would cause the Ops API to AND the conditions,
+// matching nothing. We send only the relevant param based on entity type.
+func buildHistoryQuery(entityPK, limit, ticketType, entityType string) string {
+	var pkParam string
+	switch entityType {
+	case "device":
+		pkParam = fmt.Sprintf("device_pubkey=%s", url.QueryEscape(entityPK))
+	default: // "link" and unknown — default to link param
+		pkParam = fmt.Sprintf("affected_link_pubkey=%s", url.QueryEscape(entityPK))
+	}
+	query := fmt.Sprintf("?%s&limit=%s&status=not_active", pkParam, url.QueryEscape(limit))
+	if ticketType != "" {
+		query += "&type=" + url.QueryEscape(ticketType)
+	}
+	return query
+}
+
+// GetOpsTicketHistory proxies GET /api/ops-tickets/history
+// Required query param: entity_pk (link or device pubkey).
+// Optional: limit (default 5), type (incident|maintenance).
+// No auth required.
+func (a *API) GetOpsTicketHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	entityPK := r.URL.Query().Get("entity_pk")
+	if entityPK == "" {
+		http.Error(w, "entity_pk is required", http.StatusBadRequest)
+		return
+	}
+
+	limit := r.URL.Query().Get("limit")
+	if limit == "" {
+		limit = "5"
+	}
+
+	ticketType := r.URL.Query().Get("type")
+	entityType := r.URL.Query().Get("entity_type")
+
+	query := buildHistoryQuery(entityPK, limit, ticketType, entityType)
+
+	client := newOpsClient()
+	body, err := client.get(ctx, "/tickets"+query)
+	if err != nil {
+		http.Error(w, "failed to fetch ops ticket history", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// OpsAssignee is a single assignee/contributor entry, optionally enriched with a ClickHouse pubkey.
+type OpsAssignee struct {
+	Value  string `json:"value"`
+	Label  string `json:"label"`
+	Type   string `json:"type,omitempty"`
+	Pubkey string `json:"pubkey,omitempty"`
+}
+
+// GetOpsAssignees serves GET /api/ops-tickets/assignees.
+// Builds the contributor list directly from ClickHouse dz_contributors_current.
+// The upstream /assignee-options endpoint was removed in API v1.1.0.
+func (a *API) GetOpsAssignees(w http.ResponseWriter, r *http.Request) {
+	if a.DB == nil {
+		http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	rows, err := a.DB.Query(r.Context(), `SELECT code, name, pk FROM dz_contributors_current ORDER BY name`)
+	if err != nil {
+		http.Error(w, "failed to fetch contributors", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	assignees := make([]OpsAssignee, 0)
+	for rows.Next() {
+		var code, name, pk string
+		if err := rows.Scan(&code, &name, &pk); err != nil {
+			http.Error(w, "failed to read contributors", http.StatusInternalServerError)
+			return
+		}
+		assignees = append(assignees, OpsAssignee{
+			Value:  code,
+			Label:  name,
+			Type:   "contributor",
+			Pubkey: pk,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		http.Error(w, "failed to read contributors", http.StatusInternalServerError)
+		return
+	}
+
+	data, err := json.Marshal(map[string]any{"assignees": assignees})
+	if err != nil {
+		http.Error(w, "failed to encode assignees", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}

--- a/api/handlers/ops_tickets_test.go
+++ b/api/handlers/ops_tickets_test.go
@@ -1,0 +1,249 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOpsTicketsActiveFiltersStatus(t *testing.T) {
+	t.Parallel()
+	// Verify the active status set matches the spec
+	assert.ElementsMatch(t, activeStatuses, []string{
+		"open", "acknowledged", "investigating", "mitigating",
+		"monitoring", "planned", "in-progress",
+	})
+}
+
+func TestGetOpsTicketsHistoryRejectsEmptyEntityPK(t *testing.T) {
+	t.Parallel()
+	api := &API{}
+	req := httptest.NewRequest(http.MethodGet, "/api/ops-tickets/history", nil)
+	w := httptest.NewRecorder()
+	api.GetOpsTicketHistory(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetOpsTicketsProxiesUpstream(t *testing.T) {
+	t.Parallel()
+
+	fixture := OpsTicketsListResponse{
+		Tickets: []OpsTicket{
+			{
+				ID:                  "272d6ef3-3fb6-4f26-ab2c-047de78fca55",
+				HumanReadableID:     "I20250413-a7b2",
+				Type:                OpsTicketTypeIncident,
+				Title:               "NYC-CHI packet loss",
+				Status:              "investigating",
+				AffectedLinkPubkeys: []string{"7a3f9c2e-1b4d-4e8a-9f6c-2d5e8a3b1c0d"},
+			},
+		},
+		Total: 1,
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(fixture))
+	}))
+	defer upstream.Close()
+
+	client := &opsClient{
+		httpClient: upstream.Client(),
+		apiKey:     "test-key",
+		baseURL:    upstream.URL,
+	}
+
+	body, err := client.get(context.Background(), "/tickets?status=open")
+	require.NoError(t, err)
+
+	var got OpsTicketsListResponse
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Len(t, got.Tickets, 1)
+	assert.Equal(t, "I20250413-a7b2", got.Tickets[0].HumanReadableID)
+}
+
+func TestCreateOpsTicketRequiresAuth(t *testing.T) {
+	t.Parallel()
+	api := &API{}
+
+	// No account in context → 403
+	req := httptest.NewRequest(http.MethodPost, "/api/ops-tickets", nil)
+	w := httptest.NewRecorder()
+	api.CreateOpsTicket(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCreateOpsTicketRejectsNonOpsUser(t *testing.T) {
+	t.Parallel()
+	api := &API{}
+
+	walletAccount := &Account{
+		AccountType:    AccountTypeWallet,
+		IsInternalUser: false,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/ops-tickets", nil)
+	req = req.WithContext(SetAccountInContext(req.Context(), walletAccount))
+	w := httptest.NewRecorder()
+	api.CreateOpsTicket(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCreateOpsTicketValidatesBody(t *testing.T) {
+	t.Parallel()
+	api := &API{}
+
+	opsAccount := &Account{
+		AccountType:    AccountTypeDomain,
+		IsInternalUser: true,
+		Email:          strPtr("thijs@doublezero.xyz"),
+		DisplayName:    strPtr("Thijs"),
+	}
+	// Missing title → 400
+	body := `{"type":"incident"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/ops-tickets",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(SetAccountInContext(req.Context(), opsAccount))
+	w := httptest.NewRecorder()
+	api.CreateOpsTicket(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestBuildHistoryQueryParams(t *testing.T) {
+	t.Parallel()
+	// Link entity — only affected_link_pubkey, not device_pubkey
+	qLink := buildHistoryQuery("abc123-pk", "5", "", "link")
+	assert.Contains(t, qLink, "affected_link_pubkey=abc123-pk")
+	assert.NotContains(t, qLink, "device_pubkey")
+	assert.Contains(t, qLink, "status=not_active")
+	assert.Contains(t, qLink, "limit=5")
+
+	// Device entity — only device_pubkey, not affected_link_pubkey
+	qDevice := buildHistoryQuery("abc123-pk", "5", "", "device")
+	assert.Contains(t, qDevice, "device_pubkey=abc123-pk")
+	assert.NotContains(t, qDevice, "affected_link_pubkey")
+
+	// Unknown/empty entity type — defaults to link param
+	qUnknown := buildHistoryQuery("abc123-pk", "5", "", "")
+	assert.Contains(t, qUnknown, "affected_link_pubkey=abc123-pk")
+	assert.NotContains(t, qUnknown, "device_pubkey")
+}
+
+func TestBuildHistoryQueryParamsWithType(t *testing.T) {
+	t.Parallel()
+	q := buildHistoryQuery("abc123-pk", "5", "incident", "link")
+	assert.Contains(t, q, "type=incident")
+}
+
+func TestCreateOpsTicketDefaultsStatusToOpen(t *testing.T) {
+	t.Parallel()
+	// status absent → defaults to "open"
+	req := CreateOpsTicketRequest{Type: OpsTicketTypeIncident, Title: "Test"}
+	if req.Status == "" {
+		req.Status = "open"
+	}
+	assert.Equal(t, "open", req.Status)
+
+	// explicit status preserved
+	req2 := CreateOpsTicketRequest{Status: "investigating"}
+	if req2.Status == "" {
+		req2.Status = "open"
+	}
+	assert.Equal(t, "investigating", req2.Status)
+}
+
+func TestOpsTicketUnmarshalsEnrichedFields(t *testing.T) {
+	t.Parallel()
+	raw := `{
+		"id": "abc",
+		"human_readable_id": "I20250415-0001",
+		"type": "incident",
+		"title": "Test",
+		"description": "Test",
+		"status": "open",
+		"affected_link_pubkey": [],
+		"device_pubkey": [],
+		"affected_links": [{"code": "nyc-sfo", "pubkey": "link-pk-1"}],
+		"affected_devices": [{"code": "nyc001-dz001", "pubkey": "device-pk-1"}],
+		"reporter_name": "Test",
+		"reporter_email": "test@test.com",
+		"created_at": "2025-01-01T00:00:00Z",
+		"updated_at": "2025-01-01T00:00:00Z"
+	}`
+	var ticket OpsTicket
+	require.NoError(t, json.Unmarshal([]byte(raw), &ticket))
+	require.Len(t, ticket.AffectedLinks, 1)
+	assert.Equal(t, "nyc-sfo", ticket.AffectedLinks[0].Code)
+	assert.Equal(t, "link-pk-1", ticket.AffectedLinks[0].Pubkey)
+	require.Len(t, ticket.AffectedDevices, 1)
+	assert.Equal(t, "device-pk-1", ticket.AffectedDevices[0].Pubkey)
+}
+
+func TestCreateOpsTicketRequestIncludesContributorPubkey(t *testing.T) {
+	t.Parallel()
+	pk := "4Nd1yGqnbdL2qHgJuKrpqW7TePxKzN3mHdR1ZkAeTY8a"
+	r := CreateOpsTicketRequest{
+		Type:              OpsTicketTypeIncident,
+		Title:             "Test",
+		ContributorPubkey: strPtr(pk),
+	}
+	require.NotNil(t, r.ContributorPubkey)
+	assert.Equal(t, pk, *r.ContributorPubkey)
+	data, err := json.Marshal(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "contributor_pubkey")
+	assert.Contains(t, string(data), pk)
+}
+
+func TestCreateOpsTicketRequestNullContributorPubkey(t *testing.T) {
+	t.Parallel()
+	// nil ContributorPubkey marshals as explicit null (not omitted)
+	r := CreateOpsTicketRequest{
+		Type:              OpsTicketTypeIncident,
+		Title:             "Test",
+		ContributorPubkey: nil,
+	}
+	data, err := json.Marshal(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"contributor_pubkey":null`)
+}
+
+func TestGetOpsAssigneesRequiresDB(t *testing.T) {
+	t.Parallel()
+	api := &API{DB: nil}
+	req := httptest.NewRequest(http.MethodGet, "/api/ops-tickets/assignees", nil)
+	w := httptest.NewRecorder()
+	api.GetOpsAssignees(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestGetOpsAssigneesProxiesUpstream(t *testing.T) {
+	t.Parallel()
+
+	fixture := `{"success":true,"data":[{"value":"dz_malbeclabs","label":"DZ/Malbeclabs","type":"admin"}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture)
+	}))
+	defer upstream.Close()
+
+	client := &opsClient{
+		httpClient: upstream.Client(),
+		apiKey:     "test-key",
+		baseURL:    upstream.URL,
+	}
+
+	body, err := client.get(context.Background(), "/tickets?status=active")
+	require.NoError(t, err)
+	assert.JSONEq(t, fixture, string(body))
+}

--- a/api/handlers/status_rollup.go
+++ b/api/handlers/status_rollup.go
@@ -1102,6 +1102,7 @@ type statusLinkMeta struct {
 	Code              string
 	LinkType          string
 	Contributor       string
+	ContributorPK     string
 	SideAMetro        string
 	SideZMetro        string
 	SideADevice       string
@@ -1133,6 +1134,7 @@ func queryStatusLinkMeta(ctx context.Context, db driver.Conn, linkPKs ...string)
 			l.code,
 			l.link_type,
 			COALESCE(c.code, '') as contributor,
+			COALESCE(l.contributor_pk, '') as contributor_pk,
 			ma.code as side_a_metro,
 			mz.code as side_z_metro,
 			da.code as side_a_device,
@@ -1165,7 +1167,7 @@ func queryStatusLinkMeta(ctx context.Context, db driver.Conn, linkPKs ...string)
 	for rows.Next() {
 		var m statusLinkMeta
 		if err := rows.Scan(
-			&m.PK, &m.Code, &m.LinkType, &m.Contributor,
+			&m.PK, &m.Code, &m.LinkType, &m.Contributor, &m.ContributorPK,
 			&m.SideAMetro, &m.SideZMetro, &m.SideADevice, &m.SideZDevice,
 			&m.SideADevicePK, &m.SideZDevicePK,
 			&m.SideAIfaceName, &m.SideZIfaceName,
@@ -1232,13 +1234,14 @@ func queryCurrentISISDown(ctx context.Context, db driver.Conn, linkPKs ...string
 
 // statusDeviceMeta holds static device metadata from dimension tables for status pages.
 type statusDeviceMeta struct {
-	PK          string
-	Code        string
-	DeviceType  string
-	Contributor string
-	Metro       string
-	MaxUsers    int32
-	Status      string
+	PK            string
+	Code          string
+	DeviceType    string
+	Contributor   string
+	ContributorPK string
+	Metro         string
+	MaxUsers      int32
+	Status        string
 }
 
 // queryStatusDeviceMeta fetches metadata for active devices.
@@ -1257,6 +1260,7 @@ func queryStatusDeviceMeta(ctx context.Context, db driver.Conn, devicePKs ...str
 			d.code,
 			d.device_type,
 			COALESCE(c.code, '') as contributor,
+			COALESCE(d.contributor_pk, '') as contributor_pk,
 			COALESCE(m.code, '') as metro,
 			d.max_users,
 			d.status
@@ -1275,7 +1279,7 @@ func queryStatusDeviceMeta(ctx context.Context, db driver.Conn, devicePKs ...str
 	result := make(map[string]*statusDeviceMeta)
 	for rows.Next() {
 		var m statusDeviceMeta
-		if err := rows.Scan(&m.PK, &m.Code, &m.DeviceType, &m.Contributor, &m.Metro, &m.MaxUsers, &m.Status); err != nil {
+		if err := rows.Scan(&m.PK, &m.Code, &m.DeviceType, &m.Contributor, &m.ContributorPK, &m.Metro, &m.MaxUsers, &m.Status); err != nil {
 			return nil, fmt.Errorf("device metadata scan: %w", err)
 		}
 		result[m.PK] = &m

--- a/api/main.go
+++ b/api/main.go
@@ -526,6 +526,12 @@ func main() {
 		r.Get("/api/incidents/devices", api.GetDeviceIncidents)
 		r.Get("/api/incidents/devices/csv", api.GetDeviceIncidentsCSV)
 
+		// Ops Management tickets proxy (auth required — tickets contain reporter PII)
+		r.With(api.RequireAuth).Get("/api/ops-tickets", api.GetOpsTickets)
+		r.With(api.RequireAuth).Get("/api/ops-tickets/history", api.GetOpsTicketHistory)
+		r.With(api.RequireAuth).Get("/api/ops-tickets/assignees", api.GetOpsAssignees)
+		r.With(handlers.RequireInternalDomain).Post("/api/ops-tickets", api.CreateOpsTicket)
+
 		// Search routes
 		r.Get("/api/search", api.Search)
 		r.Get("/api/search/autocomplete", api.SearchAutocomplete)

--- a/web/src/components/device-charts/DeviceHealthTimeline.tsx
+++ b/web/src/components/device-charts/DeviceHealthTimeline.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useLayoutEffect } from 'react'
 import type { DeviceMetricsResponse, DeviceMetricsBucket } from '@/lib/api'
+import { TicketOverlay, type TicketWindow } from '@/components/ops/TicketOverlay'
 
 interface DeviceHealthTimelineProps {
   data: DeviceMetricsResponse
@@ -7,6 +8,8 @@ interface DeviceHealthTimelineProps {
   hideBadges?: boolean
   onBarHover?: (range: { start: number; end: number } | null) => void
   highlightedTime?: number | null  // unix seconds
+  incidentWindows?: TicketWindow[]
+  maintenanceWindows?: TicketWindow[]
 }
 
 const healthColors: Record<string, string> = {
@@ -198,7 +201,7 @@ function useContainerBars() {
   return { containerRef, maxBars }
 }
 
-export function DeviceHealthTimeline({ data, className, hideBadges, onBarHover, highlightedTime }: DeviceHealthTimelineProps) {
+export function DeviceHealthTimeline({ data, className, hideBadges, onBarHover, highlightedTime, incidentWindows, maintenanceWindows }: DeviceHealthTimelineProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const { containerRef, maxBars } = useContainerBars()
 
@@ -207,6 +210,17 @@ export function DeviceHealthTimeline({ data, className, hideBadges, onBarHover, 
     markTrailingCollecting(merged)
     return merged
   }, [data.buckets, data.bucket_seconds, maxBars])
+
+  const rangeStartMs = useMemo(() => {
+    if (!data.buckets.length) return 0
+    return new Date(data.buckets[0].ts).getTime()
+  }, [data.buckets])
+
+  const rangeEndMs = useMemo(() => {
+    if (!data.buckets.length) return 0
+    const last = data.buckets[data.buckets.length - 1]
+    return new Date(last.ts).getTime() + data.bucket_seconds * 1000
+  }, [data.buckets, data.bucket_seconds])
 
   const highlightedBarIndex = useMemo(() => {
     if (highlightedTime == null) return -1
@@ -386,6 +400,16 @@ export function DeviceHealthTimeline({ data, className, hideBadges, onBarHover, 
             )
           })}
         </div>
+
+        {/* Ticket overlays — incidents and maintenance combined so overlapping windows cluster */}
+        {((incidentWindows?.length ?? 0) + (maintenanceWindows?.length ?? 0)) > 0 && (
+          <TicketOverlay
+            windows={[...(maintenanceWindows ?? []), ...(incidentWindows ?? [])]}
+            rangeStartMs={rangeStartMs}
+            rangeEndMs={rangeEndMs}
+            minWidthMs={bars[0] ? bars[0].spanSeconds * 1000 : data.bucket_seconds * 1000}
+          />
+        )}
 
         <div className="flex justify-between mt-1 text-[10px] text-muted-foreground">
           <span>{startLabel}</span>

--- a/web/src/components/device-charts/DeviceInterfaceIssuesChart.tsx
+++ b/web/src/components/device-charts/DeviceInterfaceIssuesChart.tsx
@@ -9,6 +9,8 @@ import { type ChartLegendSeries } from '@/components/topology/ChartLegend'
 import { ChartLegendTable } from '@/components/topology/ChartLegendTable'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { DeviceMetricsResponse, DeviceInterfaceTraffic } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface DeviceInterfaceIssuesChartProps {
   data: DeviceMetricsResponse
@@ -16,6 +18,9 @@ interface DeviceInterfaceIssuesChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 function formatCount(value: number): string {
@@ -98,7 +103,7 @@ function AggregateLegend({ seriesKeys, uPlotData, legend, hoveredIdx, hoveredTim
   return <ChartLegendTable series={legendSeries} legend={legend} values={displayValues} maxValues={maxValues} hoveredTime={hoveredTime ?? undefined} />
 }
 
-export function DeviceInterfaceIssuesChart({ data, className, loading, highlightTimeRange, onCursorTime }: DeviceInterfaceIssuesChartProps) {
+export function DeviceInterfaceIssuesChart({ data, className, loading, highlightTimeRange, onCursorTime, tickets, showIncidents, showMaintenance }: DeviceInterfaceIssuesChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
@@ -284,7 +289,7 @@ export function DeviceInterfaceIssuesChart({ data, className, loading, highlight
     ctx.restore()
   }], [])
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -342,7 +347,19 @@ export function DeviceInterfaceIssuesChart({ data, className, loading, highlight
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       {!hasPerIntfData && <AggregateLegend seriesKeys={seriesKeys} uPlotData={uPlotData} legend={legend} hoveredIdx={hoveredIdx} hoveredTime={hoveredTime} errorColor={errorColor} fcsColor={fcsColor} discardColor={discardColor} carrierColor={carrierColor} data={data} />}
       {hasPerIntfData && <div className="flex flex-col text-xs px-2 pt-1 pb-2">
         <div className="flex items-center px-1 mb-1">

--- a/web/src/components/device-charts/DeviceTrafficChart.tsx
+++ b/web/src/components/device-charts/DeviceTrafficChart.tsx
@@ -8,6 +8,8 @@ import { useUPlotChart } from '@/hooks/use-uplot-chart'
 import { useUPlotLegendSync } from '@/hooks/use-uplot-legend-sync'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { DeviceMetricsResponse, DeviceInterfaceTraffic } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface DeviceTrafficChartProps {
   data: DeviceMetricsResponse
@@ -15,6 +17,9 @@ interface DeviceTrafficChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'max'
@@ -81,6 +86,9 @@ interface CategoryChartProps {
   bucketSeconds: number
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 function CategoryChart({
@@ -97,6 +105,9 @@ function CategoryChart({
   bucketSeconds,
   highlightTimeRange,
   onCursorTime,
+  tickets,
+  showIncidents,
+  showMaintenance,
 }: CategoryChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -212,7 +223,7 @@ function CategoryChart({
     [],
   )
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -284,7 +295,19 @@ function CategoryChart({
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       {/* Per-interface legend */}
       <div className="flex flex-col text-xs px-2 pt-1 pb-2">
         <div className="flex items-center px-1 mb-1">
@@ -413,6 +436,9 @@ export function DeviceTrafficChart({
   loading,
   highlightTimeRange,
   onCursorTime,
+  tickets,
+  showIncidents,
+  showMaintenance,
 }: DeviceTrafficChartProps) {
   const [aggMode, setAggMode] = useState<AggMode>('avg')
   const [bidirectional, setBidirectional] = useState(true)
@@ -525,6 +551,9 @@ export function DeviceTrafficChart({
           bucketSeconds={data.bucket_seconds}
           highlightTimeRange={highlightTimeRange}
           onCursorTime={onCursorTime}
+          tickets={tickets}
+          showIncidents={showIncidents}
+          showMaintenance={showMaintenance}
         />
       ))}
     </div>

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -7,6 +7,8 @@ import { fetchDevice, fetchDeviceMetrics, fetchDeviceValidatorStats } from '@/li
 import { DeviceInfoContent } from '@/components/shared/DeviceInfoContent'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
+import { OpsPanel } from '@/components/ops/OpsPanel'
+import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
 import { deviceDetailToInfo } from '@/components/shared/device-info-converters'
 import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
@@ -14,6 +16,9 @@ import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInt
 import { DeviceTrafficChart } from '@/components/device-charts/DeviceTrafficChart'
 import { TimeRangeSelector } from '@/components/topology/TimeRangeSelector'
 import type { TimeRange } from '@/components/topology/utils'
+import { useActiveOpsTickets, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
+import type { OpsTicket } from '@/lib/ops-api'
+import type { TicketWindow } from '@/components/ops/TicketOverlay'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -41,6 +46,9 @@ export function DeviceDetailPage() {
     end: number
   } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
+  const [showCreateIncident, setShowCreateIncident] = useState(false)
+  const [showIncidents, setShowIncidents] = useState(true)
+  const [showMaintenance, setShowMaintenance] = useState(true)
 
   const {
     data: device,
@@ -69,6 +77,16 @@ export function DeviceDetailPage() {
     queryFn: () => fetchDeviceMetrics(pk!, metricsParams),
     enabled: !!pk,
   })
+
+  const { data: activeTicketsData } = useActiveOpsTickets()
+  const { data: ticketHistoryData } = useOpsTicketHistory(pk ?? '', undefined, 'device')
+  // Combine active tickets for this device + recently closed history
+  const tickets: OpsTicket[] = [
+    ...(activeTicketsData?.tickets ?? []).filter(
+      t => pk && (t.device_pubkey.includes(pk) || (t.affected_devices?.some(d => d.pubkey === pk) ?? false))
+    ),
+    ...(ticketHistoryData?.tickets ?? []),
+  ]
 
   useDocumentTitle(device?.code || 'Device')
 
@@ -159,6 +177,27 @@ export function DeviceDetailPage() {
 
         {/* Shared device info (stats grid + interfaces) */}
         <DeviceInfoContent device={deviceInfo} hideStatusRow hideCharts />
+        <div className="mt-6">
+          <OpsPanel
+            entityPk={device.pk}
+            entityCode={device.code}
+            entityType="device"
+            contributorCode={device.contributor_code}
+            isDown={device.status === 'down'}
+            onCreateIncident={() => setShowCreateIncident(true)}
+          />
+        </div>
+        {showCreateIncident && (
+          <CreateIncidentModal
+            entityCode={device.code}
+            entityType="device"
+            entityPk={device.pk}
+            contributorCode={device.contributor_code}
+            contributorPk={device.contributor_pk}
+            onClose={() => setShowCreateIncident(false)}
+            onSuccess={() => setShowCreateIncident(false)}
+          />
+        )}
       </div>
 
       {/* Filters + charts */}
@@ -177,6 +216,28 @@ export function DeviceDetailPage() {
             )}
           </button>
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button
+            type="button"
+            onClick={() => setShowIncidents(v => !v)}
+            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+              showIncidents
+                ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Incidents
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMaintenance(v => !v)}
+            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+              showMaintenance
+                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Maintenance
+          </button>
         </div>
 
         {metricsLoading && (
@@ -196,6 +257,30 @@ export function DeviceDetailPage() {
               data={metrics}
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
+              incidentWindows={showIncidents ? tickets
+                .filter(t => t.type === 'incident')
+                .map(t => ({
+                  startAt: t.start_at ?? new Date().toISOString(),
+                  endAt: t.end_at,
+                  type: 'incident' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  slackUrl: t.slack_message_url,
+                } as TicketWindow)) : []}
+              maintenanceWindows={showMaintenance ? tickets
+                .filter(t => t.type === 'maintenance' && t.start_at)
+                .map(t => ({
+                  startAt: t.start_at!,
+                  endAt: t.end_at,
+                  type: 'maintenance' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  slackUrl: t.slack_message_url,
+                } as TicketWindow)) : []}
             />
             <DeviceInterfaceIssuesChart
               data={metrics}
@@ -203,6 +288,9 @@ export function DeviceDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
             <DeviceTrafficChart
               data={metrics}
@@ -210,6 +298,9 @@ export function DeviceDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
           </div>
         )}

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -225,7 +225,7 @@ export function DeviceDetailPage() {
                 onClick={() => setShowIncidents(v => !v)}
                 className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
                   showIncidents
-                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -236,7 +236,7 @@ export function DeviceDetailPage() {
                 onClick={() => setShowMaintenance(v => !v)}
                 className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
                   showMaintenance
-                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -218,31 +218,31 @@ export function DeviceDetailPage() {
             )}
           </button>
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          {isOpsUser && (
-            <>
-              <button
-                type="button"
-                onClick={() => setShowIncidents(v => !v)}
-                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-                  showIncidents
-                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Incidents
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMaintenance(v => !v)}
-                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-                  showMaintenance
-                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Maintenance
-              </button>
-            </>
+          {isOpsUser && tickets.some(t => t.type === 'incident') && (
+            <button
+              type="button"
+              onClick={() => setShowIncidents(v => !v)}
+              className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                showIncidents
+                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Incidents
+            </button>
+          )}
+          {isOpsUser && tickets.some(t => t.type === 'maintenance') && (
+            <button
+              type="button"
+              onClick={() => setShowMaintenance(v => !v)}
+              className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                showMaintenance
+                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Maintenance
+            </button>
           )}
         </div>
 

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -17,6 +17,7 @@ import { DeviceTrafficChart } from '@/components/device-charts/DeviceTrafficChar
 import { TimeRangeSelector } from '@/components/topology/TimeRangeSelector'
 import type { TimeRange } from '@/components/topology/utils'
 import { useActiveOpsTickets, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import type { OpsTicket } from '@/lib/ops-api'
 import type { TicketWindow } from '@/components/ops/TicketOverlay'
 
@@ -47,6 +48,7 @@ export function DeviceDetailPage() {
   } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
   const [showCreateIncident, setShowCreateIncident] = useState(false)
+  const isOpsUser = useIsOpsUser()
   const [showIncidents, setShowIncidents] = useState(true)
   const [showMaintenance, setShowMaintenance] = useState(true)
 
@@ -216,28 +218,32 @@ export function DeviceDetailPage() {
             )}
           </button>
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          <button
-            type="button"
-            onClick={() => setShowIncidents(v => !v)}
-            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-              showIncidents
-                ? 'border-red-800/60 bg-red-900/20 text-red-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Incidents
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowMaintenance(v => !v)}
-            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-              showMaintenance
-                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Maintenance
-          </button>
+          {isOpsUser && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowIncidents(v => !v)}
+                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                  showIncidents
+                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Incidents
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMaintenance(v => !v)}
+                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                  showMaintenance
+                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Maintenance
+              </button>
+            </>
+          )}
         </div>
 
         {metricsLoading && (

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -21,6 +21,7 @@ import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { useAuth } from '@/contexts/AuthContext'
 import { IncidentBadge } from '@/components/ops/IncidentBadge'
 import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
+import { isTicketClosed } from '@/lib/ops-api'
 
 function Skeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
@@ -504,10 +505,10 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
                   </span>
                 )}
                 {/* Incident badge — visible to all authenticated users */}
-                {!!user && tickets
-                  .filter(t => t.type === 'incident')
-                  .map(t => <IncidentBadge key={t.id} ticket={t} />)
-                }
+                {!!user && (() => {
+                  const open = tickets.filter(t => t.type === 'incident' && !isTicketClosed(t.status))
+                  return open.length > 0 ? <IncidentBadge tickets={open} /> : null
+                })()}
               </div>
             )}
           </div>
@@ -546,7 +547,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
                   slackUrl: t.slack_message_url,
                 })) : []}
             />
-            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
+            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident' && !isTicketClosed(t.status)) && (
               <div className="flex justify-end mt-1">
                 <button
                   className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors opacity-0 group-hover:opacity-100"
@@ -614,7 +615,7 @@ export function DeviceStatusTimelines({
   })
 
   // Pre-fetch active tickets once for all rows — filtered client-side per device
-  useActiveOpsTickets()
+  const { data: activeTicketsData } = useActiveOpsTickets()
   const isOpsUser = useIsOpsUser()
   const [createIncidentFor, setCreateIncidentFor] = useState<{
     devicePk: string
@@ -754,6 +755,22 @@ export function DeviceStatusTimelines({
     devicesWithHealth,
   ])
 
+  const incidentCount = useMemo(() => {
+    const tickets = activeTicketsData?.tickets ?? []
+    return devicesArray.filter(({ derived }) =>
+      tickets.some(t => t.type === 'incident' &&
+        (t.device_pubkey.includes(derived.pk) || (t.affected_devices?.some(d => d.pubkey === derived.pk) ?? false)))
+    ).length
+  }, [activeTicketsData, devicesArray])
+
+  const maintenanceCount = useMemo(() => {
+    const tickets = activeTicketsData?.tickets ?? []
+    return devicesArray.filter(({ derived }) =>
+      tickets.some(t => t.type === 'maintenance' &&
+        (t.device_pubkey.includes(derived.pk) || (t.affected_devices?.some(d => d.pubkey === derived.pk) ?? false)))
+    ).length
+  }, [activeTicketsData, devicesArray])
+
   const showSkeleton = useDelayedLoading(isLoading && !data)
 
   if (isLoading && !data) {
@@ -809,31 +826,31 @@ export function DeviceStatusTimelines({
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {isOpsUser && (
-            <>
-              <button
-                type="button"
-                onClick={() => setShowIncidentOverlays(v => !v)}
-                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                  showIncidentOverlays
-                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Incidents
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMaintenanceOverlays(v => !v)}
-                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                  showMaintenanceOverlays
-                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Maintenance
-              </button>
-            </>
+          {isOpsUser && incidentCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowIncidentOverlays(v => !v)}
+              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
+                showIncidentOverlays
+                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Incidents ({incidentCount})
+            </button>
+          )}
+          {isOpsUser && maintenanceCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowMaintenanceOverlays(v => !v)}
+              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
+                showMaintenanceOverlays
+                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Maintenance ({maintenanceCount})
+            </button>
           )}
           {onTimeRangeChange && (
             <SmallDropdown

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -816,28 +816,32 @@ export function DeviceStatusTimelines({
               onChange={(v) => onTimeRangeChange(v as TimeRange)}
             />
           )}
-          <button
-            type="button"
-            onClick={() => setShowIncidentOverlays(v => !v)}
-            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
-              showIncidentOverlays
-                ? 'border-red-800/60 bg-red-900/20 text-red-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Incidents
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowMaintenanceOverlays(v => !v)}
-            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
-              showMaintenanceOverlays
-                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Maintenance
-          </button>
+          {isOpsUser && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowIncidentOverlays(v => !v)}
+                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                  showIncidentOverlays
+                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Incidents
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMaintenanceOverlays(v => !v)}
+                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                  showMaintenanceOverlays
+                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Maintenance
+              </button>
+            </>
+          )}
         </div>
       </div>
 

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -386,7 +386,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
   return (
     <div
       id={`device-row-${derivedInfo.pk}`}
-      className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}
+      className={`border-b border-border last:border-b-0 border-l-2 group ${leftBorderColor}`}
     >
       <div
         className={`px-4 py-3 transition-colors ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30' : ''}`}
@@ -549,7 +549,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
             {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
               <div className="flex justify-end mt-1">
                 <button
-                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors"
+                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors opacity-0 group-hover:opacity-100"
                   onClick={(e) => { e.stopPropagation(); onCreateIncident(derivedInfo.pk, derivedInfo.code, derivedInfo.contributor, deviceMetrics.contributor_pk, issueReasons) }}
                 >
                   Create incident
@@ -809,19 +809,12 @@ export function DeviceStatusTimelines({
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {onTimeRangeChange && (
-            <SmallDropdown
-              value={timeRange}
-              options={timeRangeOptions}
-              onChange={(v) => onTimeRangeChange(v as TimeRange)}
-            />
-          )}
           {isOpsUser && (
             <>
               <button
                 type="button"
                 onClick={() => setShowIncidentOverlays(v => !v)}
-                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
                   showIncidentOverlays
                     ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
@@ -832,7 +825,7 @@ export function DeviceStatusTimelines({
               <button
                 type="button"
                 onClick={() => setShowMaintenanceOverlays(v => !v)}
-                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
                   showMaintenanceOverlays
                     ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
@@ -841,6 +834,13 @@ export function DeviceStatusTimelines({
                 Maintenance
               </button>
             </>
+          )}
+          {onTimeRangeChange && (
+            <SmallDropdown
+              value={timeRange}
+              options={timeRangeOptions}
+              onChange={(v) => onTimeRangeChange(v as TimeRange)}
+            />
           )}
         </div>
       </div>

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -16,6 +16,11 @@ import type { DeviceMetricsResponse } from '@/lib/api'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
+import { useActiveOpsTickets, useTicketsForEntity } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
+import { useAuth } from '@/contexts/AuthContext'
+import { IncidentBadge } from '@/components/ops/IncidentBadge'
+import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
 
 function Skeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
@@ -260,15 +265,15 @@ interface DeviceRowProps {
   devicesWithIssues?: Map<string, string[]>
   initiallyExpanded?: boolean
   timeRange?: string
+  isOpsUser: boolean
+  onCreateIncident: (devicePk: string, deviceCode: string, contributorCode: string, contributorPk: string, issueReasons: string[]) => void
+  showIncidentOverlays: boolean
+  showMaintenanceOverlays: boolean
 }
 
-function DeviceRow({
-  deviceMetrics,
-  derivedInfo,
-  devicesWithIssues,
-  initiallyExpanded = false,
-  timeRange = '24h',
-}: DeviceRowProps) {
+function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExpanded = false, timeRange = '24h', isOpsUser, onCreateIncident, showIncidentOverlays, showMaintenanceOverlays }: DeviceRowProps) {
+  const tickets = useTicketsForEntity(derivedInfo.pk)
+  const { user } = useAuth()
   const [expanded, setExpanded] = useState(initiallyExpanded)
   const [hoveredTimeRange, setHoveredTimeRange] = useState<{
     start: number
@@ -492,6 +497,17 @@ function DeviceRow({
                     ISIS Unreachable
                   </span>
                 )}
+                {/* Maintenance badge — visible to all users */}
+                {tickets.some(t => t.type === 'maintenance') && (
+                  <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                    Maintenance
+                  </span>
+                )}
+                {/* Incident badge — visible to all authenticated users */}
+                {!!user && tickets
+                  .filter(t => t.type === 'incident')
+                  .map(t => <IncidentBadge key={t.id} ticket={t} />)
+                }
               </div>
             )}
           </div>
@@ -503,7 +519,43 @@ function DeviceRow({
               hideBadges
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
+              maintenanceWindows={showMaintenanceOverlays ? tickets
+                .filter(t => t.type === 'maintenance' && t.start_at)
+                .map(t => ({
+                  startAt: t.start_at!,
+                  endAt: t.end_at,
+                  type: 'maintenance' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  entityName: derivedInfo.code,
+                  slackUrl: t.slack_message_url,
+                })) : []}
+              incidentWindows={showIncidentOverlays ? tickets
+                .filter(t => t.type === 'incident')
+                .map(t => ({
+                  startAt: t.start_at ?? new Date().toISOString(),
+                  endAt: t.end_at,
+                  type: 'incident' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  entityName: derivedInfo.code,
+                  slackUrl: t.slack_message_url,
+                })) : []}
             />
+            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
+              <div className="flex justify-end mt-1">
+                <button
+                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); onCreateIncident(derivedInfo.pk, derivedInfo.code, derivedInfo.contributor, deviceMetrics.contributor_pk, issueReasons) }}
+                >
+                  Create incident
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -560,6 +612,19 @@ export function DeviceStatusTimelines({
     staleTime: 30_000,
     placeholderData: keepPreviousData,
   })
+
+  // Pre-fetch active tickets once for all rows — filtered client-side per device
+  useActiveOpsTickets()
+  const isOpsUser = useIsOpsUser()
+  const [createIncidentFor, setCreateIncidentFor] = useState<{
+    devicePk: string
+    deviceCode: string
+    contributorCode: string
+    contributorPk: string
+    issueReasons: string[]
+  } | null>(null)
+  const [showIncidentOverlays, setShowIncidentOverlays] = useState(true)
+  const [showMaintenanceOverlays, setShowMaintenanceOverlays] = useState(true)
 
   // Convert the Record<string, DeviceMetricsResponse> into an array with derived info
   const devicesArray = useMemo(() => {
@@ -743,13 +808,37 @@ export function DeviceStatusTimelines({
             {filteredDevices.length !== 1 ? 's' : ''})
           </div>
         </div>
-        {onTimeRangeChange && (
-          <SmallDropdown
-            value={timeRange}
-            options={timeRangeOptions}
-            onChange={(v) => onTimeRangeChange(v as TimeRange)}
-          />
-        )}
+        <div className="flex items-center gap-2 flex-wrap">
+          {onTimeRangeChange && (
+            <SmallDropdown
+              value={timeRange}
+              options={timeRangeOptions}
+              onChange={(v) => onTimeRangeChange(v as TimeRange)}
+            />
+          )}
+          <button
+            type="button"
+            onClick={() => setShowIncidentOverlays(v => !v)}
+            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+              showIncidentOverlays
+                ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Incidents
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMaintenanceOverlays(v => !v)}
+            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+              showMaintenanceOverlays
+                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Maintenance
+          </button>
+        </div>
       </div>
 
       {/* Legend */}
@@ -785,8 +874,24 @@ export function DeviceStatusTimelines({
             devicesWithIssues={devicesWithIssues}
             initiallyExpanded={derived.pk === expandedDevicePk}
             timeRange={timeRange}
+            isOpsUser={isOpsUser}
+            onCreateIncident={(pk, code, contributor, contributorPk, reasons) => setCreateIncidentFor({ devicePk: pk, deviceCode: code, contributorCode: contributor, contributorPk, issueReasons: reasons })}
+            showIncidentOverlays={showIncidentOverlays}
+            showMaintenanceOverlays={showMaintenanceOverlays}
           />
         ))}
+        {createIncidentFor && (
+          <CreateIncidentModal
+            entityCode={createIncidentFor.deviceCode}
+            entityType="device"
+            entityPk={createIncidentFor.devicePk}
+            contributorCode={createIncidentFor.contributorCode}
+            contributorPk={createIncidentFor.contributorPk}
+            issueReasons={createIncidentFor.issueReasons}
+            onClose={() => setCreateIncidentFor(null)}
+            onSuccess={() => setCreateIncidentFor(null)}
+          />
+        )}
       </div>
     </div>
   )

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -16,7 +16,7 @@ import type { DeviceMetricsResponse } from '@/lib/api'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
-import { useActiveOpsTickets, useTicketsForEntity } from '@/hooks/use-ops-tickets'
+import { useTicketsForEntity } from '@/hooks/use-ops-tickets'
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { useAuth } from '@/contexts/AuthContext'
 import { IncidentBadge } from '@/components/ops/IncidentBadge'
@@ -268,11 +268,9 @@ interface DeviceRowProps {
   timeRange?: string
   isOpsUser: boolean
   onCreateIncident: (devicePk: string, deviceCode: string, contributorCode: string, contributorPk: string, issueReasons: string[]) => void
-  showIncidentOverlays: boolean
-  showMaintenanceOverlays: boolean
 }
 
-function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExpanded = false, timeRange = '24h', isOpsUser, onCreateIncident, showIncidentOverlays, showMaintenanceOverlays }: DeviceRowProps) {
+function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExpanded = false, timeRange = '24h', isOpsUser, onCreateIncident }: DeviceRowProps) {
   const tickets = useTicketsForEntity(derivedInfo.pk)
   const { user } = useAuth()
   const [expanded, setExpanded] = useState(initiallyExpanded)
@@ -520,7 +518,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
               hideBadges
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
-              maintenanceWindows={showMaintenanceOverlays ? tickets
+              maintenanceWindows={tickets
                 .filter(t => t.type === 'maintenance' && t.start_at)
                 .map(t => ({
                   startAt: t.start_at!,
@@ -532,8 +530,8 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
                   status: t.status,
                   entityName: derivedInfo.code,
                   slackUrl: t.slack_message_url,
-                })) : []}
-              incidentWindows={showIncidentOverlays ? tickets
+                }))}
+              incidentWindows={tickets
                 .filter(t => t.type === 'incident')
                 .map(t => ({
                   startAt: t.start_at ?? new Date().toISOString(),
@@ -545,7 +543,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
                   status: t.status,
                   entityName: derivedInfo.code,
                   slackUrl: t.slack_message_url,
-                })) : []}
+                }))}
             />
             {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident' && !isTicketClosed(t.status)) && (
               <div className="flex justify-end mt-1">
@@ -614,8 +612,6 @@ export function DeviceStatusTimelines({
     placeholderData: keepPreviousData,
   })
 
-  // Pre-fetch active tickets once for all rows — filtered client-side per device
-  const { data: activeTicketsData } = useActiveOpsTickets()
   const isOpsUser = useIsOpsUser()
   const [createIncidentFor, setCreateIncidentFor] = useState<{
     devicePk: string
@@ -624,9 +620,6 @@ export function DeviceStatusTimelines({
     contributorPk: string
     issueReasons: string[]
   } | null>(null)
-  const [showIncidentOverlays, setShowIncidentOverlays] = useState(true)
-  const [showMaintenanceOverlays, setShowMaintenanceOverlays] = useState(true)
-
   // Convert the Record<string, DeviceMetricsResponse> into an array with derived info
   const devicesArray = useMemo(() => {
     if (!data?.devices) return []
@@ -755,22 +748,6 @@ export function DeviceStatusTimelines({
     devicesWithHealth,
   ])
 
-  const incidentCount = useMemo(() => {
-    const tickets = activeTicketsData?.tickets ?? []
-    return devicesArray.filter(({ derived }) =>
-      tickets.some(t => t.type === 'incident' &&
-        (t.device_pubkey.includes(derived.pk) || (t.affected_devices?.some(d => d.pubkey === derived.pk) ?? false)))
-    ).length
-  }, [activeTicketsData, devicesArray])
-
-  const maintenanceCount = useMemo(() => {
-    const tickets = activeTicketsData?.tickets ?? []
-    return devicesArray.filter(({ derived }) =>
-      tickets.some(t => t.type === 'maintenance' &&
-        (t.device_pubkey.includes(derived.pk) || (t.affected_devices?.some(d => d.pubkey === derived.pk) ?? false)))
-    ).length
-  }, [activeTicketsData, devicesArray])
-
   const showSkeleton = useDelayedLoading(isLoading && !data)
 
   if (isLoading && !data) {
@@ -826,32 +803,6 @@ export function DeviceStatusTimelines({
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {isOpsUser && incidentCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowIncidentOverlays(v => !v)}
-              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                showIncidentOverlays
-                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                  : 'border-border text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Incidents ({incidentCount})
-            </button>
-          )}
-          {isOpsUser && maintenanceCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowMaintenanceOverlays(v => !v)}
-              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                showMaintenanceOverlays
-                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                  : 'border-border text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Maintenance ({maintenanceCount})
-            </button>
-          )}
           {onTimeRangeChange && (
             <SmallDropdown
               value={timeRange}
@@ -897,8 +848,6 @@ export function DeviceStatusTimelines({
             timeRange={timeRange}
             isOpsUser={isOpsUser}
             onCreateIncident={(pk, code, contributor, contributorPk, reasons) => setCreateIncidentFor({ devicePk: pk, deviceCode: code, contributorCode: contributor, contributorPk, issueReasons: reasons })}
-            showIncidentOverlays={showIncidentOverlays}
-            showMaintenanceOverlays={showMaintenanceOverlays}
           />
         ))}
         {createIncidentFor && (

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -499,7 +499,7 @@ function DeviceRow({ deviceMetrics, derivedInfo, devicesWithIssues, initiallyExp
                 )}
                 {/* Maintenance badge — visible to all users */}
                 {tickets.some(t => t.type === 'maintenance') && (
-                  <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                  <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">
                     Maintenance
                   </span>
                 )}

--- a/web/src/components/device-status-timelines.tsx
+++ b/web/src/components/device-status-timelines.tsx
@@ -823,7 +823,7 @@ export function DeviceStatusTimelines({
                 onClick={() => setShowIncidentOverlays(v => !v)}
                 className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
                   showIncidentOverlays
-                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -834,7 +834,7 @@ export function DeviceStatusTimelines({
                 onClick={() => setShowMaintenanceOverlays(v => !v)}
                 className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
                   showMaintenanceOverlays
-                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -297,7 +297,7 @@ function OpsIncidentsSection({
         <span className="px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground tabular-nums">
           {relevant.length}
         </span>
-        <span className="text-xs text-muted-foreground flex-1">Incidents registered in Ops Management</span>
+        <span className="text-xs text-muted-foreground flex-1">Incidents registered in <a href="https://doublezero.xyz/ops-management" target="_blank" rel="noreferrer" className="text-blue-400 hover:underline">Ops Management</a></span>
         {isOpsUser && (
           <button
             onClick={onCreateIncident}

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -282,6 +282,7 @@ function OpsIncidentsSection({
   isOpsUser: boolean
   onCreateIncident: () => void
 }) {
+  const [open, setOpen] = useState(true)
   const relevant = tickets.filter(t =>
     t.type === 'incident' && (
       scope === 'links'
@@ -292,27 +293,38 @@ function OpsIncidentsSection({
 
   return (
     <div className="border border-border rounded-lg bg-card mb-3">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
-        <h2 className="text-sm font-semibold">Ops Incidents</h2>
-        <span className="px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground tabular-nums">
-          {relevant.length}
-        </span>
-        <span className="text-xs text-muted-foreground flex-1">Incidents registered in <a href="https://doublezero.xyz/ops-management" target="_blank" rel="noreferrer" className="text-blue-400 hover:underline">Ops Management</a></span>
+      <div className={`flex items-center gap-3 px-4 py-3 ${open ? 'border-b border-border' : ''}`}>
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex items-center gap-3 flex-1 text-left hover:bg-muted/30 transition-colors -mx-4 -my-3 px-4 py-3 rounded-t-lg"
+        >
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+              !open && '-rotate-90',
+            )}
+          />
+          <h2 className="text-sm font-semibold">Registered</h2>
+          <span className="px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground tabular-nums">
+            {relevant.length}
+          </span>
+          <span className="text-xs text-muted-foreground">Incidents registered in <a href="https://doublezero.xyz/ops-management" target="_blank" rel="noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline" onClick={e => e.stopPropagation()}>Ops Management</a></span>
+        </button>
         {isOpsUser && (
           <button
             onClick={onCreateIncident}
-            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium border border-border rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium border border-border rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground shrink-0"
           >
             <Plus className="h-3 w-3" />
             New incident
           </button>
         )}
       </div>
-      {relevant.length === 0 ? (
+      {open && relevant.length === 0 ? (
         <div className="px-4 py-4 text-sm text-muted-foreground">
           No active ops management incidents for {scope === 'links' ? 'links' : 'devices'}.
         </div>
-      ) : (
+      ) : open ? (
         <div className="overflow-hidden">
           <table className="w-full text-sm">
             <thead className="bg-muted/50">
@@ -407,7 +419,7 @@ function OpsIncidentsSection({
             </tbody>
           </table>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -1641,7 +1653,7 @@ function ActiveIncidentsTable({
                   <Link
                     to={`/dz/links/${encodeURIComponent(group.link_pk)}`}
                     state={{ backLabel: 'incidents' }}
-                    className="text-primary hover:underline inline-flex items-center gap-1"
+                    className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
                   >
                     {group.link_code}
                     <ExternalLink className="h-3 w-3" />
@@ -1757,7 +1769,7 @@ function DrainedLinksTable({ drainedLinks }: { drainedLinks: DrainedLinkInfo[] }
                 <Link
                   to={`/dz/links/${encodeURIComponent(dl.link_pk)}`}
                   state={{ backLabel: 'incidents' }}
-                  className="text-primary hover:underline inline-flex items-center gap-1 max-w-full"
+                  className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1 max-w-full"
                   title={dl.link_code}
                 >
                   <span className="truncate">{dl.link_code}</span>
@@ -1947,7 +1959,7 @@ function ActiveDeviceIncidentsTable({
               <td className="px-4 py-3">
                 <Link
                   to={`/dz/devices/${encodeURIComponent(group.device_pk)}`}
-                  className="text-primary hover:underline inline-flex items-center gap-1"
+                  className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
                 >
                   {group.device_code}
                   <ExternalLink className="h-3 w-3" />
@@ -2056,7 +2068,7 @@ function DrainedDevicesTable({ drainedDevices }: { drainedDevices: DrainedDevice
               <td className="px-4 py-3 truncate">
                 <Link
                   to={`/dz/devices/${encodeURIComponent(dd.device_pk)}`}
-                  className="text-primary hover:underline inline-flex items-center gap-1 max-w-full"
+                  className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1 max-w-full"
                   title={dd.device_code}
                 >
                   <span className="truncate">{dd.device_code}</span>

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -1203,12 +1203,14 @@ export function IncidentsPage() {
             {/* Active view */}
             {view === 'active' && (
               <>
-                <OpsIncidentsSection
-                  tickets={opsTickets}
-                  scope={scope}
-                  isOpsUser={isOpsUser}
-                  onCreateIncident={() => setShowCreateIncident(true)}
-                />
+                {isOpsUser && (
+                  <OpsIncidentsSection
+                    tickets={opsTickets}
+                    scope={scope}
+                    isOpsUser={isOpsUser}
+                    onCreateIncident={() => setShowCreateIncident(true)}
+                  />
+                )}
                 {(() => {
                   const isEmpty =
                     scope === 'links'

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -1,15 +1,7 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useState, useMemo, useEffect } from 'react'
 import { useSearchParams, useNavigate, useLocation, Link } from 'react-router-dom'
-import {
-  ShieldAlert,
-  Settings,
-  ExternalLink,
-  Info,
-  Download,
-  ChevronDown,
-  RefreshCw,
-} from 'lucide-react'
+import { ShieldAlert, Settings, ExternalLink, Info, Download, ChevronDown, RefreshCw, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   fetchLinkIncidents,
@@ -22,6 +14,10 @@ import {
 } from '@/lib/api'
 import { StatusFilters, useStatusFilters } from '@/components/status-search-bar'
 import { PageHeader } from '@/components/page-header'
+import { useActiveOpsTickets } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
+import { opsTicketUrl, type OpsTicket } from '@/lib/ops-api'
+import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
 
 const timeRanges: { value: IncidentTimeRange; label: string }[] = [
   { value: '3h', label: '3h' },
@@ -254,6 +250,168 @@ function dedupeIncidentTypes(incidents: { incident_type: string }[]): string[] {
   return result
 }
 
+const severityClass: Record<string, string> = {
+  sev1: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+  sev2: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+  sev3: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+}
+
+function OpsIncidentsBadge({ ticket }: { ticket: OpsTicket }) {
+  return (
+    <a
+      href={opsTicketUrl(ticket.id)}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 hover:underline"
+      title={ticket.title}
+    >
+      {ticket.human_readable_id}
+      <ExternalLink className="h-2.5 w-2.5" />
+    </a>
+  )
+}
+
+function OpsIncidentsSection({
+  tickets,
+  scope,
+  isOpsUser,
+  onCreateIncident,
+}: {
+  tickets: OpsTicket[]
+  scope: IncidentScope
+  isOpsUser: boolean
+  onCreateIncident: () => void
+}) {
+  const relevant = tickets.filter(t =>
+    t.type === 'incident' && (
+      scope === 'links'
+        ? (t.affected_link_pubkey.length > 0 || (t.affected_links && t.affected_links.length > 0))
+        : (t.device_pubkey.length > 0 || (t.affected_devices && t.affected_devices.length > 0))
+    )
+  )
+
+  return (
+    <div className="border border-border rounded-lg bg-card mb-3">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
+        <h2 className="text-sm font-semibold">Ops Incidents</h2>
+        <span className="px-1.5 py-0.5 text-xs rounded-full bg-muted-foreground/10 text-muted-foreground tabular-nums">
+          {relevant.length}
+        </span>
+        <span className="text-xs text-muted-foreground flex-1">Incidents registered in Ops Management</span>
+        {isOpsUser && (
+          <button
+            onClick={onCreateIncident}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium border border-border rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-3 w-3" />
+            New incident
+          </button>
+        )}
+      </div>
+      {relevant.length === 0 ? (
+        <div className="px-4 py-4 text-sm text-muted-foreground">
+          No active ops management incidents for {scope === 'links' ? 'links' : 'devices'}.
+        </div>
+      ) : (
+        <div className="overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">ID</th>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">Title</th>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">Severity</th>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">Status</th>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">
+                  {scope === 'links' ? 'Affected links' : 'Affected devices'}
+                </th>
+                <th className="text-left px-4 py-2.5 font-medium text-xs">Started</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {relevant.map(ticket => {
+                const entities: { code: string; pk: string }[] = scope === 'links'
+                  ? (ticket.affected_links?.map(l => ({ code: l.code, pk: l.pubkey }))
+                     ?? ticket.affected_link_pubkey.map(pk => ({ code: pk, pk })))
+                  : (ticket.affected_devices?.map(d => ({ code: d.code, pk: d.pubkey }))
+                     ?? ticket.device_pubkey.map(pk => ({ code: pk, pk })))
+                const detailPath = scope === 'links' ? '/dz/links/' : '/dz/devices/'
+                return (
+                  <tr key={ticket.id} className="hover:bg-muted/30">
+                    <td className="px-4 py-2.5 whitespace-nowrap">
+                      <div className="flex items-center gap-2">
+                        <a
+                          href={opsTicketUrl(ticket.id)}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
+                        >
+                          {ticket.human_readable_id}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                        {ticket.slack_message_url && (
+                          <a
+                            href={ticket.slack_message_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-[10px] text-[#4A9CC7] hover:underline shrink-0"
+                            title="View Slack thread"
+                          >
+                            Slack ↗
+                          </a>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 max-w-[280px]">
+                      <span className="line-clamp-2">{ticket.title}</span>
+                      {ticket.contributor_name && (
+                        <div className="text-xs text-muted-foreground">{ticket.contributor_name}</div>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 whitespace-nowrap">
+                      {ticket.severity ? (
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${severityClass[ticket.severity] ?? ''}`}>
+                          {ticket.severity}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 whitespace-nowrap">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground capitalize">
+                        {ticket.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex flex-wrap gap-1">
+                        {entities.slice(0, 3).map((e, i) => (
+                          <Link
+                            key={i}
+                            to={`${detailPath}${e.pk}`}
+                            className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                          >
+                            {e.code}
+                          </Link>
+                        ))}
+                        {entities.length > 3 && (
+                          <span className="text-xs text-muted-foreground">+{entities.length - 3} more</span>
+                        )}
+                        {entities.length === 0 && <span className="text-muted-foreground">—</span>}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 whitespace-nowrap text-xs text-muted-foreground">
+                      {ticket.start_at ? formatTimeAgo(ticket.start_at) : formatTimeAgo(ticket.created_at)}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function IncidentsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -281,6 +439,19 @@ export function IncidentsPage() {
   const showLinkInterfaces = searchParams.get('link_interfaces') === 'true'
 
   const [showSettings, setShowSettings] = useState(false)
+  const [showCreateIncident, setShowCreateIncident] = useState(false)
+  const [createIncidentFor, setCreateIncidentFor] = useState<{
+    entityCode: string
+    entityType: 'link' | 'device'
+    entityPk: string
+    contributorCode: string
+    contributorPk: string
+    issueReasons: string[]
+    downSince?: string
+  } | null>(null)
+  const isOpsUser = useIsOpsUser()
+  const { data: opsTicketsData } = useActiveOpsTickets()
+  const opsTickets = opsTicketsData?.tickets ?? []
 
   // Local settings state — only applied on "Apply"
   const [localSettings, setLocalSettings] = useState({
@@ -671,15 +842,45 @@ export function IncidentsPage() {
           icon={ShieldAlert}
           title="Incidents"
           actions={
-            <a
-              href={exportUrl}
-              className="inline-flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground border border-border rounded-md hover:bg-muted transition-colors"
-            >
-              <Download className="h-3 w-3" />
-              Export CSV
-            </a>
+            <div className="flex items-center gap-2">
+              {isOpsUser && (
+                <button
+                  onClick={() => setShowCreateIncident(true)}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground border border-border rounded-md hover:bg-muted transition-colors"
+                >
+                  <Plus className="h-4 w-4" />
+                  New incident
+                </button>
+              )}
+              <a
+                href={exportUrl}
+                className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground border border-border rounded-md hover:bg-muted transition-colors"
+              >
+                <Download className="h-4 w-4" />
+                Export CSV
+              </a>
+            </div>
           }
         />
+        {showCreateIncident && (
+          <CreateIncidentModal
+            onClose={() => setShowCreateIncident(false)}
+            onSuccess={() => setShowCreateIncident(false)}
+          />
+        )}
+        {createIncidentFor && (
+          <CreateIncidentModal
+            entityCode={createIncidentFor.entityCode}
+            entityType={createIncidentFor.entityType}
+            entityPk={createIncidentFor.entityPk}
+            contributorCode={createIncidentFor.contributorCode}
+            contributorPk={createIncidentFor.contributorPk}
+            issueReasons={createIncidentFor.issueReasons}
+            downSince={createIncidentFor.downSince}
+            onClose={() => setCreateIncidentFor(null)}
+            onSuccess={() => setCreateIncidentFor(null)}
+          />
+        )}
 
         {/* Scope toggle */}
         <div className="flex items-center gap-2 mb-4">
@@ -1002,6 +1203,12 @@ export function IncidentsPage() {
             {/* Active view */}
             {view === 'active' && (
               <>
+                <OpsIncidentsSection
+                  tickets={opsTickets}
+                  scope={scope}
+                  isOpsUser={isOpsUser}
+                  onCreateIncident={() => setShowCreateIncident(true)}
+                />
                 {(() => {
                   const isEmpty =
                     scope === 'links'
@@ -1120,7 +1327,11 @@ export function IncidentsPage() {
                                   toggleSort={toggleSort}
                                   coalesceGapMinutes={coalesceGap}
                                   typeFilter={selectedTypes}
-                                />
+                                  opsTickets={opsTickets}
+                                sectionKey={key}
+                                onCreateIncident={isOpsUser ? (pk, code, contributorCode, contributorPk, issueReasons, issueSince) =>
+                                  setCreateIncidentFor({ entityCode: code, entityType: 'link', entityPk: pk, contributorCode, contributorPk, issueReasons, downSince: issueSince }) : undefined}
+                              />
                               ) : (
                                 <ActiveDeviceIncidentsTable
                                   incidents={sectionIncidents as DeviceIncident[]}
@@ -1128,10 +1339,15 @@ export function IncidentsPage() {
                                   sortDir={sortDir}
                                   toggleSort={toggleSort}
                                   typeFilter={selectedTypes}
-                                />
+                                  opsTickets={opsTickets}
+                                sectionKey={key}
+                                onCreateIncident={isOpsUser ? (pk, code, contributorCode, contributorPk, issueReasons, issueSince) =>
+                                  setCreateIncidentFor({ entityCode: code, entityType: 'device', entityPk: pk, contributorCode, contributorPk, issueReasons, downSince: issueSince }) : undefined}
+                              />
                               )}
                             </IncidentSection>
                           ),
+
                         )}
                       </div>
                     </>
@@ -1182,6 +1398,7 @@ type GroupedLinkIncident = {
   side_a_metro: string
   side_z_metro: string
   contributor_code: string
+  contributor_pk: string
   is_drained: boolean
   started_at: string
   is_ongoing: boolean
@@ -1251,6 +1468,7 @@ function groupIncidentsByLink(
         side_a_metro: earliest.side_a_metro,
         side_z_metro: earliest.side_z_metro,
         contributor_code: earliest.contributor_code,
+        contributor_pk: '',
         is_drained: cluster.some((i) => i.is_drained),
         started_at: earliest.started_at,
         is_ongoing: anyOngoing,
@@ -1268,6 +1486,7 @@ type GroupedDeviceIncident = {
   device_type: string
   metro: string
   contributor_code: string
+  contributor_pk: string
   is_drained: boolean
   started_at: string
   is_ongoing: boolean
@@ -1297,6 +1516,7 @@ function groupIncidentsByDevice(incidents: DeviceIncident[]): GroupedDeviceIncid
       device_type: earliest.device_type,
       metro: earliest.metro,
       contributor_code: earliest.contributor_code,
+      contributor_pk: '',
       is_drained: incs.some((i) => i.is_drained),
       started_at: earliest.started_at,
       is_ongoing: anyOngoing,
@@ -1314,6 +1534,9 @@ function ActiveIncidentsTable({
   toggleSort,
   coalesceGapMinutes = 180,
   typeFilter,
+  opsTickets = [],
+  sectionKey,
+  onCreateIncident,
 }: {
   incidents: LinkIncident[]
   sortField: string
@@ -1321,6 +1544,9 @@ function ActiveIncidentsTable({
   toggleSort: (field: 'started_at' | 'ended_at' | 'duration') => void
   coalesceGapMinutes?: number
   typeFilter?: Set<string>
+  opsTickets?: OpsTicket[]
+  sectionKey?: string
+  onCreateIncident?: (pk: string, code: string, contributorCode: string, contributorPk: string, issueReasons: string[], issueSince?: string) => void
 }) {
   // Stable timestamp for computing ongoing durations — avoids calling Date.now() during render
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1404,6 +1630,9 @@ function ActiveIncidentsTable({
               }
             }
             const interfaces = Array.from(allInterfaces)
+            const correlated = opsTickets.filter(t =>
+              t.type === 'incident' && t.affected_link_pubkey.includes(group.link_pk)
+            )
             return (
               <tr key={`${group.link_pk}-${group.started_at}`} className="hover:bg-muted/30">
                 <td className="px-4 py-3 whitespace-nowrap">
@@ -1422,6 +1651,21 @@ function ActiveIncidentsTable({
                       {group.side_a_metro} &rarr; {group.side_z_metro}
                     </span>
                   </div>
+                  {sectionKey !== 'resolved' && onCreateIncident && correlated.length === 0 && (
+                    <button
+                      onClick={() => onCreateIncident(
+                        group.link_pk,
+                        group.link_code,
+                        group.contributor_code,
+                        group.contributor_pk,
+                        [...new Set(group.incidents.map(i => i.incident_type))],
+                        group.started_at,
+                      )}
+                      className="mt-1 text-[11px] text-muted-foreground hover:text-foreground border border-border/50 hover:border-border px-1.5 py-0.5 transition-colors"
+                    >
+                      + Create incident
+                    </button>
+                  )}
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center gap-1.5 flex-wrap">
@@ -1439,6 +1683,7 @@ function ActiveIncidentsTable({
                       </span>
                     ))}
                     {group.is_drained && <DrainedBadge />}
+                    {correlated.map(t => <OpsIncidentsBadge key={t.id} ticket={t} />)}
                   </div>
                   {interfaces.length > 0 && (
                     <div className="text-xs text-muted-foreground mt-0.5 font-mono">
@@ -1603,12 +1848,18 @@ function ActiveDeviceIncidentsTable({
   sortDir,
   toggleSort,
   typeFilter,
+  opsTickets = [],
+  sectionKey,
+  onCreateIncident,
 }: {
   incidents: DeviceIncident[]
   sortField: string
   sortDir: string
   toggleSort: (field: 'started_at' | 'ended_at' | 'duration') => void
   typeFilter?: Set<string>
+  opsTickets?: OpsTicket[]
+  sectionKey?: string
+  onCreateIncident?: (pk: string, code: string, contributorCode: string, contributorPk: string, issueReasons: string[], issueSince?: string) => void
 }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const renderTimestamp = useMemo(() => Date.now(), [incidents])
@@ -1686,44 +1937,60 @@ function ActiveDeviceIncidentsTable({
               }
             }
             const interfaces = Array.from(allInterfaces)
+            const correlated = opsTickets.filter(t =>
+              t.type === 'incident' && t.device_pubkey.includes(group.device_pk)
+            )
             return (
-              <tr key={group.device_pk + group.started_at} className="hover:bg-muted/30">
-                <td className="px-4 py-3 whitespace-nowrap">
-                  <Link
-                    to={`/dz/devices/${encodeURIComponent(group.device_pk)}`}
-                    className="text-primary hover:underline inline-flex items-center gap-1"
-                  >
-                    {group.device_code}
-                    <ExternalLink className="h-3 w-3" />
-                  </Link>
-                  <div className="text-xs text-muted-foreground">
-                    {group.contributor_code} · {group.device_type}
-                    {group.metro && (
-                      <>
-                        <span className="mx-1">·</span>
-                        <span className="font-mono">{group.metro}</span>
-                      </>
+            <tr key={group.device_pk + group.started_at} className="hover:bg-muted/30">
+              <td className="px-4 py-3">
+                <Link
+                  to={`/dz/devices/${encodeURIComponent(group.device_pk)}`}
+                  className="text-primary hover:underline inline-flex items-center gap-1"
+                >
+                  {group.device_code}
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+                <div className="text-xs text-muted-foreground">
+                  {group.contributor_code} · {group.device_type}
+                  {group.metro && <><span className="mx-1">·</span><span className="font-mono">{group.metro}</span></>}
+                </div>
+                {sectionKey !== 'resolved' && onCreateIncident && correlated.length === 0 && (
+                  <button
+                    onClick={() => onCreateIncident(
+                      group.device_pk,
+                      group.device_code,
+                      group.contributor_code,
+                      group.contributor_pk,
+                      [...new Set(group.incidents.map(i => i.incident_type))],
+                      group.started_at,
                     )}
+                    className="mt-1 text-[11px] text-muted-foreground hover:text-foreground border border-border/50 hover:border-border px-1.5 py-0.5 transition-colors"
+                  >
+                    + Create incident
+                  </button>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {Array.from(byType.entries()).map(([type, agg]) => (
+                    <span key={type} className="inline-flex items-center gap-1">
+                      <IncidentTypeBadge type={type} />
+                      {agg.peakCount != null && (
+                        <span className="text-xs text-muted-foreground">
+                          ({agg.peakCount})
+                        </span>
+                      )}
+                    </span>
+                  ))}
+                  {group.is_drained && <DrainedBadge />}
+                  {correlated.map(t => <OpsIncidentsBadge key={t.id} ticket={t} />)}
+                </div>
+                {interfaces.length > 0 && (
+                  <div className="text-xs text-muted-foreground mt-0.5 font-mono">
+                    {interfaces.join(', ')}
                   </div>
-                </td>
-                <td className="px-4 py-3 whitespace-nowrap">
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    {Array.from(byType.entries()).map(([type, agg]) => (
-                      <span key={type} className="inline-flex items-center gap-1">
-                        <IncidentTypeBadge type={type} />
-                        {agg.peakCount != null && (
-                          <span className="text-xs text-muted-foreground">({agg.peakCount})</span>
-                        )}
-                      </span>
-                    ))}
-                    {group.is_drained && <DrainedBadge />}
-                  </div>
-                  {interfaces.length > 0 && (
-                    <div className="text-xs text-muted-foreground mt-0.5 font-mono">
-                      {interfaces.join(', ')}
-                    </div>
-                  )}
-                </td>
+                )}
+              </td>
                 <td className="px-4 py-3 whitespace-nowrap">
                   <div>{formatTimeAgo(group.started_at)}</div>
                   <div className="text-xs text-muted-foreground">

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -365,7 +365,7 @@ function OpsIncidentsSection({
                             href={ticket.slack_message_url}
                             target="_blank"
                             rel="noreferrer"
-                            className="text-[10px] text-[#4A9CC7] hover:underline shrink-0"
+                            className="text-[10px] text-blue-600 dark:text-blue-400 hover:underline shrink-0"
                             title="View Slack thread"
                           >
                             Slack ↗

--- a/web/src/components/link-charts/LinkHealthTimeline.tsx
+++ b/web/src/components/link-charts/LinkHealthTimeline.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useLayoutEffect } from 'react'
 import type { LinkMetricsResponse, LinkMetricsBucket } from '@/lib/api'
+import { TicketOverlay, type TicketWindow } from '@/components/ops/TicketOverlay'
 
 interface LinkHealthTimelineProps {
   data: LinkMetricsResponse
@@ -7,6 +8,8 @@ interface LinkHealthTimelineProps {
   hideBadges?: boolean
   onBarHover?: (range: { start: number; end: number } | null) => void
   highlightedTime?: number | null  // unix seconds
+  incidentWindows?: TicketWindow[]
+  maintenanceWindows?: TicketWindow[]
 }
 
 // Hard-drained: dark stripes over health color
@@ -275,7 +278,7 @@ function useContainerBars() {
   return { containerRef, maxBars }
 }
 
-export function LinkHealthTimeline({ data, className, hideBadges, onBarHover, highlightedTime }: LinkHealthTimelineProps) {
+export function LinkHealthTimeline({ data, className, hideBadges, onBarHover, highlightedTime, incidentWindows, maintenanceWindows }: LinkHealthTimelineProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const { containerRef, maxBars } = useContainerBars()
 
@@ -284,6 +287,17 @@ export function LinkHealthTimeline({ data, className, hideBadges, onBarHover, hi
     markTrailingCollecting(merged)
     return merged
   }, [data.buckets, data.bucket_seconds, maxBars])
+
+  const rangeStartMs = useMemo(() => {
+    if (!data.buckets.length) return 0
+    return new Date(data.buckets[0].ts).getTime()
+  }, [data.buckets])
+
+  const rangeEndMs = useMemo(() => {
+    if (!data.buckets.length) return 0
+    const last = data.buckets[data.buckets.length - 1]
+    return new Date(last.ts).getTime() + data.bucket_seconds * 1000
+  }, [data.buckets, data.bucket_seconds])
 
   const highlightedBarIndex = useMemo(() => {
     if (highlightedTime == null) return -1
@@ -496,6 +510,16 @@ export function LinkHealthTimeline({ data, className, hideBadges, onBarHover, hi
             )
           })}
         </div>
+
+        {/* Ticket overlays — incidents and maintenance combined so overlapping windows cluster */}
+        {((incidentWindows?.length ?? 0) + (maintenanceWindows?.length ?? 0)) > 0 && (
+          <TicketOverlay
+            windows={[...(maintenanceWindows ?? []), ...(incidentWindows ?? [])]}
+            rangeStartMs={rangeStartMs}
+            rangeEndMs={rangeEndMs}
+            minWidthMs={bars[0] ? bars[0].spanSeconds * 1000 : data.bucket_seconds * 1000}
+          />
+        )}
 
         {/* Time labels */}
         <div className="flex justify-between mt-1 text-[10px] text-muted-foreground">

--- a/web/src/components/link-charts/LinkInterfaceIssuesChart.tsx
+++ b/web/src/components/link-charts/LinkInterfaceIssuesChart.tsx
@@ -7,6 +7,8 @@ import { useUPlotChart } from '@/hooks/use-uplot-chart'
 import { useUPlotLegendSync } from '@/hooks/use-uplot-legend-sync'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { LinkMetricsResponse } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface LinkInterfaceIssuesChartProps {
   data: LinkMetricsResponse
@@ -14,6 +16,9 @@ interface LinkInterfaceIssuesChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 function formatCount(value: number): string {
@@ -33,7 +38,7 @@ interface SideSeries {
   extract: (b: LinkMetricsResponse['buckets'][number]) => number | null
 }
 
-export function LinkInterfaceIssuesChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkInterfaceIssuesChartProps) {
+export function LinkInterfaceIssuesChart({ data, className, loading, highlightTimeRange, onCursorTime, tickets, showIncidents, showMaintenance }: LinkInterfaceIssuesChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
@@ -150,7 +155,7 @@ export function LinkInterfaceIssuesChart({ data, className, loading, highlightTi
     ctx.restore()
   }], [])
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -228,7 +233,19 @@ export function LinkInterfaceIssuesChart({ data, className, loading, highlightTi
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       {/* Per-series legend */}
       <div className="flex flex-col text-xs px-2 pt-1 pb-2">
         <div className="flex items-center px-1 mb-1">

--- a/web/src/components/link-charts/LinkJitterChart.tsx
+++ b/web/src/components/link-charts/LinkJitterChart.tsx
@@ -10,6 +10,8 @@ import { type ChartLegendSeries } from '@/components/topology/ChartLegend'
 import { ChartLegendTable } from '@/components/topology/ChartLegendTable'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { LinkMetricsResponse } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface LinkJitterChartProps {
   data: LinkMetricsResponse
@@ -17,6 +19,9 @@ interface LinkJitterChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'min' | 'max'
@@ -42,6 +47,9 @@ export function LinkJitterChart({
   loading,
   highlightTimeRange,
   onCursorTime,
+  tickets,
+  showIncidents,
+  showMaintenance,
 }: LinkJitterChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -178,7 +186,7 @@ export function LinkJitterChart({
     [],
   )
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -271,7 +279,19 @@ export function LinkJitterChart({
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       <ChartLegendTable
         series={legendSeries}
         legend={legend}

--- a/web/src/components/link-charts/LinkLatencyChart.tsx
+++ b/web/src/components/link-charts/LinkLatencyChart.tsx
@@ -10,6 +10,8 @@ import { type ChartLegendSeries } from '@/components/topology/ChartLegend'
 import { ChartLegendTable } from '@/components/topology/ChartLegendTable'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { LinkMetricsResponse } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface LinkLatencyChartProps {
   data: LinkMetricsResponse
@@ -17,6 +19,9 @@ interface LinkLatencyChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'min' | 'max'
@@ -46,6 +51,9 @@ export function LinkLatencyChart({
   loading,
   highlightTimeRange,
   onCursorTime,
+  tickets,
+  showIncidents,
+  showMaintenance,
 }: LinkLatencyChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -177,7 +185,7 @@ export function LinkLatencyChart({
     [],
   )
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -270,7 +278,19 @@ export function LinkLatencyChart({
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       <ChartLegendTable
         series={legendSeries}
         legend={legend}

--- a/web/src/components/link-charts/LinkPacketLossChart.tsx
+++ b/web/src/components/link-charts/LinkPacketLossChart.tsx
@@ -9,6 +9,8 @@ import { type ChartLegendSeries } from '@/components/topology/ChartLegend'
 import { ChartLegendTable } from '@/components/topology/ChartLegendTable'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { LinkMetricsResponse } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface LinkPacketLossChartProps {
   data: LinkMetricsResponse
@@ -16,9 +18,12 @@ interface LinkPacketLossChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
-export function LinkPacketLossChart({ data, className, loading, highlightTimeRange, onCursorTime }: LinkPacketLossChartProps) {
+export function LinkPacketLossChart({ data, className, loading, highlightTimeRange, onCursorTime, tickets, showIncidents, showMaintenance }: LinkPacketLossChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
 
@@ -109,7 +114,7 @@ export function LinkPacketLossChart({ data, className, loading, highlightTimeRan
     ctx.restore()
   }], [])
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -187,7 +192,19 @@ export function LinkPacketLossChart({ data, className, loading, highlightTimeRan
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       <ChartLegendTable series={legendSeries} legend={legend} values={displayValues} maxValues={maxValues} hoveredTime={hoveredTime} />
     </div>
   )

--- a/web/src/components/link-charts/LinkTrafficChart.tsx
+++ b/web/src/components/link-charts/LinkTrafficChart.tsx
@@ -10,6 +10,8 @@ import { type ChartLegendSeries } from '@/components/topology/ChartLegend'
 import { ChartLegendTable } from '@/components/topology/ChartLegendTable'
 import { formatHoveredTime } from '@/components/topology/utils'
 import type { LinkMetricsResponse, LinkMetricsTraffic } from '@/lib/api'
+import { TicketChartBands } from '@/components/ops/TicketChartBands'
+import type { OpsTicket } from '@/lib/ops-api'
 
 interface LinkTrafficChartProps {
   data: LinkMetricsResponse
@@ -17,6 +19,9 @@ interface LinkTrafficChartProps {
   loading?: boolean
   highlightTimeRange?: { start: number; end: number } | null
   onCursorTime?: (time: number | null) => void
+  tickets?: OpsTicket[]
+  showIncidents?: boolean
+  showMaintenance?: boolean
 }
 
 type AggMode = 'avg' | 'p50' | 'p90' | 'p95' | 'p99' | 'max'
@@ -62,6 +67,9 @@ export function LinkTrafficChart({
   loading,
   highlightTimeRange,
   onCursorTime,
+  tickets,
+  showIncidents,
+  showMaintenance,
 }: LinkTrafficChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -206,7 +214,7 @@ export function LinkTrafficChart({
     [],
   )
 
-  const { plotRef } = useUPlotChart({
+  const { plotRef, plotVersion } = useUPlotChart({
     containerRef: chartRef,
     data: uPlotData,
     series: uPlotSeries,
@@ -322,7 +330,19 @@ export function LinkTrafficChart({
           <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
         )}
       </div>
-      <div ref={chartRef} className="h-36" />
+      <div className="relative overflow-hidden">
+        <div ref={chartRef} className="h-36" />
+        {tickets && tickets.length > 0 && (
+          <TicketChartBands
+            containerRef={chartRef}
+            plotRef={plotRef}
+            plotVersion={plotVersion}
+            tickets={tickets}
+            showIncidents={showIncidents ?? true}
+            showMaintenance={showMaintenance ?? true}
+          />
+        )}
+      </div>
       <ChartLegendTable
         series={legendSeries}
         legend={legend}

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -188,7 +188,7 @@ export function LinkDetailPage() {
                 onClick={() => setShowIncidents(v => !v)}
                 className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
                   showIncidents
-                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -199,7 +199,7 @@ export function LinkDetailPage() {
                 onClick={() => setShowMaintenance(v => !v)}
                 className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
                   showMaintenance
-                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -181,31 +181,31 @@ export function LinkDetailPage() {
             effectiveBucketLabel={effectiveBucketLabel}
           />
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          {isOpsUser && (
-            <>
-              <button
-                type="button"
-                onClick={() => setShowIncidents(v => !v)}
-                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-                  showIncidents
-                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Incidents
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMaintenance(v => !v)}
-                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-                  showMaintenance
-                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Maintenance
-              </button>
-            </>
+          {isOpsUser && tickets.some(t => t.type === 'incident') && (
+            <button
+              type="button"
+              onClick={() => setShowIncidents(v => !v)}
+              className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                showIncidents
+                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Incidents
+            </button>
+          )}
+          {isOpsUser && tickets.some(t => t.type === 'maintenance') && (
+            <button
+              type="button"
+              onClick={() => setShowMaintenance(v => !v)}
+              className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                showMaintenance
+                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Maintenance
+            </button>
           )}
         </div>
 

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -21,6 +21,7 @@ import { useBackLink } from '@/hooks/use-back-link'
 import { OpsPanel } from '@/components/ops/OpsPanel'
 import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
 import { useActiveOpsTickets, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import type { OpsTicket } from '@/lib/ops-api'
 import type { TicketWindow } from '@/components/ops/TicketOverlay'
 
@@ -36,6 +37,7 @@ export function LinkDetailPage() {
   } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
   const [showCreateIncident, setShowCreateIncident] = useState(false)
+  const isOpsUser = useIsOpsUser()
   const [showIncidents, setShowIncidents] = useState(true)
   const [showMaintenance, setShowMaintenance] = useState(true)
 
@@ -179,28 +181,32 @@ export function LinkDetailPage() {
             effectiveBucketLabel={effectiveBucketLabel}
           />
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          <button
-            type="button"
-            onClick={() => setShowIncidents(v => !v)}
-            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-              showIncidents
-                ? 'border-red-800/60 bg-red-900/20 text-red-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Incidents
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowMaintenance(v => !v)}
-            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
-              showMaintenance
-                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Maintenance
-          </button>
+          {isOpsUser && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowIncidents(v => !v)}
+                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                  showIncidents
+                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Incidents
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMaintenance(v => !v)}
+                className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+                  showMaintenance
+                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Maintenance
+              </button>
+            </>
+          )}
         </div>
 
         {metricsLoading && (

--- a/web/src/components/link-detail-page.tsx
+++ b/web/src/components/link-detail-page.tsx
@@ -18,6 +18,11 @@ import type { TimeRange, BucketSize } from '@/components/topology/utils'
 import { bucketLabels, resolveAutoBucket, type TimeRangePreset } from '@/components/topology/utils'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
+import { OpsPanel } from '@/components/ops/OpsPanel'
+import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
+import { useActiveOpsTickets, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
+import type { OpsTicket } from '@/lib/ops-api'
+import type { TicketWindow } from '@/components/ops/TicketOverlay'
 
 export function LinkDetailPage() {
   const { pk } = useParams<{ pk: string }>()
@@ -30,6 +35,9 @@ export function LinkDetailPage() {
     end: number
   } | null>(null)
   const [chartHoveredTime, setChartHoveredTime] = useState<number | null>(null)
+  const [showCreateIncident, setShowCreateIncident] = useState(false)
+  const [showIncidents, setShowIncidents] = useState(true)
+  const [showMaintenance, setShowMaintenance] = useState(true)
 
   const effectiveBucketLabel =
     bucket === 'auto'
@@ -57,6 +65,16 @@ export function LinkDetailPage() {
     queryFn: () => fetchLinkMetrics(pk!, metricsParams),
     enabled: !!pk,
   })
+
+  const { data: activeTicketsData } = useActiveOpsTickets()
+  const { data: ticketHistoryData } = useOpsTicketHistory(pk ?? '', undefined, 'link')
+  // Combine active tickets for this link + recently closed history
+  const tickets: OpsTicket[] = [
+    ...(activeTicketsData?.tickets ?? []).filter(
+      t => pk && (t.affected_link_pubkey.includes(pk) || (t.affected_links?.some(l => l.pubkey === pk) ?? false))
+    ),
+    ...(ticketHistoryData?.tickets ?? []),
+  ]
 
   useDocumentTitle(link?.code || 'Link')
 
@@ -117,6 +135,27 @@ export function LinkDetailPage() {
       {/* Link stats - constrained width, hide status row and charts */}
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pb-6">
         <LinkInfoContent link={linkDetailToInfo(link)} hideStatusRow hideCharts />
+        <div className="mt-6">
+          <OpsPanel
+            entityPk={link.pk}
+            entityCode={link.code}
+            entityType="link"
+            contributorCode={link.contributor_code}
+            isDown={link.status === 'down'}
+            onCreateIncident={() => setShowCreateIncident(true)}
+          />
+        </div>
+        {showCreateIncident && (
+          <CreateIncidentModal
+            entityCode={link.code}
+            entityType="link"
+            entityPk={link.pk}
+            contributorCode={link.contributor_code}
+            contributorPk={link.contributor_pk}
+            onClose={() => setShowCreateIncident(false)}
+            onSuccess={() => setShowCreateIncident(false)}
+          />
+        )}
       </div>
 
       {/* Filters + charts */}
@@ -140,6 +179,28 @@ export function LinkDetailPage() {
             effectiveBucketLabel={effectiveBucketLabel}
           />
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button
+            type="button"
+            onClick={() => setShowIncidents(v => !v)}
+            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+              showIncidents
+                ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Incidents
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMaintenance(v => !v)}
+            className={`text-[11px] font-medium px-2 py-1 border transition-colors ${
+              showMaintenance
+                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Maintenance
+          </button>
         </div>
 
         {metricsLoading && (
@@ -159,6 +220,30 @@ export function LinkDetailPage() {
               data={metrics}
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
+              incidentWindows={showIncidents ? tickets
+                .filter(t => t.type === 'incident')
+                .map(t => ({
+                  startAt: t.start_at ?? new Date().toISOString(),
+                  endAt: t.end_at,
+                  type: 'incident' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  slackUrl: t.slack_message_url,
+                } as TicketWindow)) : []}
+              maintenanceWindows={showMaintenance ? tickets
+                .filter(t => t.type === 'maintenance' && t.start_at)
+                .map(t => ({
+                  startAt: t.start_at!,
+                  endAt: t.end_at,
+                  type: 'maintenance' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  slackUrl: t.slack_message_url,
+                } as TicketWindow)) : []}
             />
             <LinkPacketLossChart
               data={metrics}
@@ -166,6 +251,9 @@ export function LinkDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
             <LinkInterfaceIssuesChart
               data={metrics}
@@ -173,6 +261,9 @@ export function LinkDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
             <LinkTrafficChart
               data={metrics}
@@ -180,6 +271,9 @@ export function LinkDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
             <LinkLatencyChart
               data={metrics}
@@ -187,6 +281,9 @@ export function LinkDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
             <LinkJitterChart
               data={metrics}
@@ -194,6 +291,9 @@ export function LinkDetailPage() {
               className="rounded-lg border border-border p-4"
               highlightTimeRange={hoveredTimeRange}
               onCursorTime={setChartHoveredTime}
+              tickets={tickets}
+              showIncidents={showIncidents}
+              showMaintenance={showMaintenance}
             />
           </div>
         )}

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -18,6 +18,10 @@ import { LinkInterfaceIssuesChart } from '@/components/link-charts/LinkInterface
 import { LinkLatencyChart } from '@/components/link-charts/LinkLatencyChart'
 import { LinkHealthTimeline } from '@/components/link-charts/LinkHealthTimeline'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
+import { useActiveOpsTickets, useTicketsForEntity } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
+import { IncidentBadge } from '@/components/ops/IncidentBadge'
+import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
 
 function Skeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
@@ -338,21 +342,53 @@ function addBucketIssues(b: LinkMetricsBucket, issues: Set<string>) {
 
 const cardClass = 'rounded-lg border border-border p-4'
 
+// Find when the most recent contiguous issue period started in the loaded buckets.
+// Anchors on the last bucket with issues, then walks backward to the start of that run.
+function computeIssueSince(buckets: LinkMetricsBucket[]): string | undefined {
+  if (buckets.length === 0) return undefined
+  const sorted = [...buckets].sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime())
+
+  // Find the most recent bucket that has issues
+  let anchorIdx = -1
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const issues = new Set<string>()
+    addBucketIssues(sorted[i], issues)
+    if (issues.size > 0 || sorted[i].status?.isis_down) {
+      anchorIdx = i
+      break
+    }
+  }
+  if (anchorIdx === -1) return undefined
+
+  // Walk backward from anchor to find where this contiguous run started
+  let issueStartMs = new Date(sorted[anchorIdx].ts).getTime()
+  for (let i = anchorIdx - 1; i >= 0; i--) {
+    const issues = new Set<string>()
+    addBucketIssues(sorted[i], issues)
+    if (issues.size > 0 || sorted[i].status?.isis_down) {
+      issueStartMs = new Date(sorted[i].ts).getTime()
+    } else {
+      break
+    }
+  }
+
+  return new Date(issueStartMs).toISOString()
+}
+
 interface LinkRowProps {
   linkMetrics: LinkMetricsResponse
   derivedInfo: DerivedLinkInfo
   linksWithIssues?: Map<string, string[]>
   criticalityMap?: Map<string, 'critical' | 'important' | 'redundant'>
   metricsTimeRange: string
+  isOpsUser: boolean
+  onCreateIncident: (linkPk: string, linkCode: string, contributorCode: string, contributorPk: string, issueReasons: string[], issueSince?: string) => void
+  showIncidentOverlays: boolean
+  showMaintenanceOverlays: boolean
 }
 
-function LinkRow({
-  linkMetrics,
-  derivedInfo,
-  linksWithIssues,
-  criticalityMap,
-  metricsTimeRange,
-}: LinkRowProps) {
+function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, metricsTimeRange, isOpsUser, onCreateIncident, showIncidentOverlays, showMaintenanceOverlays }: LinkRowProps) {
+  const tickets = useTicketsForEntity(derivedInfo.pk)
   const [expanded, setExpanded] = useState(false)
   const [hoveredTimeRange, setHoveredTimeRange] = useState<{
     start: number
@@ -625,6 +661,17 @@ function LinkRow({
                       ISIS Down
                     </span>
                   )}
+                  {/* Maintenance badge — visible to all users */}
+                  {tickets.some(t => t.type === 'maintenance') && (
+                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                      Maintenance
+                    </span>
+                  )}
+                  {/* Incident badge with tooltip — ops users only */}
+                  {isOpsUser && tickets
+                    .filter(t => t.type === 'incident')
+                    .map(t => <IncidentBadge key={t.id} ticket={t} />)
+                  }
                 </div>
               )}
             </div>
@@ -645,7 +692,43 @@ function LinkRow({
               hideBadges
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
+              maintenanceWindows={showMaintenanceOverlays ? tickets
+                .filter(t => t.type === 'maintenance' && t.start_at)
+                .map(t => ({
+                  startAt: t.start_at!,
+                  endAt: t.end_at,
+                  type: 'maintenance' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  entityName: derivedInfo.code,
+                  slackUrl: t.slack_message_url,
+                })) : []}
+              incidentWindows={showIncidentOverlays ? tickets
+                .filter(t => t.type === 'incident')
+                .map(t => ({
+                  startAt: t.start_at ?? new Date().toISOString(),
+                  endAt: t.end_at,
+                  type: 'incident' as const,
+                  id: t.id,
+                  humanReadableId: t.human_readable_id,
+                  title: t.title,
+                  status: t.status,
+                  entityName: derivedInfo.code,
+                  slackUrl: t.slack_message_url,
+                })) : []}
             />
+            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
+              <div className="flex justify-end mt-1">
+                <button
+                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); onCreateIncident(derivedInfo.pk, derivedInfo.code, derivedInfo.contributor, linkMetrics.contributor_pk, issueReasons, computeIssueSince(linkMetrics.buckets)) }}
+                >
+                  Create incident
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -671,6 +754,9 @@ function LinkRow({
                       className={cardClass}
                       highlightTimeRange={hoveredTimeRange}
                       onCursorTime={setChartHoveredTime}
+                      tickets={tickets}
+                      showIncidents={showIncidentOverlays}
+                      showMaintenance={showMaintenanceOverlays}
                     />
                   )}
                   {hasLoss && (
@@ -680,6 +766,9 @@ function LinkRow({
                       className={cardClass}
                       highlightTimeRange={hoveredTimeRange}
                       onCursorTime={setChartHoveredTime}
+                      tickets={tickets}
+                      showIncidents={showIncidentOverlays}
+                      showMaintenance={showMaintenanceOverlays}
                     />
                   )}
                 </>
@@ -710,6 +799,9 @@ function LinkRow({
                 className={cardClass}
                 highlightTimeRange={hoveredTimeRange}
                 onCursorTime={setChartHoveredTime}
+                tickets={tickets}
+                showIncidents={showIncidentOverlays}
+                showMaintenance={showMaintenanceOverlays}
               />
             ) : null
           })()}
@@ -767,6 +859,20 @@ export function LinkStatusTimelines({
     staleTime: 30_000,
     placeholderData: keepPreviousData,
   })
+
+  // Pre-fetch active tickets once for all rows — filtered client-side per link
+  useActiveOpsTickets()
+  const isOpsUser = useIsOpsUser()
+  const [createIncidentFor, setCreateIncidentFor] = useState<{
+    linkPk: string
+    linkCode: string
+    contributorCode: string
+    contributorPk: string
+    issueReasons: string[]
+    downSince?: string
+  } | null>(null)
+  const [showIncidentOverlays, setShowIncidentOverlays] = useState(true)
+  const [showMaintenanceOverlays, setShowMaintenanceOverlays] = useState(true)
 
   // Convert the Record<string, LinkMetricsResponse> into an array with derived info
   const linksArray = useMemo(() => {
@@ -1050,6 +1156,28 @@ export function LinkStatusTimelines({
               onChange={(v) => onTimeRangeChange(v as TimeRange)}
             />
           )}
+          <button
+            type="button"
+            onClick={() => setShowIncidentOverlays(v => !v)}
+            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+              showIncidentOverlays
+                ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Incidents
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMaintenanceOverlays(v => !v)}
+            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+              showMaintenanceOverlays
+                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Maintenance
+          </button>
         </div>
       </div>
 
@@ -1092,8 +1220,25 @@ export function LinkStatusTimelines({
             linksWithIssues={linksWithIssues}
             criticalityMap={criticalityMap}
             metricsTimeRange={timeRange}
+            isOpsUser={isOpsUser}
+            onCreateIncident={(pk, code, contributor, contributorPk, reasons, issueSince) => setCreateIncidentFor({ linkPk: pk, linkCode: code, contributorCode: contributor, contributorPk, issueReasons: reasons, downSince: issueSince })}
+            showIncidentOverlays={showIncidentOverlays}
+            showMaintenanceOverlays={showMaintenanceOverlays}
           />
         ))}
+        {createIncidentFor && (
+          <CreateIncidentModal
+            entityCode={createIncidentFor.linkCode}
+            entityType="link"
+            entityPk={createIncidentFor.linkPk}
+            contributorCode={createIncidentFor.contributorCode}
+            contributorPk={createIncidentFor.contributorPk}
+            issueReasons={createIncidentFor.issueReasons}
+            downSince={createIncidentFor.downSince}
+            onClose={() => setCreateIncidentFor(null)}
+            onSuccess={() => setCreateIncidentFor(null)}
+          />
+        )}
       </div>
     </div>
   )

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -18,7 +18,7 @@ import { LinkInterfaceIssuesChart } from '@/components/link-charts/LinkInterface
 import { LinkLatencyChart } from '@/components/link-charts/LinkLatencyChart'
 import { LinkHealthTimeline } from '@/components/link-charts/LinkHealthTimeline'
 import { useDelayedLoading } from '@/hooks/use-delayed-loading'
-import { useActiveOpsTickets, useTicketsForEntity } from '@/hooks/use-ops-tickets'
+import { useTicketsForEntity } from '@/hooks/use-ops-tickets'
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { IncidentBadge } from '@/components/ops/IncidentBadge'
 import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
@@ -384,11 +384,9 @@ interface LinkRowProps {
   metricsTimeRange: string
   isOpsUser: boolean
   onCreateIncident: (linkPk: string, linkCode: string, contributorCode: string, contributorPk: string, issueReasons: string[], issueSince?: string) => void
-  showIncidentOverlays: boolean
-  showMaintenanceOverlays: boolean
 }
 
-function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, metricsTimeRange, isOpsUser, onCreateIncident, showIncidentOverlays, showMaintenanceOverlays }: LinkRowProps) {
+function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, metricsTimeRange, isOpsUser, onCreateIncident }: LinkRowProps) {
   const tickets = useTicketsForEntity(derivedInfo.pk)
   const [expanded, setExpanded] = useState(false)
   const [hoveredTimeRange, setHoveredTimeRange] = useState<{
@@ -693,7 +691,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
               hideBadges
               onBarHover={setHoveredTimeRange}
               highlightedTime={chartHoveredTime}
-              maintenanceWindows={showMaintenanceOverlays ? tickets
+              maintenanceWindows={tickets
                 .filter(t => t.type === 'maintenance' && t.start_at)
                 .map(t => ({
                   startAt: t.start_at!,
@@ -705,8 +703,8 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                   status: t.status,
                   entityName: derivedInfo.code,
                   slackUrl: t.slack_message_url,
-                })) : []}
-              incidentWindows={showIncidentOverlays ? tickets
+                }))}
+              incidentWindows={tickets
                 .filter(t => t.type === 'incident')
                 .map(t => ({
                   startAt: t.start_at ?? new Date().toISOString(),
@@ -718,7 +716,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                   status: t.status,
                   entityName: derivedInfo.code,
                   slackUrl: t.slack_message_url,
-                })) : []}
+                }))}
             />
             {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident' && !isTicketClosed(t.status)) && (
               <div className="flex justify-end mt-1">
@@ -756,8 +754,8 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                       highlightTimeRange={hoveredTimeRange}
                       onCursorTime={setChartHoveredTime}
                       tickets={tickets}
-                      showIncidents={showIncidentOverlays}
-                      showMaintenance={showMaintenanceOverlays}
+                      showIncidents={true}
+                      showMaintenance={true}
                     />
                   )}
                   {hasLoss && (
@@ -768,8 +766,8 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                       highlightTimeRange={hoveredTimeRange}
                       onCursorTime={setChartHoveredTime}
                       tickets={tickets}
-                      showIncidents={showIncidentOverlays}
-                      showMaintenance={showMaintenanceOverlays}
+                      showIncidents={true}
+                      showMaintenance={true}
                     />
                   )}
                 </>
@@ -801,8 +799,8 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                 highlightTimeRange={hoveredTimeRange}
                 onCursorTime={setChartHoveredTime}
                 tickets={tickets}
-                showIncidents={showIncidentOverlays}
-                showMaintenance={showMaintenanceOverlays}
+                showIncidents={true}
+                showMaintenance={true}
               />
             ) : null
           })()}
@@ -861,8 +859,6 @@ export function LinkStatusTimelines({
     placeholderData: keepPreviousData,
   })
 
-  // Pre-fetch active tickets once for all rows — filtered client-side per link
-  const { data: activeTicketsData } = useActiveOpsTickets()
   const isOpsUser = useIsOpsUser()
   const [createIncidentFor, setCreateIncidentFor] = useState<{
     linkPk: string
@@ -872,9 +868,6 @@ export function LinkStatusTimelines({
     issueReasons: string[]
     downSince?: string
   } | null>(null)
-  const [showIncidentOverlays, setShowIncidentOverlays] = useState(true)
-  const [showMaintenanceOverlays, setShowMaintenanceOverlays] = useState(true)
-
   // Convert the Record<string, LinkMetricsResponse> into an array with derived info
   const linksArray = useMemo(() => {
     if (!data?.links) return []
@@ -1045,22 +1038,6 @@ export function LinkStatusTimelines({
     return linksArray.filter(({ derived }) => derived.provisioning).length
   }, [linksArray])
 
-  const incidentCount = useMemo(() => {
-    const tickets = activeTicketsData?.tickets ?? []
-    return linksArray.filter(({ derived }) =>
-      tickets.some(t => t.type === 'incident' &&
-        (t.affected_link_pubkey.includes(derived.pk) || (t.affected_links?.some(l => l.pubkey === derived.pk) ?? false)))
-    ).length
-  }, [activeTicketsData, linksArray])
-
-  const maintenanceCount = useMemo(() => {
-    const tickets = activeTicketsData?.tickets ?? []
-    return linksArray.filter(({ derived }) =>
-      tickets.some(t => t.type === 'maintenance' &&
-        (t.affected_link_pubkey.includes(derived.pk) || (t.affected_links?.some(l => l.pubkey === derived.pk) ?? false)))
-    ).length
-  }, [activeTicketsData, linksArray])
-
   const showSkeleton = useDelayedLoading(isLoading && !data)
 
   if (isLoading && !data) {
@@ -1166,32 +1143,6 @@ export function LinkStatusTimelines({
               </span>
             </button>
           )}
-          {isOpsUser && incidentCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowIncidentOverlays(v => !v)}
-              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                showIncidentOverlays
-                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                  : 'border-border text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Incidents ({incidentCount})
-            </button>
-          )}
-          {isOpsUser && maintenanceCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowMaintenanceOverlays(v => !v)}
-              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                showMaintenanceOverlays
-                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                  : 'border-border text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Maintenance ({maintenanceCount})
-            </button>
-          )}
           {onTimeRangeChange && (
             <SmallDropdown
               value={timeRange}
@@ -1243,8 +1194,6 @@ export function LinkStatusTimelines({
             metricsTimeRange={timeRange}
             isOpsUser={isOpsUser}
             onCreateIncident={(pk, code, contributor, contributorPk, reasons, issueSince) => setCreateIncidentFor({ linkPk: pk, linkCode: code, contributorCode: contributor, contributorPk, issueReasons: reasons, downSince: issueSince })}
-            showIncidentOverlays={showIncidentOverlays}
-            showMaintenanceOverlays={showMaintenanceOverlays}
           />
         ))}
         {createIncidentFor && (

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -1163,7 +1163,7 @@ export function LinkStatusTimelines({
                 onClick={() => setShowIncidentOverlays(v => !v)}
                 className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
                   showIncidentOverlays
-                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -1174,7 +1174,7 @@ export function LinkStatusTimelines({
                 onClick={() => setShowMaintenanceOverlays(v => !v)}
                 className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
                   showMaintenanceOverlays
-                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
                 }`}
               >

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -663,7 +663,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                   )}
                   {/* Maintenance badge — visible to all users */}
                   {tickets.some(t => t.type === 'maintenance') && (
-                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">
                       Maintenance
                     </span>
                   )}

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -1156,28 +1156,32 @@ export function LinkStatusTimelines({
               onChange={(v) => onTimeRangeChange(v as TimeRange)}
             />
           )}
-          <button
-            type="button"
-            onClick={() => setShowIncidentOverlays(v => !v)}
-            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
-              showIncidentOverlays
-                ? 'border-red-800/60 bg-red-900/20 text-red-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Incidents
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowMaintenanceOverlays(v => !v)}
-            className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
-              showMaintenanceOverlays
-                ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
-                : 'border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Maintenance
-          </button>
+          {isOpsUser && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowIncidentOverlays(v => !v)}
+                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                  showIncidentOverlays
+                    ? 'border-red-800/60 bg-red-900/20 text-red-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Incidents
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMaintenanceOverlays(v => !v)}
+                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                  showMaintenanceOverlays
+                    ? 'border-blue-700/60 bg-blue-900/20 text-blue-300'
+                    : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Maintenance
+              </button>
+            </>
+          )}
         </div>
       </div>
 

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -22,6 +22,7 @@ import { useActiveOpsTickets, useTicketsForEntity } from '@/hooks/use-ops-ticket
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { IncidentBadge } from '@/components/ops/IncidentBadge'
 import { CreateIncidentModal } from '@/components/ops/CreateIncidentModal'
+import { isTicketClosed } from '@/lib/ops-api'
 
 function Skeleton({ className }: { className?: string }) {
   return <div className={`animate-pulse bg-muted rounded ${className || ''}`} />
@@ -668,10 +669,10 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                     </span>
                   )}
                   {/* Incident badge with tooltip — ops users only */}
-                  {isOpsUser && tickets
-                    .filter(t => t.type === 'incident')
-                    .map(t => <IncidentBadge key={t.id} ticket={t} />)
-                  }
+                  {isOpsUser && (() => {
+                    const open = tickets.filter(t => t.type === 'incident' && !isTicketClosed(t.status))
+                    return open.length > 0 ? <IncidentBadge tickets={open} /> : null
+                  })()}
                 </div>
               )}
             </div>
@@ -719,7 +720,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
                   slackUrl: t.slack_message_url,
                 })) : []}
             />
-            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
+            {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident' && !isTicketClosed(t.status)) && (
               <div className="flex justify-end mt-1">
                 <button
                   className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors opacity-0 group-hover:opacity-100"
@@ -861,7 +862,7 @@ export function LinkStatusTimelines({
   })
 
   // Pre-fetch active tickets once for all rows — filtered client-side per link
-  useActiveOpsTickets()
+  const { data: activeTicketsData } = useActiveOpsTickets()
   const isOpsUser = useIsOpsUser()
   const [createIncidentFor, setCreateIncidentFor] = useState<{
     linkPk: string
@@ -1044,6 +1045,22 @@ export function LinkStatusTimelines({
     return linksArray.filter(({ derived }) => derived.provisioning).length
   }, [linksArray])
 
+  const incidentCount = useMemo(() => {
+    const tickets = activeTicketsData?.tickets ?? []
+    return linksArray.filter(({ derived }) =>
+      tickets.some(t => t.type === 'incident' &&
+        (t.affected_link_pubkey.includes(derived.pk) || (t.affected_links?.some(l => l.pubkey === derived.pk) ?? false)))
+    ).length
+  }, [activeTicketsData, linksArray])
+
+  const maintenanceCount = useMemo(() => {
+    const tickets = activeTicketsData?.tickets ?? []
+    return linksArray.filter(({ derived }) =>
+      tickets.some(t => t.type === 'maintenance' &&
+        (t.affected_link_pubkey.includes(derived.pk) || (t.affected_links?.some(l => l.pubkey === derived.pk) ?? false)))
+    ).length
+  }, [activeTicketsData, linksArray])
+
   const showSkeleton = useDelayedLoading(isLoading && !data)
 
   if (isLoading && !data) {
@@ -1149,31 +1166,31 @@ export function LinkStatusTimelines({
               </span>
             </button>
           )}
-          {isOpsUser && (
-            <>
-              <button
-                type="button"
-                onClick={() => setShowIncidentOverlays(v => !v)}
-                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                  showIncidentOverlays
-                    ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Incidents
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMaintenanceOverlays(v => !v)}
-                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
-                  showMaintenanceOverlays
-                    ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
-                    : 'border-border text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Maintenance
-              </button>
-            </>
+          {isOpsUser && incidentCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowIncidentOverlays(v => !v)}
+              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
+                showIncidentOverlays
+                  ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Incidents ({incidentCount})
+            </button>
+          )}
+          {isOpsUser && maintenanceCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowMaintenanceOverlays(v => !v)}
+              className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
+                showMaintenanceOverlays
+                  ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Maintenance ({maintenanceCount})
+            </button>
           )}
           {onTimeRangeChange && (
             <SmallDropdown

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -484,7 +484,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
   return (
     <div
       id={`link-row-${derivedInfo.code}`}
-      className={`border-b border-border last:border-b-0 border-l-2 ${leftBorderColor}`}
+      className={`border-b border-border last:border-b-0 border-l-2 group ${leftBorderColor}`}
     >
       <div
         className={`px-4 py-3 transition-colors ${hasExpandableContent ? 'cursor-pointer hover:bg-muted/30' : ''}`}
@@ -722,7 +722,7 @@ function LinkRow({ linkMetrics, derivedInfo, linksWithIssues, criticalityMap, me
             {isOpsUser && issueReasons.length > 0 && !tickets.some(t => t.type === 'incident') && (
               <div className="flex justify-end mt-1">
                 <button
-                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors"
+                  className="text-[10px] font-medium px-2 py-0.5 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors opacity-0 group-hover:opacity-100"
                   onClick={(e) => { e.stopPropagation(); onCreateIncident(derivedInfo.pk, derivedInfo.code, derivedInfo.contributor, linkMetrics.contributor_pk, issueReasons, computeIssueSince(linkMetrics.buckets)) }}
                 >
                   Create incident
@@ -1100,7 +1100,7 @@ export function LinkStatusTimelines({
           {onShowDrainedChange && (
             <button
               onClick={() => onShowDrainedChange(!showDrained)}
-              className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
             >
               <div
                 className={`w-3 h-3 rounded-sm transition-colors ${showDrained ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}
@@ -1126,7 +1126,7 @@ export function LinkStatusTimelines({
           {onShowProvisioningChange && (
             <button
               onClick={() => onShowProvisioningChange(!showProvisioning)}
-              className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border bg-background/50 transition-colors hover:bg-muted/50"
             >
               <div
                 className={`w-3 h-3 rounded-sm transition-colors ${showProvisioning ? 'bg-primary' : 'bg-muted-foreground/20 border border-muted-foreground/30'}`}
@@ -1149,19 +1149,12 @@ export function LinkStatusTimelines({
               </span>
             </button>
           )}
-          {onTimeRangeChange && (
-            <SmallDropdown
-              value={timeRange}
-              options={timeRangeOptions}
-              onChange={(v) => onTimeRangeChange(v as TimeRange)}
-            />
-          )}
           {isOpsUser && (
             <>
               <button
                 type="button"
                 onClick={() => setShowIncidentOverlays(v => !v)}
-                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
                   showIncidentOverlays
                     ? 'border-red-600/60 bg-red-500/10 text-red-700 dark:border-red-800/60 dark:bg-red-900/20 dark:text-red-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
@@ -1172,7 +1165,7 @@ export function LinkStatusTimelines({
               <button
                 type="button"
                 onClick={() => setShowMaintenanceOverlays(v => !v)}
-                className={`text-[10px] font-medium px-2 py-0.5 border transition-colors ${
+                className={`text-xs font-medium px-2.5 py-1.5 rounded-md border transition-colors ${
                   showMaintenanceOverlays
                     ? 'border-blue-600/60 bg-blue-500/10 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300'
                     : 'border-border text-muted-foreground hover:text-foreground'
@@ -1181,6 +1174,13 @@ export function LinkStatusTimelines({
                 Maintenance
               </button>
             </>
+          )}
+          {onTimeRangeChange && (
+            <SmallDropdown
+              value={timeRange}
+              options={timeRangeOptions}
+              onChange={(v) => onTimeRangeChange(v as TimeRange)}
+            />
           )}
         </div>
       </div>

--- a/web/src/components/ops/CreateIncidentModal.tsx
+++ b/web/src/components/ops/CreateIncidentModal.tsx
@@ -573,7 +573,7 @@ export function CreateIncidentModal({
             <button
               type="submit"
               disabled={isPending}
-              className="text-xs font-medium px-3.5 py-1.5 border border-red-500/50 bg-red-500/12 text-red-300 hover:bg-red-500/20 hover:border-red-500/75 transition-colors disabled:opacity-50"
+              className="text-xs font-medium px-3.5 py-1.5 border border-red-600/50 bg-red-500/10 text-red-700 dark:border-red-500/50 dark:bg-red-500/12 dark:text-red-300 hover:bg-red-500/20 hover:border-red-600/75 dark:hover:border-red-500/75 transition-colors disabled:opacity-50"
             >
               {isPending
                 ? (isBlankMode ? 'Creating…' : 'Opening…')

--- a/web/src/components/ops/CreateIncidentModal.tsx
+++ b/web/src/components/ops/CreateIncidentModal.tsx
@@ -210,7 +210,7 @@ export function CreateIncidentModal({
           affected_link_pubkey: linkPks,
           device_pubkey: devicePks,
           contributor_pubkey: selectedAssignee?.pubkey ?? null,
-          ...(ticketType === 'maintenance' && startAt ? { start_at: utcDatetimeLocalToISO(startAt) } : {}),
+          ...(startAt ? { start_at: utcDatetimeLocalToISO(startAt) } : {}),
           ...(ticketType === 'maintenance' && endAt ? { end_at: utcDatetimeLocalToISO(endAt) } : {}),
         },
         { onSuccess: () => { onSuccess(); onClose() } }
@@ -288,6 +288,7 @@ export function CreateIncidentModal({
                   required
                 >
                   <option value="">Select contributor…</option>
+                  <option value="__dz__">DZ / Malbec Labs</option>
                   {assignees.map(a => (
                     <option key={a.value} value={a.value}>{a.label}</option>
                   ))}
@@ -322,6 +323,7 @@ export function CreateIncidentModal({
                   required
                 >
                   <option value="">Select contributor…</option>
+                  <option value="__dz__">DZ / Malbec Labs</option>
                   {assignees.map(a => (
                     <option key={a.value} value={a.value}>{a.label}</option>
                   ))}
@@ -517,33 +519,38 @@ export function CreateIncidentModal({
             </div>
           </div>
 
-          {/* Maintenance time fields — blank mode only */}
-          {isBlankMode && ticketType === 'maintenance' && (
+          {/* Time fields — blank mode only */}
+          {isBlankMode && (
             <div className="flex gap-3 mb-3.5">
               <div className="flex-1">
                 <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
-                  Start time <span className="normal-case tracking-normal">(UTC)</span>
+                  {ticketType === 'maintenance' ? 'Start time' : 'Started at'}{' '}
+                  <span className="normal-case tracking-normal text-muted-foreground/60">
+                    {ticketType === 'maintenance' ? '(UTC)' : '(UTC, optional)'}
+                  </span>
                 </label>
                 <input
                   type="datetime-local"
                   value={startAt}
                   onChange={e => setStartAt(e.target.value)}
                   className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
-                  required
+                  required={ticketType === 'maintenance'}
                 />
               </div>
-              <div className="flex-1">
-                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
-                  End time{' '}
-                  <span className="normal-case tracking-normal text-muted-foreground/60">(UTC, optional)</span>
-                </label>
-                <input
-                  type="datetime-local"
-                  value={endAt}
-                  onChange={e => setEndAt(e.target.value)}
-                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
-                />
-              </div>
+              {ticketType === 'maintenance' && (
+                <div className="flex-1">
+                  <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                    End time{' '}
+                    <span className="normal-case tracking-normal text-muted-foreground/60">(UTC, optional)</span>
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={endAt}
+                    onChange={e => setEndAt(e.target.value)}
+                    className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                  />
+                </div>
+              )}
             </div>
           )}
 

--- a/web/src/components/ops/CreateIncidentModal.tsx
+++ b/web/src/components/ops/CreateIncidentModal.tsx
@@ -1,0 +1,589 @@
+// web/src/components/ops/CreateIncidentModal.tsx
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useCreateOpsTicket, useOpsAssignees } from '@/hooks/use-ops-tickets'
+import { useAuth } from '@/contexts/AuthContext'
+import { fetchLinks, fetchDevices } from '@/lib/api'
+import type { OpsTicketSeverity, OpsTicketType, OpsTicketStatus } from '@/lib/ops-api'
+
+const ISSUE_REASON_LABELS: Record<string, string> = {
+  packet_loss: 'packet loss',
+  high_latency: 'high latency',
+  high_utilization: 'high utilization',
+  interface_errors: 'interface errors',
+  fcs_errors: 'FCS errors',
+  discards: 'discards',
+  carrier_transitions: 'carrier transitions',
+  missing_adjacency: 'ISIS adjacency down',
+  isis_overload: 'ISIS overload',
+  isis_unreachable: 'ISIS unreachable',
+  drained: 'drained',
+  no_data: 'no data',
+}
+
+const SEVERITIES: { value: OpsTicketSeverity; label: string }[] = [
+  { value: 'sev1', label: 'sev1 — critical' },
+  { value: 'sev2', label: 'sev2 — major' },
+  { value: 'sev3', label: 'sev3 — minor' },
+]
+
+interface CreateIncidentModalProps {
+  entityCode?: string          // e.g. "lax-tve2:sea-tve2" — omit for blank mode
+  entityType?: 'link' | 'device'
+  entityPk?: string
+  contributorCode?: string
+  contributorPk?: string       // Solana pubkey of the entity's contributor
+  downSince?: string
+  issueReasons?: string[]      // pass from timeline row for smart defaults
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function deriveEntityContextDefaults(
+  entityCode: string,
+  entityType: 'link' | 'device',
+  issueReasons?: string[]
+): { title: string; description: string } {
+  const kind = entityType === 'link' ? 'Link' : 'Device'
+  if (!issueReasons || issueReasons.length === 0) {
+    return {
+      title: `${entityCode} is down`,
+      description: `${kind} is currently down. Please investigate.`,
+    }
+  }
+  if (issueReasons.length === 1) {
+    const label = ISSUE_REASON_LABELS[issueReasons[0]] ?? issueReasons[0]
+    return {
+      title: `${entityCode} — ${label}`,
+      description: `${kind} is experiencing ${label}. Please investigate.`,
+    }
+  }
+  const labels = issueReasons.map(r => ISSUE_REASON_LABELS[r] ?? r).join(', ')
+  return {
+    title: `${entityCode} — multiple issues`,
+    description: `${kind} is experiencing: ${labels}. Please investigate.`,
+  }
+}
+
+// Returns a datetime-local string in UTC so the input always displays UTC time.
+function toUTCDatetimeLocal(isoStr?: string): string {
+  const d = isoStr ? new Date(isoStr) : new Date()
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`
+}
+
+// Interprets a datetime-local string as UTC and returns an ISO string.
+function utcDatetimeLocalToISO(s: string): string {
+  // datetime-local format is "YYYY-MM-DDTHH:MM" — append :00Z to force UTC interpretation
+  return new Date(s + ':00Z').toISOString()
+}
+
+export function CreateIncidentModal({
+  entityCode,
+  entityType,
+  entityPk,
+  contributorCode,
+  downSince,
+  issueReasons,
+  onClose,
+  onSuccess,
+}: CreateIncidentModalProps) {
+  const { user } = useAuth()
+  const { mutate: createTicket, isPending, error } = useCreateOpsTicket()
+
+  const defaults = entityCode && entityType
+    ? deriveEntityContextDefaults(entityCode, entityType, issueReasons)
+    : { title: '', description: '' }
+
+  const [title, setTitle] = useState(defaults.title)
+  const [description, setDescription] = useState(defaults.description)
+  const [severity, setSeverity] = useState<OpsTicketSeverity>('sev3')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const isBlankMode = !entityCode
+
+  // Entity-context mode: "started at" datetime (prefilled, editable)
+  const [entityStartAt, setEntityStartAt] = useState(() => toUTCDatetimeLocal(downSince))
+
+  // Blank mode state
+  const [ticketType, setTicketType] = useState<OpsTicketType>('incident')
+  const [entityScope, setEntityScope] = useState<'link' | 'device' | 'both' | null>(null)
+  const [linkQuery, setLinkQuery] = useState('')
+  const [selectedLink, setSelectedLink] = useState<{ pk: string; code: string } | null>(null)
+  const [linkDropdownOpen, setLinkDropdownOpen] = useState(false)
+  const [deviceQuery, setDeviceQuery] = useState('')
+  const [selectedDevice, setSelectedDevice] = useState<{ pk: string; code: string } | null>(null)
+  const [deviceDropdownOpen, setDeviceDropdownOpen] = useState(false)
+  const [blankStatus, setBlankStatus] = useState<OpsTicketStatus>('open')
+  const [startAt, setStartAt] = useState('')
+  const [endAt, setEndAt] = useState('')
+  const [assigneeId, setAssigneeId] = useState('')
+  const { data: assigneesData } = useOpsAssignees()
+  const assignees = assigneesData?.assignees ?? []
+
+  // Auto-prefill assignee from contributorCode once assignees load (entity-context mode only)
+  useEffect(() => {
+    if (!isBlankMode && !assigneeId && contributorCode && assignees.length > 0) {
+      const match = assignees.find(a => a.value === contributorCode)
+      if (match) setAssigneeId(match.value)
+    }
+  }, [assignees, contributorCode, isBlankMode, assigneeId])
+
+  // Fetch all links/devices for entity search — blank mode only
+  const { data: linksData } = useQuery({
+    queryKey: ['links-for-ops-create'],
+    queryFn: () => fetchLinks(1000),
+    enabled: isBlankMode,
+    staleTime: 5 * 60 * 1000,
+  })
+  const { data: devicesData } = useQuery({
+    queryKey: ['devices-for-ops-create'],
+    queryFn: () => fetchDevices(1000),
+    enabled: isBlankMode,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const allLinks = linksData?.items ?? []
+  const allDevices = devicesData?.items ?? []
+
+  const filteredLinks = linkQuery
+    ? allLinks.filter(l => l.code.toLowerCase().includes(linkQuery.toLowerCase()))
+    : allLinks
+
+  const filteredDevices = deviceQuery
+    ? allDevices.filter(d => d.code.toLowerCase().includes(deviceQuery.toLowerCase()))
+    : allDevices
+
+  const incidentStatuses: OpsTicketStatus[] = ['open', 'acknowledged', 'investigating', 'mitigating', 'monitoring']
+  const maintenanceStatuses: OpsTicketStatus[] = ['planned', 'in-progress']
+  const statusOptions = ticketType === 'incident' ? incidentStatuses : maintenanceStatuses
+
+  // Reset status when type changes to keep it valid
+  useEffect(() => {
+    setBlankStatus(ticketType === 'incident' ? 'open' : 'planned')
+  }, [ticketType])
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const reporterFirstName = user?.display_name
+    ? user.display_name.split(' ')[0]
+    : ''
+  const reporterEmail = user?.email ?? ''
+
+  function validateBlankMode(): string | null {
+    if (!assigneeId) return 'Contributor is required'
+    if (!title.trim()) return 'Title is required'
+    if (title.length > 100) return 'Title must be 100 characters or fewer'
+    if (!description.trim()) return 'Description is required'
+    if (description.length > 500) return 'Description must be 500 characters or fewer'
+    if (!entityScope) return 'Select an entity scope (Link, Device, or Both)'
+    if ((entityScope === 'link' || entityScope === 'both') && !selectedLink) return 'Select a link'
+    if ((entityScope === 'device' || entityScope === 'both') && !selectedDevice) return 'Select a device'
+    if (ticketType === 'maintenance' && !startAt) return 'Start time is required for maintenance'
+    return null
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitError(null)
+
+    if (isBlankMode) {
+      const err = validateBlankMode()
+      if (err) { setSubmitError(err); return }
+
+      const linkPks = (entityScope === 'link' || entityScope === 'both') && selectedLink ? [selectedLink.pk] : []
+      const devicePks = (entityScope === 'device' || entityScope === 'both') && selectedDevice ? [selectedDevice.pk] : []
+      const selectedAssignee = assignees.find(a => a.value === assigneeId)
+
+      createTicket(
+        {
+          type: ticketType,
+          title,
+          description,
+          severity,
+          status: blankStatus,
+          affected_link_pubkey: linkPks,
+          device_pubkey: devicePks,
+          contributor_pubkey: selectedAssignee?.pubkey ?? null,
+          ...(ticketType === 'maintenance' && startAt ? { start_at: utcDatetimeLocalToISO(startAt) } : {}),
+          ...(ticketType === 'maintenance' && endAt ? { end_at: utcDatetimeLocalToISO(endAt) } : {}),
+        },
+        { onSuccess: () => { onSuccess(); onClose() } }
+      )
+      return
+    }
+
+    // Entity-context mode
+    if (!assigneeId) { setSubmitError('Contributor is required'); return }
+
+    const selectedAssigneeEntity = assignees.find(a => a.value === assigneeId)
+    const linkPkField: string[] = entityType === 'link' && entityPk ? [entityPk] : []
+    const devicePkField: string[] = entityType === 'device' && entityPk ? [entityPk] : []
+
+    createTicket(
+      {
+        type: 'incident' as OpsTicketType,
+        title,
+        description,
+        severity,
+        status: 'open',
+        affected_link_pubkey: linkPkField,
+        device_pubkey: devicePkField,
+        contributor_pubkey: selectedAssigneeEntity?.pubkey ?? null,
+        ...(entityStartAt ? { start_at: utcDatetimeLocalToISO(entityStartAt) } : {}),
+      },
+      { onSuccess: () => { onSuccess(); onClose() } }
+    )
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/65 flex items-center justify-center z-50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="bg-background border border-border w-full max-w-[480px] p-6 shadow-2xl relative">
+        <button
+          className="absolute top-4 right-4 text-muted-foreground hover:text-foreground text-lg leading-none px-1.5"
+          onClick={onClose}
+        >
+          ×
+        </button>
+
+        <h2 className="font-serif font-normal text-[17px] mb-1">Create incident</h2>
+        <p className="text-xs text-muted-foreground mb-5">
+          {entityCode
+            ? 'Review or edit the defaults, then click Open incident.'
+            : 'Fill in the details below to create a new ticket.'}
+        </p>
+
+        {/* Context strip — only shown when opening for a specific entity */}
+        {entityCode && (
+          <div className="flex flex-col border border-border mb-4 text-xs text-muted-foreground">
+            <div className="flex-1 px-2.5 py-1.5">
+              <div className="text-[10px] uppercase tracking-wide mb-0.5">
+                {entityType === 'link' ? 'Link' : 'Device'}
+              </div>
+              <span className="font-mono text-sm text-foreground">{entityCode}</span>
+            </div>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          {/* Entity-context mode: assignee + started at */}
+          {!isBlankMode && (
+            <>
+              <div className="mb-3.5">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Contributor <span className="normal-case tracking-normal text-red-400">*</span>
+                </label>
+                <select
+                  value={assigneeId}
+                  onChange={e => setAssigneeId(e.target.value)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                  required
+                >
+                  <option value="">Select contributor…</option>
+                  {assignees.map(a => (
+                    <option key={a.value} value={a.value}>{a.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="mb-3.5">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Started at <span className="normal-case tracking-normal">(UTC)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  value={entityStartAt}
+                  onChange={e => setEntityStartAt(e.target.value)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                />
+              </div>
+            </>
+          )}
+
+          {/* Blank mode: type + entity scope + entity search */}
+          {isBlankMode && (
+            <>
+              {/* Assignee — required, first field */}
+              <div className="mb-3.5">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Contributor <span className="normal-case tracking-normal text-red-400">*</span>
+                </label>
+                <select
+                  value={assigneeId}
+                  onChange={e => setAssigneeId(e.target.value)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                  required
+                >
+                  <option value="">Select contributor…</option>
+                  {assignees.map(a => (
+                    <option key={a.value} value={a.value}>{a.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Type toggle */}
+              <div className="mb-3.5">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Type
+                </label>
+                <div className="flex border border-border/60 overflow-hidden">
+                  {(['incident', 'maintenance'] as OpsTicketType[]).map(t => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setTicketType(t)}
+                      className={`flex-1 text-[12px] py-1.5 transition-colors ${
+                        ticketType === t
+                          ? 'bg-foreground/10 text-foreground font-medium'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {t}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Entity scope toggle */}
+              <div className="mb-3.5">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Entity scope
+                </label>
+                <div className="flex border border-border/60 overflow-hidden">
+                  {(['link', 'device', 'both'] as const).map(scope => (
+                    <button
+                      key={scope}
+                      type="button"
+                      onClick={() => setEntityScope(scope)}
+                      className={`flex-1 text-[12px] py-1.5 capitalize transition-colors ${
+                        entityScope === scope
+                          ? 'bg-foreground/10 text-foreground font-medium'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {scope}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Link search */}
+              {(entityScope === 'link' || entityScope === 'both') && (
+                <div className="mb-3.5 relative">
+                  <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                    Link
+                  </label>
+                  <input
+                    type="text"
+                    value={selectedLink ? selectedLink.code : linkQuery}
+                    onChange={e => {
+                      setSelectedLink(null)
+                      setLinkQuery(e.target.value)
+                      setLinkDropdownOpen(true)
+                    }}
+                    onFocus={() => setLinkDropdownOpen(true)}
+                    onBlur={() => setTimeout(() => setLinkDropdownOpen(false), 150)}
+                    placeholder="Search by link code…"
+                    className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border font-mono"
+                  />
+                  {linkDropdownOpen && filteredLinks.length > 0 && !selectedLink && (
+                    <ul className="absolute z-10 w-full mt-0.5 border border-border bg-background shadow-lg max-h-40 overflow-y-auto">
+                      {filteredLinks.slice(0, 20).map(l => (
+                        <li
+                          key={l.pk}
+                          className="px-2.5 py-1.5 text-[12px] font-mono cursor-pointer hover:bg-muted/40 text-foreground"
+                          onMouseDown={() => {
+                            setSelectedLink({ pk: l.pk, code: l.code })
+                            setLinkQuery('')
+                            setLinkDropdownOpen(false)
+                          }}
+                        >
+                          {l.code}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+
+              {/* Device search */}
+              {(entityScope === 'device' || entityScope === 'both') && (
+                <div className="mb-3.5 relative">
+                  <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                    Device
+                  </label>
+                  <input
+                    type="text"
+                    value={selectedDevice ? selectedDevice.code : deviceQuery}
+                    onChange={e => {
+                      setSelectedDevice(null)
+                      setDeviceQuery(e.target.value)
+                      setDeviceDropdownOpen(true)
+                    }}
+                    onFocus={() => setDeviceDropdownOpen(true)}
+                    onBlur={() => setTimeout(() => setDeviceDropdownOpen(false), 150)}
+                    placeholder="Search by device code…"
+                    className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border font-mono"
+                  />
+                  {deviceDropdownOpen && filteredDevices.length > 0 && !selectedDevice && (
+                    <ul className="absolute z-10 w-full mt-0.5 border border-border bg-background shadow-lg max-h-40 overflow-y-auto">
+                      {filteredDevices.slice(0, 20).map(d => (
+                        <li
+                          key={d.pk}
+                          className="px-2.5 py-1.5 text-[12px] font-mono cursor-pointer hover:bg-muted/40 text-foreground"
+                          onMouseDown={() => {
+                            setSelectedDevice({ pk: d.pk, code: d.code })
+                            setDeviceQuery('')
+                            setDeviceDropdownOpen(false)
+                          }}
+                        >
+                          {d.code}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="mb-3.5">
+            <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+              Title
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+              required
+            />
+          </div>
+
+          <div className="mb-3.5">
+            <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              rows={3}
+              className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border resize-y leading-relaxed"
+            />
+          </div>
+
+          <div className="flex gap-3 mb-3.5">
+            <div className="flex-1">
+              <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                Severity
+              </label>
+              <select
+                value={severity}
+                onChange={e => setSeverity(e.target.value as OpsTicketSeverity)}
+                className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                required
+              >
+                {SEVERITIES.map(s => (
+                  <option key={s.value} value={s.value}>{s.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1">
+              <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                Status
+              </label>
+              {isBlankMode ? (
+                <select
+                  value={blankStatus}
+                  onChange={e => setBlankStatus(e.target.value as OpsTicketStatus)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                >
+                  {statusOptions.map(s => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              ) : (
+                <div className="text-[13px] px-2.5 py-1.5 bg-muted/40 border border-border text-muted-foreground">
+                  open
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Maintenance time fields — blank mode only */}
+          {isBlankMode && ticketType === 'maintenance' && (
+            <div className="flex gap-3 mb-3.5">
+              <div className="flex-1">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Start time <span className="normal-case tracking-normal">(UTC)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  value={startAt}
+                  onChange={e => setStartAt(e.target.value)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                  required
+                />
+              </div>
+              <div className="flex-1">
+                <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                  End time{' '}
+                  <span className="normal-case tracking-normal text-muted-foreground/60">(UTC, optional)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  value={endAt}
+                  onChange={e => setEndAt(e.target.value)}
+                  className="w-full text-[13px] px-2.5 py-1.5 bg-muted/30 border border-border/60 text-foreground outline-none focus:border-border"
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="mb-3.5">
+            <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1.5">
+              Reporter
+            </label>
+            <div className="text-[13px] px-2.5 py-1.5 bg-muted/40 border border-border text-muted-foreground">
+              {reporterFirstName} · {reporterEmail}
+            </div>
+          </div>
+
+          {(error || submitError) && (
+            <p className="text-xs text-red-400 mb-3">
+              {submitError ?? 'Failed to create incident. Please try again.'}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs px-3.5 py-1.5 border border-border text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className="text-xs font-medium px-3.5 py-1.5 border border-red-500/50 bg-red-500/12 text-red-300 hover:bg-red-500/20 hover:border-red-500/75 transition-colors disabled:opacity-50"
+            >
+              {isPending
+                ? (isBlankMode ? 'Creating…' : 'Opening…')
+                : (isBlankMode
+                    ? (ticketType === 'maintenance' ? 'Schedule maintenance' : 'Open incident')
+                    : 'Open incident')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ops/IncidentBadge.tsx
+++ b/web/src/components/ops/IncidentBadge.tsx
@@ -1,8 +1,10 @@
 // web/src/components/ops/IncidentBadge.tsx
+import { useState, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { type OpsTicket, opsTicketUrl } from '@/lib/ops-api'
 
 interface IncidentBadgeProps {
-  ticket: OpsTicket
+  tickets: OpsTicket[]
 }
 
 const severityClass: Record<string, string> = {
@@ -11,69 +13,147 @@ const severityClass: Record<string, string> = {
   sev3: 'bg-gray-400/15 text-gray-600 dark:text-gray-300',
 }
 
-const statusClass = 'bg-blue-500/15 text-blue-700 dark:text-blue-300'
-
 function timeAgo(isoStr: string): string {
   const diffMs = Date.now() - new Date(isoStr).getTime()
   const mins = Math.floor(diffMs / 60_000)
   if (mins < 60) return `${mins}m ago`
   const hrs = Math.floor(mins / 60)
   if (hrs < 24) return `${hrs}h ${mins % 60}m ago`
-  return `${Math.floor(hrs / 24)}d ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
 }
 
 /**
- * Badge shown on link/device rows when there is an active incident.
- * Hover reveals a sticky tooltip with full details (ops users only —
- * the parent is responsible for only rendering this component for ops users).
+ * Badge shown on link/device rows when there is at least one active incident.
+ * Always renders a single "Incident" label; hover reveals a fixed-position portal
+ * tooltip listing all open incidents (ops users only — parent is responsible for gating).
  */
-export function IncidentBadge({ ticket }: IncidentBadgeProps) {
+export function IncidentBadge({ tickets }: IncidentBadgeProps) {
+  const first = tickets[0]
+  const badgeRef = useRef<HTMLSpanElement>(null)
+  const [visible, setVisible] = useState(false)
+  const [pos, setPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const show = useCallback(() => {
+    if (hideTimer.current) clearTimeout(hideTimer.current)
+    if (badgeRef.current) {
+      const r = badgeRef.current.getBoundingClientRect()
+      setPos({ top: r.bottom + 4, left: r.left })
+    }
+    setVisible(true)
+  }, [])
+
+  const scheduleHide = useCallback(() => {
+    hideTimer.current = setTimeout(() => setVisible(false), 200)
+  }, [])
+
+  const cancelHide = useCallback(() => {
+    if (hideTimer.current) clearTimeout(hideTimer.current)
+  }, [])
+
+  if (!first) return null
+
   return (
-    <span
-      className="relative inline-block text-[10px] px-1.5 py-0.5 font-medium cursor-default bg-red-500/15 text-red-700 dark:text-red-300 [&:hover_.incident-tip]:block"
-      style={{ zIndex: 1 }}
-    >
-      Incident
-      {/* Tooltip — stays open because it is a DOM child of the badge */}
-      <div
-        className="incident-tip hidden absolute top-full left-0 z-50 min-w-[250px] bg-popover border border-border p-2.5 shadow-xl text-xs"
-        style={{ pointerEvents: 'auto' }}
+    <>
+      <span
+        ref={badgeRef}
+        className="inline-block text-[10px] px-1.5 py-0.5 font-medium cursor-default bg-red-500/15 text-red-700 dark:text-red-300"
+        onMouseEnter={show}
+        onMouseLeave={scheduleHide}
       >
-        <a
-          href={opsTicketUrl(ticket.id)}
-          target="_blank"
-          rel="noreferrer"
-          className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline block mb-1"
+        Incident
+      </span>
+      {visible && createPortal(
+        <div
+          className="fixed z-[9999] min-w-[250px] max-w-[300px] bg-popover border border-border p-2.5 shadow-xl text-xs"
+          style={{ top: pos.top, left: pos.left }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={scheduleHide}
           onClick={(e) => e.stopPropagation()}
         >
-          {ticket.human_readable_id} ↗
-        </a>
-        <div className="font-medium mb-2">{ticket.title}</div>
-        <div className="flex gap-1.5 mb-2">
-          {ticket.severity && (
-            <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[ticket.severity] ?? ''}`}>
-              {ticket.severity}
-            </span>
+          {tickets.length === 1 ? (
+            <>
+              <a
+                href={opsTicketUrl(first.id)}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline block mb-1"
+              >
+                {first.human_readable_id} ↗
+              </a>
+              <div className="font-medium mb-2">{first.title}</div>
+              <div className="flex gap-1.5 mb-2">
+                {first.severity && (
+                  <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[first.severity] ?? ''}`}>
+                    {first.severity}
+                  </span>
+                )}
+                <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">
+                  {first.status}
+                </span>
+              </div>
+              <div className="border-t border-border pt-1.5 text-muted-foreground">
+                Started {first.created_at ? timeAgo(first.created_at) : '—'}
+                {first.slack_message_url && (
+                  <a
+                    href={first.slack_message_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 dark:text-blue-300 hover:underline block mt-1"
+                  >
+                    Slack ↗
+                  </a>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="text-muted-foreground text-[10px] mb-1.5">
+                {tickets.length} open incidents
+              </div>
+              {tickets.map((t, ti) => (
+                <div key={t.id} className={`py-1.5 ${ti > 0 ? 'border-t border-border/50' : ''}`}>
+                  <div className="flex items-center gap-1.5 mb-0.5">
+                    <a
+                      href={opsTicketUrl(t.id)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline"
+                    >
+                      {t.human_readable_id} ↗
+                    </a>
+                    {t.severity && (
+                      <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[t.severity] ?? ''}`}>
+                        {t.severity}
+                      </span>
+                    )}
+                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">
+                      {t.status}
+                    </span>
+                  </div>
+                  <div className="text-muted-foreground truncate">{t.title}</div>
+                  <div className="text-muted-foreground text-[10px] mt-0.5">
+                    Started {t.created_at ? timeAgo(t.created_at) : '—'}
+                    {t.slack_message_url && (
+                      <a
+                        href={t.slack_message_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue-600 dark:text-blue-300 hover:underline ml-2"
+                      >
+                        Slack ↗
+                      </a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </>
           )}
-          <span className={`text-[10px] px-1.5 py-0.5 font-medium ${statusClass}`}>
-            {ticket.status}
-          </span>
-        </div>
-        <div className="border-t border-border pt-1.5 text-muted-foreground">
-          Started {ticket.created_at ? timeAgo(ticket.created_at) : '—'}
-          {ticket.slack_message_url && (
-            <a
-              href={ticket.slack_message_url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-blue-600 dark:text-blue-300 hover:underline block mt-1"
-              onClick={(e) => e.stopPropagation()}
-            >
-              Slack ↗
-            </a>
-          )}
-        </div>
-      </div>
-    </span>
+        </div>,
+        document.body
+      )}
+    </>
   )
 }

--- a/web/src/components/ops/IncidentBadge.tsx
+++ b/web/src/components/ops/IncidentBadge.tsx
@@ -1,0 +1,79 @@
+// web/src/components/ops/IncidentBadge.tsx
+import { type OpsTicket, opsTicketUrl } from '@/lib/ops-api'
+
+interface IncidentBadgeProps {
+  ticket: OpsTicket
+}
+
+const severityClass: Record<string, string> = {
+  sev1: 'bg-red-500/20 text-red-300',
+  sev2: 'bg-orange-500/20 text-orange-300',
+  sev3: 'bg-gray-400/20 text-gray-300',
+}
+
+const statusClass = 'bg-blue-500/20 text-blue-300'
+
+function timeAgo(isoStr: string): string {
+  const diffMs = Date.now() - new Date(isoStr).getTime()
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ${mins % 60}m ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+/**
+ * Badge shown on link/device rows when there is an active incident.
+ * Hover reveals a sticky tooltip with full details (ops users only —
+ * the parent is responsible for only rendering this component for ops users).
+ */
+export function IncidentBadge({ ticket }: IncidentBadgeProps) {
+  return (
+    <span
+      className="relative inline-block text-[10px] px-1.5 py-0.5 font-medium cursor-default bg-red-500/15 text-red-300 [&:hover_.incident-tip]:block"
+      style={{ zIndex: 1 }}
+    >
+      Incident
+      {/* Tooltip — stays open because it is a DOM child of the badge */}
+      <div
+        className="incident-tip hidden absolute top-full left-0 z-50 min-w-[250px] bg-popover border border-border p-2.5 shadow-xl text-xs"
+        style={{ pointerEvents: 'auto' }}
+      >
+        <a
+          href={opsTicketUrl(ticket.id)}
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono text-[11px] text-blue-300 hover:underline block mb-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {ticket.human_readable_id} ↗
+        </a>
+        <div className="font-medium mb-2">{ticket.title}</div>
+        <div className="flex gap-1.5 mb-2">
+          {ticket.severity && (
+            <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[ticket.severity] ?? ''}`}>
+              {ticket.severity}
+            </span>
+          )}
+          <span className={`text-[10px] px-1.5 py-0.5 font-medium ${statusClass}`}>
+            {ticket.status}
+          </span>
+        </div>
+        <div className="border-t border-border pt-1.5 text-muted-foreground">
+          Started {ticket.created_at ? timeAgo(ticket.created_at) : '—'}
+          {ticket.slack_message_url && (
+            <a
+              href={ticket.slack_message_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-300 hover:underline block mt-1"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Slack ↗
+            </a>
+          )}
+        </div>
+      </div>
+    </span>
+  )
+}

--- a/web/src/components/ops/IncidentBadge.tsx
+++ b/web/src/components/ops/IncidentBadge.tsx
@@ -6,12 +6,12 @@ interface IncidentBadgeProps {
 }
 
 const severityClass: Record<string, string> = {
-  sev1: 'bg-red-500/20 text-red-300',
-  sev2: 'bg-orange-500/20 text-orange-300',
-  sev3: 'bg-gray-400/20 text-gray-300',
+  sev1: 'bg-red-500/15 text-red-700 dark:text-red-300',
+  sev2: 'bg-orange-500/15 text-orange-700 dark:text-orange-300',
+  sev3: 'bg-gray-400/15 text-gray-600 dark:text-gray-300',
 }
 
-const statusClass = 'bg-blue-500/20 text-blue-300'
+const statusClass = 'bg-blue-500/15 text-blue-700 dark:text-blue-300'
 
 function timeAgo(isoStr: string): string {
   const diffMs = Date.now() - new Date(isoStr).getTime()
@@ -30,7 +30,7 @@ function timeAgo(isoStr: string): string {
 export function IncidentBadge({ ticket }: IncidentBadgeProps) {
   return (
     <span
-      className="relative inline-block text-[10px] px-1.5 py-0.5 font-medium cursor-default bg-red-500/15 text-red-300 [&:hover_.incident-tip]:block"
+      className="relative inline-block text-[10px] px-1.5 py-0.5 font-medium cursor-default bg-red-500/15 text-red-700 dark:text-red-300 [&:hover_.incident-tip]:block"
       style={{ zIndex: 1 }}
     >
       Incident
@@ -43,7 +43,7 @@ export function IncidentBadge({ ticket }: IncidentBadgeProps) {
           href={opsTicketUrl(ticket.id)}
           target="_blank"
           rel="noreferrer"
-          className="font-mono text-[11px] text-blue-300 hover:underline block mb-1"
+          className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline block mb-1"
           onClick={(e) => e.stopPropagation()}
         >
           {ticket.human_readable_id} ↗
@@ -66,7 +66,7 @@ export function IncidentBadge({ ticket }: IncidentBadgeProps) {
               href={ticket.slack_message_url}
               target="_blank"
               rel="noreferrer"
-              className="text-blue-300 hover:underline block mt-1"
+              className="text-blue-600 dark:text-blue-300 hover:underline block mt-1"
               onClick={(e) => e.stopPropagation()}
             >
               Slack ↗

--- a/web/src/components/ops/OpsPanel.tsx
+++ b/web/src/components/ops/OpsPanel.tsx
@@ -15,9 +15,9 @@ interface OpsPanelProps {
 }
 
 const severityClass: Record<string, string> = {
-  sev1: 'bg-red-500/20 text-red-300',
-  sev2: 'bg-orange-500/20 text-orange-300',
-  sev3: 'bg-gray-400/20 text-gray-300',
+  sev1: 'bg-red-500/15 text-red-700 dark:text-red-300',
+  sev2: 'bg-orange-500/15 text-orange-700 dark:text-orange-300',
+  sev3: 'bg-gray-400/15 text-gray-600 dark:text-gray-300',
 }
 
 function daysAgo(isoStr: string): string {
@@ -46,7 +46,7 @@ function HistoryRow({ ticket }: { ticket: OpsTicket }) {
         href={opsTicketUrl(ticket.id)}
         target="_blank"
         rel="noreferrer"
-        className="font-mono text-[11px] text-blue-300 hover:underline shrink-0"
+        className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline shrink-0"
       >
         {ticket.human_readable_id} ↗
       </a>
@@ -58,7 +58,7 @@ function HistoryRow({ ticket }: { ticket: OpsTicket }) {
           </span>
         )}
         {ticket.type === 'maintenance' && (
-          <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">Maintenance</span>
+          <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">Maintenance</span>
         )}
         <span className="text-[10px] px-1.5 py-0.5 font-medium bg-gray-400/15 text-gray-400">
           {ticket.status}
@@ -109,7 +109,7 @@ function HistoryPanel({ entityPk, entityType }: { entityPk: string; entityType: 
             href="https://doublezero.xyz/ops-management"
             target="_blank"
             rel="noreferrer"
-            className="block text-right px-3.5 py-1.5 text-[11px] text-blue-300 hover:underline border-t border-border"
+            className="block text-right px-3.5 py-1.5 text-[11px] text-blue-600 dark:text-blue-300 hover:underline border-t border-border"
           >
             {viewAllLabel}
           </a>
@@ -154,7 +154,7 @@ export function OpsPanel({
                       href={opsTicketUrl(ticket.id)}
                       target="_blank"
                       rel="noreferrer"
-                      className="font-mono text-[11px] text-blue-300 hover:underline"
+                      className="font-mono text-[11px] text-blue-600 dark:text-blue-300 hover:underline"
                     >
                       {ticket.human_readable_id} ↗
                     </a>
@@ -163,7 +163,7 @@ export function OpsPanel({
                         {ticket.severity}
                       </span>
                     )}
-                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/15 text-blue-700 dark:text-blue-300">
                       {ticket.status}
                     </span>
                     {ticket.start_at && (
@@ -179,7 +179,7 @@ export function OpsPanel({
                     href={ticket.slack_message_url}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-[11px] text-blue-300 hover:underline shrink-0"
+                    className="text-[11px] text-blue-600 dark:text-blue-300 hover:underline shrink-0"
                   >
                     Slack ↗
                   </a>

--- a/web/src/components/ops/OpsPanel.tsx
+++ b/web/src/components/ops/OpsPanel.tsx
@@ -1,0 +1,208 @@
+// web/src/components/ops/OpsPanel.tsx
+import { useState, useMemo } from 'react'
+import { useTicketsForEntity, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
+import { opsTicketUrl, type OpsTicket, type OpsTicketType } from '@/lib/ops-api'
+
+interface OpsPanelProps {
+  entityPk: string
+  entityCode: string
+  entityType: 'link' | 'device'
+  contributorCode: string
+  isDown: boolean
+  downSince?: string   // ISO timestamp or human string
+  onCreateIncident: () => void
+}
+
+const severityClass: Record<string, string> = {
+  sev1: 'bg-red-500/20 text-red-300',
+  sev2: 'bg-orange-500/20 text-orange-300',
+  sev3: 'bg-gray-400/20 text-gray-300',
+}
+
+function HistoryRow({ ticket }: { ticket: OpsTicket }) {
+  const now = useMemo(() => Date.now(), [])
+  const age = ticket.updated_at
+    ? Math.floor((now - new Date(ticket.updated_at).getTime()) / 86_400_000) + 'd ago'
+    : '—'
+
+  const borderColor =
+    ticket.type === 'maintenance'
+      ? 'border-l-blue-500/50'
+      : ticket.severity === 'sev1'
+      ? 'border-l-red-500/50'
+      : ticket.severity === 'sev2'
+      ? 'border-l-orange-500/50'
+      : 'border-l-gray-400/40'
+
+  return (
+    <div className={`flex items-baseline gap-2.5 px-3.5 py-1.5 border-b border-border last:border-b-0 border-l-2 ${borderColor} text-xs`}>
+      <a
+        href={opsTicketUrl(ticket.id)}
+        target="_blank"
+        rel="noreferrer"
+        className="font-mono text-[11px] text-blue-300 hover:underline shrink-0"
+      >
+        {ticket.human_readable_id} ↗
+      </a>
+      <span className="flex-1 min-w-0 text-muted-foreground truncate">{ticket.title}</span>
+      <div className="flex gap-1.5 items-center shrink-0 text-muted-foreground">
+        {ticket.severity && (
+          <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[ticket.severity]}`}>
+            {ticket.severity}
+          </span>
+        )}
+        {ticket.type === 'maintenance' && (
+          <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">Maintenance</span>
+        )}
+        <span className="text-[10px] px-1.5 py-0.5 font-medium bg-gray-400/15 text-gray-400">
+          {ticket.status}
+        </span>
+        <span>{age}</span>
+      </div>
+    </div>
+  )
+}
+
+function HistoryPanel({ entityPk, entityType }: { entityPk: string; entityType: 'link' | 'device' }) {
+  const [tab, setTab] = useState<OpsTicketType>('incident')
+  const { data } = useOpsTicketHistory(entityPk, tab, entityType)
+  const tickets = data?.tickets ?? []
+
+  const tabClass = (t: OpsTicketType) =>
+    `text-[11px] uppercase tracking-wide px-3.5 py-1.5 border-none cursor-pointer font-sans transition-colors ${
+      tab === t
+        ? 'bg-muted/30 text-foreground'
+        : 'bg-transparent text-muted-foreground hover:text-foreground'
+    }`
+
+  const viewAllLabel = tab === 'incident'
+    ? 'View all incidents on Ops Management ↗'
+    : 'View all maintenance on Ops Management ↗'
+
+  return (
+    <div className="border border-border">
+      <div className="flex items-center justify-between bg-muted/50 border-b border-border">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground px-3.5 py-1.5">
+          Past tickets{' '}
+          <span className="normal-case tracking-normal text-[10px] text-muted-foreground/60">
+            5 most recent
+          </span>
+        </span>
+        <div className="flex border-l border-border">
+          <button className={tabClass('incident')} onClick={() => setTab('incident')}>Incidents</button>
+          <button className={tabClass('maintenance')} onClick={() => setTab('maintenance')}>Maintenance</button>
+        </div>
+      </div>
+
+      {tickets.length === 0 ? (
+        <div className="px-3.5 py-2 text-xs text-muted-foreground">No past {tab}s found.</div>
+      ) : (
+        <>
+          {tickets.map(t => <HistoryRow key={t.id} ticket={t} />)}
+          <a
+            href="https://doublezero.xyz/ops-management"
+            target="_blank"
+            rel="noreferrer"
+            className="block text-right px-3.5 py-1.5 text-[11px] text-blue-300 hover:underline border-t border-border"
+          >
+            {viewAllLabel}
+          </a>
+        </>
+      )}
+    </div>
+  )
+}
+
+export function OpsPanel({
+  entityPk, entityType, isDown, onCreateIncident,
+}: OpsPanelProps) {
+  const isOpsUser = useIsOpsUser()
+  const tickets = useTicketsForEntity(entityPk)
+  const now = useMemo(() => Date.now(), [])
+
+  const activeTickets = tickets // already filtered to active by the hook
+  const hasActiveIncident = activeTickets.some(t => t.type === 'incident')
+
+  // Nothing to show for non-ops users
+  if (!isOpsUser) return null
+
+  return (
+    <>
+      {/* Active tickets panel */}
+      {activeTickets.length > 0 && (
+        <div className="border border-border">
+          <div className="px-4 py-1.5 bg-muted/50 border-b border-border text-[11px] uppercase tracking-wide text-muted-foreground">
+            Active tickets
+          </div>
+          <div className="p-3 space-y-2.5">
+            {activeTickets.map(ticket => (
+              <div
+                key={ticket.id}
+                className={`flex items-start gap-3 p-2.5 border border-border border-l-2 bg-muted/20 ${
+                  ticket.type === 'incident' ? 'border-l-red-500' : 'border-l-blue-500/90'
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-[13px] font-medium mb-1 truncate">{ticket.title}</div>
+                  <div className="flex flex-wrap gap-1.5 items-center text-[11px] text-muted-foreground">
+                    <a
+                      href={opsTicketUrl(ticket.id)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-mono text-[11px] text-blue-300 hover:underline"
+                    >
+                      {ticket.human_readable_id} ↗
+                    </a>
+                    {ticket.severity && (
+                      <span className={`text-[10px] px-1.5 py-0.5 font-medium ${severityClass[ticket.severity]}`}>
+                        {ticket.severity}
+                      </span>
+                    )}
+                    <span className="text-[10px] px-1.5 py-0.5 font-medium bg-blue-500/20 text-blue-300">
+                      {ticket.status}
+                    </span>
+                    {ticket.start_at && (
+                      <span>· Started {Math.floor((now - new Date(ticket.start_at).getTime()) / 60_000)}m ago</span>
+                    )}
+                    {!ticket.start_at && ticket.created_at && (
+                      <span>· {Math.floor((now - new Date(ticket.created_at).getTime()) / 60_000)}m ago</span>
+                    )}
+                  </div>
+                </div>
+                {ticket.slack_message_url && (
+                  <a
+                    href={ticket.slack_message_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[11px] text-blue-300 hover:underline shrink-0"
+                  >
+                    Slack ↗
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Create incident prompt — shown when down with no active incident */}
+      {isDown && !hasActiveIncident && (
+        <div className="flex items-center justify-between px-4 py-2.5 border border-border bg-red-500/[0.04] border-l border-red-500/30">
+          <span className="text-xs text-muted-foreground">
+            Link is down — no open incident
+          </span>
+          <button
+            className="text-[11px] font-medium px-2.5 py-1 border border-gray-400/40 text-muted-foreground hover:text-foreground hover:border-gray-400/70 transition-colors"
+            onClick={onCreateIncident}
+          >
+            Create incident
+          </button>
+        </div>
+      )}
+
+      {/* History panel */}
+      <HistoryPanel entityPk={entityPk} entityType={entityType} />
+    </>
+  )
+}

--- a/web/src/components/ops/OpsPanel.tsx
+++ b/web/src/components/ops/OpsPanel.tsx
@@ -1,5 +1,5 @@
 // web/src/components/ops/OpsPanel.tsx
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { useTicketsForEntity, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { opsTicketUrl, type OpsTicket, type OpsTicketType } from '@/lib/ops-api'
@@ -20,11 +20,16 @@ const severityClass: Record<string, string> = {
   sev3: 'bg-gray-400/20 text-gray-300',
 }
 
+function daysAgo(isoStr: string): string {
+  return Math.floor((Date.now() - new Date(isoStr).getTime()) / 86_400_000) + 'd ago'
+}
+
+function minutesAgo(isoStr: string): string {
+  return Math.floor((Date.now() - new Date(isoStr).getTime()) / 60_000) + 'm ago'
+}
+
 function HistoryRow({ ticket }: { ticket: OpsTicket }) {
-  const now = useMemo(() => Date.now(), [])
-  const age = ticket.updated_at
-    ? Math.floor((now - new Date(ticket.updated_at).getTime()) / 86_400_000) + 'd ago'
-    : '—'
+  const age = ticket.updated_at ? daysAgo(ticket.updated_at) : '—'
 
   const borderColor =
     ticket.type === 'maintenance'
@@ -119,7 +124,6 @@ export function OpsPanel({
 }: OpsPanelProps) {
   const isOpsUser = useIsOpsUser()
   const tickets = useTicketsForEntity(entityPk)
-  const now = useMemo(() => Date.now(), [])
 
   const activeTickets = tickets // already filtered to active by the hook
   const hasActiveIncident = activeTickets.some(t => t.type === 'incident')
@@ -163,10 +167,10 @@ export function OpsPanel({
                       {ticket.status}
                     </span>
                     {ticket.start_at && (
-                      <span>· Started {Math.floor((now - new Date(ticket.start_at).getTime()) / 60_000)}m ago</span>
+                      <span>· Started {minutesAgo(ticket.start_at)}</span>
                     )}
                     {!ticket.start_at && ticket.created_at && (
-                      <span>· {Math.floor((now - new Date(ticket.created_at).getTime()) / 60_000)}m ago</span>
+                      <span>· {minutesAgo(ticket.created_at)}</span>
                     )}
                   </div>
                 </div>

--- a/web/src/components/ops/OpsPanel.tsx
+++ b/web/src/components/ops/OpsPanel.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react'
 import { useTicketsForEntity, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
-import { opsTicketUrl, type OpsTicket, type OpsTicketType } from '@/lib/ops-api'
+import { opsTicketUrl, isTicketClosed, type OpsTicket, type OpsTicketType } from '@/lib/ops-api'
 
 interface OpsPanelProps {
   entityPk: string
@@ -24,8 +24,16 @@ function daysAgo(isoStr: string): string {
   return Math.floor((Date.now() - new Date(isoStr).getTime()) / 86_400_000) + 'd ago'
 }
 
-function minutesAgo(isoStr: string): string {
-  return Math.floor((Date.now() - new Date(isoStr).getTime()) / 60_000) + 'm ago'
+function timeAgo(isoStr: string): string {
+  const diffMs = Date.now() - new Date(isoStr).getTime()
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ${mins % 60}m ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
 }
 
 function HistoryRow({ ticket }: { ticket: OpsTicket }) {
@@ -71,14 +79,17 @@ function HistoryRow({ ticket }: { ticket: OpsTicket }) {
 
 function HistoryPanel({ entityPk, entityType }: { entityPk: string; entityType: 'link' | 'device' }) {
   const [tab, setTab] = useState<OpsTicketType>('incident')
-  const { data } = useOpsTicketHistory(entityPk, tab, entityType)
-  const tickets = data?.tickets ?? []
+  const { data: incidentData } = useOpsTicketHistory(entityPk, 'incident', entityType)
+  const { data: maintenanceData } = useOpsTicketHistory(entityPk, 'maintenance', entityType)
+  const tickets = (tab === 'incident' ? incidentData?.tickets : maintenanceData?.tickets) ?? []
+  const incidentCount = incidentData?.tickets?.length ?? 0
+  const maintenanceCount = maintenanceData?.tickets?.length ?? 0
 
   const tabClass = (t: OpsTicketType) =>
     `text-[11px] uppercase tracking-wide px-3.5 py-1.5 border-none cursor-pointer font-sans transition-colors ${
       tab === t
-        ? 'bg-muted/30 text-foreground'
-        : 'bg-transparent text-muted-foreground hover:text-foreground'
+        ? 'bg-muted text-foreground'
+        : 'bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50'
     }`
 
   const viewAllLabel = tab === 'incident'
@@ -95,8 +106,12 @@ function HistoryPanel({ entityPk, entityType }: { entityPk: string; entityType: 
           </span>
         </span>
         <div className="flex border-l border-border">
-          <button className={tabClass('incident')} onClick={() => setTab('incident')}>Incidents</button>
-          <button className={tabClass('maintenance')} onClick={() => setTab('maintenance')}>Maintenance</button>
+          <button className={tabClass('incident')} onClick={() => setTab('incident')}>
+            Incidents{incidentCount > 0 ? ` (${incidentCount})` : ''}
+          </button>
+          <button className={tabClass('maintenance')} onClick={() => setTab('maintenance')}>
+            Maintenance{maintenanceCount > 0 ? ` (${maintenanceCount})` : ''}
+          </button>
         </div>
       </div>
 
@@ -126,7 +141,7 @@ export function OpsPanel({
   const tickets = useTicketsForEntity(entityPk)
 
   const activeTickets = tickets // already filtered to active by the hook
-  const hasActiveIncident = activeTickets.some(t => t.type === 'incident')
+  const hasActiveIncident = activeTickets.some(t => t.type === 'incident' && !isTicketClosed(t.status))
 
   // Nothing to show for non-ops users
   if (!isOpsUser) return null
@@ -167,10 +182,10 @@ export function OpsPanel({
                       {ticket.status}
                     </span>
                     {ticket.start_at && (
-                      <span>· Started {minutesAgo(ticket.start_at)}</span>
+                      <span>· Started {timeAgo(ticket.start_at)}</span>
                     )}
                     {!ticket.start_at && ticket.created_at && (
-                      <span>· {minutesAgo(ticket.created_at)}</span>
+                      <span>· {timeAgo(ticket.created_at)}</span>
                     )}
                   </div>
                 </div>

--- a/web/src/components/ops/TicketChartBands.tsx
+++ b/web/src/components/ops/TicketChartBands.tsx
@@ -1,0 +1,121 @@
+// web/src/components/ops/TicketChartBands.tsx
+import { useState, useCallback, useEffect, useLayoutEffect, type RefObject, type MutableRefObject } from 'react'
+import uPlot from 'uplot'
+import type { OpsTicket } from '@/lib/ops-api'
+
+interface BandRect {
+  left: number   // CSS px from container left
+  width: number  // CSS px
+  top: number    // CSS px — top of the plot area (excludes x-axis labels)
+  height: number // CSS px — height of the plot area
+  type: 'incident' | 'maintenance'
+}
+
+interface TicketChartBandsProps {
+  containerRef: RefObject<HTMLDivElement | null>
+  plotRef: MutableRefObject<uPlot | null>
+  plotVersion: number
+  tickets: OpsTicket[]
+  showIncidents: boolean
+  showMaintenance: boolean
+}
+
+const COLORS = {
+  incident:    { bg: 'rgba(153,27,27,0.28)', border: 'rgba(153,27,27,0.70)' },
+  maintenance: { bg: 'rgba(29,78,216,0.22)',  border: 'rgba(29,78,216,0.60)' },
+}
+
+/**
+ * Renders absolutely-positioned ticket-range bands inside a uPlot chart container.
+ * Purely decorative — pointer-events-none so chart cursor interaction is preserved.
+ * The parent must have position:relative and overflow-hidden.
+ */
+export function TicketChartBands({ containerRef, plotRef, plotVersion, tickets, showIncidents, showMaintenance }: TicketChartBandsProps) {
+  const [bands, setBands] = useState<BandRect[]>([])
+
+  const computeBands = useCallback(() => {
+    const u = plotRef.current
+    if (!u || !u.over) return
+
+    // Use u.over's CSS dimensions to get DPR-safe pixel coordinates.
+    // u.over is the plot-area element positioned within the uPlot root (= containerRef).
+    const plotLeft = u.over.offsetLeft
+    const plotWidth = u.over.offsetWidth
+    const plotTop = u.over.offsetTop
+    const plotHeight = u.over.offsetHeight
+
+    const xMin = u.scales.x.min ?? 0
+    const xMax = u.scales.x.max ?? 0
+    const range = xMax - xMin
+    if (range <= 0) return
+
+    const computed: BandRect[] = []
+
+    for (const t of tickets) {
+      if (t.type === 'incident' && !showIncidents) continue
+      if (t.type === 'maintenance' && !showMaintenance) continue
+
+      const startSec = t.start_at ? new Date(t.start_at).getTime() / 1000 : null
+      const endSec = t.end_at ? new Date(t.end_at).getTime() / 1000 : Date.now() / 1000
+
+      if (!startSec) continue
+      if (endSec < xMin || startSec > xMax) continue
+
+      const startPct = (Math.max(startSec, xMin) - xMin) / range
+      const endPct = (Math.min(endSec, xMax) - xMin) / range
+
+      const startPos = plotLeft + startPct * plotWidth
+      const endPos = plotLeft + endPct * plotWidth
+
+      computed.push({
+        left: startPos,
+        width: Math.max(endPos - startPos, 2),
+        top: plotTop,
+        height: plotHeight,
+        type: t.type,
+      })
+    }
+    setBands(computed)
+  }, [plotRef, tickets, showIncidents, showMaintenance])
+
+  // Recompute on container resize
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const ro = new ResizeObserver(computeBands)
+    ro.observe(container)
+    computeBands()
+    return () => ro.disconnect()
+  }, [containerRef, computeBands])
+
+  // Recompute after uPlot initializes (plotVersion increments after uPlot is created)
+  useEffect(() => {
+    computeBands()
+  }, [computeBands, plotVersion])
+
+  if (bands.length === 0) return null
+
+  return (
+    <>
+      {bands.map((b, i) => {
+        const colors = COLORS[b.type]
+        return (
+          <div
+            key={i}
+            className="absolute pointer-events-none"
+            style={{
+              left: b.left,
+              width: b.width,
+              top: b.top,
+              height: b.height,
+              background: colors.bg,
+              borderLeft: `1px solid ${colors.border}`,
+              borderRight: `1px solid ${colors.border}`,
+              zIndex: 3,
+            }}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/web/src/components/ops/TicketOverlay.tsx
+++ b/web/src/components/ops/TicketOverlay.tsx
@@ -182,7 +182,7 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
                   href={first.slackUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="block mt-1 text-[#4A9CC7] hover:underline"
+                  className="block mt-1 text-blue-600 dark:text-blue-300 hover:underline"
                 >
                   View Slack thread →
                 </a>
@@ -217,7 +217,7 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
                           href={t.slackUrl}
                           target="_blank"
                           rel="noreferrer"
-                          className="text-[#4A9CC7] hover:underline text-[10px] shrink-0"
+                          className="text-blue-600 dark:text-blue-300 hover:underline text-[10px] shrink-0"
                           title="Open Slack thread"
                         >
                           #

--- a/web/src/components/ops/TicketOverlay.tsx
+++ b/web/src/components/ops/TicketOverlay.tsx
@@ -162,7 +162,7 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
         >
           {isSingle ? (
             <>
-              <div className="font-mono text-[11px] text-blue-300 mb-1">{first.humanReadableId}</div>
+              <div className="font-mono text-[11px] text-blue-600 dark:text-blue-300 mb-1">{first.humanReadableId}</div>
               <div className="text-foreground font-medium mb-1 leading-tight">{first.title}</div>
               <div className="text-muted-foreground space-y-0.5">
                 <div>Type: <span className="text-foreground capitalize">{first.type}</span></div>
@@ -174,7 +174,7 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
                 href={opsTicketUrl(first.id)}
                 target="_blank"
                 rel="noreferrer"
-                className="block mt-2 text-blue-300 hover:underline"
+                className="block mt-2 text-blue-600 dark:text-blue-300 hover:underline"
               >
                 View in ops management →
               </a>
@@ -199,16 +199,16 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
                   <div key={t.id} className={`py-1.5 ${ti > 0 ? 'border-t border-border/30' : ''}`}>
                     <div className="flex items-center gap-1.5">
                       <span className={`text-[9px] font-bold px-1 py-0.5 rounded shrink-0 ${
-                        t.type === 'incident' ? 'bg-red-900/60 text-red-200' : 'bg-blue-900/60 text-blue-200'
+                        t.type === 'incident' ? 'bg-red-500/15 text-red-700 dark:bg-red-900/60 dark:text-red-200' : 'bg-blue-500/15 text-blue-700 dark:bg-blue-900/60 dark:text-blue-200'
                       }`}>
                         {t.type === 'incident' ? 'I' : 'M'}
                       </span>
-                      <span className="font-mono text-[10px] text-blue-300 shrink-0">{t.humanReadableId}</span>
+                      <span className="font-mono text-[10px] text-blue-600 dark:text-blue-300 shrink-0">{t.humanReadableId}</span>
                       <a
                         href={opsTicketUrl(t.id)}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-blue-300 hover:underline text-[10px] ml-auto shrink-0"
+                        className="text-blue-600 dark:text-blue-300 hover:underline text-[10px] ml-auto shrink-0"
                         title="Open in ops management"
                       >
                         ↗

--- a/web/src/components/ops/TicketOverlay.tsx
+++ b/web/src/components/ops/TicketOverlay.tsx
@@ -21,16 +21,15 @@ interface TicketOverlayProps {
   minWidthMs?: number   // minimum strip width; use visual bar span (bar.spanSeconds * 1000)
 }
 
-// Fully opaque — no alpha blending with health bar colors underneath
 const COLORS = {
   incident: {
-    bg: 'rgb(153,27,27)',
-    border: 'rgb(120,20,20)',
+    bg: 'rgba(153,27,27,0.50)',
+    border: 'rgba(153,27,27,0.80)',
     fg: 'rgb(255,255,255)',
   },
   maintenance: {
-    bg: 'rgb(29,78,216)',
-    border: 'rgb(20,55,180)',
+    bg: 'rgba(29,78,216,0.45)',
+    border: 'rgba(29,78,216,0.75)',
     fg: 'rgb(255,255,255)',
   },
 }
@@ -127,7 +126,7 @@ function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps)
         ref={stripRef}
         className="absolute"
         style={{
-          left: 0, right: 0, bottom: '1px', height: '13px',
+          left: 0, right: 0, bottom: 0, height: '13px',
           borderRadius: '2px', overflow: 'hidden',
           background: colors.bg,
           border: `1px solid ${colors.border}`,

--- a/web/src/components/ops/TicketOverlay.tsx
+++ b/web/src/components/ops/TicketOverlay.tsx
@@ -1,0 +1,324 @@
+// web/src/components/ops/TicketOverlay.tsx
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { opsTicketUrl } from '@/lib/ops-api'
+
+export interface TicketWindow {
+  startAt: string       // ISO timestamp
+  endAt?: string        // ISO timestamp; omit/undefined = ongoing
+  type: 'incident' | 'maintenance'
+  id: string            // UUID (used for key + ops URL)
+  humanReadableId: string
+  title: string
+  status: string
+  entityName?: string
+  slackUrl?: string  // Slack message/thread URL, shown when present
+}
+
+interface TicketOverlayProps {
+  windows: TicketWindow[]
+  rangeStartMs: number  // unix ms
+  rangeEndMs: number    // unix ms
+  minWidthMs?: number   // minimum strip width; use visual bar span (bar.spanSeconds * 1000)
+}
+
+// Fully opaque — no alpha blending with health bar colors underneath
+const COLORS = {
+  incident: {
+    bg: 'rgb(153,27,27)',
+    border: 'rgb(120,20,20)',
+    fg: 'rgb(255,255,255)',
+  },
+  maintenance: {
+    bg: 'rgb(29,78,216)',
+    border: 'rgb(20,55,180)',
+    fg: 'rgb(255,255,255)',
+  },
+}
+
+const LABELS = {
+  incident:    { min: 'I', med: 'INC', long: 'Incident' },
+  maintenance: { min: 'M', med: 'MNT', long: 'Maintenance' },
+}
+const MED_MIN = 28, LONG_MIN = 80
+
+interface TicketCluster {
+  startMs: number
+  endMs: number
+  tickets: TicketWindow[]  // all tickets are the same type within a cluster
+}
+
+interface ClusterStripProps {
+  cluster: TicketCluster
+  leftPct: number
+  widthPct: number
+  zIndex: number
+}
+
+function ClusterStrip({ cluster, leftPct, widthPct, zIndex }: ClusterStripProps) {
+  const { tickets } = cluster
+  const isSingle = tickets.length === 1
+  const first = tickets[0]
+  const type = first.type  // all tickets in a cluster share the same type
+
+  const colors = COLORS[type]
+  const L = LABELS[type]
+
+  const [label, setLabel] = useState(L.min)
+  const [tooltipVisible, setTooltipVisible] = useState(false)
+  const [tooltipSide, setTooltipSide] = useState<'left' | 'right'>('left')
+  const stripRef = useRef<HTMLDivElement>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const el = stripRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => {
+      const px = el.getBoundingClientRect().width
+      if (isSingle) {
+        setLabel(px >= LONG_MIN ? L.long : px >= MED_MIN ? L.med : L.min)
+      } else {
+        const multi = `${tickets.length}${type === 'incident' ? 'I' : 'M'}`
+        setLabel(px >= MED_MIN ? multi : px >= 10 ? `${tickets.length}` : '+')
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [L, isSingle, tickets.length, type])
+
+  const tooltipRight = leftPct + widthPct / 2 > 70
+
+  const showTooltip = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    setTooltipVisible(true)
+    setTooltipSide(tooltipRight ? 'right' : 'left')
+  }, [tooltipRight])
+
+  const scheduleHide = useCallback(() => {
+    hideTimerRef.current = setTimeout(() => setTooltipVisible(false), 600)
+  }, [])
+
+  const cancelHide = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+  }, [])
+
+  const startSec = first.startAt
+    ? new Date(first.startAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    : '—'
+
+  return (
+    <div
+      className="absolute top-0"
+      style={{
+        left: `${leftPct}%`, width: `${widthPct}%`,
+        height: '24px', zIndex: tooltipVisible ? 100 : zIndex,
+        pointerEvents: 'none', overflow: 'visible',
+      }}
+    >
+      {/* Transparent bridge above — keeps tooltip reachable when mousing upward */}
+      <div
+        className="absolute"
+        style={{ bottom: '100%', left: '-4px', right: '-4px', height: '24px', pointerEvents: 'auto' }}
+        onMouseEnter={cancelHide}
+        onMouseLeave={scheduleHide}
+      />
+
+      {/* Badge strip — overlays bottom of health bar; opaque so no color blending */}
+      <div
+        ref={stripRef}
+        className="absolute"
+        style={{
+          left: 0, right: 0, bottom: '1px', height: '13px',
+          borderRadius: '2px', overflow: 'hidden',
+          background: colors.bg,
+          border: `1px solid ${colors.border}`,
+          display: 'flex', alignItems: 'center',
+          padding: '0 4px',
+          pointerEvents: 'auto',
+        }}
+        onMouseEnter={showTooltip}
+        onMouseLeave={scheduleHide}
+      >
+        <span style={{
+          fontSize: '9px', fontWeight: 700, lineHeight: 1,
+          color: colors.fg, whiteSpace: 'nowrap', overflow: 'hidden',
+        }}>
+          {label}
+        </span>
+      </div>
+
+      {/* Hover tooltip */}
+      {tooltipVisible && (
+        <div
+          className="absolute bg-popover border border-border shadow-lg p-2.5 text-xs z-50"
+          style={{
+            bottom: 'calc(100% + 8px)',
+            ...(tooltipSide === 'right' ? { right: 0 } : { left: 0 }),
+            pointerEvents: 'auto',
+            minWidth: '200px',
+            maxWidth: isSingle ? '280px' : '300px',
+          }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={() => setTooltipVisible(false)}
+        >
+          {isSingle ? (
+            <>
+              <div className="font-mono text-[11px] text-blue-300 mb-1">{first.humanReadableId}</div>
+              <div className="text-foreground font-medium mb-1 leading-tight">{first.title}</div>
+              <div className="text-muted-foreground space-y-0.5">
+                <div>Type: <span className="text-foreground capitalize">{first.type}</span></div>
+                <div>Status: <span className="text-foreground">{first.status}</span></div>
+                <div>Started: <span className="text-foreground">{startSec}</span></div>
+                {first.entityName && <div>Entity: <span className="text-foreground font-mono text-[10px]">{first.entityName}</span></div>}
+              </div>
+              <a
+                href={opsTicketUrl(first.id)}
+                target="_blank"
+                rel="noreferrer"
+                className="block mt-2 text-blue-300 hover:underline"
+              >
+                View in ops management →
+              </a>
+              {first.slackUrl && (
+                <a
+                  href={first.slackUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block mt-1 text-[#4A9CC7] hover:underline"
+                >
+                  View Slack thread →
+                </a>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="text-muted-foreground text-[10px] mb-1.5">
+                {tickets.length} {type}{tickets.length !== 1 ? 's' : ''} in this window
+              </div>
+              <div>
+                {tickets.map((t, ti) => (
+                  <div key={t.id} className={`py-1.5 ${ti > 0 ? 'border-t border-border/30' : ''}`}>
+                    <div className="flex items-center gap-1.5">
+                      <span className={`text-[9px] font-bold px-1 py-0.5 rounded shrink-0 ${
+                        t.type === 'incident' ? 'bg-red-900/60 text-red-200' : 'bg-blue-900/60 text-blue-200'
+                      }`}>
+                        {t.type === 'incident' ? 'I' : 'M'}
+                      </span>
+                      <span className="font-mono text-[10px] text-blue-300 shrink-0">{t.humanReadableId}</span>
+                      <a
+                        href={opsTicketUrl(t.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue-300 hover:underline text-[10px] ml-auto shrink-0"
+                        title="Open in ops management"
+                      >
+                        ↗
+                      </a>
+                      {t.slackUrl && (
+                        <a
+                          href={t.slackUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[#4A9CC7] hover:underline text-[10px] shrink-0"
+                          title="Open Slack thread"
+                        >
+                          #
+                        </a>
+                      )}
+                    </div>
+                    <div
+                      className="text-[10px] text-foreground leading-snug mt-0.5 overflow-hidden"
+                      style={{ maxWidth: '240px', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
+                    >
+                      {t.title}
+                    </div>
+                    <div className="text-[9px] text-muted-foreground mt-0.5">{t.status}</div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function buildClusters(
+  windows: TicketWindow[],
+  rangeStartMs: number,
+  rangeEndMs: number,
+  minWidthMs: number | undefined,
+): TicketCluster[] {
+  const expanded = windows.flatMap(w => {
+    const rawStart = new Date(w.startAt).getTime()
+    const rawEnd = w.endAt ? new Date(w.endAt).getTime() : rangeEndMs
+    const start = Math.max(rawStart, rangeStartMs)
+    let end = Math.min(rawEnd, rangeEndMs)
+    if (end <= start) return []
+    if (minWidthMs && end - start < minWidthMs) {
+      end = Math.min(start + minWidthMs, rangeEndMs)
+    }
+    if (end <= start) return []
+    return [{ w, startMs: start, endMs: end }]
+  })
+
+  expanded.sort((a, b) => a.startMs - b.startMs)
+
+  const clusters: TicketCluster[] = []
+  for (const { w, startMs, endMs } of expanded) {
+    const last = clusters[clusters.length - 1]
+    if (last && startMs < last.endMs) {
+      last.endMs = Math.max(last.endMs, endMs)
+      last.tickets.push(w)
+    } else {
+      clusters.push({ startMs, endMs, tickets: [w] })
+    }
+  }
+  return clusters
+}
+
+/**
+ * Renders ticket badge strips overlaid on the bottom of a health bar zone.
+ *
+ * Incidents and maintenance are clustered independently, then rendered in layers:
+ * maintenance underneath (z-index 3), incidents on top (z-index 4). Where a short
+ * incident overlaps a long maintenance window the incident strip covers only its
+ * actual duration — the maintenance strip remains visible for the rest.
+ */
+export function TicketOverlay({ windows, rangeStartMs, rangeEndMs, minWidthMs }: TicketOverlayProps) {
+  const rangeDuration = rangeEndMs - rangeStartMs
+  if (rangeDuration <= 0 || windows.length === 0) return null
+
+  const incidentClusters = buildClusters(
+    windows.filter(w => w.type === 'incident'),
+    rangeStartMs, rangeEndMs, minWidthMs,
+  )
+  const maintenanceClusters = buildClusters(
+    windows.filter(w => w.type === 'maintenance'),
+    rangeStartMs, rangeEndMs, minWidthMs,
+  )
+
+  function renderCluster(cluster: TicketCluster, zIndex: number) {
+    const leftPct = ((cluster.startMs - rangeStartMs) / rangeDuration) * 100
+    const widthPct = ((cluster.endMs - cluster.startMs) / rangeDuration) * 100
+    const safeLeft = Math.max(0, Math.min(leftPct, 100 - widthPct))
+    return (
+      <ClusterStrip
+        key={cluster.tickets[0].id}
+        cluster={cluster}
+        leftPct={safeLeft}
+        widthPct={widthPct}
+        zIndex={zIndex}
+      />
+    )
+  }
+
+  return (
+    <>
+      {/* Maintenance first (z 3), incidents on top (z 4) — incident covers only its
+          own duration, maintenance strip remains visible for the rest */}
+      {maintenanceClusters.map(c => renderCluster(c, 3))}
+      {incidentClusters.map(c => renderCluster(c, 4))}
+    </>
+  )
+}

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -9,6 +9,9 @@ import { useTheme } from '@/hooks/use-theme'
 import type { TopologyMetro, TopologyDevice, TopologyLink, TopologyValidator, MultiPathResponse, SimulateLinkRemovalResponse, SimulateLinkAdditionResponse, WhatIfRemovalResponse, MetroDevicePathsResponse } from '@/lib/api'
 import { fetchISISPaths, fetchISISTopology, fetchCriticalLinks, fetchSimulateLinkRemoval, fetchSimulateLinkAddition, fetchWhatIfRemoval, fetchLinkHealth, fetchTopologyCompare, fetchMetroDevicePaths } from '@/lib/api'
 import { useTopology, useMulticastState, TopologyControlBar, TopologyPanel, DeviceDetails, LinkDetails, MetroDetails, ValidatorDetails, EntityLink as TopologyEntityLink, PathModePanel, MetroPathModePanel, CriticalityPanel, WhatIfRemovalPanel, WhatIfAdditionPanel, ImpactPanel, ComparePanel, StakeOverlayPanel, LinkHealthOverlayPanel, TrafficFlowOverlayPanel, MetroClusteringOverlayPanel, ContributorsOverlayPanel, ValidatorsOverlayPanel, DeviceTypeOverlayPanel, LinkTypeOverlayPanel, MulticastTreesOverlayPanel, LINK_TYPE_COLORS, MULTICAST_PUBLISHER_COLORS, type DeviceOption, type MetroOption } from '@/components/topology'
+import { useActiveOpsTickets } from '@/hooks/use-ops-tickets'
+import { opsTicketUrl } from '@/lib/ops-api'
+import type { OpsTicket } from '@/lib/ops-api'
 
 // Path colors for multi-path visualization
 const PATH_COLORS = [
@@ -342,10 +345,13 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
   const [hoveredMetro, setHoveredMetro] = useState<HoveredMetroInfo | null>(null)
   const [hoveredValidator, setHoveredValidator] = useState<HoveredValidatorInfo | null>(null)
   const [mousePos, setMousePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+  const mousePosRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [pinnedTooltipPos, setPinnedTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
   const [selectedItem, setSelectedItemState] = useState<SelectedItem | null>(null)
   const mapRef = useRef<MapRef>(null)
   const [mapReady, setMapReady] = useState(false)
   const markerClickedRef = useRef(false)
+  const linkHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Get unified topology context
   const { mode, setMode, overlays, toggleOverlay, panel, openPanel, closePanel, selection, impactDevices, toggleImpactDevice, clearImpactDevices, hoveredDiscrepancyKey } = useTopology()
@@ -392,6 +398,18 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
     restoreFromParams: restoreMulticastParams, getSelectionParams: getMulticastSelectionParams,
   } = mc
   const [linkAnimating, setLinkAnimating] = useState(true)
+
+  const { data: activeTicketsData } = useActiveOpsTickets()
+
+  const hoveredLinkTickets = useMemo((): OpsTicket[] => {
+    if (!hoveredLink || !activeTicketsData) return []
+    const pk = hoveredLink.pk
+    return activeTicketsData.tickets.filter(
+      t =>
+        t.affected_link_pubkey.includes(pk) ||
+        (t.affected_links?.some(l => l.pubkey === pk) ?? false)
+    )
+  }, [hoveredLink, activeTicketsData])
 
   // Auto-disable link animation when entering analysis mode (overlays, modes, selection).
   // User can re-enable via the toggle even while in analysis mode.
@@ -2660,6 +2678,9 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
 
       const props = e.features[0].properties
 
+      // Pin tooltip position at hover start so it stays reachable as user moves toward it
+      setPinnedTooltipPos(mousePosRef.current)
+
       // Handle inter-metro links
       if (pk?.startsWith('inter-metro-') && props?.isInterMetro) {
         setHoveredLink({
@@ -2705,11 +2726,12 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
   }, [linkMap, buildLinkInfo, multicastTreesMode, dimOtherLinks, multicastTreeLinkPKs])
 
   const handleLinkMouseLeave = useCallback(() => {
-    setHoveredLink(null)
+    linkHideTimerRef.current = setTimeout(() => setHoveredLink(null), 400)
   }, [])
 
   // Track mouse position for cursor-following popover
   const handleMouseMove = useCallback((e: maplibregl.MapMouseEvent) => {
+    mousePosRef.current = { x: e.point.x, y: e.point.y }
     setMousePos({ x: e.point.x, y: e.point.y })
   }, [])
 
@@ -3364,11 +3386,17 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
       {/* Hover tooltip - cursor-following */}
       {(hoveredLink || hoveredDevice || hoveredMetro || hoveredValidator) && (
         <div
-          className="absolute z-[1000] bg-[var(--card)]/95 backdrop-blur border border-[var(--border)] rounded-md shadow-lg px-3 py-2 pointer-events-none"
+          className={`absolute z-[1000] bg-[var(--card)]/95 backdrop-blur border border-[var(--border)] rounded-md shadow-lg px-3 py-2 ${
+            hoveredLinkTickets.length > 0 ? '' : 'pointer-events-none'
+          }`}
           style={{
-            left: mousePos.x + 16,
-            top: mousePos.y + 16,
+            left: (hoveredLink ? pinnedTooltipPos.x : mousePos.x) + 16,
+            top: (hoveredLink ? pinnedTooltipPos.y : mousePos.y) + 16,
           }}
+          onMouseEnter={() => {
+            if (linkHideTimerRef.current) clearTimeout(linkHideTimerRef.current)
+          }}
+          onMouseLeave={() => setHoveredLink(null)}
         >
           {hoveredLink && (
             <div className="space-y-1">
@@ -3396,6 +3424,37 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
                   </>
                 )}
               </div>
+              {hoveredLinkTickets.length > 0 && (
+                <div className="mt-1.5 pt-1.5 border-t border-border/50 space-y-0.5">
+                  {hoveredLinkTickets.map(t => (
+                    <div key={t.id} className="flex items-center gap-1.5">
+                      <span className={`text-[9px] font-semibold ${t.type === 'incident' ? 'text-red-400' : 'text-blue-400'}`}>
+                        {t.type === 'incident' ? '⚠' : '🔧'}
+                      </span>
+                      <a
+                        href={opsTicketUrl(t.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[11px] font-mono text-blue-300 hover:underline"
+                      >
+                        {t.human_readable_id}
+                      </a>
+                      <span className="text-[10px] text-muted-foreground">{t.status}</span>
+                      {t.slack_message_url && (
+                        <a
+                          href={t.slack_message_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[10px] text-[#4A9CC7] hover:underline ml-auto"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Slack ↗
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
           {hoveredDevice && !hoveredLink && (

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -3428,14 +3428,14 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
                 <div className="mt-1.5 pt-1.5 border-t border-border/50 space-y-0.5">
                   {hoveredLinkTickets.map(t => (
                     <div key={t.id} className="flex items-center gap-1.5">
-                      <span className={`text-[9px] font-semibold ${t.type === 'incident' ? 'text-red-400' : 'text-blue-400'}`}>
+                      <span className={`text-[9px] font-semibold ${t.type === 'incident' ? 'text-red-600 dark:text-red-400' : 'text-blue-600 dark:text-blue-400'}`}>
                         {t.type === 'incident' ? '⚠' : '🔧'}
                       </span>
                       <a
                         href={opsTicketUrl(t.id)}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-[11px] font-mono text-blue-300 hover:underline"
+                        className="text-[11px] font-mono text-blue-600 dark:text-blue-300 hover:underline"
                       >
                         {t.human_readable_id}
                       </a>

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -3445,7 +3445,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
                           href={t.slack_message_url}
                           target="_blank"
                           rel="noreferrer"
-                          className="text-[10px] text-[#4A9CC7] hover:underline ml-auto"
+                          className="text-[10px] text-blue-600 dark:text-blue-300 hover:underline ml-auto"
                           onClick={(e) => e.stopPropagation()}
                         >
                           Slack ↗

--- a/web/src/hooks/use-is-ops-user.ts
+++ b/web/src/hooks/use-is-ops-user.ts
@@ -1,0 +1,12 @@
+// web/src/hooks/use-is-ops-user.ts
+import { useAuth } from '@/contexts/AuthContext'
+
+/**
+ * Returns true if the current user is authenticated with an internal-domain
+ * Google account (@doublezero.xyz, @doublezero.us, @malbeclabs.com).
+ * This mirrors the server-side isInternalDomain() check in auth.go.
+ */
+export function useIsOpsUser(): boolean {
+  const { user } = useAuth()
+  return user?.is_internal_user === true
+}

--- a/web/src/hooks/use-ops-tickets.ts
+++ b/web/src/hooks/use-ops-tickets.ts
@@ -1,0 +1,72 @@
+// web/src/hooks/use-ops-tickets.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  fetchActiveOpsTickets,
+  fetchOpsTicketHistory,
+  fetchOpsAssignees,
+  createOpsTicket,
+  type OpsTicket,
+  type OpsTicketType,
+  type CreateOpsTicketInput,
+} from '@/lib/ops-api'
+
+const STALE_TIME = 5 * 60 * 1000 // 5 minutes
+
+// Fetch all active tickets once; filter client-side per entity.
+// Returns undefined data (empty state) for unauthenticated users — no error shown.
+export function useActiveOpsTickets() {
+  return useQuery({
+    queryKey: ['ops-tickets', 'active'],
+    queryFn: fetchActiveOpsTickets,
+    staleTime: STALE_TIME,
+    retry: false,
+    throwOnError: false,
+  })
+}
+
+// Returns active tickets that affect a specific link or device pubkey.
+// Checks both the flat pubkey arrays and the enriched object arrays returned by
+// tickets created via the Ops Management web UI.
+export function useTicketsForEntity(entityPk: string): OpsTicket[] {
+  const { data } = useActiveOpsTickets()
+  if (!data) return []
+  return data.tickets.filter(
+    (t) =>
+      t.affected_link_pubkey.includes(entityPk) ||
+      t.device_pubkey.includes(entityPk) ||
+      (t.affected_links?.some(l => l.pubkey === entityPk) ?? false) ||
+      (t.affected_devices?.some(d => d.pubkey === entityPk) ?? false)
+  )
+}
+
+// Fetch 5 most recent closed tickets for a specific entity (detail page only).
+export function useOpsTicketHistory(entityPk: string, ticketType?: OpsTicketType, entityType?: 'link' | 'device') {
+  return useQuery({
+    queryKey: ['ops-tickets', 'history', entityPk, ticketType, entityType],
+    queryFn: () => fetchOpsTicketHistory(entityPk, ticketType, entityType),
+    staleTime: STALE_TIME,
+    enabled: !!entityPk,
+  })
+}
+
+// Create a new incident ticket and invalidate the active tickets cache on success.
+export function useCreateOpsTicket() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: CreateOpsTicketInput) => createOpsTicket(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ops-tickets', 'active'] })
+    },
+  })
+}
+
+// Fetch the list of valid assignees. Cached for 5 minutes.
+export function useOpsAssignees() {
+  return useQuery({
+    queryKey: ['ops-assignees'],
+    queryFn: fetchOpsAssignees,
+    staleTime: STALE_TIME,
+    retry: false,
+    throwOnError: false,
+  })
+}

--- a/web/src/hooks/use-uplot-chart.ts
+++ b/web/src/hooks/use-uplot-chart.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MutableRefObject, type RefObject } from 'react'
+import { useEffect, useRef, useState, type MutableRefObject, type RefObject } from 'react'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import { useTheme } from '@/hooks/use-theme'
@@ -25,8 +25,9 @@ export function useUPlotChart({
   onCursorIdx,
   onFocusSeries,
   drawHooks,
-}: UseUPlotChartOptions): { plotRef: MutableRefObject<uPlot | null> } {
+}: UseUPlotChartOptions): { plotRef: MutableRefObject<uPlot | null>; plotVersion: number } {
   const plotRef = useRef<uPlot | null>(null)
+  const [plotVersion, setPlotVersion] = useState(0)
   const { resolvedTheme } = useTheme()
   const onCursorIdxRef = useRef(onCursorIdx)
   onCursorIdxRef.current = onCursorIdx
@@ -123,6 +124,7 @@ export function useUPlotChart({
     }
 
     plotRef.current = new uPlot(opts, data, container)
+    setPlotVersion(v => v + 1)
 
     const resizeObserver = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width
@@ -141,5 +143,5 @@ export function useUPlotChart({
     }
   }, [containerRef, data, series, height, axes, scales, resolvedTheme])
 
-  return { plotRef }
+  return { plotRef, plotVersion }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5520,6 +5520,7 @@ export interface LinkMetricsResponse {
   link_code: string
   link_type: string
   contributor_code: string
+  contributor_pk: string
   side_a_metro: string
   side_z_metro: string
   side_a_device: string
@@ -5662,6 +5663,7 @@ export interface DeviceMetricsResponse {
   device_code: string
   device_type: string
   contributor_code: string
+  contributor_pk: string
   metro: string
   max_users: number
   time_range: string

--- a/web/src/lib/ops-api.ts
+++ b/web/src/lib/ops-api.ts
@@ -1,0 +1,115 @@
+// web/src/lib/ops-api.ts
+import { apiFetch } from './api'
+
+export type OpsTicketType = 'incident' | 'maintenance'
+
+export type OpsTicketStatus =
+  | 'open' | 'acknowledged' | 'investigating' | 'mitigating'
+  | 'monitoring' | 'planned' | 'in-progress'
+  | 'resolved' | 'closed' | 'completed'
+
+export type OpsTicketSeverity = 'sev1' | 'sev2' | 'sev3'
+
+export interface OpsTicket {
+  id: string                         // UUID
+  human_readable_id: string          // e.g. "I20250413-a7b2"
+  type: OpsTicketType
+  title: string
+  description: string
+  severity?: OpsTicketSeverity
+  status: OpsTicketStatus
+  affected_link_pubkey: string[]
+  device_pubkey: string[]
+  // Enriched link/device objects (code + pubkey) returned by upstream API
+  affected_links?: Array<{ code: string; pubkey: string }>
+  affected_devices?: Array<{ code: string; pubkey: string }>
+  reporter_name: string
+  reporter_email: string
+  contributor_name?: string
+  start_at?: string                  // ISO timestamp
+  end_at?: string                    // ISO timestamp
+  slack_message_url?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface OpsTicketsListResponse {
+  tickets: OpsTicket[]
+  total: number
+}
+
+export interface CreateOpsTicketInput {
+  type: OpsTicketType
+  title: string
+  description: string
+  severity?: OpsTicketSeverity
+  status?: OpsTicketStatus
+  affected_link_pubkey?: string[]
+  device_pubkey?: string[]
+  start_at?: string
+  end_at?: string
+  contributor_pubkey?: string | null
+}
+
+// Fetch all active tickets (maintenance + incidents across all entities).
+// Called once per status-page load; filtered client-side per entity.
+export async function fetchActiveOpsTickets(): Promise<OpsTicketsListResponse> {
+  const res = await apiFetch('/api/ops-tickets?status=active')
+  if (!res.ok) throw new Error(`Failed to fetch ops tickets: ${res.status}`)
+  const json = await res.json()
+  return json.data ?? json
+}
+
+// Fetch the 5 most recent closed tickets for a specific link or device.
+export async function fetchOpsTicketHistory(
+  entityPk: string,
+  ticketType?: OpsTicketType,
+  entityType?: 'link' | 'device'
+): Promise<OpsTicketsListResponse> {
+  const params = new URLSearchParams({ entity_pk: entityPk, limit: '5' })
+  if (ticketType) params.set('type', ticketType)
+  if (entityType) params.set('entity_type', entityType)
+  const res = await apiFetch(`/api/ops-tickets/history?${params}`)
+  if (!res.ok) throw new Error(`Failed to fetch ops ticket history: ${res.status}`)
+  const json = await res.json()
+  return json.data ?? json
+}
+
+// Create a new incident ticket. Reporter fields are set server-side.
+export async function createOpsTicket(input: CreateOpsTicketInput): Promise<OpsTicket> {
+  const res = await apiFetch('/api/ops-tickets', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) throw new Error(`Failed to create ops ticket: ${res.status}`)
+  const json = await res.json()
+  return json.data ?? json
+}
+
+// opsTicketUrl returns the Ops Management deep-link for a ticket.
+export function opsTicketUrl(ticketId: string): string {
+  return `https://doublezero.xyz/ops-management/tickets/${ticketId}`
+}
+
+export interface OpsAssignee {
+  value: string   // contributor code, e.g. "rox" or "dz_malbeclabs"
+  label: string   // display name, e.g. "RockawayX"
+  type?: string   // "admin" | "contributor"
+  pubkey?: string // Solana pubkey, joined server-side from ClickHouse
+}
+
+export interface OpsAssigneesResponse {
+  assignees: OpsAssignee[]
+}
+
+// Fetch the list of valid assignees from the Ops Management API.
+export async function fetchOpsAssignees(): Promise<OpsAssigneesResponse> {
+  const res = await apiFetch('/api/ops-tickets/assignees')
+  if (!res.ok) throw new Error(`Failed to fetch assignees: ${res.status}`)
+  const json = await res.json()
+  // Handle plain array, {data: [...]}, and {assignees: [...]} shapes
+  if (Array.isArray(json)) return { assignees: json }
+  if (Array.isArray(json.data)) return { assignees: json.data }
+  return json
+}

--- a/web/src/lib/ops-api.ts
+++ b/web/src/lib/ops-api.ts
@@ -10,6 +10,10 @@ export type OpsTicketStatus =
 
 export type OpsTicketSeverity = 'sev1' | 'sev2' | 'sev3'
 
+export function isTicketClosed(status: OpsTicketStatus): boolean {
+  return status === 'resolved' || status === 'closed' || status === 'completed'
+}
+
 export interface OpsTicket {
   id: string                         // UUID
   human_readable_id: string          // e.g. "I20250413-a7b2"


### PR DESCRIPTION
## Summary of Changes
- Add a Go proxy for the Ops Management API (`/api/ops-tickets`) that fetches, creates, and lists incident and maintenance tickets; contributors list is sourced from ClickHouse `dz_contributors_current`
- Add `TicketOverlay` component that renders colored badge strips (red = incident, blue = maintenance) directly on health bar timelines across status, incidents, and detail pages, with clustered multi-ticket tooltips and deep-links to Ops Management
- Add `TicketChartBands` component that draws shaded vertical bands behind uPlot charts on link and device detail pages for the duration of each ticket
- Add `OpsPanel` on link and device detail pages showing active tickets and a "Create incident" button (internal-domain users only)
- Add `CreateIncidentModal` supporting both entity-context mode (pre-filled from a specific link/device) and blank mode (full ticket creation with type, entity search, contributor, status, and maintenance scheduling)
- Surface active incident/maintenance counts in topology map edge tooltips
- Conform to Ops Management API v1.1.0: replace `assignee` with `contributor_pubkey`, replace removed `/assignee-options` endpoint with direct ClickHouse query

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net    |
|--------------|-------|---------------|--------|
| Core logic   |    14 | +2688 / -78   | +2610  |
| Scaffolding  |    18 | +261 / -31    | +230   |
| Tests        |     1 | +249 / -0     | +249   |
| **Total**    |    33 | +3198 / -109  | +3089  |

Predominantly new UI components and a new API proxy; scaffolding is chart wiring and route registration.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/ops/CreateIncidentModal.tsx` — full incident/maintenance creation modal with entity-context and blank modes, contributor dropdown, entity search, and maintenance scheduling
- `web/src/components/ops/TicketOverlay.tsx` — badge strip overlay for health bar timelines; clusters overlapping tickets per type, renders maintenance (z=3) under incidents (z=4), hover tooltip with Ops Management deep-link
- `api/handlers/ops_tickets.go` — Go proxy for Ops Management API: GET active/history tickets, POST create ticket, GET contributors from ClickHouse; reporter fields set server-side from authenticated session
- `web/src/components/incidents-page.tsx` — adds correlated active ticket display per link/device row, create incident button for ops users, incident/maintenance toggle filters
- `web/src/components/link-status-timelines.tsx` — adds `TicketOverlay` on health bars and "Create incident" button on issue rows (ops users only)
- `web/src/components/ops/OpsPanel.tsx` — panel shown on detail pages listing active tickets with status badges, Slack links, and create incident prompt when entity is down
- `web/src/components/ops/TicketChartBands.tsx` — uPlot plugin that draws shaded background bands for ticket windows on detail page charts
- `web/src/lib/ops-api.ts` — TypeScript client types and fetch functions for all ops ticket endpoints

</details>

## Testing Verification
- Created incident and maintenance tickets via the modal in both entity-context and blank modes; tickets appeared in Ops Management and overlays updated on the status page
- Confirmed "Create incident" button is hidden for non-internal users (wallet auth and unauthenticated) across all surfaces; server-side `RequireInternalDomain` provides a second enforcement layer
- Verified ticket overlays render correctly on health timelines with correct color separation (red incident strips over blue maintenance strips), tooltip z-index fixed so tooltips are not obscured by adjacent row strips
- Confirmed `OPS_MANAGEMENT_API_KEY` is documented in both `.env.example` files with empty value