### PR TITLE
api: move rate limits into its own docs section

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -61,7 +61,11 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 	var humaAPI huma.API
 	r.Route(BasePath, func(r chi.Router) {
 		config := huma.DefaultConfig("DoubleZero Data API", Version)
-		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program.\n\n## Rate Limits\n\nRequests are rate limited to 100 per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header."
+		config.Info.Description = "Public API for DoubleZero Data — the analytics platform for the DoubleZero network. Exposes data on network telemetry, Solana validators, and the shred subscription program."
+		config.Tags = append(config.Tags, &huma.Tag{
+			Name:        "Rate Limits",
+			Description: "Requests are rate limited to 50 per minute per IP. On `429 Too Many Requests` responses, honor the `Retry-After` header.",
+		})
 		config.OpenAPIPath = "/openapi"
 		config.SchemasPath = "/schemas"
 		// DocsPath is empty so huma doesn't register its built-in docs route —


### PR DESCRIPTION
## Summary

- Move the rate limit guidance out of the `Info.Description` (where Scalar renders it under "Introduction") into a dedicated top-level `Rate Limits` tag so it shows as its own scannable section in the docs sidebar.
- Lower the documented limit to 50/min. Note: the actual limiter in `api/handlers/ratelimit.go` is still 100/min — follow-up work to reconcile.

## Testing Verification

- Verified the rendered `/api/v1/openapi.json` now lists `Rate Limits` under top-level `tags` with the expected description and no `## Rate Limits` heading in `info.description`.