### PR TITLE
indexer, admin: always refresh existing remote proxies, drop --force

### DIFF
--- a/admin/cmd/admin/main.go
+++ b/admin/cmd/admin/main.go
@@ -144,7 +144,6 @@ func run() error {
 	remoteClickhouseUserFlag := flag.String("remote-clickhouse-user", "", "Remote ClickHouse user (or set REMOTE_CH_USER env var)")
 	remoteClickhousePasswordFlag := flag.String("remote-clickhouse-password", "", "Remote ClickHouse password (or set REMOTE_CH_PASSWORD env var)")
 	remoteClickhouseDatabaseFlag := flag.String("remote-clickhouse-database", "", "Remote ClickHouse database to discover tables from (or set REMOTE_CH_DATABASE env var, default: lake)")
-	forceFlag := flag.Bool("force", false, "Force overwrite existing non-proxy tables when setting up remote tables")
 
 	flag.Parse()
 
@@ -520,7 +519,6 @@ func run() error {
 			RemoteUser:     *remoteClickhouseUserFlag,
 			RemotePassword: *remoteClickhousePasswordFlag,
 			RemoteDatabase: *remoteClickhouseDatabaseFlag,
-			Force:          *forceFlag,
 		})
 	}
 

--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -53,9 +53,6 @@ type Config struct {
 	// ClickHouse pushes multi-table queries to the remote where the database
 	// name must match.
 	RemoteDatabase string
-
-	// Force overwrites existing non-proxy tables.
-	Force bool
 }
 
 // Setup creates remoteSecure() proxy tables in local ClickHouse
@@ -109,23 +106,19 @@ func Setup(log *slog.Logger, cfg Config) error {
 	}
 	defer rows.Close()
 
