### PR TITLE
api: add versioned /api/v1 API with OpenAPI docs

### DIFF
--- a/api/handlers/shred_subscribers.go
+++ b/api/handlers/shred_subscribers.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+// ShredSubscriberRow is the raw, internal shape of a shred subscriber (client seat)
+// returned by FetchShredSubscribers. Consumers (including the v1 API) map this
+// to their own public shapes.
+type ShredSubscriberRow struct {
+	PK                       string
+	DeviceKey                string
+	DeviceCode               string
+	MetroPK                  string
+	MetroCode                string
+	ClientIP                 string
+	TenureEpochs             uint16
+	FundedEpoch              uint64
+	ActiveEpoch              uint64
+	HasPriceOverride         uint8
+	OverrideUSDCPriceDollars uint16
+	EscrowCount              uint32
+	TotalUSDCBalance         uint64
+	PricePerEpochDollars     int64
+	FundingAuthorityKey      string
+	UserPK                   string
+	UserOwnerPubkey          string
+	UserStatus               string
+	LastActivity             *time.Time
+}
+
+// FetchShredSubscribers returns a page of shred subscribers (client seats),
+// optionally filtered by funder pubkey (funding_authority_key, exact match).
+// Ordered by active_epoch DESC, pk ASC.
+func (a *API) FetchShredSubscribers(ctx context.Context, funder string, limit, offset int) ([]ShredSubscriberRow, uint64, error) {
+	var whereSQL string
+	var whereArgs []any
+	if funder != "" {
+		whereSQL = " WHERE s.funding_authority_key = ?"
+		whereArgs = append(whereArgs, funder)
+	}
+
+	start := time.Now()
+
+	countQuery := `
+		SELECT count(*)
+		FROM dim_dz_shred_client_seats_current s
+	` + whereSQL
+
+	var total uint64
+	if err := a.envDB(ctx).QueryRow(ctx, countQuery, whereArgs...).Scan(&total); err != nil {
+		metrics.RecordClickHouseQuery(time.Since(start), err)
+		return nil, 0, err
+	}
+
+	query := `
+		WITH escrow_balances AS (
+			SELECT client_seat_key, sum(usdc_balance) as total_usdc_balance
+			FROM dim_dz_shred_payment_escrows_current
+			GROUP BY client_seat_key
+		),
+		last_events AS (
+			SELECT client_seat_pk, max(event_ts) as last_activity
+			FROM fact_dz_shred_escrow_events FINAL
+			GROUP BY client_seat_pk
+		)
+		SELECT
+			s.pk, s.device_key, COALESCE(d.code, '') as device_code,
+			COALESCE(d.metro_pk, '') as metro_pk, COALESCE(m.code, '') as metro_code,
+			s.client_ip, s.tenure_epochs, s.funded_epoch, s.active_epoch,
+			s.has_price_override, s.override_usdc_price_dollars, s.escrow_count,
+			COALESCE(eb.total_usdc_balance, 0) as total_usdc_balance,
+			CASE
+				WHEN s.has_price_override = 1 THEN toInt64(s.override_usdc_price_dollars)
+				ELSE toInt64(COALESCE(mh.current_usdc_price_dollars, 0)) + toInt64(COALESCE(dh.current_usdc_metro_premium_dollars, 0))
+			END as price_per_epoch_dollars,
+			s.funding_authority_key,
+			COALESCE(u.pk, '') as user_pk,
+			COALESCE(u.owner_pubkey, '') as user_owner_pubkey,
+			COALESCE(u.status, '') as user_status,
+			le.last_activity as last_activity
+		FROM dim_dz_shred_client_seats_current s
+		LEFT JOIN dz_devices_current d ON s.device_key = d.pk
+		LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
+		LEFT JOIN dim_dz_shred_metro_histories_current mh ON mh.exchange_key = d.metro_pk
+		LEFT JOIN dim_dz_shred_device_histories_current dh ON dh.device_key = s.device_key
+		ANY LEFT JOIN dz_users_current u ON u.device_pk = s.device_key AND u.client_ip = s.client_ip
+		LEFT JOIN escrow_balances eb ON eb.client_seat_key = s.pk
+		LEFT JOIN last_events le ON le.client_seat_pk = s.pk
+	` + whereSQL + ` ORDER BY s.active_epoch DESC, s.pk ASC LIMIT ? OFFSET ?`
+
+	queryArgs := append(whereArgs, limit, offset)
+
+	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var items []ShredSubscriberRow
+	for rows.Next() {
+		var s ShredSubscriberRow
+		if err := rows.Scan(
+			&s.PK, &s.DeviceKey, &s.DeviceCode, &s.MetroPK, &s.MetroCode,
+			&s.ClientIP, &s.TenureEpochs, &s.FundedEpoch, &s.ActiveEpoch,
+			&s.HasPriceOverride, &s.OverrideUSDCPriceDollars, &s.EscrowCount, &s.TotalUSDCBalance,
+			&s.PricePerEpochDollars, &s.FundingAuthorityKey,
+			&s.UserPK, &s.UserOwnerPubkey, &s.UserStatus, &s.LastActivity,
+		); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}

--- a/api/handlers/v1_api_test.go
+++ b/api/handlers/v1_api_test.go
@@ -40,8 +40,8 @@ func TestV1OpenAPI_Spec(t *testing.T) {
 	assert.Equal(t, "/api/v1", spec.Servers[0].URL)
 
 	expected := []string{
-		"/shreds/publishers/leaders",
-		"/shreds/subscribers",
+		"/edge/shreds/publishers/leaders",
+		"/edge/shreds/subscribers",
 		"/solana/validators-metadata",
 	}
 	for _, p := range expected {

--- a/api/handlers/v1_api_test.go
+++ b/api/handlers/v1_api_test.go
@@ -1,0 +1,64 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+)
+
+// TestV1OpenAPI_Spec verifies the OpenAPI spec is served and advertises
+// every operation we expect. New v1 endpoints should be added here so a
+// missing registration fails loudly.
+func TestV1OpenAPI_Spec(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/openapi.json", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var spec struct {
+		OpenAPI string                          `json:"openapi"`
+		Info    struct{ Title, Version string } `json:"info"`
+		Servers []struct{ URL string }          `json:"servers"`
+		Paths   map[string]any                  `json:"paths"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &spec))
+
+	assert.NotEmpty(t, spec.OpenAPI, "openapi version must be set")
+	assert.Equal(t, "DoubleZero Data API", spec.Info.Title)
+	require.Len(t, spec.Servers, 1)
+	assert.Equal(t, "/api/v1", spec.Servers[0].URL)
+
+	expected := []string{
+		"/shreds/publishers/leaders",
+		"/shreds/subscribers",
+		"/solana/validators-metadata",
+	}
+	for _, p := range expected {
+		_, ok := spec.Paths[p]
+		assert.True(t, ok, "OpenAPI spec must advertise %s (all v1 ops must be registered)", p)
+	}
+}
+
+func TestV1Docs_Served(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/docs", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Header().Get("Content-Type"), "text/html")
+}

--- a/api/handlers/v1_shreds_publishers_test.go
+++ b/api/handlers/v1_shreds_publishers_test.go
@@ -23,7 +23,7 @@ func newV1Router(t *testing.T, api *handlers.API) *chi.Mux {
 }
 
 // v1ShredsPublishersContractFields is the authoritative list of JSON keys
-// in the public /api/v1/shreds/publishers/leaders response. A mismatch means the
+// in the public /api/v1/edge/shreds/publishers/leaders response. A mismatch means the
 // public contract has changed — bump the API version instead of renaming.
 var v1ShredsPublishersContractFields = struct {
 	top       []string
@@ -79,7 +79,7 @@ func TestV1ShredsPublishers_Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -99,7 +99,7 @@ func TestV1ShredsPublishers_Contract(t *testing.T) {
 	insertPublisherCheckTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -125,7 +125,7 @@ func TestV1ShredsPublishers_AllPublishers(t *testing.T) {
 	insertPublisherCheckTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -155,7 +155,7 @@ func TestV1ShredsPublishers_FilterByDZID(t *testing.T) {
 	insertPublisherCheckTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders?q=dzuser1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders?q=dzuser1", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -173,7 +173,7 @@ func TestV1ShredsPublishers_FilterByIP(t *testing.T) {
 	insertPublisherCheckTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders?q=10.0.0.1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders?q=10.0.0.1", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -195,14 +195,14 @@ func TestV1ShredsPublishers_EpochsAndSlotsParams(t *testing.T) {
 		url        string
 		wantStatus int
 	}{
-		{"default", "/api/v1/shreds/publishers/leaders", http.StatusOK},
-		{"epochs=1", "/api/v1/shreds/publishers/leaders?epochs=1", http.StatusOK},
-		{"slots=500", "/api/v1/shreds/publishers/leaders?slots=500", http.StatusOK},
-		{"slots with epochs (slots takes precedence)", "/api/v1/shreds/publishers/leaders?slots=500&epochs=5", http.StatusOK},
+		{"default", "/api/v1/edge/shreds/publishers/leaders", http.StatusOK},
+		{"epochs=1", "/api/v1/edge/shreds/publishers/leaders?epochs=1", http.StatusOK},
+		{"slots=500", "/api/v1/edge/shreds/publishers/leaders?slots=500", http.StatusOK},
+		{"slots with epochs (slots takes precedence)", "/api/v1/edge/shreds/publishers/leaders?slots=500&epochs=5", http.StatusOK},
 		// huma validates input — invalid values return 422 (part of the v1 error contract).
-		{"non-numeric epochs is rejected", "/api/v1/shreds/publishers/leaders?epochs=abc", http.StatusUnprocessableEntity},
-		{"out-of-range epochs is rejected", "/api/v1/shreds/publishers/leaders?epochs=99", http.StatusUnprocessableEntity},
-		{"out-of-range slots is rejected", "/api/v1/shreds/publishers/leaders?slots=9999", http.StatusUnprocessableEntity},
+		{"non-numeric epochs is rejected", "/api/v1/edge/shreds/publishers/leaders?epochs=abc", http.StatusUnprocessableEntity},
+		{"out-of-range epochs is rejected", "/api/v1/edge/shreds/publishers/leaders?epochs=99", http.StatusUnprocessableEntity},
+		{"out-of-range slots is rejected", "/api/v1/edge/shreds/publishers/leaders?slots=9999", http.StatusUnprocessableEntity},
 	}
 
 	r := newV1Router(t, api)

--- a/api/handlers/v1_shreds_publishers_test.go
+++ b/api/handlers/v1_shreds_publishers_test.go
@@ -1,0 +1,217 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+func newV1Router(t *testing.T, api *handlers.API) *chi.Mux {
+	t.Helper()
+	r := chi.NewRouter()
+	v1.Mount(r, api)
+	return r
+}
+
+// v1ShredsPublishersContractFields is the authoritative list of JSON keys
+// in the public /api/v1/shreds/publishers/leaders response. A mismatch means the
+// public contract has changed — bump the API version instead of renaming.
+var v1ShredsPublishersContractFields = struct {
+	top       []string
+	publisher []string
+}{
+	top: []string{
+		"$schema", // huma adds this for spec-linkage; part of the v1 contract.
+		"epoch",
+		"max_slot",
+		"total_network_stake",
+		"total_publishers",
+		"total_publisher_stake",
+		"publishers",
+	},
+	publisher: []string{
+		"publisher_ip",
+		"client_ip",
+		"node_pubkey",
+		"vote_pubkey",
+		"dz_user_pubkey",
+		"dz_device_code",
+		"dz_metro_code",
+		"activated_stake",
+		"multicast_connected",
+		"publishing_leader_shreds",
+		"publishing_retransmitted",
+		"leader_slots",
+		"total_slots",
+		"total_unique_shreds",
+		"slots_needing_repair",
+		"validator_client",
+		"validator_version",
+		"validator_name",
+		"validator_version_ok",
+		"is_backup",
+	},
+}
+
+func TestV1ShredsPublishers_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	createPublisherShredStatsTable(t, api)
+
+	ctx := t.Context()
+	err := api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('bebop-group', now(), now(), generateUUIDv4(), 0, 1,
+			 '31fdXyG3x8k5Ache7jKNQsuwaMf44oqYQndoBsT1JfVj', '', 'bebop', '233.84.178.1', 100000000, 'activated', 0, 0)
+	`)
+	require.NoError(t, err)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsPublishersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Empty(t, resp.Publishers)
+}
+
+// TestV1ShredsPublishers_Contract locks down the public JSON shape of the
+// shreds publishers endpoint. If a field is renamed or removed, downstream
+// consumers break — bump the API version instead of changing a field.
+func TestV1ShredsPublishers_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1ShredsPublishersContractFields.top, "response")
+
+	publishers, ok := raw["publishers"].([]any)
+	require.True(t, ok, "publishers must be a JSON array")
+	require.NotEmpty(t, publishers, "test data should produce publishers")
+	for i, p := range publishers {
+		obj, ok := p.(map[string]any)
+		require.True(t, ok, "publishers[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1ShredsPublishersContractFields.publisher, "publishers[i]")
+	}
+}
+
+func TestV1ShredsPublishers_AllPublishers(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsPublishersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, uint64(800), resp.Epoch)
+	require.Len(t, resp.Publishers, 3)
+
+	pub1 := resp.Publishers[0]
+	assert.Equal(t, "10.0.0.1", pub1.PublisherIP)
+	assert.Equal(t, "dzuser1", pub1.DZUserPubkey)
+	assert.True(t, pub1.MulticastConnected)
+	assert.True(t, pub1.PublishingLeaderShreds)
+	assert.Equal(t, uint64(1), pub1.LeaderSlots)
+	assert.Equal(t, uint64(2), pub1.TotalSlots)
+	assert.Equal(t, "Validator 1", pub1.ValidatorName)
+	assert.Equal(t, "Jito", pub1.ValidatorClient)
+	assert.Equal(t, "2.2.3", pub1.ValidatorVersion)
+	assert.True(t, pub1.ValidatorVersionOk)
+}
+
+func TestV1ShredsPublishers_FilterByDZID(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders?q=dzuser1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsPublishersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Publishers, 1)
+	assert.Equal(t, "dzuser1", resp.Publishers[0].DZUserPubkey)
+}
+
+func TestV1ShredsPublishers_FilterByIP(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/publishers/leaders?q=10.0.0.1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsPublishersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Publishers, 1)
+	assert.Equal(t, "10.0.0.1", resp.Publishers[0].PublisherIP)
+}
+
+func TestV1ShredsPublishers_EpochsAndSlotsParams(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	cases := []struct {
+		name       string
+		url        string
+		wantStatus int
+	}{
+		{"default", "/api/v1/shreds/publishers/leaders", http.StatusOK},
+		{"epochs=1", "/api/v1/shreds/publishers/leaders?epochs=1", http.StatusOK},
+		{"slots=500", "/api/v1/shreds/publishers/leaders?slots=500", http.StatusOK},
+		{"slots with epochs (slots takes precedence)", "/api/v1/shreds/publishers/leaders?slots=500&epochs=5", http.StatusOK},
+		// huma validates input — invalid values return 422 (part of the v1 error contract).
+		{"non-numeric epochs is rejected", "/api/v1/shreds/publishers/leaders?epochs=abc", http.StatusUnprocessableEntity},
+		{"out-of-range epochs is rejected", "/api/v1/shreds/publishers/leaders?epochs=99", http.StatusUnprocessableEntity},
+		{"out-of-range slots is rejected", "/api/v1/shreds/publishers/leaders?slots=9999", http.StatusUnprocessableEntity},
+	}
+
+	r := newV1Router(t, api)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			require.Equal(t, tc.wantStatus, rr.Code, "body: %s", rr.Body.String())
+		})
+	}
+}

