### PR TITLE
web/api/indexer: add facilities section, device-style detail pages, and capacity metrics

### DIFF
--- a/docs/superpowers/plans/2026-04-23-metro-facility-device-style.md
+++ b/docs/superpowers/plans/2026-04-23-metro-facility-device-style.md
@@ -1,0 +1,300 @@
+# Metro & Facility Device-Style Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `dl`-card info sections on Metro and Facility detail pages with stat pills + split Used/Available capacity cards, matching the Device page's visual style.
+
+**Architecture:** Two self-contained JSX block replacements — one per page. Each removes the `grid grid-cols-3` bordered-card section and replaces it with a CSS grid of stat pills (2 rows × 4 cols + map column) followed by three split capacity cards. No new components, no backend changes.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS v4, existing `MiniMap` and `CopyableText` components.
+
+---
+
+### Task 1: Facility detail page — replace info grid
+
+**Files:**
+- Modify: `web/src/components/facility-detail-page.tsx:198-324`
+
+- [ ] **Step 1: Replace the info grid block**
+
+In `web/src/components/facility-detail-page.tsx`, find and replace the entire `{/* Info grid */}` block (lines 198–324 — from `{/* Info grid */}` through the closing `</div>` of the outer grid) with the following:
+
+```tsx
+        {/* Info grid */}
+        <div
+          className="grid gap-1.5 mb-6"
+          style={{ gridTemplateColumns: '1fr 1fr 1fr 1fr 1.8fr', gridTemplateRows: 'auto auto' }}
+        >
+          {/* Row 1 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{facility.country || '—'}</div>
+            <div className="text-xs text-muted-foreground">Country</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium font-mono">
+              {facility.metro_pk
+                ? <Link to={`/dz/metros/${facility.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline">{facility.metro_code}</Link>
+                : (facility.metro_code || '—')}
+            </div>
+            <div className="text-xs text-muted-foreground">Metro</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium tabular-nums">
+              {facility.user_count}
+              {facility.max_users > 0 && <span className="text-muted-foreground">/{facility.max_users}</span>}
+            </div>
+            <div className="text-xs text-muted-foreground">Users</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{facility.device_count}</div>
+            <div className="text-xs text-muted-foreground">Devices</div>
+          </div>
+          {/* Map — spans both rows */}
+          {facility.lat !== 0 && facility.lng !== 0 ? (
+            <div className="rounded-lg overflow-hidden border border-border" style={{ gridRow: 'span 2' }}>
+              <MiniMap
+                lat={facility.lat}
+                lng={facility.lng}
+                googleMapsHref={`https://www.google.com/maps?q=${facility.lat},${facility.lng}`}
+              />
+            </div>
+          ) : (
+            <div style={{ gridRow: 'span 2' }} />
+          )}
+          {/* Row 2 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center" style={{ gridColumn: 'span 2' }}>
+            <div className="text-sm font-medium font-mono">
+              <CopyableText text={facility.pk} className="font-mono text-sm">
+                {facility.pk.slice(0, 4)}...{facility.pk.slice(-4)}
+              </CopyableText>
+            </div>
+            <div className="text-xs text-muted-foreground">Pubkey</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium font-mono">
+              <CopyableText text={facility.code} className="font-mono text-sm" />
+            </div>
+            <div className="text-xs text-muted-foreground">Code</div>
+          </div>
+          {facility.loc_id > 0 ? (
+            <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+              <div className="text-sm font-medium font-mono">
+                <a
+                  href={`https://www.peeringdb.com/fac/${facility.loc_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground/85 hover:text-foreground hover:underline"
+                >
+                  {facility.loc_id}
+                </a>
+              </div>
+              <div className="text-xs text-muted-foreground">PeeringDB</div>
+            </div>
+          ) : (
+            <div />
+          )}
+        </div>
+
+        {/* Capacity cards */}
+        {(() => {
+          const effUnicastMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.unicast_users, d.max_unicast_users > 0 ? d.max_unicast_users : d.unicast_users + rem)
+              }, 0)
+            : (facility.max_unicast_users > 0 ? facility.max_unicast_users : facility.max_users)
+          const effSubsMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.multicast_subscribers_count, d.max_multicast_subscribers > 0 ? d.max_multicast_subscribers : d.multicast_subscribers_count + rem)
+              }, 0)
+            : (facility.max_multicast_subscribers > 0 ? facility.max_multicast_subscribers : facility.max_users)
+          const effPubsMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.multicast_publishers_count, d.max_multicast_publishers > 0 ? d.max_multicast_publishers : d.multicast_publishers_count + rem)
+              }, 0)
+            : (facility.max_multicast_publishers > 0 ? facility.max_multicast_publishers : facility.max_users)
+          const hasCapacity = effUnicastMax > 0 || effSubsMax > 0 || effPubsMax > 0
+            || facility.unicast_users_count > 0 || facility.multicast_subscribers_count > 0 || facility.multicast_publishers_count > 0
+          if (!hasCapacity) return null
+          return (
+            <div className="grid grid-cols-3 gap-1.5 mb-6">
+              {[
+                { label: 'Unicast', used: facility.unicast_users_count, max: effUnicastMax },
+                { label: 'Subscribers', used: facility.multicast_subscribers_count, max: effSubsMax },
+                { label: 'Publishers', used: facility.multicast_publishers_count, max: effPubsMax },
+              ].map(({ label, used, max }) => {
+                const available = max > used ? max - used : 0
+                const pct = max > 0 ? Math.min(100, (used / max) * 100) : 0
+                const fillColor = pct >= 90 ? 'bg-red-500/50' : pct >= 70 ? 'bg-amber-500/40' : 'bg-blue-500/30'
+                return (
+                  <div key={label} className="border border-border rounded-lg overflow-hidden">
+                    <div className="grid grid-cols-2 divide-x divide-border">
+                      <div className="p-2.5 text-center bg-muted/30">
+                        <div className="text-sm font-medium tabular-nums">{used}</div>
+                        <div className="text-xs text-muted-foreground">{label}</div>
+                      </div>
+                      <div className="p-2.5 text-center bg-muted/10">
+                        <div className="text-sm font-medium tabular-nums text-muted-foreground">{available}</div>
+                        <div className="text-xs text-muted-foreground/60">Available</div>
+                      </div>
+                    </div>
+                    {pct > 0 && (
+                      <div className="relative h-[3px] bg-muted/60">
+                        <div className={`absolute inset-y-0 left-0 ${fillColor}`} style={{ width: `${pct}%` }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })()}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd web && bun run tsc -b
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/facility-detail-page.tsx
+git commit -m "web: facility detail — device-style stat pills and capacity cards"
+```
+
+---
+
+### Task 2: Metro detail page — replace info grid
+
+**Files:**
+- Modify: `web/src/components/metro-detail-page.tsx:1` (import line) and `:201-295` (info grid)
+
+- [ ] **Step 1: Remove `Info` from the lucide-react import**
+
+In `web/src/components/metro-detail-page.tsx` line 3, change:
+
+```tsx
+import { Loader2, MapPin, AlertCircle, ArrowLeft, Info, ChevronUp, ChevronDown } from 'lucide-react'
+```
+
+to:
+
+```tsx
+import { Loader2, MapPin, AlertCircle, ArrowLeft, ChevronUp, ChevronDown } from 'lucide-react'
+```
+
+- [ ] **Step 2: Replace the info grid block**
+
+Find and replace the entire `{/* Info grid */}` block (lines 201–295 — from `{/* Info grid */}` through the closing `</div>`) with the following:
+
+```tsx
+        {/* Info grid */}
+        <div
+          className="grid gap-1.5 mb-6"
+          style={{ gridTemplateColumns: '1fr 1fr 1fr 1fr 1.8fr', gridTemplateRows: 'auto auto' }}
+        >
+          {/* Row 1 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.device_count}</div>
+            <div className="text-xs text-muted-foreground">Devices</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.facility_count}</div>
+            <div className="text-xs text-muted-foreground">Facilities</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium tabular-nums">
+              {metro.user_count}
+              {metro.max_users > 0 && <span className="text-muted-foreground">/{metro.max_users}</span>}
+            </div>
+            <div className="text-xs text-muted-foreground">Users</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.validator_count}</div>
+            <div className="text-xs text-muted-foreground">Validators</div>
+          </div>
+          {/* Map — spans both rows */}
+          <div className="rounded-lg overflow-hidden border border-border" style={{ gridRow: 'span 2' }}>
+            <MiniMap
+              lat={metro.latitude}
+              lng={metro.longitude}
+              googleMapsHref={`https://www.google.com/maps?q=${metro.latitude},${metro.longitude}`}
+            />
+          </div>
+          {/* Row 2 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{formatBps(metro.in_bps)}</div>
+            <div className="text-xs text-muted-foreground">Inbound</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{formatBps(metro.out_bps)}</div>
+            <div className="text-xs text-muted-foreground">Outbound</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center" style={{ gridColumn: 'span 2' }}>
+            <div className="text-sm font-medium">{formatStake(metro.stake_sol)}</div>
+            <div className="text-xs text-muted-foreground">Total Stake</div>
+          </div>
+        </div>
+
+        {/* Capacity cards */}
+        {(() => {
+          const effUnicast = Math.max(metro.unicast_users_count, metro.max_unicast_users)
+          const effSubs = Math.max(metro.multicast_subscribers_count, metro.max_multicast_subscribers)
+          const effPubs = Math.max(metro.multicast_publishers_count, metro.max_multicast_publishers)
+          const hasCapacity = effUnicast > 0 || effSubs > 0 || effPubs > 0
+          if (!hasCapacity) return null
+          return (
+            <div className="grid grid-cols-3 gap-1.5 mb-10">
+              {[
+                { label: 'Unicast', used: metro.unicast_users_count, max: effUnicast },
+                { label: 'Subscribers', used: metro.multicast_subscribers_count, max: effSubs },
+                { label: 'Publishers', used: metro.multicast_publishers_count, max: effPubs },
+              ].map(({ label, used, max }) => {
+                const available = max > used ? max - used : 0
+                const pct = max > 0 ? Math.min(100, (used / max) * 100) : 0
+                const fillColor = pct >= 90 ? 'bg-red-500/50' : pct >= 70 ? 'bg-amber-500/40' : 'bg-blue-500/30'
+                return (
+                  <div key={label} className="border border-border rounded-lg overflow-hidden">
+                    <div className="grid grid-cols-2 divide-x divide-border">
+                      <div className="p-2.5 text-center bg-muted/30">
+                        <div className="text-sm font-medium tabular-nums">{used}</div>
+                        <div className="text-xs text-muted-foreground">{label}</div>
+                      </div>
+                      <div className="p-2.5 text-center bg-muted/10">
+                        <div className="text-sm font-medium tabular-nums text-muted-foreground">{available}</div>
+                        <div className="text-xs text-muted-foreground/60">Available</div>
+                      </div>
+                    </div>
+                    {pct > 0 && (
+                      <div className="relative h-[3px] bg-muted/60">
+                        <div className={`absolute inset-y-0 left-0 ${fillColor}`} style={{ width: `${pct}%` }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })()}
+```
+
+- [ ] **Step 3: Verify TypeScript**
+
+```bash
+cd web && bun run tsc -b
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/metro-detail-page.tsx
+git commit -m "web: metro detail — device-style stat pills and capacity cards"
+```

--- a/docs/superpowers/specs/2026-04-23-metro-facility-device-style-design.md
+++ b/docs/superpowers/specs/2026-04-23-metro-facility-device-style-design.md
@@ -1,0 +1,89 @@
+# Metro & Facility Detail Pages — Device-Style Redesign
+
+**Date:** 2026-04-23  
+**Status:** Approved
+
+## Overview
+
+Redesign the Metro and Facility detail pages to match the visual language of the Device detail page. The Device page uses stat pills and split Used/Available capacity cards instead of traditional bordered `dl` cards. The goal is a consistent look across all three entity detail pages.
+
+## What Changes
+
+### Both pages: remove the 3-column `dl` card layout
+
+The current layout has three bordered `bg-card` cards (Infrastructure, Details/Traffic, Map) each containing a `<dl>` key-value list. This entire section is replaced.
+
+### New layout: stat pills grid + map column + capacity cards
+
+**Stat pills grid (2 rows × 4 cols + map spanning both rows):**
+
+```
+[ pill ][ pill ][ pill ][ pill ][ map         ]
+[ pill ][ pill ][ pill ][ pill ][ (spans rows) ]
+```
+
+Grid: `grid-template-columns: 1fr 1fr 1fr 1fr 1.8fr`, `grid-template-rows: auto auto`, `gap-1.5`.
+
+- Each pill: `bg-muted/30 rounded-lg px-2 py-2.5 text-center` — value on top (`text-sm font-medium`), label below (`text-xs text-muted-foreground`). Matches Device page's stat grid style.
+- Map column (`grid-row: span 2`): `MiniMap` component with `rounded-lg overflow-hidden border border-border`. Same dark look as current mini-maps. Only rendered when `lat/lng !== 0`. If no coordinates, the 4th cell of row 2 fills the last column instead.
+
+**Capacity cards (3 cards, full width, below the grid):**
+
+```
+[ Unicast  Used | Available ][ Subscribers Used | Available ][ Publishers Used | Available ]
+```
+
+`grid-cols-3 gap-1.5`. Same split card as Device page (`DeviceInfoContent`):
+- `border border-border rounded-lg overflow-hidden`
+- Left half: used count, `bg-muted/30`; right half: available count, `bg-muted/10` dimmed
+- 3px progress bar at bottom — blue < 70%, amber 70–89%, red ≥ 90%
+- Only rendered when at least one of the three capacity values > 0
+
+---
+
+### Facility pills
+
+| Row | Pills (left→right) |
+|-----|-------------------|
+| 1 | Country, Metro (link), Users `count/max`, Devices |
+| 2 | Pubkey `pk[0:4]…pk[-4]` (CopyableText, spans 2 cols), Code (CopyableText), PeeringDB ID (link, only if `loc_id > 0`) |
+
+Notes:
+- "Pubkey" displays `facility.pk` abbreviated — same as existing Details card
+- PeeringDB pill omitted (cell left empty / map fills) if `loc_id === 0`
+- Metro pill is a `Link` to `/dz/metros/:metro_pk` when `metro_pk` is set
+
+Capacity values: use the effective-max computation already in the component (sum of device `effUnicast`/`effSubs`/`effPubs` from `rawDevices`).
+
+---
+
+### Metro pills
+
+| Row | Pills (left→right) |
+|-----|-------------------|
+| 1 | Devices, Facilities, Users `count/max`, Validators |
+| 2 | Inbound (`formatBps`), Outbound (`formatBps`), Stake (`formatStake`), _(empty — map fills)_ |
+
+Notes:
+- `MetroDetail` has no `stake_share` field — omit that pill
+- If `metro.stake_sol === 0`, Stake pill shows `—`
+- Row 2 has only 3 pills; the 4th slot in the grid aligns with the map column naturally (map spans both rows, so no orphan cell)
+
+Capacity values: use the existing `effUnicast = Math.max(metro.unicast_users_count, metro.max_unicast_users)` etc., same as current code.
+
+---
+
+## What Does NOT Change
+
+- Page header (icon + title + status pill + back button)
+- Devices table and Facilities table (Metro page)
+- Loading / error states
+- All sorting logic
+- API calls and data fetching
+
+## Files to Edit
+
+1. `web/src/components/facility-detail-page.tsx` — replace info grid section (lines ~198–308)
+2. `web/src/components/metro-detail-page.tsx` — replace info grid section (lines ~201–295)
+
+No backend changes. No new components — reuses `MiniMap` and `CopyableText` already imported.

--- a/web/src/components/facility-detail-page.tsx
+++ b/web/src/components/facility-detail-page.tsx
@@ -196,117 +196,136 @@ export function FacilityDetailPage() {
         </div>
 
         {/* Info grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
-          <div className="border border-border rounded-lg p-4 bg-card">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3">Details</h3>
-            <dl className="space-y-2">
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Country</dt>
-                <dd className="text-sm">{facility.country || '—'}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Metro</dt>
-                <dd className="text-sm font-mono">
-                  {facility.metro_pk
-                    ? <Link to={`/dz/metros/${facility.metro_pk}`} className="font-mono text-foreground/85 hover:text-foreground hover:underline">{facility.metro_code}</Link>
-                    : (facility.metro_code || '—')}
-                </dd>
-              </div>
-              <div className="flex justify-between items-center">
-                <dt className="text-sm text-muted-foreground">Pubkey</dt>
-                <dd className="text-sm font-mono">
-                  <CopyableText text={facility.pk} className="font-mono text-sm">
-                    {facility.pk.slice(0, 4)}...{facility.pk.slice(-4)}
-                  </CopyableText>
-                </dd>
-              </div>
-              <div className="flex justify-between items-center">
-                <dt className="text-sm text-muted-foreground">Code</dt>
-                <dd className="text-sm font-mono">
-                  <CopyableText text={facility.code} className="font-mono text-sm" />
-                </dd>
-              </div>
-              {facility.loc_id > 0 && (
-                <div className="flex justify-between">
-                  <dt className="text-sm text-muted-foreground">PeeringDB ID</dt>
-                  <dd className="text-sm font-mono">
-                    <a
-                      href={`https://www.peeringdb.com/fac/${facility.loc_id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 dark:text-blue-400 hover:underline"
-                    >
-                      {facility.loc_id}
-                    </a>
-                  </dd>
-                </div>
-              )}
-            </dl>
+        <div
+          className="grid gap-1.5 mb-6"
+          style={{ gridTemplateColumns: '1fr 1fr 1fr 1fr 1.8fr', gridTemplateRows: 'auto auto' }}
+        >
+          {/* Row 1 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{facility.country || '—'}</div>
+            <div className="text-xs text-muted-foreground">Country</div>
           </div>
-
-          <div className="border border-border rounded-lg p-4 bg-card">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3">Infrastructure</h3>
-            <dl className="space-y-2">
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Devices</dt>
-                <dd className="text-sm">{facility.device_count}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Users</dt>
-                <dd className="text-sm tabular-nums">
-                  {facility.user_count}
-                  {facility.max_users > 0 && <span className="text-muted-foreground">/{facility.max_users}</span>}
-                </dd>
-              </div>
-              {(() => {
-                const effUnicastMax = facility.max_unicast_users > 0 ? facility.max_unicast_users : facility.max_users
-                const effSubsMax = facility.max_multicast_subscribers > 0 ? facility.max_multicast_subscribers : facility.max_users
-                const effPubsMax = facility.max_multicast_publishers > 0 ? facility.max_multicast_publishers : facility.max_users
-                return (
-                  <>
-                    {(facility.unicast_users_count > 0 || effUnicastMax > 0) && (
-                      <div className="flex justify-between">
-                        <dt className="text-sm text-muted-foreground pl-3">Unicast</dt>
-                        <dd className="text-sm tabular-nums">
-                          {facility.unicast_users_count}
-                          {effUnicastMax > 0 && <span className="text-muted-foreground">/{effUnicastMax}</span>}
-                        </dd>
-                      </div>
-                    )}
-                    {(facility.multicast_subscribers_count > 0 || effSubsMax > 0) && (
-                      <div className="flex justify-between">
-                        <dt className="text-sm text-muted-foreground pl-3">Subscribers</dt>
-                        <dd className="text-sm tabular-nums">
-                          {facility.multicast_subscribers_count}
-                          {effSubsMax > 0 && <span className="text-muted-foreground">/{effSubsMax}</span>}
-                        </dd>
-                      </div>
-                    )}
-                    {(facility.multicast_publishers_count > 0 || effPubsMax > 0) && (
-                      <div className="flex justify-between">
-                        <dt className="text-sm text-muted-foreground pl-3">Publishers</dt>
-                        <dd className="text-sm tabular-nums">
-                          {facility.multicast_publishers_count}
-                          {effPubsMax > 0 && <span className="text-muted-foreground">/{effPubsMax}</span>}
-                        </dd>
-                      </div>
-                    )}
-                  </>
-                )
-              })()}
-            </dl>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium font-mono">
+              {facility.metro_pk
+                ? <Link to={`/dz/metros/${facility.metro_pk}`} className="text-foreground/85 hover:text-foreground hover:underline">{facility.metro_code}</Link>
+                : (facility.metro_code || '—')}
+            </div>
+            <div className="text-xs text-muted-foreground">Metro</div>
           </div>
-
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium tabular-nums">
+              {facility.user_count}
+              {facility.max_users > 0 && <span className="text-muted-foreground">/{facility.max_users}</span>}
+            </div>
+            <div className="text-xs text-muted-foreground">Users</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{facility.device_count}</div>
+            <div className="text-xs text-muted-foreground">Devices</div>
+          </div>
+          {/* Map — spans both rows */}
           {facility.lat !== 0 && facility.lng !== 0 ? (
-            <div className="border border-border rounded-lg overflow-hidden bg-card" style={{ height: '160px' }}>
+            <div className="rounded-lg overflow-hidden border border-border" style={{ gridRow: 'span 2' }}>
               <MiniMap
                 lat={facility.lat}
                 lng={facility.lng}
                 googleMapsHref={`https://www.google.com/maps?q=${facility.lat},${facility.lng}`}
               />
             </div>
-          ) : null}
+          ) : (
+            <div style={{ gridRow: 'span 2' }} />
+          )}
+          {/* Row 2 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center" style={{ gridColumn: 'span 2' }}>
+            <div className="text-sm font-medium font-mono">
+              <CopyableText text={facility.pk} className="font-mono text-sm">
+                {facility.pk.slice(0, 4)}...{facility.pk.slice(-4)}
+              </CopyableText>
+            </div>
+            <div className="text-xs text-muted-foreground">Pubkey</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium font-mono">
+              <CopyableText text={facility.code} className="font-mono text-sm" />
+            </div>
+            <div className="text-xs text-muted-foreground">Code</div>
+          </div>
+          {facility.loc_id > 0 ? (
+            <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+              <div className="text-sm font-medium font-mono">
+                <a
+                  href={`https://www.peeringdb.com/fac/${facility.loc_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground/85 hover:text-foreground hover:underline"
+                >
+                  {facility.loc_id}
+                </a>
+              </div>
+              <div className="text-xs text-muted-foreground">PeeringDB</div>
+            </div>
+          ) : (
+            <div />
+          )}
         </div>
+
+        {/* Capacity cards */}
+        {(() => {
+          const effUnicastMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.unicast_users, d.max_unicast_users > 0 ? d.max_unicast_users : d.unicast_users + rem)
+              }, 0)
+            : (facility.max_unicast_users > 0 ? facility.max_unicast_users : facility.max_users)
+          const effSubsMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.multicast_subscribers_count, d.max_multicast_subscribers > 0 ? d.max_multicast_subscribers : d.multicast_subscribers_count + rem)
+              }, 0)
+            : (facility.max_multicast_subscribers > 0 ? facility.max_multicast_subscribers : facility.max_users)
+          const effPubsMax = rawDevices.length > 0
+            ? rawDevices.reduce((sum, d) => {
+                const rem = d.max_users > 0 ? Math.max(0, d.max_users - d.current_users) : 0
+                return sum + Math.max(d.multicast_publishers_count, d.max_multicast_publishers > 0 ? d.max_multicast_publishers : d.multicast_publishers_count + rem)
+              }, 0)
+            : (facility.max_multicast_publishers > 0 ? facility.max_multicast_publishers : facility.max_users)
+          const hasCapacity = effUnicastMax > 0 || effSubsMax > 0 || effPubsMax > 0
+            || facility.unicast_users_count > 0 || facility.multicast_subscribers_count > 0 || facility.multicast_publishers_count > 0
+          if (!hasCapacity) return null
+          return (
+            <div className="grid grid-cols-3 gap-1.5 mb-6">
+              {[
+                { label: 'Unicast', used: facility.unicast_users_count, max: effUnicastMax },
+                { label: 'Subscribers', used: facility.multicast_subscribers_count, max: effSubsMax },
+                { label: 'Publishers', used: facility.multicast_publishers_count, max: effPubsMax },
+              ].map(({ label, used, max }) => {
+                const available = max > used ? max - used : 0
+                const pct = max > 0 ? Math.min(100, (used / max) * 100) : 0
+                const fillColor = pct >= 90 ? 'bg-red-500/50' : pct >= 70 ? 'bg-amber-500/40' : 'bg-blue-500/30'
+                return (
+                  <div key={label} className="border border-border rounded-lg overflow-hidden">
+                    <div className="grid grid-cols-2 divide-x divide-border">
+                      <div className="p-2.5 text-center bg-muted/30">
+                        <div className="text-sm font-medium tabular-nums">{used}</div>
+                        <div className="text-xs text-muted-foreground">{label}</div>
+                      </div>
+                      <div className="p-2.5 text-center bg-muted/10">
+                        <div className="text-sm font-medium tabular-nums text-muted-foreground">{available}</div>
+                        <div className="text-xs text-muted-foreground/60">Available</div>
+                      </div>
+                    </div>
+                    {pct > 0 && (
+                      <div className="relative h-[3px] bg-muted/60">
+                        <div className={`absolute inset-y-0 left-0 ${fillColor}`} style={{ width: `${pct}%` }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })()}
 
         {/* Devices table */}
         <div>

--- a/web/src/components/metro-detail-page.tsx
+++ b/web/src/components/metro-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Loader2, MapPin, AlertCircle, ArrowLeft, Info, ChevronUp, ChevronDown } from 'lucide-react'
+import { Loader2, MapPin, AlertCircle, ArrowLeft, ChevronUp, ChevronDown } from 'lucide-react'
 import { fetchMetro, fetchDevicesByMetro, fetchFacilitiesByMetro } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
@@ -199,100 +199,93 @@ export function MetroDetailPage() {
         </div>
 
         {/* Info grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
-          {/* Infrastructure */}
-          <div className="border border-border rounded-lg p-4 bg-card">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3">Infrastructure</h3>
-            <dl className="space-y-2">
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Devices</dt>
-                <dd className="text-sm">{metro.device_count}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Facilities</dt>
-                <dd className="text-sm">{metro.facility_count}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Users</dt>
-                <dd className="text-sm tabular-nums">
-                  {metro.user_count}
-                  <span className="text-muted-foreground">/{metro.max_users}</span>
-                </dd>
-              </div>
-              {(() => {
-                const effUnicast = Math.max(metro.unicast_users_count, metro.max_unicast_users)
-                const effSubs = Math.max(metro.multicast_subscribers_count, metro.max_multicast_subscribers)
-                const effPubs = Math.max(metro.multicast_publishers_count, metro.max_multicast_publishers)
-                const isDerivedUnicast = metro.raw_max_unicast_users === 0 && effUnicast > 0
-                const isDerivedSubs = metro.raw_max_multicast_subscribers === 0 && effSubs > 0
-                const isDerivedPubs = metro.raw_max_multicast_publishers === 0 && effPubs > 0
-                return (
-                  <>
-                    <div className="flex justify-between">
-                      <dt className="text-sm text-muted-foreground">Unicast</dt>
-                      <dd className="text-sm tabular-nums">
-                        {metro.unicast_users_count}{effUnicast > 0 && <> / {isDerivedUnicast
-                          ? <span className="text-muted-foreground/50 inline-flex items-center gap-0.5" title="Calculated from max_users">{effUnicast}<Info className="h-2.5 w-2.5" /></span>
-                          : <span className="text-muted-foreground">{effUnicast}</span>
-                        }</>}
-                      </dd>
-                    </div>
-                    <div className="flex justify-between">
-                      <dt className="text-sm text-muted-foreground">Subscribers</dt>
-                      <dd className="text-sm tabular-nums">
-                        {metro.multicast_subscribers_count}{effSubs > 0 && <> / {isDerivedSubs
-                          ? <span className="text-muted-foreground/50 inline-flex items-center gap-0.5" title="Calculated from max_users">{effSubs}<Info className="h-2.5 w-2.5" /></span>
-                          : <span className="text-muted-foreground">{effSubs}</span>
-                        }</>}
-                      </dd>
-                    </div>
-                    <div className="flex justify-between">
-                      <dt className="text-sm text-muted-foreground">Publishers</dt>
-                      <dd className="text-sm tabular-nums">
-                        {metro.multicast_publishers_count}{effPubs > 0 && <> / {isDerivedPubs
-                          ? <span className="text-muted-foreground/50 inline-flex items-center gap-0.5" title="Calculated from max_users">{effPubs}<Info className="h-2.5 w-2.5" /></span>
-                          : <span className="text-muted-foreground">{effPubs}</span>
-                        }</>}
-                      </dd>
-                    </div>
-                  </>
-                )
-              })()}
-            </dl>
+        <div
+          className="grid gap-1.5 mb-6"
+          style={{ gridTemplateColumns: '1fr 1fr 1fr 1fr 1.8fr', gridTemplateRows: 'auto auto' }}
+        >
+          {/* Row 1 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.device_count}</div>
+            <div className="text-xs text-muted-foreground">Devices</div>
           </div>
-
-          {/* Traffic + Validators */}
-          <div className="border border-border rounded-lg p-4 bg-card">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3">Traffic</h3>
-            <dl className="space-y-2">
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Inbound</dt>
-                <dd className="text-sm">{formatBps(metro.in_bps)}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Outbound</dt>
-                <dd className="text-sm">{formatBps(metro.out_bps)}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Validators</dt>
-                <dd className="text-sm">{metro.validator_count}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-muted-foreground">Total Stake</dt>
-                <dd className="text-sm">{formatStake(metro.stake_sol)}</dd>
-              </div>
-            </dl>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.facility_count}</div>
+            <div className="text-xs text-muted-foreground">Facilities</div>
           </div>
-
-          {/* Map */}
-          <div className="border border-border rounded-lg overflow-hidden bg-card min-h-40">
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium tabular-nums">
+              {metro.user_count}
+              {metro.max_users > 0 && <span className="text-muted-foreground">/{metro.max_users}</span>}
+            </div>
+            <div className="text-xs text-muted-foreground">Users</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{metro.validator_count}</div>
+            <div className="text-xs text-muted-foreground">Validators</div>
+          </div>
+          {/* Map — spans both rows */}
+          <div className="rounded-lg overflow-hidden border border-border" style={{ gridRow: 'span 2' }}>
             <MiniMap
               lat={metro.latitude}
               lng={metro.longitude}
               googleMapsHref={`https://www.google.com/maps?q=${metro.latitude},${metro.longitude}`}
             />
           </div>
+          {/* Row 2 */}
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{formatBps(metro.in_bps)}</div>
+            <div className="text-xs text-muted-foreground">Inbound</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
+            <div className="text-sm font-medium">{formatBps(metro.out_bps)}</div>
+            <div className="text-xs text-muted-foreground">Outbound</div>
+          </div>
+          <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center" style={{ gridColumn: 'span 2' }}>
+            <div className="text-sm font-medium">{formatStake(metro.stake_sol)}</div>
+            <div className="text-xs text-muted-foreground">Total Stake</div>
+          </div>
         </div>
+
+        {/* Capacity cards */}
+        {(() => {
+          const effUnicast = Math.max(metro.unicast_users_count, metro.max_unicast_users)
+          const effSubs = Math.max(metro.multicast_subscribers_count, metro.max_multicast_subscribers)
+          const effPubs = Math.max(metro.multicast_publishers_count, metro.max_multicast_publishers)
+          const hasCapacity = effUnicast > 0 || effSubs > 0 || effPubs > 0
+          if (!hasCapacity) return null
+          return (
+            <div className="grid grid-cols-3 gap-1.5 mb-10">
+              {[
+                { label: 'Unicast', used: metro.unicast_users_count, max: effUnicast },
+                { label: 'Subscribers', used: metro.multicast_subscribers_count, max: effSubs },
+                { label: 'Publishers', used: metro.multicast_publishers_count, max: effPubs },
+              ].map(({ label, used, max }) => {
+                const available = max > used ? max - used : 0
+                const pct = max > 0 ? Math.min(100, (used / max) * 100) : 0
+                const fillColor = pct >= 90 ? 'bg-red-500/50' : pct >= 70 ? 'bg-amber-500/40' : 'bg-blue-500/30'
+                return (
+                  <div key={label} className="border border-border rounded-lg overflow-hidden">
+                    <div className="grid grid-cols-2 divide-x divide-border">
+                      <div className="p-2.5 text-center bg-muted/30">
+                        <div className="text-sm font-medium tabular-nums">{used}</div>
+                        <div className="text-xs text-muted-foreground">{label}</div>
+                      </div>
+                      <div className="p-2.5 text-center bg-muted/10">
+                        <div className="text-sm font-medium tabular-nums text-muted-foreground">{available}</div>
+                        <div className="text-xs text-muted-foreground/60">Available</div>
+                      </div>
+                    </div>
+                    {pct > 0 && (
+                      <div className="relative h-[3px] bg-muted/60">
+                        <div className={`absolute inset-y-0 left-0 ${fillColor}`} style={{ width: `${pct}%` }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })()}
 
         {/* Devices table */}
         {devices.length > 0 && (


### PR DESCRIPTION
## Summary of Changes
- Adds a full **Facilities** section (list + detail pages) with sortable device tables, PeeringDB integration, and mini-maps; renames Locations → Facilities throughout the stack
- Rewrites **Metro detail** with sortable devices/facilities tables, stat pills layout, and MapLibre mini-map
- Redesigns **Metro and Facility detail** info sections to match Device page style: stat pills grid + split Used/Available capacity cards for Unicast, Subscribers, and Publishers
- Adds **unicast/multicast capacity fields** (max_unicast_users, max_multicast_subscribers, max_multicast_publishers) to devices, propagated through indexer migrations, API, and all detail/list views
- Adds **Shreds Economics** page and **Geoloc** probes/users pages
- Replaces OSM iframes with theme-aware **MapLibre mini-maps** on metro and facility detail pages
- Enriches contributor detail with a links table and devices list; adds metro/facility columns to users, devices, and links lists

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net    |
|--------------|-------|---------------|--------|
| Core logic   |    46 | +7432 / -500  | +6932  |
| Scaffolding  |    17 | +294  / -24   |  +270  |
| Tests        |     2 | +13   / -8    |    +5  |
| Docs         |     2 | +389  / -0    |  +389  |
| Config/build |     1 | +1    / -1    |    +0  |
| **Total**    |    68 | +8129 / -533  | +7596  |

Almost entirely new feature surface — facilities/geoloc/shreds are net-new pages; existing pages are extended, not rewritten.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/shreds-economics-page.tsx` — new Shreds Economics analytics page (+1779)
- `web/src/components/facility-detail-page.tsx` — new facility detail: stat pills, capacity cards, sortable devices table, PeeringDB data, mini-map (+448)
- `web/src/components/facilities-page.tsx` — new facilities list with sortable columns and filters (+368)
- `web/src/components/contributor-detail-page.tsx` — adds links table and devices list to contributor detail (+366/-4)
- `web/src/components/metro-detail-page.tsx` — full rewrite: stat pills, capacity cards, sortable devices/facilities tables, mini-map (+369/-56)
- `api/handlers/facilities.go` — new facilities handler with CTE-based device/user/metro enrichment (+348)
- `api/handlers/metros.go` — metro detail enriched with facility count, unicast/multicast capacity, devices and facilities sub-queries (+283/-36)
- `web/src/components/geoloc-probes-page.tsx` — new geoloc probes list page (+293)

</details>

## Testing Verification
- Facility list and detail pages verified with real data: device counts, user capacity, PeeringDB lookup, mini-map render
- Metro detail capacity cards verified: Used/Available values match device-level sums
- Unicast/multicast capacity propagation tested across device list, metro detail, and facility detail
- Mini-maps confirmed theme-aware (light/dark) on both metro and facility detail pages