### PR TITLE
api: paginate v1 shreds publishers leaders endpoint

### DIFF
--- a/api/handlers/v1_shreds_publishers_test.go
+++ b/api/handlers/v1_shreds_publishers_test.go
@@ -37,6 +37,9 @@ var v1EdgeShredsPublishersContractFields = struct {
 		"total_publishers",
 		"total_publisher_stake",
 		"publishers",
+		"total",
+		"limit",
+		"offset",
 	},
 	publisher: []string{
 		"publisher_ip",
@@ -183,6 +186,71 @@ func TestV1EdgeShredsPublishers_FilterByIP(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Publishers, 1)
 	assert.Equal(t, "10.0.0.1", resp.Publishers[0].PublisherIP)
+}
+
+func TestV1EdgeShredsPublishers_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertPublisherCheckTestData(t, api)
+
+	r := newV1Router(t, api)
+
+	// Default: returns all 3 publishers, total reflects matched set.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsPublishersResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 100, resp.Limit)
+	assert.Equal(t, 0, resp.Offset)
+	require.Len(t, resp.Publishers, 3)
+
+	// limit=1 returns the first publisher only; total still reflects the full match count.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders?limit=1", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 1, resp.Limit)
+	assert.Equal(t, 0, resp.Offset)
+	require.Len(t, resp.Publishers, 1)
+	first := resp.Publishers[0]
+
+	// offset=1&limit=1 returns the second publisher.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders?limit=1&offset=1", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 1, resp.Offset)
+	require.Len(t, resp.Publishers, 1)
+	assert.NotEqual(t, first.DZUserPubkey, resp.Publishers[0].DZUserPubkey)
+
+	// offset past the end returns an empty page with total still set.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/publishers/leaders?offset=100", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Empty(t, resp.Publishers)
+
+	// Invalid bounds are rejected by huma.
+	for _, url := range []string{
+		"/api/v1/edge/shreds/publishers/leaders?limit=0",
+		"/api/v1/edge/shreds/publishers/leaders?limit=9999",
+		"/api/v1/edge/shreds/publishers/leaders?offset=-1",
+	} {
+		req = httptest.NewRequest(http.MethodGet, url, nil)
+		rr = httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
 }
 
 func TestV1EdgeShredsPublishers_EpochsAndSlotsParams(t *testing.T) {

--- a/api/v1/shreds_publishers.go
+++ b/api/v1/shreds_publishers.go
@@ -42,6 +42,9 @@ type EdgeShredsPublishersResponse struct {
 	TotalPublishers     uint64                `json:"total_publishers" doc:"Count of activated DZ publishers with a matched vote account"`
 	TotalPublisherStake int64                 `json:"total_publisher_stake" doc:"Total activated stake across all DZ publishers (lamports)"`
 	Publishers          []EdgeShredsPublisher `json:"publishers"`
+	Total               int                   `json:"total" doc:"Total publishers matching the q filter (ignores limit/offset)"`
+	Limit               int                   `json:"limit"`
+	Offset              int                   `json:"offset"`
 }
 
 // EdgeShredsPublishersInput is the request for the shreds publishers endpoint.
@@ -49,6 +52,8 @@ type EdgeShredsPublishersInput struct {
 	Q      string `query:"q" doc:"Optional filter: DZ user pubkey, publisher IP, or client IP"`
 	Epochs int    `query:"epochs" minimum:"1" maximum:"10" default:"2" doc:"Number of recent epochs to include (ignored if slots > 0)"`
 	Slots  int    `query:"slots" minimum:"0" maximum:"5000" default:"0" doc:"If > 0, restrict the window to this many most-recent slots instead of epochs. Recommended values: 100, 500, 1000, 5000."`
+	Limit  int    `query:"limit" minimum:"1" maximum:"1000" default:"100" doc:"Maximum publishers to return"`
+	Offset int    `query:"offset" minimum:"0" default:"0" doc:"Offset into the result set"`
 }
 
 // EdgeShredsPublishersOutput wraps the response body for huma.
@@ -69,13 +74,24 @@ func registerEdgeShredsPublishers(humaAPI huma.API, api *handlers.API) {
 		if err != nil {
 			return nil, huma.Error500InternalServerError("failed to fetch shreds publishers", err)
 		}
-		return &EdgeShredsPublishersOutput{Body: toEdgeShredsPublishersResponse(resp)}, nil
+		return &EdgeShredsPublishersOutput{Body: toEdgeShredsPublishersResponse(resp, input.Limit, input.Offset)}, nil
 	})
 }
 
-func toEdgeShredsPublishersResponse(r *handlers.PublisherCheckResponse) EdgeShredsPublishersResponse {
-	publishers := make([]EdgeShredsPublisher, len(r.Publishers))
-	for i, p := range r.Publishers {
+func toEdgeShredsPublishersResponse(r *handlers.PublisherCheckResponse, limit, offset int) EdgeShredsPublishersResponse {
+	total := len(r.Publishers)
+	start := offset
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+	pageRows := r.Publishers[start:end]
+
+	publishers := make([]EdgeShredsPublisher, len(pageRows))
+	for i, p := range pageRows {
 		publishers[i] = EdgeShredsPublisher{
 			PublisherIP:             p.PublisherIP,
 			ClientIP:                p.ClientIP,
@@ -106,5 +122,8 @@ func toEdgeShredsPublishersResponse(r *handlers.PublisherCheckResponse) EdgeShre
 		TotalPublishers:     r.TotalPublishers,
 		TotalPublisherStake: r.TotalPublisherStake,
 		Publishers:          publishers,
+		Total:               total,
+		Limit:               limit,
+		Offset:              offset,
 	}
 }


### PR DESCRIPTION
## Summary

- Add `limit` (1-1000, default 100) and `offset` (default 0) query params to `GET /api/v1/edge/shreds/publishers/leaders`, plus `total`/`limit`/`offset` response fields. The endpoint previously returned every DZ validator-publisher in one shot, which is already a large payload and will keep growing with the network.
- Mirrors the shape of the existing `/api/v1/edge/shreds/subscribers` endpoint so SDK consumers see a consistent pagination contract across `Edge/Shreds`.
- Slicing is done in the v1 layer rather than pushed into `FetchPublisherCheckData` so the v0 page-cached `/api/publisher-check` endpoint and the worker that warms its cache continue to get the full list. The DB query is unchanged; only the v1 response payload is bounded.
- The OpenAPI spec at `/api/v1/openapi.json` and Scalar docs at `/api/v1/docs` pick up the new fields automatically via huma reflection — no manual spec update needed.
- The existing `total_publishers` field is unchanged (network-wide DZ publisher count); the new `total` is the post-`q`-filter result count.

## Testing Verification

- New `TestV1EdgeShredsPublishers_Pagination` covers default response, `limit=1`, `offset=1` returning a different row, offset past the end returning an empty page with `total` still set, and huma rejecting out-of-range `limit`/`offset`.
- Updated the contract test (`TestV1EdgeShredsPublishers_Contract`) so the JSON-key allowlist includes the three new top-level fields.