--- a/api/handlers/v1_shreds_publishers_test.go
+++ b/api/handlers/v1_shreds_publishers_test.go
@@ -22,10 +22,10 @@ func newV1Router(t *testing.T, api *handlers.API) *chi.Mux {
 	return r
 }
 
-// v1ShredsPublishersContractFields is the authoritative list of JSON keys
+// v1EdgeShredsPublishersContractFields is the authoritative list of JSON keys
 // in the public /api/v1/edge/shreds/publishers/leaders response. A mismatch means the
 // public contract has changed — bump the API version instead of renaming.
-var v1ShredsPublishersContractFields = struct {
+var v1EdgeShredsPublishersContractFields = struct {
 	top       []string
 	publisher []string
 }{
@@ -62,7 +62,7 @@ var v1ShredsPublishersContractFields = struct {
 	},
 }
 
-func TestV1ShredsPublishers_Empty(t *testing.T) {
+func TestV1EdgeShredsPublishers_Empty(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	createPublisherShredStatsTable(t, api)
@@ -85,15 +85,15 @@ func TestV1ShredsPublishers_Empty(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsPublishersResponse
+	var resp v1.EdgeShredsPublishersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Empty(t, resp.Publishers)
 }
 
-// TestV1ShredsPublishers_Contract locks down the public JSON shape of the
+// TestV1EdgeShredsPublishers_Contract locks down the public JSON shape of the
 // shreds publishers endpoint. If a field is renamed or removed, downstream
 // consumers break — bump the API version instead of changing a field.
-func TestV1ShredsPublishers_Contract(t *testing.T) {
+func TestV1EdgeShredsPublishers_Contract(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertPublisherCheckTestData(t, api)
@@ -107,7 +107,7 @@ func TestV1ShredsPublishers_Contract(t *testing.T) {
 
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
-	assertJSONKeys(t, raw, v1ShredsPublishersContractFields.top, "response")
+	assertJSONKeys(t, raw, v1EdgeShredsPublishersContractFields.top, "response")
 
 	publishers, ok := raw["publishers"].([]any)
 	require.True(t, ok, "publishers must be a JSON array")
@@ -115,11 +115,11 @@ func TestV1ShredsPublishers_Contract(t *testing.T) {
 	for i, p := range publishers {
 		obj, ok := p.(map[string]any)
 		require.True(t, ok, "publishers[%d] must be a JSON object", i)
-		assertJSONKeys(t, obj, v1ShredsPublishersContractFields.publisher, "publishers[i]")
+		assertJSONKeys(t, obj, v1EdgeShredsPublishersContractFields.publisher, "publishers[i]")
 	}
 }
 
-func TestV1ShredsPublishers_AllPublishers(t *testing.T) {
+func TestV1EdgeShredsPublishers_AllPublishers(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertPublisherCheckTestData(t, api)
@@ -131,7 +131,7 @@ func TestV1ShredsPublishers_AllPublishers(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsPublishersResponse
+	var resp v1.EdgeShredsPublishersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, uint64(800), resp.Epoch)
 	require.Len(t, resp.Publishers, 3)
@@ -149,7 +149,7 @@ func TestV1ShredsPublishers_AllPublishers(t *testing.T) {
 	assert.True(t, pub1.ValidatorVersionOk)
 }
 
-func TestV1ShredsPublishers_FilterByDZID(t *testing.T) {
+func TestV1EdgeShredsPublishers_FilterByDZID(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertPublisherCheckTestData(t, api)
@@ -161,13 +161,13 @@ func TestV1ShredsPublishers_FilterByDZID(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsPublishersResponse
+	var resp v1.EdgeShredsPublishersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Publishers, 1)
 	assert.Equal(t, "dzuser1", resp.Publishers[0].DZUserPubkey)
 }
 
-func TestV1ShredsPublishers_FilterByIP(t *testing.T) {
+func TestV1EdgeShredsPublishers_FilterByIP(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertPublisherCheckTestData(t, api)
@@ -179,13 +179,13 @@ func TestV1ShredsPublishers_FilterByIP(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsPublishersResponse
+	var resp v1.EdgeShredsPublishersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Publishers, 1)
 	assert.Equal(t, "10.0.0.1", resp.Publishers[0].PublisherIP)
 }
 
-func TestV1ShredsPublishers_EpochsAndSlotsParams(t *testing.T) {
+func TestV1EdgeShredsPublishers_EpochsAndSlotsParams(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertPublisherCheckTestData(t, api)

--- a/api/handlers/v1_shreds_subscribers_test.go
+++ b/api/handlers/v1_shreds_subscribers_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // v1ShredsSubscribersContractFields is the authoritative JSON keys for the
-// /api/v1/shreds/subscribers response. A mismatch means the public contract
+// /api/v1/edge/shreds/subscribers response. A mismatch means the public contract
 // has changed — bump the API version.
 var v1ShredsSubscribersContractFields = struct {
 	top        []string
@@ -44,7 +44,7 @@ func TestV1ShredsSubscribers_Empty(t *testing.T) {
 	api := apitesting.NewTestAPI(t, testChDB)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -63,7 +63,7 @@ func TestV1ShredsSubscribers_Contract(t *testing.T) {
 	insertShredsTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -94,7 +94,7 @@ func TestV1ShredsSubscribers_AllSubscribers(t *testing.T) {
 	insertShredsTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -125,7 +125,7 @@ func TestV1ShredsSubscribers_FilterByFunder(t *testing.T) {
 	insertShredsTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?funder=funder-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers?funder=funder-1", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -150,7 +150,7 @@ func TestV1ShredsSubscribers_FilterByFunder_ExactMatchNotSubstring(t *testing.T)
 	// because the v1 filter is exact match. Guards against regressions
 	// where someone swaps to ILIKE/startsWith.
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?funder=funder", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers?funder=funder", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -168,7 +168,7 @@ func TestV1ShredsSubscribers_Pagination(t *testing.T) {
 	insertShredsTestData(t, api)
 
 	r := newV1Router(t, api)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?limit=2&offset=0", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers?limit=2&offset=0", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -181,7 +181,7 @@ func TestV1ShredsSubscribers_Pagination(t *testing.T) {
 	assert.Equal(t, 0, resp.Offset)
 	require.Len(t, resp.Items, 2)
 
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?limit=2&offset=2", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/subscribers?limit=2&offset=2", nil)
 	rr = httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 

--- a/api/handlers/v1_shreds_subscribers_test.go
+++ b/api/handlers/v1_shreds_subscribers_test.go
@@ -1,0 +1,193 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1ShredsSubscribersContractFields is the authoritative JSON keys for the
+// /api/v1/shreds/subscribers response. A mismatch means the public contract
+// has changed — bump the API version.
+var v1ShredsSubscribersContractFields = struct {
+	top        []string
+	subscriber []string
+}{
+	top: []string{"items", "total", "limit", "offset", "$schema"},
+	subscriber: []string{
+		"seat_pk",
+		"device_key",
+		"device_code",
+		"metro_pk",
+		"metro_code",
+		"tenure_epochs",
+		"active_epoch",
+		"total_usdc_balance",
+		"price_per_epoch_dollars",
+		"funding_authority_key",
+		"user_pk",
+		"user_owner_pubkey",
+		"user_status",
+		"last_activity",
+	},
+}
+
+func TestV1ShredsSubscribers_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var resp v1.ShredsSubscribersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Empty(t, resp.Items)
+	assert.Equal(t, 0, resp.Total)
+}
+
+func TestV1ShredsSubscribers_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	// $schema is added by huma for spec-linkage; acceptable in the public contract.
+	assertJSONKeys(t, raw, v1ShredsSubscribersContractFields.top, "response")
+
+	items, ok := raw["items"].([]any)
+	require.True(t, ok, "items must be a JSON array")
+	require.NotEmpty(t, items, "test data should produce subscribers")
+	for i, it := range items {
+		obj, ok := it.(map[string]any)
+		require.True(t, ok, "items[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1ShredsSubscribersContractFields.subscriber, "items[i]")
+
+		// client_ip must NOT be exposed in the v1 contract.
+		_, hasIP := obj["client_ip"]
+		assert.False(t, hasIP, "items[%d]: client_ip must not be exposed in v1", i)
+	}
+}
+
+func TestV1ShredsSubscribers_AllSubscribers(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsSubscribersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	require.Len(t, resp.Items, 3)
+
+	// Ordered by active_epoch DESC, pk ASC.
+	assert.Equal(t, "seat-1", resp.Items[0].SeatPK)
+	assert.Equal(t, uint64(950), resp.Items[0].ActiveEpoch)
+	assert.Equal(t, "funder-1", resp.Items[0].FundingAuthorityKey)
+	assert.Equal(t, "dev-1", resp.Items[0].DeviceKey)
+	assert.Equal(t, "NYC-CORE-01", resp.Items[0].DeviceCode)
+	assert.Equal(t, "metro-nyc", resp.Items[0].MetroPK)
+	assert.Equal(t, "NYC", resp.Items[0].MetroCode)
+	assert.Equal(t, "50.000000", resp.Items[0].TotalUSDCBalance)
+
+	assert.Equal(t, "seat-2", resp.Items[1].SeatPK)
+	assert.Equal(t, "seat-3", resp.Items[2].SeatPK)
+}
+
+func TestV1ShredsSubscribers_FilterByFunder(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?funder=funder-1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsSubscribersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.Total, "funder-1 owns 2 seats")
+	require.Len(t, resp.Items, 2)
+	for _, s := range resp.Items {
+		assert.Equal(t, "funder-1", s.FundingAuthorityKey)
+	}
+	assert.ElementsMatch(t, []string{"seat-1", "seat-3"}, []string{resp.Items[0].SeatPK, resp.Items[1].SeatPK})
+}
+
+func TestV1ShredsSubscribers_FilterByFunder_ExactMatchNotSubstring(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	// "funder" is a substring of "funder-1"/"funder-2" but must NOT match
+	// because the v1 filter is exact match. Guards against regressions
+	// where someone swaps to ILIKE/startsWith.
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?funder=funder", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsSubscribersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Items)
+}
+
+func TestV1ShredsSubscribers_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?limit=2&offset=0", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.ShredsSubscribersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 2, resp.Limit)
+	assert.Equal(t, 0, resp.Offset)
+	require.Len(t, resp.Items, 2)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/shreds/subscribers?limit=2&offset=2", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 2, resp.Offset)
+	require.Len(t, resp.Items, 1)
+}

--- a/api/handlers/v1_shreds_subscribers_test.go
+++ b/api/handlers/v1_shreds_subscribers_test.go
@@ -13,10 +13,10 @@ import (
 	v1 "github.com/malbeclabs/lake/api/v1"
 )
 
-// v1ShredsSubscribersContractFields is the authoritative JSON keys for the
+// v1EdgeShredsSubscribersContractFields is the authoritative JSON keys for the
 // /api/v1/edge/shreds/subscribers response. A mismatch means the public contract
 // has changed — bump the API version.
-var v1ShredsSubscribersContractFields = struct {
+var v1EdgeShredsSubscribersContractFields = struct {
 	top        []string
 	subscriber []string
 }{
@@ -39,7 +39,7 @@ var v1ShredsSubscribersContractFields = struct {
 	},
 }
 
-func TestV1ShredsSubscribers_Empty(t *testing.T) {
+func TestV1EdgeShredsSubscribers_Empty(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 
@@ -51,13 +51,13 @@ func TestV1ShredsSubscribers_Empty(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
 
-	var resp v1.ShredsSubscribersResponse
+	var resp v1.EdgeShredsSubscribersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Empty(t, resp.Items)
 	assert.Equal(t, 0, resp.Total)
 }
 
-func TestV1ShredsSubscribers_Contract(t *testing.T) {
+func TestV1EdgeShredsSubscribers_Contract(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertShredsTestData(t, api)
@@ -72,7 +72,7 @@ func TestV1ShredsSubscribers_Contract(t *testing.T) {
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
 	// $schema is added by huma for spec-linkage; acceptable in the public contract.
-	assertJSONKeys(t, raw, v1ShredsSubscribersContractFields.top, "response")
+	assertJSONKeys(t, raw, v1EdgeShredsSubscribersContractFields.top, "response")
 
 	items, ok := raw["items"].([]any)
 	require.True(t, ok, "items must be a JSON array")
@@ -80,7 +80,7 @@ func TestV1ShredsSubscribers_Contract(t *testing.T) {
 	for i, it := range items {
 		obj, ok := it.(map[string]any)
 		require.True(t, ok, "items[%d] must be a JSON object", i)
-		assertJSONKeys(t, obj, v1ShredsSubscribersContractFields.subscriber, "items[i]")
+		assertJSONKeys(t, obj, v1EdgeShredsSubscribersContractFields.subscriber, "items[i]")
 
 		// client_ip must NOT be exposed in the v1 contract.
 		_, hasIP := obj["client_ip"]
@@ -88,7 +88,7 @@ func TestV1ShredsSubscribers_Contract(t *testing.T) {
 	}
 }
 
-func TestV1ShredsSubscribers_AllSubscribers(t *testing.T) {
+func TestV1EdgeShredsSubscribers_AllSubscribers(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertShredsTestData(t, api)
@@ -100,7 +100,7 @@ func TestV1ShredsSubscribers_AllSubscribers(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsSubscribersResponse
+	var resp v1.EdgeShredsSubscribersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, 3, resp.Total)
 	require.Len(t, resp.Items, 3)
@@ -119,7 +119,7 @@ func TestV1ShredsSubscribers_AllSubscribers(t *testing.T) {
 	assert.Equal(t, "seat-3", resp.Items[2].SeatPK)
 }
 
-func TestV1ShredsSubscribers_FilterByFunder(t *testing.T) {
+func TestV1EdgeShredsSubscribers_FilterByFunder(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertShredsTestData(t, api)
@@ -131,7 +131,7 @@ func TestV1ShredsSubscribers_FilterByFunder(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsSubscribersResponse
+	var resp v1.EdgeShredsSubscribersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, 2, resp.Total, "funder-1 owns 2 seats")
 	require.Len(t, resp.Items, 2)
@@ -141,7 +141,7 @@ func TestV1ShredsSubscribers_FilterByFunder(t *testing.T) {
 	assert.ElementsMatch(t, []string{"seat-1", "seat-3"}, []string{resp.Items[0].SeatPK, resp.Items[1].SeatPK})
 }
 
-func TestV1ShredsSubscribers_FilterByFunder_ExactMatchNotSubstring(t *testing.T) {
+func TestV1EdgeShredsSubscribers_FilterByFunder_ExactMatchNotSubstring(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertShredsTestData(t, api)
@@ -156,13 +156,13 @@ func TestV1ShredsSubscribers_FilterByFunder_ExactMatchNotSubstring(t *testing.T)
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsSubscribersResponse
+	var resp v1.EdgeShredsSubscribersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, 0, resp.Total)
 	assert.Empty(t, resp.Items)
 }
 
-func TestV1ShredsSubscribers_Pagination(t *testing.T) {
+func TestV1EdgeShredsSubscribers_Pagination(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertShredsTestData(t, api)
@@ -174,7 +174,7 @@ func TestV1ShredsSubscribers_Pagination(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 
-	var resp v1.ShredsSubscribersResponse
+	var resp v1.EdgeShredsSubscribersResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, 3, resp.Total)
 	assert.Equal(t, 2, resp.Limit)

--- a/api/handlers/v1_test_helpers_test.go
+++ b/api/handlers/v1_test_helpers_test.go
@@ -1,0 +1,16 @@
+package handlers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertJSONKeys(t *testing.T, obj map[string]any, want []string, label string) {
+	t.Helper()
+	got := make([]string, 0, len(obj))
+	for k := range obj {
+		got = append(got, k)
+	}
+	assert.ElementsMatch(t, want, got, "%s: public JSON keys must match the v1 contract exactly (renames/removals require a new API version)", label)
+}

--- a/api/handlers/v1_validators_metadata_test.go
+++ b/api/handlers/v1_validators_metadata_test.go
@@ -1,0 +1,135 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1ValidatorsMetadataContractFields is the authoritative JSON keys for each
+// item in the /api/v1/solana/validators-metadata response. A mismatch means the
+// public contract has changed — bump the API version.
+var v1ValidatorsMetadataContractFields = []string{
+	"ip",
+	"active_stake",
+	"vote_account",
+	"software_client",
+	"software_version",
+}
+
+func seedValidatorsAppData(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_validatorsapp_validators_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 account, name, vote_account, software_version, software_client, software_client_id,
+			 jito, jito_commission, is_active, is_dz, active_stake, commission, delinquent,
+			 epoch, epoch_credits, skipped_slot_percent, total_score,
+			 data_center_key, autonomous_system_number, latitude, longitude, ip, stake_pools_list)
+		VALUES
+			('n1', now(), now(), generateUUIDv4(), 0, 1,
+			 'n1', 'Validator 1', 'vote1', '2.2.3', 'Jito', 2,
+			 1, 0, 1, 1, 50000000000, 0, 0,
+			 800, 1000, '0.5', 100,
+			 'US-NY', 0, '', '', '1.2.3.4', ''),
+			('n2', now(), now(), generateUUIDv4(), 0, 2,
+			 'n2', 'Validator 2', 'vote2', '2.1.0', 'Agave', 1,
+			 0, 0, 1, 1, 10000000000, 0, 0,
+			 800, 500, '1.0', 50,
+			 'EU-AMS', 0, '', '', '5.6.7.8', ''),
+			('n3', now(), now(), generateUUIDv4(), 0, 3,
+			 'n3', 'Inactive Validator', 'vote3', '2.0.0', 'Agave', 1,
+			 0, 0, 0, 0, 0, 0, 1,
+			 800, 0, '0', 0,
+			 '', 0, '', '', '9.9.9.9', '')
+	`))
+}
+
+func TestV1ValidatorsMetadata_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/solana/validators-metadata", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var items []v1.ValidatorMetadata
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&items))
+	assert.Empty(t, items)
+}
+
+func TestV1ValidatorsMetadata_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedValidatorsAppData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/solana/validators-metadata", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	require.NotEmpty(t, raw)
+	for i, item := range raw {
+		assertJSONKeys(t, item, v1ValidatorsMetadataContractFields, "items[i]")
+		_ = i
+	}
+}
+
+func TestV1ValidatorsMetadata_ActiveOnly(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedValidatorsAppData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/solana/validators-metadata", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var items []v1.ValidatorMetadata
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&items))
+
+	// Only is_active = 1 rows, ordered by active_stake DESC.
+	require.Len(t, items, 2)
+	assert.Equal(t, "1.2.3.4", items[0].IP)
+	assert.Equal(t, int64(50000000000), items[0].ActiveStake)
+	assert.Equal(t, "vote1", items[0].VoteAccount)
+	assert.Equal(t, "Jito", items[0].SoftwareClient)
+	assert.Equal(t, "2.2.3", items[0].SoftwareVersion)
+
+	assert.Equal(t, "5.6.7.8", items[1].IP)
+	assert.Equal(t, int64(10000000000), items[1].ActiveStake)
+}
+
+// TestV1ValidatorsMetadata_LegacyRedirect verifies the pre-namespace path
+// still resolves (via 308) to the canonical /solana/validators-metadata
+// path, so existing consumers keep working during migration.
+func TestV1ValidatorsMetadata_LegacyRedirect(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/validators-metadata", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusPermanentRedirect, rr.Code, "body: %s", rr.Body.String())
+	assert.Equal(t, "/api/v1/solana/validators-metadata", rr.Header().Get("Location"))
+}

--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -290,18 +290,17 @@ func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type ValidatorMetadataItem struct {
-	IP              string `json:"ip"`
-	ActiveStake     int64  `json:"active_stake"`
-	VoteAccount     string `json:"vote_account"`
-	SoftwareClient  string `json:"software_client"`
-	SoftwareVersion string `json:"software_version"`
+type ValidatorMetadataRow struct {
+	IP              string
+	ActiveStake     int64
+	VoteAccount     string
+	SoftwareClient  string
+	SoftwareVersion string
 }
 
-func (a *API) GetValidatorsMetadata(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
+// FetchValidatorsMetadata returns active validator metadata ordered by
+// active_stake DESC.
+func (a *API) FetchValidatorsMetadata(ctx context.Context) ([]ValidatorMetadataRow, error) {
 	start := time.Now()
 	query := `
 		SELECT
@@ -316,41 +315,24 @@ func (a *API) GetValidatorsMetadata(w http.ResponseWriter, r *http.Request) {
 	`
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
-	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
-
+	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
-		logError("validators metadata query failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, err
 	}
 	defer rows.Close()
 
-	var items []ValidatorMetadataItem
+	var items []ValidatorMetadataRow
 	for rows.Next() {
-		var item ValidatorMetadataItem
+		var item ValidatorMetadataRow
 		if err := rows.Scan(&item.IP, &item.ActiveStake, &item.VoteAccount, &item.SoftwareClient, &item.SoftwareVersion); err != nil {
-			logError("validators metadata row scan failed", "error", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			return nil, err
 		}
 		items = append(items, item)
 	}
-
 	if err := rows.Err(); err != nil {
-		logError("validators metadata rows iteration failed", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, err
 	}
-
-	if items == nil {
-		items = []ValidatorMetadataItem{}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(items); err != nil {
-		logError("failed to encode response", "error", err)
-	}
+	return items, nil
 }
 
 type ValidatorDetail struct {

--- a/api/main.go
+++ b/api/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/malbeclabs/lake/api/config"
 	"github.com/malbeclabs/lake/api/handlers"
 	"github.com/malbeclabs/lake/api/metrics"
+	v1 "github.com/malbeclabs/lake/api/v1"
 	"github.com/malbeclabs/lake/api/worker"
 	slackbot "github.com/malbeclabs/lake/slack/bot"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -584,7 +585,8 @@ func main() {
 		r.Get("/api/solana/gossip-nodes/{pubkey}", api.GetGossipNode)
 		r.Get("/api/solana/ledger", api.GetSolanaLedger)
 		r.Get("/api/solana/validator-performance", api.GetValidatorPerformance)
-		r.Get("/api/v1/validators-metadata", api.GetValidatorsMetadata)
+		// Public v1 API (huma-generated OpenAPI at /api/v1/openapi.json, docs at /api/v1/docs).
+		v1.Mount(r, api)
 
 		// Stake analytics routes
 		r.Get("/api/stake/overview", api.GetStakeOverview)

--- a/api/main.go
+++ b/api/main.go
@@ -501,6 +501,11 @@ func main() {
 	r.Get("/api/config", api.GetConfig)
 	r.Get("/api/version", api.GetVersion)
 
+	// /api/docs redirects to the current default API version docs.
+	r.Get("/api/docs", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/api/v1/docs", http.StatusTemporaryRedirect)
+	})
+
 	// Database query endpoints (rate limited)
 	r.Group(func(r chi.Router) {
 		r.Use(handlers.QueryRateLimitMiddleware)

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -37,7 +37,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 	var humaAPI huma.API
 	r.Route(BasePath, func(r chi.Router) {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
-		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program."
+		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program.\n\nRate limited to 100 requests per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header."
 		config.OpenAPIPath = "/openapi"
 		config.DocsPath = "/docs"
 		config.SchemasPath = "/schemas"

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -46,8 +46,8 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 
 		humaAPI = humachi.New(r, config)
 
-		registerShredsPublishers(humaAPI, api)
-		registerShredsSubscribers(humaAPI, api)
+		registerEdgeShredsPublishers(humaAPI, api)
+		registerEdgeShredsSubscribers(humaAPI, api)
 		registerValidatorsMetadata(humaAPI, api)
 
 		// Register 308 redirects from deprecated paths to their current

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -37,7 +37,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 	var humaAPI huma.API
 	r.Route(BasePath, func(r chi.Router) {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
-		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program.\n\nRate limited to 100 requests per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header."
+		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program.\n\n## Rate Limits\n\nRequests are rate limited to 100 per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header."
 		config.OpenAPIPath = "/openapi"
 		config.DocsPath = "/docs"
 		config.SchemasPath = "/schemas"

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -37,7 +37,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 	var humaAPI huma.API
 	r.Route(BasePath, func(r chi.Router) {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
-		config.Info.Description = "Public API for DoubleZero network telemetry and the shred subscription program."
+		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program."
 		config.OpenAPIPath = "/openapi"
 		config.DocsPath = "/docs"
 		config.SchemasPath = "/schemas"

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -1,0 +1,106 @@
+// Package v1 defines the public, versioned /api/v1 surface. Operations are
+// declared with huma, so the OpenAPI spec is generated from handler
+// signatures (drift-free). The v1 contract is intentionally decoupled from
+// internal/UI types so it can evolve independently.
+package v1
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// legacyRedirects maps deprecated v1 paths (relative to BasePath) to their
+// current canonical paths. Entries should be removed once consumers have
+// migrated. Keep this list short and well-commented — each entry is tech debt.
+var legacyRedirects = map[string]string{
+	// Pre-namespace path. Moved under /solana/ for consistency with other
+	// Solana-scoped endpoints.
+	"/validators-metadata": "/solana/validators-metadata",
+}
+
+// redocHTML is a minimal Redoc shell that loads the v1 OpenAPI spec.
+// Redoc isn't bundled with huma, so we disable huma's docs route and serve
+// our own page here. The spec URL is absolute so the page works regardless
+// of how the host is reached.
+const redocHTML = `<!DOCTYPE html>
+<html>
+<head>
+<title>DoubleZero Data API</title>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<redoc spec-url="` + BasePath + `/openapi.json"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
+</body>
+</html>`
+
+// Version is the v1 API version reported in the OpenAPI spec.
+const Version = "1.0.0"
+
+// BasePath is the URL prefix under which all v1 operations are mounted.
+const BasePath = "/api/v1"
+
+// Mount mounts the v1 huma API (operations + docs + OpenAPI spec) on the
+// given chi router under BasePath. The OpenAPI spec is served at
+// {BasePath}/openapi.[json|yaml], docs at {BasePath}/docs, and JSON schemas
+// at {BasePath}/schemas/{schema}.
+func Mount(r chi.Router, api *handlers.API) huma.API {
+	var humaAPI huma.API
+	r.Route(BasePath, func(r chi.Router) {
+		config := huma.DefaultConfig("DoubleZero Data API", Version)
+		config.Info.Description = "Public API for DoubleZero network telemetry and the shred subscription program."
+		config.OpenAPIPath = "/openapi"
+		config.SchemasPath = "/schemas"
+		// DocsPath is empty so huma doesn't register its built-in docs route —
+		// we serve Redoc ourselves below.
+		config.DocsPath = ""
+		config.Servers = []*huma.Server{{URL: BasePath}}
+
+		humaAPI = humachi.New(r, config)
+
+		// Scoped CSP for the docs page: allows just what Redoc needs from
+		// jsdelivr + Google Fonts. This intentionally overrides the app-wide
+		// CSP set in main.go (which whitelists a different set of CDNs for
+		// the web app) — huma's built-in renderers do the same trick.
+		docsCSP := strings.Join([]string{
+			"default-src 'none'",
+			"base-uri 'none'",
+			"connect-src 'self'",
+			"script-src 'unsafe-eval' https://cdn.jsdelivr.net",
+			"style-src 'unsafe-inline' https://fonts.googleapis.com",
+			"font-src https://fonts.gstatic.com",
+			"img-src 'self' data: blob: https:",
+			"worker-src blob:",
+			"frame-ancestors 'none'",
+			"form-action 'none'",
+		}, "; ")
+		r.Get("/docs", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Security-Policy", docsCSP)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(redocHTML))
+		})
+
+		registerShredsPublishers(humaAPI, api)
+		registerShredsSubscribers(humaAPI, api)
+		registerValidatorsMetadata(humaAPI, api)
+
+		// Register 308 redirects from deprecated paths to their current
+		// canonical paths. These keep existing consumers working while the
+		// OpenAPI spec only advertises the new paths.
+		for from, to := range legacyRedirects {
+			target := BasePath + to
+			r.Get(from, func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, target, http.StatusPermanentRedirect)
+			})
+		}
+	})
+	return humaAPI
+}

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -6,6 +6,7 @@ package v1
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
@@ -29,7 +30,30 @@ const Version = "1.0.0"
 // BasePath is the URL prefix under which all v1 operations are mounted.
 const BasePath = "/api/v1"
 
-// Mount mounts the v1 huma API (operations + docs + OpenAPI spec) on the
+// scalarBundleURL is pinned to match the version huma bundles; keep in sync
+// when upgrading huma. Integrity hash is taken from huma's Scalar renderer.
+const scalarBundleURL = "https://unpkg.com/@scalar/api-reference@1.44.20/dist/browser/standalone.js"
+const scalarBundleSRI = "sha384-tMz7GAo6dMy55x9tLFtH+sHtogji6Scmb+feBR31TAHmvSPRUTboK9H3M5NFaP4R"
+
+// docsHTML is a minimal Scalar shell. We serve this ourselves (instead of
+// huma's built-in docs renderer) so we can include an explicit favicon link
+// and a CSP permissive enough to load it — huma's default CSP blocks images.
+const docsHTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="referrer" content="no-referrer">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="/favicon.ico">
+    <title>DoubleZero Data API</title>
+  </head>
+  <body>
+    <script id="api-reference" data-url="` + BasePath + `/openapi.json"></script>
+    <script src="` + scalarBundleURL + `" crossorigin integrity="` + scalarBundleSRI + `"></script>
+  </body>
+</html>`
+
+// Mount mounts the v1 huma API (operations + OpenAPI spec + docs) on the
 // given chi router under BasePath. The OpenAPI spec is served at
 // {BasePath}/openapi.[json|yaml], docs at {BasePath}/docs, and JSON schemas
 // at {BasePath}/schemas/{schema}.
@@ -39,12 +63,33 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
 		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program.\n\n## Rate Limits\n\nRequests are rate limited to 100 per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header."
 		config.OpenAPIPath = "/openapi"
-		config.DocsPath = "/docs"
 		config.SchemasPath = "/schemas"
-		config.DocsRenderer = huma.DocsRendererScalar
+		// DocsPath is empty so huma doesn't register its built-in docs route —
+		// we serve Scalar ourselves below so we can include a favicon.
+		config.DocsPath = ""
 		config.Servers = []*huma.Server{{URL: BasePath}}
 
 		humaAPI = humachi.New(r, config)
+
+		// Scoped CSP for the docs page: mirrors huma's built-in Scalar CSP
+		// but adds img-src so the favicon can load. Overrides the app-wide
+		// CSP set in main.go — huma's built-in renderers do the same trick.
+		docsCSP := strings.Join([]string{
+			"default-src 'none'",
+			"base-uri 'none'",
+			"connect-src 'self'",
+			"img-src 'self' data:",
+			"form-action 'none'",
+			"frame-ancestors 'none'",
+			"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox",
+			"script-src 'unsafe-eval' " + scalarBundleURL,
+			"style-src 'unsafe-inline'",
+		}, "; ")
+		r.Get("/docs", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Security-Policy", docsCSP)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(docsHTML))
+		})
 
 		registerEdgeShredsPublishers(humaAPI, api)
 		registerEdgeShredsSubscribers(humaAPI, api)

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -6,7 +6,6 @@ package v1
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
@@ -24,24 +23,6 @@ var legacyRedirects = map[string]string{
 	"/validators-metadata": "/solana/validators-metadata",
 }
 
-// redocHTML is a minimal Redoc shell that loads the v1 OpenAPI spec.
-// Redoc isn't bundled with huma, so we disable huma's docs route and serve
-// our own page here. The spec URL is absolute so the page works regardless
-// of how the host is reached.
-const redocHTML = `<!DOCTYPE html>
-<html>
-<head>
-<title>DoubleZero Data API</title>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<style>body { margin: 0; padding: 0; }</style>
-</head>
-<body>
-<redoc spec-url="` + BasePath + `/openapi.json"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
-</body>
-</html>`
-
 // Version is the v1 API version reported in the OpenAPI spec.
 const Version = "1.0.0"
 
@@ -58,35 +39,12 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
 		config.Info.Description = "Public API for DoubleZero network telemetry and the shred subscription program."
 		config.OpenAPIPath = "/openapi"
+		config.DocsPath = "/docs"
 		config.SchemasPath = "/schemas"
-		// DocsPath is empty so huma doesn't register its built-in docs route —
-		// we serve Redoc ourselves below.
-		config.DocsPath = ""
+		config.DocsRenderer = huma.DocsRendererScalar
 		config.Servers = []*huma.Server{{URL: BasePath}}
 
 		humaAPI = humachi.New(r, config)
-
-		// Scoped CSP for the docs page: allows just what Redoc needs from
-		// jsdelivr + Google Fonts. This intentionally overrides the app-wide
-		// CSP set in main.go (which whitelists a different set of CDNs for
-		// the web app) — huma's built-in renderers do the same trick.
-		docsCSP := strings.Join([]string{
-			"default-src 'none'",
-			"base-uri 'none'",
-			"connect-src 'self'",
-			"script-src 'unsafe-eval' https://cdn.jsdelivr.net",
-			"style-src 'unsafe-inline' https://fonts.googleapis.com",
-			"font-src https://fonts.gstatic.com",
-			"img-src 'self' data: blob: https:",
-			"worker-src blob:",
-			"frame-ancestors 'none'",
-			"form-action 'none'",
-		}, "; ")
-		r.Get("/docs", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Security-Policy", docsCSP)
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			_, _ = w.Write([]byte(redocHTML))
-		})
 
 		registerShredsPublishers(humaAPI, api)
 		registerShredsSubscribers(humaAPI, api)

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -63,7 +63,7 @@ func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/publishers/leaders",
 		Summary:     "List shreds leader publishers",
 		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /edge/shreds/publishers.",
-		Tags:        []string{"shreds"},
+		Tags:        []string{"edge", "shreds"},
 	}, func(ctx context.Context, input *ShredsPublishersInput) (*ShredsPublishersOutput, error) {
 		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)
 		if err != nil {

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -1,0 +1,110 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// ShredsPublisher is a stable public shape for a single shreds publisher.
+// It is intentionally decoupled from internal/UI types so the v1 contract
+// can evolve independently.
+type ShredsPublisher struct {
+	PublisherIP             string `json:"publisher_ip" doc:"DoubleZero-assigned IP of the publisher"`
+	ClientIP                string `json:"client_ip" doc:"Validator gossip IP advertised to Solana"`
+	NodePubkey              string `json:"node_pubkey" doc:"Solana node identity pubkey"`
+	VotePubkey              string `json:"vote_pubkey" doc:"Solana vote account pubkey"`
+	DZUserPubkey            string `json:"dz_user_pubkey" doc:"DoubleZero user account pubkey"`
+	DZDeviceCode            string `json:"dz_device_code" doc:"DoubleZero edge device code"`
+	DZMetroCode             string `json:"dz_metro_code" doc:"DoubleZero metro code"`
+	ActivatedStake          uint64 `json:"activated_stake" doc:"Activated stake in lamports"`
+	MulticastConnected      bool   `json:"multicast_connected" doc:"Whether the publisher is connected to the shred multicast group"`
+	PublishingLeaderShreds  bool   `json:"publishing_leader_shreds" doc:"Whether the publisher has produced leader shreds in the window"`
+	PublishingRetransmitted bool   `json:"publishing_retransmitted" doc:"Whether the publisher meets the retransmit volume thresholds"`
+	LeaderSlots             uint64 `json:"leader_slots" doc:"Distinct slots where this publisher produced leader shreds"`
+	TotalSlots              uint64 `json:"total_slots" doc:"Distinct slots observed for this publisher"`
+	TotalUniqueShreds       uint64 `json:"total_unique_shreds" doc:"Unique shreds observed across all slots in the window"`
+	SlotsNeedingRepair      uint64 `json:"slots_needing_repair" doc:"Number of slots that required repair"`
+	ValidatorClient         string `json:"validator_client" doc:"Validator client name (e.g. Agave, Jito, Firedancer)"`
+	ValidatorVersion        string `json:"validator_version" doc:"Validator client version"`
+	ValidatorName           string `json:"validator_name" doc:"Validator display name from validators.app"`
+	ValidatorVersionOk      bool   `json:"validator_version_ok" doc:"Whether the version meets the minimum for its client"`
+	IsBackup                bool   `json:"is_backup" doc:"Whether this gossip node lacks an active vote account (hot-spare)"`
+}
+
+// ShredsPublishersResponse is the body returned by the shreds publishers endpoint.
+type ShredsPublishersResponse struct {
+	Epoch               uint64            `json:"epoch" doc:"Current Solana epoch at query time"`
+	MaxSlot             uint64            `json:"max_slot" doc:"Highest slot observed in the query window"`
+	TotalNetworkStake   int64             `json:"total_network_stake" doc:"Total active stake across all Solana validators (lamports)"`
+	TotalPublishers     uint64            `json:"total_publishers" doc:"Count of activated DZ publishers with a matched vote account"`
+	TotalPublisherStake int64             `json:"total_publisher_stake" doc:"Total activated stake across all DZ publishers (lamports)"`
+	Publishers          []ShredsPublisher `json:"publishers"`
+}
+
+// ShredsPublishersInput is the request for the shreds publishers endpoint.
+type ShredsPublishersInput struct {
+	Q      string `query:"q" doc:"Optional filter: DZ user pubkey, publisher IP, or client IP"`
+	Epochs int    `query:"epochs" minimum:"1" maximum:"10" default:"2" doc:"Number of recent epochs to include (ignored if slots > 0)"`
+	Slots  int    `query:"slots" minimum:"0" maximum:"5000" default:"0" doc:"If > 0, restrict the window to this many most-recent slots instead of epochs. Recommended values: 100, 500, 1000, 5000."`
+}
+
+// ShredsPublishersOutput wraps the response body for huma.
+type ShredsPublishersOutput struct {
+	Body ShredsPublishersResponse
+}
+
+func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-shreds-leader-publishers",
+		Method:      "GET",
+		Path:        "/shreds/publishers/leaders",
+		Summary:     "List shreds leader publishers",
+		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /shreds/publishers.",
+		Tags:        []string{"shreds"},
+	}, func(ctx context.Context, input *ShredsPublishersInput) (*ShredsPublishersOutput, error) {
+		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch shreds publishers", err)
+		}
+		return &ShredsPublishersOutput{Body: toShredsPublishersResponse(resp)}, nil
+	})
+}
+
+func toShredsPublishersResponse(r *handlers.PublisherCheckResponse) ShredsPublishersResponse {
+	publishers := make([]ShredsPublisher, len(r.Publishers))
+	for i, p := range r.Publishers {
+		publishers[i] = ShredsPublisher{
+			PublisherIP:             p.PublisherIP,
+			ClientIP:                p.ClientIP,
+			NodePubkey:              p.NodePubkey,
+			VotePubkey:              p.VotePubkey,
+			DZUserPubkey:            p.DZUserPubkey,
+			DZDeviceCode:            p.DZDeviceCode,
+			DZMetroCode:             p.DZMetroCode,
+			ActivatedStake:          p.ActivatedStake,
+			MulticastConnected:      p.MulticastConnected,
+			PublishingLeaderShreds:  p.PublishingLeaderShreds,
+			PublishingRetransmitted: p.PublishingRetransmitted,
+			LeaderSlots:             p.LeaderSlots,
+			TotalSlots:              p.TotalSlots,
+			TotalUniqueShreds:       p.TotalUniqueShreds,
+			SlotsNeedingRepair:      p.SlotsNeedingRepair,
+			ValidatorClient:         p.ValidatorClient,
+			ValidatorVersion:        p.ValidatorVersion,
+			ValidatorName:           p.ValidatorName,
+			ValidatorVersionOk:      p.ValidatorVersionOk,
+			IsBackup:                p.IsBackup,
+		}
+	}
+	return ShredsPublishersResponse{
+		Epoch:               r.Epoch,
+		MaxSlot:             r.MaxSlot,
+		TotalNetworkStake:   r.TotalNetworkStake,
+		TotalPublishers:     r.TotalPublishers,
+		TotalPublisherStake: r.TotalPublisherStake,
+		Publishers:          publishers,
+	}
+}

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -8,10 +8,10 @@ import (
 	"github.com/malbeclabs/lake/api/handlers"
 )
 
-// ShredsPublisher is a stable public shape for a single shreds publisher.
+// EdgeShredsPublisher is a stable public shape for a single shreds publisher.
 // It is intentionally decoupled from internal/UI types so the v1 contract
 // can evolve independently.
-type ShredsPublisher struct {
+type EdgeShredsPublisher struct {
 	PublisherIP             string `json:"publisher_ip" doc:"DoubleZero-assigned IP of the publisher"`
 	ClientIP                string `json:"client_ip" doc:"Validator gossip IP advertised to Solana"`
 	NodePubkey              string `json:"node_pubkey" doc:"Solana node identity pubkey"`
@@ -34,29 +34,29 @@ type ShredsPublisher struct {
 	IsBackup                bool   `json:"is_backup" doc:"Whether this gossip node lacks an active vote account (hot-spare)"`
 }
 
-// ShredsPublishersResponse is the body returned by the shreds publishers endpoint.
-type ShredsPublishersResponse struct {
+// EdgeShredsPublishersResponse is the body returned by the shreds publishers endpoint.
+type EdgeShredsPublishersResponse struct {
 	Epoch               uint64            `json:"epoch" doc:"Current Solana epoch at query time"`
 	MaxSlot             uint64            `json:"max_slot" doc:"Highest slot observed in the query window"`
 	TotalNetworkStake   int64             `json:"total_network_stake" doc:"Total active stake across all Solana validators (lamports)"`
 	TotalPublishers     uint64            `json:"total_publishers" doc:"Count of activated DZ publishers with a matched vote account"`
 	TotalPublisherStake int64             `json:"total_publisher_stake" doc:"Total activated stake across all DZ publishers (lamports)"`
-	Publishers          []ShredsPublisher `json:"publishers"`
+	Publishers          []EdgeShredsPublisher `json:"publishers"`
 }
 
-// ShredsPublishersInput is the request for the shreds publishers endpoint.
-type ShredsPublishersInput struct {
+// EdgeShredsPublishersInput is the request for the shreds publishers endpoint.
+type EdgeShredsPublishersInput struct {
 	Q      string `query:"q" doc:"Optional filter: DZ user pubkey, publisher IP, or client IP"`
 	Epochs int    `query:"epochs" minimum:"1" maximum:"10" default:"2" doc:"Number of recent epochs to include (ignored if slots > 0)"`
 	Slots  int    `query:"slots" minimum:"0" maximum:"5000" default:"0" doc:"If > 0, restrict the window to this many most-recent slots instead of epochs. Recommended values: 100, 500, 1000, 5000."`
 }
 
-// ShredsPublishersOutput wraps the response body for huma.
-type ShredsPublishersOutput struct {
-	Body ShredsPublishersResponse
+// EdgeShredsPublishersOutput wraps the response body for huma.
+type EdgeShredsPublishersOutput struct {
+	Body EdgeShredsPublishersResponse
 }
 
-func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
+func registerEdgeShredsPublishers(humaAPI huma.API, api *handlers.API) {
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "list-edge-shreds-leader-publishers",
 		Method:      "GET",
@@ -64,19 +64,19 @@ func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
 		Summary:     "List shreds leader publishers",
 		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /edge/shreds/publishers.",
 		Tags:        []string{"edge/shreds"},
-	}, func(ctx context.Context, input *ShredsPublishersInput) (*ShredsPublishersOutput, error) {
+	}, func(ctx context.Context, input *EdgeShredsPublishersInput) (*EdgeShredsPublishersOutput, error) {
 		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("failed to fetch shreds publishers", err)
 		}
-		return &ShredsPublishersOutput{Body: toShredsPublishersResponse(resp)}, nil
+		return &EdgeShredsPublishersOutput{Body: toEdgeShredsPublishersResponse(resp)}, nil
 	})
 }
 
-func toShredsPublishersResponse(r *handlers.PublisherCheckResponse) ShredsPublishersResponse {
-	publishers := make([]ShredsPublisher, len(r.Publishers))
+func toEdgeShredsPublishersResponse(r *handlers.PublisherCheckResponse) EdgeShredsPublishersResponse {
+	publishers := make([]EdgeShredsPublisher, len(r.Publishers))
 	for i, p := range r.Publishers {
-		publishers[i] = ShredsPublisher{
+		publishers[i] = EdgeShredsPublisher{
 			PublisherIP:             p.PublisherIP,
 			ClientIP:                p.ClientIP,
 			NodePubkey:              p.NodePubkey,
@@ -99,7 +99,7 @@ func toShredsPublishersResponse(r *handlers.PublisherCheckResponse) ShredsPublis
 			IsBackup:                p.IsBackup,
 		}
 	}
-	return ShredsPublishersResponse{
+	return EdgeShredsPublishersResponse{
 		Epoch:               r.Epoch,
 		MaxSlot:             r.MaxSlot,
 		TotalNetworkStake:   r.TotalNetworkStake,

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -58,11 +58,11 @@ type ShredsPublishersOutput struct {
 
 func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
 	huma.Register(humaAPI, huma.Operation{
-		OperationID: "list-shreds-leader-publishers",
+		OperationID: "list-edge-shreds-leader-publishers",
 		Method:      "GET",
-		Path:        "/shreds/publishers/leaders",
+		Path:        "/edge/shreds/publishers/leaders",
 		Summary:     "List shreds leader publishers",
-		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /shreds/publishers.",
+		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /edge/shreds/publishers.",
 		Tags:        []string{"shreds"},
 	}, func(ctx context.Context, input *ShredsPublishersInput) (*ShredsPublishersOutput, error) {
 		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -63,7 +63,7 @@ func registerShredsPublishers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/publishers/leaders",
 		Summary:     "List shreds leader publishers",
 		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /edge/shreds/publishers.",
-		Tags:        []string{"edge", "shreds"},
+		Tags:        []string{"edge/shreds"},
 	}, func(ctx context.Context, input *ShredsPublishersInput) (*ShredsPublishersOutput, error) {
 		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)
 		if err != nil {

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -63,7 +63,7 @@ func registerEdgeShredsPublishers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/publishers/leaders",
 		Summary:     "List shreds leader publishers",
 		Description: "Returns the status of every DoubleZero validator-publisher in the shred multicast group for a recent window (epochs or slots). Includes activated stake, leader/retransmit activity, and validator client/version info. A broader publishers endpoint (covering non-validator publishers) may be introduced later at /edge/shreds/publishers.",
-		Tags:        []string{"edge/shreds"},
+		Tags:        []string{"Edge/Shreds"},
 	}, func(ctx context.Context, input *EdgeShredsPublishersInput) (*EdgeShredsPublishersOutput, error) {
 		resp, err := api.FetchPublisherCheckData(ctx, input.Q, input.Epochs, input.Slots)
 		if err != nil {

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -36,11 +36,11 @@ type EdgeShredsPublisher struct {
 
 // EdgeShredsPublishersResponse is the body returned by the shreds publishers endpoint.
 type EdgeShredsPublishersResponse struct {
-	Epoch               uint64            `json:"epoch" doc:"Current Solana epoch at query time"`
-	MaxSlot             uint64            `json:"max_slot" doc:"Highest slot observed in the query window"`
-	TotalNetworkStake   int64             `json:"total_network_stake" doc:"Total active stake across all Solana validators (lamports)"`
-	TotalPublishers     uint64            `json:"total_publishers" doc:"Count of activated DZ publishers with a matched vote account"`
-	TotalPublisherStake int64             `json:"total_publisher_stake" doc:"Total activated stake across all DZ publishers (lamports)"`
+	Epoch               uint64                `json:"epoch" doc:"Current Solana epoch at query time"`
+	MaxSlot             uint64                `json:"max_slot" doc:"Highest slot observed in the query window"`
+	TotalNetworkStake   int64                 `json:"total_network_stake" doc:"Total active stake across all Solana validators (lamports)"`
+	TotalPublishers     uint64                `json:"total_publishers" doc:"Count of activated DZ publishers with a matched vote account"`
+	TotalPublisherStake int64                 `json:"total_publisher_stake" doc:"Total activated stake across all DZ publishers (lamports)"`
 	Publishers          []EdgeShredsPublisher `json:"publishers"`
 }
 

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -70,7 +70,7 @@ func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/subscribers",
 		Summary:     "List shreds subscribers",
 		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
-		Tags:        []string{"edge", "shreds"},
+		Tags:        []string{"edge/shreds"},
 	}, func(ctx context.Context, input *ShredsSubscribersInput) (*ShredsSubscribersOutput, error) {
 		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
 		if err != nil {

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -65,9 +65,9 @@ type ShredsSubscribersOutput struct {
 
 func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 	huma.Register(humaAPI, huma.Operation{
-		OperationID: "list-shreds-subscribers",
+		OperationID: "list-edge-shreds-subscribers",
 		Method:      "GET",
-		Path:        "/shreds/subscribers",
+		Path:        "/edge/shreds/subscribers",
 		Summary:     "List shreds subscribers",
 		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
 		Tags:        []string{"shreds"},

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -46,9 +46,9 @@ type EdgeShredsSubscriber struct {
 // EdgeShredsSubscribersResponse is the paginated response body.
 type EdgeShredsSubscribersResponse struct {
 	Items  []EdgeShredsSubscriber `json:"items"`
-	Total  int                `json:"total" doc:"Total matching subscribers (ignores limit/offset)"`
-	Limit  int                `json:"limit"`
-	Offset int                `json:"offset"`
+	Total  int                    `json:"total" doc:"Total matching subscribers (ignores limit/offset)"`
+	Limit  int                    `json:"limit"`
+	Offset int                    `json:"offset"`
 }
 
 // EdgeShredsSubscribersInput is the request for the subscribers endpoint.

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -70,7 +70,7 @@ func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/subscribers",
 		Summary:     "List shreds subscribers",
 		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
-		Tags:        []string{"shreds"},
+		Tags:        []string{"edge", "shreds"},
 	}, func(ctx context.Context, input *ShredsSubscribersInput) (*ShredsSubscribersOutput, error) {
 		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
 		if err != nil {

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -70,7 +70,7 @@ func registerEdgeShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 		Path:        "/edge/shreds/subscribers",
 		Summary:     "List shreds subscribers",
 		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
-		Tags:        []string{"edge/shreds"},
+		Tags:        []string{"Edge/Shreds"},
 	}, func(ctx context.Context, input *EdgeShredsSubscribersInput) (*EdgeShredsSubscribersOutput, error) {
 		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
 		if err != nil {

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -1,0 +1,109 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// usdcMicroDecimals is the on-chain USDC decimal scale on Solana.
+const usdcMicroDecimals = 1_000_000
+
+// formatUSDC converts a micro-USDC integer (6 decimals) to a fixed-width
+// decimal string like "50.000000". Strings are used instead of floats to
+// avoid precision loss for monetary values.
+func formatUSDC(microUSDC uint64) string {
+	whole := microUSDC / usdcMicroDecimals
+	frac := microUSDC % usdcMicroDecimals
+	return fmt.Sprintf("%d.%06d", whole, frac)
+}
+
+// ShredsSubscriber is a stable public shape for a single shreds subscriber
+// (a client seat in the shred subscription program). client_ip is
+// intentionally omitted: v1 is unauthed and the internal handler redacts it
+// for non-internal callers.
+type ShredsSubscriber struct {
+	SeatPK               string `json:"seat_pk" doc:"Client seat pubkey"`
+	DeviceKey            string `json:"device_key" doc:"DoubleZero edge device pubkey"`
+	DeviceCode           string `json:"device_code" doc:"DoubleZero edge device code"`
+	MetroPK              string `json:"metro_pk" doc:"DoubleZero metro pubkey"`
+	MetroCode            string `json:"metro_code" doc:"DoubleZero metro code"`
+	TenureEpochs         uint16 `json:"tenure_epochs" doc:"Number of epochs this seat has been active"`
+	ActiveEpoch          uint64 `json:"active_epoch" doc:"Epoch the seat became active"`
+	TotalUSDCBalance     string `json:"total_usdc_balance" doc:"Sum of USDC balances across all escrows, as a decimal USDC string (6 fractional digits)" example:"50.000000"`
+	PricePerEpochDollars int64  `json:"price_per_epoch_dollars" doc:"Effective per-epoch price (override or metro + device premium)"`
+	FundingAuthorityKey  string `json:"funding_authority_key" doc:"Funder pubkey (on-chain authority that funded this seat)"`
+	UserPK               string `json:"user_pk" doc:"Linked DoubleZero user pubkey, if any"`
+	UserOwnerPubkey      string `json:"user_owner_pubkey" doc:"Solana wallet that owns the linked DZ user"`
+	UserStatus           string `json:"user_status" doc:"Linked DZ user status (e.g. activated)"`
+	LastActivity         string `json:"last_activity" doc:"RFC3339 timestamp of the last escrow event for this seat, if any" example:"2026-04-23T12:34:56Z"`
+}
+
+// ShredsSubscribersResponse is the paginated response body.
+type ShredsSubscribersResponse struct {
+	Items  []ShredsSubscriber `json:"items"`
+	Total  int                `json:"total" doc:"Total matching subscribers (ignores limit/offset)"`
+	Limit  int                `json:"limit"`
+	Offset int                `json:"offset"`
+}
+
+// ShredsSubscribersInput is the request for the subscribers endpoint.
+type ShredsSubscribersInput struct {
+	Funder string `query:"funder" doc:"Filter by funder pubkey (funding_authority_key, exact match)" example:""`
+	Limit  int    `query:"limit" minimum:"1" maximum:"1000" default:"100" doc:"Maximum items to return"`
+	Offset int    `query:"offset" minimum:"0" default:"0" doc:"Offset into the result set"`
+}
+
+// ShredsSubscribersOutput wraps the response body for huma.
+type ShredsSubscribersOutput struct {
+	Body ShredsSubscribersResponse
+}
+
+func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-shreds-subscribers",
+		Method:      "GET",
+		Path:        "/shreds/subscribers",
+		Summary:     "List shreds subscribers",
+		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
+		Tags:        []string{"shreds"},
+	}, func(ctx context.Context, input *ShredsSubscribersInput) (*ShredsSubscribersOutput, error) {
+		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch shreds subscribers", err)
+		}
+
+		items := make([]ShredsSubscriber, len(rows))
+		for i, r := range rows {
+			items[i] = ShredsSubscriber{
+				SeatPK:               r.PK,
+				DeviceKey:            r.DeviceKey,
+				DeviceCode:           r.DeviceCode,
+				MetroPK:              r.MetroPK,
+				MetroCode:            r.MetroCode,
+				TenureEpochs:         r.TenureEpochs,
+				ActiveEpoch:          r.ActiveEpoch,
+				TotalUSDCBalance:     formatUSDC(r.TotalUSDCBalance),
+				PricePerEpochDollars: r.PricePerEpochDollars,
+				FundingAuthorityKey:  r.FundingAuthorityKey,
+				UserPK:               r.UserPK,
+				UserOwnerPubkey:      r.UserOwnerPubkey,
+				UserStatus:           r.UserStatus,
+			}
+			if r.LastActivity != nil && !r.LastActivity.IsZero() {
+				items[i].LastActivity = r.LastActivity.UTC().Format(time.RFC3339)
+			}
+		}
+
+		return &ShredsSubscribersOutput{Body: ShredsSubscribersResponse{
+			Items:  items,
+			Total:  int(total),
+			Limit:  input.Limit,
+			Offset: input.Offset,
+		}}, nil
+	})
+}

--- a/api/v1/shreds_subscribers.go
+++ b/api/v1/shreds_subscribers.go
@@ -22,11 +22,11 @@ func formatUSDC(microUSDC uint64) string {
 	return fmt.Sprintf("%d.%06d", whole, frac)
 }
 
-// ShredsSubscriber is a stable public shape for a single shreds subscriber
+// EdgeShredsSubscriber is a stable public shape for a single shreds subscriber
 // (a client seat in the shred subscription program). client_ip is
 // intentionally omitted: v1 is unauthed and the internal handler redacts it
 // for non-internal callers.
-type ShredsSubscriber struct {
+type EdgeShredsSubscriber struct {
 	SeatPK               string `json:"seat_pk" doc:"Client seat pubkey"`
 	DeviceKey            string `json:"device_key" doc:"DoubleZero edge device pubkey"`
 	DeviceCode           string `json:"device_code" doc:"DoubleZero edge device code"`
@@ -43,27 +43,27 @@ type ShredsSubscriber struct {
 	LastActivity         string `json:"last_activity" doc:"RFC3339 timestamp of the last escrow event for this seat, if any" example:"2026-04-23T12:34:56Z"`
 }
 
-// ShredsSubscribersResponse is the paginated response body.
-type ShredsSubscribersResponse struct {
-	Items  []ShredsSubscriber `json:"items"`
+// EdgeShredsSubscribersResponse is the paginated response body.
+type EdgeShredsSubscribersResponse struct {
+	Items  []EdgeShredsSubscriber `json:"items"`
 	Total  int                `json:"total" doc:"Total matching subscribers (ignores limit/offset)"`
 	Limit  int                `json:"limit"`
 	Offset int                `json:"offset"`
 }
 
-// ShredsSubscribersInput is the request for the subscribers endpoint.
-type ShredsSubscribersInput struct {
+// EdgeShredsSubscribersInput is the request for the subscribers endpoint.
+type EdgeShredsSubscribersInput struct {
 	Funder string `query:"funder" doc:"Filter by funder pubkey (funding_authority_key, exact match)" example:""`
 	Limit  int    `query:"limit" minimum:"1" maximum:"1000" default:"100" doc:"Maximum items to return"`
 	Offset int    `query:"offset" minimum:"0" default:"0" doc:"Offset into the result set"`
 }
 
-// ShredsSubscribersOutput wraps the response body for huma.
-type ShredsSubscribersOutput struct {
-	Body ShredsSubscribersResponse
+// EdgeShredsSubscribersOutput wraps the response body for huma.
+type EdgeShredsSubscribersOutput struct {
+	Body EdgeShredsSubscribersResponse
 }
 
-func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
+func registerEdgeShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "list-edge-shreds-subscribers",
 		Method:      "GET",
@@ -71,15 +71,15 @@ func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 		Summary:     "List shreds subscribers",
 		Description: "Returns a paginated list of shreds subscribers (client seats in the DoubleZero shred subscription program). Optionally filter by funder pubkey.",
 		Tags:        []string{"edge/shreds"},
-	}, func(ctx context.Context, input *ShredsSubscribersInput) (*ShredsSubscribersOutput, error) {
+	}, func(ctx context.Context, input *EdgeShredsSubscribersInput) (*EdgeShredsSubscribersOutput, error) {
 		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("failed to fetch shreds subscribers", err)
 		}
 
-		items := make([]ShredsSubscriber, len(rows))
+		items := make([]EdgeShredsSubscriber, len(rows))
 		for i, r := range rows {
-			items[i] = ShredsSubscriber{
+			items[i] = EdgeShredsSubscriber{
 				SeatPK:               r.PK,
 				DeviceKey:            r.DeviceKey,
 				DeviceCode:           r.DeviceCode,
@@ -99,7 +99,7 @@ func registerShredsSubscribers(humaAPI huma.API, api *handlers.API) {
 			}
 		}
 
-		return &ShredsSubscribersOutput{Body: ShredsSubscribersResponse{
+		return &EdgeShredsSubscribersOutput{Body: EdgeShredsSubscribersResponse{
 			Items:  items,
 			Total:  int(total),
 			Limit:  input.Limit,

--- a/api/v1/validators_metadata.go
+++ b/api/v1/validators_metadata.go
@@ -30,7 +30,7 @@ func registerValidatorsMetadata(humaAPI huma.API, api *handlers.API) {
 		Path:        "/solana/validators-metadata",
 		Summary:     "List Solana validator metadata",
 		Description: "Returns client name/version/stake metadata for every active Solana validator, ordered by active stake descending.",
-		Tags:        []string{"solana"},
+		Tags:        []string{"Solana"},
 	}, func(ctx context.Context, _ *struct{}) (*ValidatorsMetadataOutput, error) {
 		rows, err := api.FetchValidatorsMetadata(ctx)
 		if err != nil {

--- a/api/v1/validators_metadata.go
+++ b/api/v1/validators_metadata.go
@@ -1,0 +1,53 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// ValidatorMetadata is a stable public shape for a single validator's
+// client/version/stake metadata.
+type ValidatorMetadata struct {
+	IP              string `json:"ip" doc:"Validator gossip IP"`
+	ActiveStake     int64  `json:"active_stake" doc:"Active stake in lamports"`
+	VoteAccount     string `json:"vote_account" doc:"Solana vote account pubkey"`
+	SoftwareClient  string `json:"software_client" doc:"Validator client name (e.g. Agave, Jito, Firedancer)"`
+	SoftwareVersion string `json:"software_version" doc:"Validator client version"`
+}
+
+// ValidatorsMetadataOutput wraps the response body for huma.
+type ValidatorsMetadataOutput struct {
+	Body []ValidatorMetadata
+}
+
+func registerValidatorsMetadata(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-solana-validators-metadata",
+		Method:      "GET",
+		Path:        "/solana/validators-metadata",
+		Summary:     "List Solana validator metadata",
+		Description: "Returns client name/version/stake metadata for every active Solana validator, ordered by active stake descending.",
+		Tags:        []string{"solana"},
+	}, func(ctx context.Context, _ *struct{}) (*ValidatorsMetadataOutput, error) {
+		rows, err := api.FetchValidatorsMetadata(ctx)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch validators metadata", err)
+		}
+
+		items := make([]ValidatorMetadata, len(rows))
+		for i, r := range rows {
+			items[i] = ValidatorMetadata{
+				IP:              r.IP,
+				ActiveStake:     r.ActiveStake,
+				VoteAccount:     r.VoteAccount,
+				SoftwareClient:  r.SoftwareClient,
+				SoftwareVersion: r.SoftwareVersion,
+			}
+		}
+
+		return &ValidatorsMetadataOutput{Body: items}, nil
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/danielgtaylor/huma/v2 v2.37.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHf
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/danielgtaylor/huma/v2 v2.37.3 h1:6Av0Vj45Vk5lDxRVfoO2iPlEdvCvwLc7pl5nbqGOkYM=
+github.com/danielgtaylor/huma/v2 v2.37.3/go.mod h1:OeHHtCEAaNiuVbAVdYu4IQ0UOmnb4x3yMUOShNlZ53g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -400,6 +402,7 @@ github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23n
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,7 @@ import { SettingsPage } from '@/components/settings-page'
 import { ChangelogPage } from '@/components/changelog-page'
 import { TermsPage } from '@/components/terms-page'
 import { MCPDocsPage } from '@/components/mcp-docs-page'
+import { DocsIndexPage } from '@/components/docs-index-page'
 import { ConnectionError } from '@/components/ConnectionError'
 import { EnvBanner } from '@/components/env-banner'
 import { EnvProvider } from '@/contexts/EnvContext'
@@ -681,6 +682,7 @@ function AppContent() {
             <Route path="/terms" element={<TermsPage />} />
 
             {/* Docs */}
+            <Route path="/docs" element={<DocsIndexPage />} />
             <Route path="/docs/mcp" element={<MCPDocsPage />} />
 
             {/* DZ entity routes */}

--- a/web/src/components/docs-index-page.tsx
+++ b/web/src/components/docs-index-page.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom'
+import { ArrowRight, Cable, Code, ExternalLink } from 'lucide-react'
+
+export function DocsIndexPage() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-3xl mx-auto px-8 py-12">
+        <h1 className="text-2xl font-semibold mb-2">Developer Docs</h1>
+        <p className="text-muted-foreground mb-8">
+          Programmatic access to DoubleZero Data for applications and AI agents.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <a
+            href="/api/v1/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group rounded-xl border border-border bg-secondary/50 p-5 transition-colors hover:bg-secondary hover:border-muted-foreground/30"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+              <ExternalLink className="h-4 w-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors" />
+            </div>
+            <div className="font-medium text-sm mb-1">REST API v1</div>
+            <div className="text-xs text-muted-foreground">
+              Network telemetry, Solana validators, and the shred subscription program. OpenAPI reference.
+            </div>
+          </a>
+
+          <Link
+            to="/docs/mcp"
+            className="group rounded-xl border border-border bg-secondary/50 p-5 transition-colors hover:bg-secondary hover:border-muted-foreground/30"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <Cable className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+              <ArrowRight className="h-4 w-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors" />
+            </div>
+            <div className="font-medium text-sm mb-1">Connect Your Own AI</div>
+            <div className="text-xs text-muted-foreground">
+              Use DoubleZero Data from Claude, Cursor, or any MCP-compatible client.
+            </div>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/mcp-docs-page.tsx
+++ b/web/src/components/mcp-docs-page.tsx
@@ -110,6 +110,14 @@ export function MCPDocsPage() {
           </div>
         </section>
 
+        {/* Rate Limits */}
+        <section className="mb-10">
+          <h2 className="text-lg font-medium mb-3">Rate Limits</h2>
+          <p className="text-muted-foreground">
+            Tool calls are rate limited to 100 requests per minute per IP. If you hit the limit, calls return an error — wait a moment and retry.
+          </p>
+        </section>
+
         {/* Desktop Apps */}
         <section className="mb-10">
           <h2 className="text-lg font-medium mb-3">Claude Desktop & Codex Desktop</h2>

--- a/web/src/components/mcp-docs-page.tsx
+++ b/web/src/components/mcp-docs-page.tsx
@@ -110,14 +110,6 @@ export function MCPDocsPage() {
           </div>
         </section>
 
-        {/* Rate Limits */}
-        <section className="mb-10">
-          <h2 className="text-lg font-medium mb-3">Rate Limits</h2>
-          <p className="text-muted-foreground">
-            Tool calls are rate limited to 100 requests per minute per IP. If you hit the limit, calls return an error — wait a moment and retry.
-          </p>
-        </section>
-
         {/* Desktop Apps */}
         <section className="mb-10">
           <h2 className="text-lg font-medium mb-3">Claude Desktop & Codex Desktop</h2>
@@ -151,6 +143,14 @@ export function MCPDocsPage() {
             >
               Streamable HTTP transport
             </a>.
+          </p>
+        </section>
+
+        {/* Rate Limits */}
+        <section className="mb-10">
+          <h2 className="text-lg font-medium mb-3">Rate Limits</h2>
+          <p className="text-muted-foreground">
+            Tool calls are rate limited to 100 requests per minute per IP. If you hit the limit, calls return an error — wait a moment and retry.
           </p>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- New public API surface at `/api/v1` powered by huma; OpenAPI is generated from Go handler signatures, so spec and code can't drift.
- OpenAPI at `/api/v1/openapi.json`; Scalar docs at `/api/v1/docs`.
- Endpoints:
  - `GET /api/v1/shreds/publishers/leaders` — validator publishers with leader/retransmit status.
  - `GET /api/v1/shreds/subscribers` — paginated client seats; optional `?funder=<pubkey>` exact-match filter.
  - `GET /api/v1/solana/validators-metadata` — active validator client/version/stake metadata. 308 redirect from `/api/v1/validators-metadata` preserves existing consumers.
- Closes #519

## Testing Verification
- Per-endpoint JSON contract tests lock down field names (renames fail loudly).
- Pagination, filter semantics (funder exact-match-not-substring), huma 422 validation, and the legacy 308 redirect all covered.
- OpenAPI contract test asserts every expected operation is advertised.