### PR TITLE
api: allow downloads in docs CSP sandbox

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -81,7 +81,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 			"img-src 'self' data:",
 			"form-action 'none'",
 			"frame-ancestors 'none'",
-			"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox",
+			"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads",
 			"script-src 'unsafe-eval' " + scalarBundleURL,
 			"style-src 'unsafe-inline'",
 		}, "; ")


### PR DESCRIPTION
## Summary

- The \"Download OpenAPI Document\" button on `/api/v1/docs` did nothing when clicked because the CSP `sandbox` directive was missing `allow-downloads`, causing the browser to silently block the download.
- Added `allow-downloads` to the sandbox token list.

## Testing Verification

- Clicked \"Download OpenAPI Document\" on `/api/v1/docs` and confirmed the browser now downloads the OpenAPI JSON.