### PR TITLE
web: apply ?env= query param before route redirects

### DIFF
--- a/web/src/contexts/EnvContext.tsx
+++ b/web/src/contexts/EnvContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
 import { getEnv, setEnv as setEnvStorage, type AppConfig } from '@/lib/api'
 
 interface EnvContextType {
@@ -21,7 +21,22 @@ export function useEnv() {
 }
 
 export function EnvProvider({ config, children }: { config: AppConfig; children: ReactNode }) {
-  const [env, setEnvState] = useState(getEnv)
+  // Consume ?env= synchronously on first render so it survives downstream
+  // redirects (e.g. `/` → `/status`) that strip the query string.
+  const [env, setEnvState] = useState(() => {
+    const params = new URLSearchParams(window.location.search)
+    const envParam = params.get('env')
+    if (envParam) {
+      setEnvStorage(envParam)
+      params.delete('env')
+      const newUrl = params.toString()
+        ? `${window.location.pathname}?${params.toString()}`
+        : window.location.pathname
+      window.history.replaceState({}, '', newUrl)
+      return envParam
+    }
+    return getEnv()
+  })
 
   const setEnv = useCallback((newEnv: string) => {
     setEnvStorage(newEnv)
@@ -29,24 +44,6 @@ export function EnvProvider({ config, children }: { config: AppConfig; children:
     // Reload the page to re-fetch all data with new env
     window.location.reload()
   }, [])
-
-  // Handle ?env= query param on mount
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const envParam = params.get('env')
-    if (envParam && envParam !== env) {
-      setEnvStorage(envParam)
-      setEnvState(envParam)
-      // Remove the param from URL
-      params.delete('env')
-      const newUrl = params.toString()
-        ? `${window.location.pathname}?${params.toString()}`
-        : window.location.pathname
-      window.history.replaceState({}, '', newUrl)
-      // Reload to apply
-      window.location.reload()
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <EnvContext.Provider


### PR DESCRIPTION
## Summary

- Visiting `https://data.malbeclabs.com/?env=testnet` wasn't switching to testnet because the `/` → `/status` `<Navigate>` strips the query string before `EnvProvider`'s `useEffect` could read it (child effects run before parent effects on mount).
- Move `?env=` handling into `EnvProvider`'s `useState` initializer so the param is consumed synchronously on first render, before any child render or navigation effect fires.
- Also drops the `window.location.reload()` that the old `useEffect` path needed — initial render already has the right env, and `setEnvStorage` writes to localStorage synchronously for any downstream `getEnv()` reads.

## Testing Verification

- `https://data.malbeclabs.com/?env=testnet` now lands on `/status/...` with testnet selected.
- Deep links like `/status?env=testnet` no longer flash the wrong env before reloading.