-	created, existing, skipped := 0, 0, 0
+	created, skipped := 0, 0
 	for rows.Next() {
 		var tableName string
 		if err := rows.Scan(&tableName); err != nil {
 			return fmt.Errorf("failed to scan table name: %w", err)
 		}
 
-		result, err := checkTable(ctx, localConn, cfg.RemoteDatabase, tableName, cfg.Force, log)
+		result, err := checkTable(ctx, localConn, cfg.RemoteDatabase, tableName, log)
 		if err != nil {
 			return err
 		}
 		if result == tableSkipped {
 			skipped++
-			continue
-		}
-		if result == tableExisting {
-			existing++
 			continue
 		}
 
@@ -139,38 +132,27 @@ func Setup(log *slog.Logger, cfg Config) error {
 		log.Info("created proxy table", "table", fmt.Sprintf("%s.%s", cfg.RemoteDatabase, tableName))
 		created++
 	}
-	if created == 0 && existing > 0 && skipped == 0 {
-		fmt.Printf("All %d proxy tables in %s already exist (from remote %s database)\n", existing, cfg.RemoteDatabase, cfg.RemoteDatabase)
-	} else {
-		fmt.Printf("Created %d proxy tables in %s (from remote %s database", created, cfg.RemoteDatabase, cfg.RemoteDatabase)
-		if existing > 0 {
-			fmt.Printf(", %d already existed", existing)
-		}
-		if skipped > 0 {
-			fmt.Printf(", skipped %d non-proxy tables", skipped)
-		}
-		fmt.Println(")")
+	fmt.Printf("Created %d proxy tables in %s (from remote %s database", created, cfg.RemoteDatabase, cfg.RemoteDatabase)
+	if skipped > 0 {
+		fmt.Printf(", skipped %d non-proxy tables", skipped)
 	}
+	fmt.Println(")")
 
 	// Create external table proxies in their original databases
 	// (e.g., shredder.publisher_shred_stats) since the API references them
 	// with fully qualified names.
-	extCreated, extExisting, extSkipped := 0, 0, 0
+	extCreated, extSkipped := 0, 0
 	for _, t := range externalRemoteTables {
 		if err := localConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", t.RemoteDB)); err != nil {
 			return fmt.Errorf("failed to create database %s: %w", t.RemoteDB, err)
 		}
 
-		result, err := checkTable(ctx, localConn, t.RemoteDB, t.RemoteTable, cfg.Force, log)
+		result, err := checkTable(ctx, localConn, t.RemoteDB, t.RemoteTable, log)
 		if err != nil {
 			return err
 		}
 		if result == tableSkipped {
 			extSkipped++
-			continue
-		}
-		if result == tableExisting {
-			extExisting++
 			continue
 		}
 
@@ -184,18 +166,11 @@ func Setup(log *slog.Logger, cfg Config) error {
 		log.Info("created external proxy table", "table", fmt.Sprintf("%s.%s", t.RemoteDB, t.RemoteTable))
 		extCreated++
 	}
-	if extCreated == 0 && extExisting > 0 && extSkipped == 0 {
-		fmt.Printf("All %d external proxy tables already exist\n", extExisting)
-	} else {
-		fmt.Printf("Created %d external proxy tables", extCreated)
-		if extExisting > 0 {
-			fmt.Printf(" (%d already existed)", extExisting)
-		}
-		if extSkipped > 0 {
-			fmt.Printf(" (skipped %d non-proxy tables)", extSkipped)
-		}
-		fmt.Println()
+	fmt.Printf("Created %d external proxy tables", extCreated)
+	if extSkipped > 0 {
+		fmt.Printf(" (skipped %d non-proxy tables)", extSkipped)
 	}
+	fmt.Println()
 
 	return nil
 }
@@ -203,14 +178,12 @@ func Setup(log *slog.Logger, cfg Config) error {
 type tableCheckResult int
 
 const (
-	tableNew      tableCheckResult = iota // table doesn't exist, create it
-	tableExisting                         // proxy already exists, skip it
-	tableSkipped                          // non-proxy table exists, skip unless --force
-	tableForced                           // non-proxy table exists but --force was set
+	tableNew     tableCheckResult = iota // table doesn't exist or is a proxy, (re)create it
+	tableSkipped                         // non-proxy table exists, leave it alone
 )
 
 // checkTable checks whether a table already exists and what action to take.
-func checkTable(ctx context.Context, conn clickhouse.Connection, database, table string, force bool, log *slog.Logger) (tableCheckResult, error) {
+func checkTable(ctx context.Context, conn clickhouse.Connection, database, table string, log *slog.Logger) (tableCheckResult, error) {
 	rows, err := conn.Query(ctx,
 		"SELECT engine FROM system.tables WHERE database = ? AND name = ?",
 		database, table,
@@ -230,18 +203,9 @@ func checkTable(ctx context.Context, conn clickhouse.Connection, database, table
 	}
 
 	if engine == "StorageProxy" {
-		if force {
-			return tableNew, nil
-		}
-		return tableExisting, nil
+		return tableNew, nil
 	}
 
-	fqn := fmt.Sprintf("%s.%s", database, table)
-	if force {
-		log.Warn("overwriting existing non-proxy table (--force)", "table", fqn, "engine", engine)
-		return tableForced, nil
-	}
-
-	log.Warn("skipping existing non-proxy table (use --force to overwrite)", "table", fqn, "engine", engine)
+	log.Warn("skipping existing non-proxy table", "table", fmt.Sprintf("%s.%s", database, table), "engine", engine)
 	return tableSkipped, nil
 }

--- a/api/handlers/facilities.go
+++ b/api/handlers/facilities.go
@@ -62,7 +62,7 @@ var facilitySortFields = map[string]string{
 	"loc_id":  "loc_id",
 	"metro":   "metro_code",
 	"devices": "device_count",
-	"users": "if(user_count = 0 AND max_users = 0 AND max_unicast_users = 0 AND max_multicast_subscribers = 0 AND max_multicast_publishers = 0, 1, 0)|toFloat64(user_count) / toFloat64(greatest(1, user_count + least(if(max_users > 0, greatest(0, toInt64(max_users) - toInt64(user_count)), toInt64(999999999)), if(max_unicast_users > 0, greatest(0, toInt64(max_unicast_users) - toInt64(unicast_users_count)), toInt64(999999999)), if(max_multicast_subscribers > 0, greatest(0, toInt64(max_multicast_subscribers) - toInt64(multicast_subscribers_count)), toInt64(999999999)), if(max_multicast_publishers > 0, greatest(0, toInt64(max_multicast_publishers) - toInt64(multicast_publishers_count)), toInt64(999999999)))))",
+	"users":   "if(user_count = 0 AND max_users = 0 AND max_unicast_users = 0 AND max_multicast_subscribers = 0 AND max_multicast_publishers = 0, 1, 0)|toFloat64(user_count) / toFloat64(greatest(1, user_count + least(if(max_users > 0, greatest(0, toInt64(max_users) - toInt64(user_count)), toInt64(999999999)), if(max_unicast_users > 0, greatest(0, toInt64(max_unicast_users) - toInt64(unicast_users_count)), toInt64(999999999)), if(max_multicast_subscribers > 0, greatest(0, toInt64(max_multicast_subscribers) - toInt64(multicast_subscribers_count)), toInt64(999999999)), if(max_multicast_publishers > 0, greatest(0, toInt64(max_multicast_publishers) - toInt64(multicast_publishers_count)), toInt64(999999999)))))",
 }
 
 var facilityFilterFields = map[string]FilterFieldConfig{

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -363,7 +363,6 @@ func run() error {
 				RemoteUser:     remoteUser,
 				RemotePassword: remotePassword,
 				RemoteDatabase: remoteDatabase,
-				Force:          true,
 			}); err != nil {
 				return fmt.Errorf("failed to set up remote tables: %w", err)
 			}

--- a/scripts/setup-remote-tables.sh
+++ b/scripts/setup-remote-tables.sh
@@ -19,22 +19,11 @@ set -euo pipefail
 #
 # Usage:
 #   ./scripts/setup-remote-tables.sh            # Create proxies in lake database
-#   ./scripts/setup-remote-tables.sh --force     # Overwrite existing non-proxy tables
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$ROOT_DIR"
-
-# ─── Parse flags ─────────────────────────────────────────────────────────────
-
-FORCE=""
-for arg in "$@"; do
-  case "$arg" in
-    --force) FORCE="--force" ;;
-    *) echo "Unknown flag: $arg" >&2; exit 1 ;;
-  esac
-done
 
 # ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -110,13 +99,7 @@ should_skip_table() {
     return 1
   fi
 
-  # Real data table exists
-  if [[ -n "$FORCE" ]]; then
-    echo "  WARNING: overwriting existing non-proxy table ${db}.${table} (engine: ${engine})"
-    return 1
-  fi
-
-  echo "  SKIP: ${db}.${table} exists with engine ${engine} (use --force to overwrite)"
+  echo "  SKIP: ${db}.${table} exists with engine ${engine}"
   return 0
 }
 


### PR DESCRIPTION
## Summary

- Existing proxy tables are now always recreated via `CREATE OR REPLACE` on every `setup-remote-tables` run, so remote schema drift is picked up without any flag.
- Non-proxy tables sharing a name with a remote table are always skipped with a warning — the `--force` flag, `Config.Force` field, and the `tableForced` fall-through (which silently overwrote real data tables) are gone.
- The indexer previously passed `Force: true`, so any accidental non-proxy table in `lake` / `shredder` / `shredder_qa` would be dropped and replaced on every indexer restart. That footgun is removed.

## Why

The force flag only gated one scenario — overwriting a real data table with a proxy — and the indexer hardcoded it to `true`. That made the init path unsafe while adding no real value, since the common case (refreshing existing proxies) doesn't need a flag.