### PR TITLE
api: speed up status page Links tab

### DIFF
--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -1079,15 +1079,32 @@ type CriticalLinksResponse struct {
 // GetCriticalLinks returns links that are critical for network connectivity
 // Critical links are identified based on node degrees and connectivity patterns
 func (a *API) GetCriticalLinks(w http.ResponseWriter, r *http.Request) {
+	if isMainnet(r.Context()) {
+		if data, err := a.readPageCache(r.Context(), "critical_links"); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			_, _ = w.Write(data)
+			return
+		}
+	}
+
+	w.Header().Set("X-Cache", "MISS")
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
+	response := a.FetchCriticalLinksData(ctx)
+	writeJSON(w, response)
+}
+
+// FetchCriticalLinksData runs the Neo4j query that backs GetCriticalLinks. It
+// always returns a non-nil response; query errors are surfaced via response.Error.
+func (a *API) FetchCriticalLinksData(ctx context.Context) *CriticalLinksResponse {
 	start := time.Now()
 
 	session := a.neo4jSession(ctx)
 	defer session.Close(ctx)
 
-	response := CriticalLinksResponse{
+	response := &CriticalLinksResponse{
 		Links: []CriticalLink{},
 	}
 
@@ -1126,16 +1143,14 @@ func (a *API) GetCriticalLinks(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logError("critical links query error", "error", err)
 		response.Error = err.Error()
-		writeJSON(w, response)
-		return
+		return response
 	}
 
 	records, err := result.Collect(ctx)
 	if err != nil {
 		logError("critical links collect error", "error", err)
 		response.Error = err.Error()
-		writeJSON(w, response)
-		return
+		return response
 	}
 
 	for _, record := range records {
@@ -1188,7 +1203,7 @@ func (a *API) GetCriticalLinks(w http.ResponseWriter, r *http.Request) {
 	}
 	slog.Info("critical links query completed", "links", len(response.Links), "critical", criticalCount, "important", importantCount, "duration", duration)
 
-	writeJSON(w, response)
+	return response
 }
 
 // RedundancyIssue represents a single redundancy issue in the network

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -75,6 +75,13 @@ func (a *Activities) entries() []cacheEntry {
 		{"link history", "link_history:24h:72", func(ctx context.Context) (any, error) {
 			return api.FetchLinkHistoryData(ctx, "24h", 72)
 		}},
+		{"critical links", "critical_links", func(ctx context.Context) (any, error) {
+			resp := api.FetchCriticalLinksData(ctx)
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
+		}},
 		{"device history", "device_history:24h:72", func(ctx context.Context) (any, error) {
 			return api.FetchDeviceHistoryData(ctx, "24h", 72)
 		}},


### PR DESCRIPTION
## Summary

- Cache `/api/topology/critical-links` in the page cache. The Links tab blocks rendering on this endpoint, which runs an uncached Neo4j query and adds 1–2s after the rest of the page loads from cache.
- Enable gzip on all API responses via chi's `Compress` middleware. The status page Links tab pulls ~11.5MB of JSON across two endpoints (link-history ~3.7MB, bulk-link-metrics ~7.8MB); compression cuts these ~5–9x.

## Testing Verification

- `curl -o /dev/null -w '%header{x-cache} | %{time_total}s' .../critical-links` returns `HIT | 0.005s` after the page-cache worker populates the entry, down from 1–2s for the cold Neo4j query.
- `curl -H 'Accept-Encoding: gzip' .../link-history?range=24h&buckets=72` returns `Content-Encoding: gzip` and 414KB (was 3.7MB).