### PR TITLE
api, web: display link speed on status page

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -85,16 +85,17 @@ type LinkHealth struct {
 }
 
 type LinkIssue struct {
-	Code        string  `json:"code"`
-	LinkType    string  `json:"link_type"`
-	Contributor string  `json:"contributor"`
-	Issue       string  `json:"issue"`     // "packet_loss", "high_latency", "down"
-	Value       float64 `json:"value"`     // The problematic value
-	Threshold   float64 `json:"threshold"` // The threshold exceeded
-	SideAMetro  string  `json:"side_a_metro"`
-	SideZMetro  string  `json:"side_z_metro"`
-	Since       string  `json:"since"`   // ISO timestamp when issue started
-	IsDown      bool    `json:"is_down"` // 100% loss in last 5 minutes
+	Code         string  `json:"code"`
+	LinkType     string  `json:"link_type"`
+	Contributor  string  `json:"contributor"`
+	Issue        string  `json:"issue"`     // "packet_loss", "high_latency", "down"
+	Value        float64 `json:"value"`     // The problematic value
+	Threshold    float64 `json:"threshold"` // The threshold exceeded
+	SideAMetro   string  `json:"side_a_metro"`
+	SideZMetro   string  `json:"side_z_metro"`
+	Since        string  `json:"since"`   // ISO timestamp when issue started
+	IsDown       bool    `json:"is_down"` // 100% loss in last 5 minutes
+	BandwidthBps int64   `json:"bandwidth_bps"`
 }
 
 type LinkMetric struct {
@@ -185,6 +186,7 @@ type NonActivatedLink struct {
 	Status              string   `json:"status"`
 	Since               string   `json:"since"` // ISO timestamp when entered this status
 	ActiveIncidentTypes []string `json:"active_incident_types,omitempty"`
+	BandwidthBps        int64    `json:"bandwidth_bps"`
 }
 
 type ISISDeviceIssue struct {
@@ -635,27 +637,29 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 			// Track issues (top 10)
 			if lossPct >= LossWarningPct && len(issues) < 10 {
 				issues = append(issues, LinkIssue{
-					Code:        code,
-					LinkType:    linkType,
-					Contributor: contributor,
-					Issue:       "packet_loss",
-					Value:       lossPct,
-					Threshold:   LossWarningPct,
-					SideAMetro:  sideAMetro,
-					SideZMetro:  sideZMetro,
-					IsDown:      isDown,
+					Code:         code,
+					LinkType:     linkType,
+					Contributor:  contributor,
+					Issue:        "packet_loss",
+					Value:        lossPct,
+					Threshold:    LossWarningPct,
+					SideAMetro:   sideAMetro,
+					SideZMetro:   sideZMetro,
+					IsDown:       isDown,
+					BandwidthBps: bandwidthBps,
 				})
 			}
 			if isInterMetroWAN && latencyOveragePct >= LatencyWarningPct && len(issues) < 10 {
 				issues = append(issues, LinkIssue{
-					Code:        code,
-					LinkType:    linkType,
-					Contributor: contributor,
-					Issue:       "high_latency",
-					Value:       latencyOveragePct, // Now shows % over committed
-					Threshold:   LatencyWarningPct,
-					SideAMetro:  sideAMetro,
-					SideZMetro:  sideZMetro,
+					Code:         code,
+					LinkType:     linkType,
+					Contributor:  contributor,
+					Issue:        "high_latency",
+					Value:        latencyOveragePct, // Now shows % over committed
+					Threshold:    LatencyWarningPct,
+					SideAMetro:   sideAMetro,
+					SideZMetro:   sideZMetro,
+					BandwidthBps: bandwidthBps,
 				})
 			}
 
@@ -858,7 +862,8 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 				COALESCE(c.code, '') as contributor,
 				COALESCE(ma.code, '') as side_a_metro,
 				COALESCE(mz.code, '') as side_z_metro,
-				lls.last_seen
+				lls.last_seen,
+				l.bandwidth_bps
 			FROM link_last_seen lls
 			JOIN dz_links_current l ON lls.link_pk = l.pk
 			LEFT JOIN dz_contributors_current c ON l.contributor_pk = c.pk
@@ -879,19 +884,21 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 			for noDataRows.Next() {
 				var code, linkType, contributor, sideAMetro, sideZMetro string
 				var lastSeen time.Time
-				if err := noDataRows.Scan(&code, &linkType, &contributor, &sideAMetro, &sideZMetro, &lastSeen); err == nil {
+				var bwBps int64
+				if err := noDataRows.Scan(&code, &linkType, &contributor, &sideAMetro, &sideZMetro, &lastSeen, &bwBps); err == nil {
 					// The outage started when we last saw data (plus 5 min buffer for expected interval)
 					since := lastSeen.Add(5 * time.Minute)
 					issues = append(issues, LinkIssue{
-						Code:        code,
-						LinkType:    linkType,
-						Contributor: contributor,
-						Issue:       "no_data",
-						Value:       0,
-						Threshold:   0,
-						SideAMetro:  sideAMetro,
-						SideZMetro:  sideZMetro,
-						Since:       since.UTC().Format(time.RFC3339),
+						Code:         code,
+						LinkType:     linkType,
+						Contributor:  contributor,
+						Issue:        "no_data",
+						Value:        0,
+						Threshold:    0,
+						SideAMetro:   sideAMetro,
+						SideZMetro:   sideZMetro,
+						Since:        since.UTC().Format(time.RFC3339),
+						BandwidthBps: bwBps,
 					})
 				}
 			}
@@ -1097,7 +1104,8 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 				ma.code as side_a_metro,
 				mz.code as side_z_metro,
 				CASE WHEN l.committed_rtt_ns = ? THEN 'provisioning' ELSE l.status END as effective_status,
-				formatDateTime(l.snapshot_ts, '%Y-%m-%dT%H:%i:%sZ', 'UTC') as since
+				formatDateTime(l.snapshot_ts, '%Y-%m-%dT%H:%i:%sZ', 'UTC') as since,
+				l.bandwidth_bps
 			FROM dz_links_current l
 			JOIN dz_devices_current da ON l.side_a_pk = da.pk
 			JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
@@ -1117,7 +1125,7 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 		var links []NonActivatedLink
 		for rows.Next() {
 			var link NonActivatedLink
-			if err := rows.Scan(&link.PK, &link.Code, &link.LinkType, &link.SideAMetro, &link.SideZMetro, &link.Status, &link.Since); err != nil {
+			if err := rows.Scan(&link.PK, &link.Code, &link.LinkType, &link.SideAMetro, &link.SideZMetro, &link.Status, &link.Since, &link.BandwidthBps); err != nil {
 				return err
 			}
 			links = append(links, link)
@@ -1220,7 +1228,8 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 				COALESCE(c.code, '') as contributor,
 				COALESCE(ma.code, '') as side_a_metro,
 				COALESCE(mz.code, '') as side_z_metro,
-				l.pk as link_pk
+				l.pk as link_pk,
+				l.bandwidth_bps
 			FROM dz_links_current l
 			LEFT JOIN dz_contributors_current c ON l.contributor_pk = c.pk
 			LEFT JOIN dz_devices_current da ON l.side_a_pk = da.pk
@@ -1253,11 +1262,12 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 
 		type missingAdj struct {
 			code, linkType, contributor, sideAMetro, sideZMetro, linkPK string
+			bandwidthBps                                                int64
 		}
 		var missing []missingAdj
 		for rows.Next() {
 			var m missingAdj
-			if err := rows.Scan(&m.code, &m.linkType, &m.contributor, &m.sideAMetro, &m.sideZMetro, &m.linkPK); err != nil {
+			if err := rows.Scan(&m.code, &m.linkType, &m.contributor, &m.sideAMetro, &m.sideZMetro, &m.linkPK, &m.bandwidthBps); err != nil {
 				return err
 			}
 			missing = append(missing, m)
@@ -1297,14 +1307,15 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 
 		for _, m := range missing {
 			missingAdjIssues = append(missingAdjIssues, LinkIssue{
-				Code:        m.code,
-				LinkType:    m.linkType,
-				Contributor: m.contributor,
-				Issue:       "missing_adjacency",
-				SideAMetro:  m.sideAMetro,
-				SideZMetro:  m.sideZMetro,
-				Since:       lastSeen[m.linkPK],
-				IsDown:      true,
+				Code:         m.code,
+				LinkType:     m.linkType,
+				Contributor:  m.contributor,
+				Issue:        "missing_adjacency",
+				SideAMetro:   m.sideAMetro,
+				SideZMetro:   m.sideZMetro,
+				Since:        lastSeen[m.linkPK],
+				IsDown:       true,
+				BandwidthBps: m.bandwidthBps,
 			})
 		}
 		return nil

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -87,6 +87,13 @@ function formatBandwidth(bps: number): string {
   return `${bps} bps`
 }
 
+function formatBandwidthShort(bps: number): string {
+  if (bps >= 1_000_000_000) return `${(bps / 1_000_000_000).toFixed(0)}G`
+  if (bps >= 1_000_000) return `${(bps / 1_000_000).toFixed(0)}M`
+  if (bps >= 1_000) return `${(bps / 1_000).toFixed(0)}K`
+  return `${bps}`
+}
+
 interface DerivedLinkInfo {
   pk: string
   code: string
@@ -477,6 +484,7 @@ function LinkRow({
                 {derivedInfo.linkType}
                 {derivedInfo.contributor && ` · ${derivedInfo.contributor}`} ·{' '}
                 {derivedInfo.sideAMetro} ↔ {derivedInfo.sideZMetro}
+                {derivedInfo.bandwidthBps > 0 && ` · ${formatBandwidthShort(derivedInfo.bandwidthBps)}`}
               </div>
               {(derivedInfo.isDown ||
                 derivedInfo.drainStatus ||

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -88,10 +88,7 @@ function formatBandwidth(bps: number): string {
 }
 
 function formatBandwidthShort(bps: number): string {
-  if (bps >= 1_000_000_000) return `${(bps / 1_000_000_000).toFixed(0)}G`
-  if (bps >= 1_000_000) return `${(bps / 1_000_000).toFixed(0)}M`
-  if (bps >= 1_000) return `${(bps / 1_000).toFixed(0)}K`
-  return `${bps}`
+  return `${(bps / 1e9).toFixed(0)}G`
 }
 
 interface DerivedLinkInfo {

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -506,6 +506,7 @@ function IssueDetails({
                         {first.side_a_metro} → {first.side_z_metro} ·{" "}
                         {first.link_type}
                         {first.contributor && ` · ${first.contributor}`}
+                        {first.bandwidth_bps > 0 && ` · ${formatBandwidthShort(first.bandwidth_bps)}`}
                         {mostRecentSince && (
                           <span
                             className="text-muted-foreground font-normal"
@@ -526,6 +527,7 @@ function IssueDetails({
                           {first.side_a_metro} → {first.side_z_metro} ·{" "}
                           {first.link_type}
                           {first.contributor && ` · ${first.contributor}`}
+                          {first.bandwidth_bps > 0 && ` · ${formatBandwidthShort(first.bandwidth_bps)}`}
                         </div>
                       </div>
                     </div>
@@ -713,6 +715,7 @@ function IssueDetails({
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {link.side_a_metro} → {link.side_z_metro} · {link.link_type}
+                    {link.bandwidth_bps > 0 && ` · ${formatBandwidthShort(link.bandwidth_bps)}`}
                     <span className="hidden xs:inline"> · </span>
                     <span className="block xs:inline">
                       <span className="capitalize text-slate-600 dark:text-slate-400 font-bold">
@@ -735,6 +738,7 @@ function IssueDetails({
                     <div className="text-xs text-muted-foreground">
                       {link.side_a_metro} → {link.side_z_metro} ·{" "}
                       {link.link_type}
+                      {link.bandwidth_bps > 0 && ` · ${formatBandwidthShort(link.bandwidth_bps)}`}
                     </div>
                     {link.status !== "provisioning" && (
                       <div className="flex flex-wrap gap-1 mt-1">
@@ -1646,6 +1650,13 @@ function formatBandwidth(bps: number): string {
     return `${(bps / 1e3).toFixed(1)} Kbps`;
   }
   return `${bps.toFixed(0)} bps`;
+}
+
+function formatBandwidthShort(bps: number): string {
+  if (bps >= 1e9) return `${(bps / 1e9).toFixed(0)}G`;
+  if (bps >= 1e6) return `${(bps / 1e6).toFixed(0)}M`;
+  if (bps >= 1e3) return `${(bps / 1e3).toFixed(0)}K`;
+  return `${bps}`;
 }
 
 function TopLinkUtilization({

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -1653,10 +1653,7 @@ function formatBandwidth(bps: number): string {
 }
 
 function formatBandwidthShort(bps: number): string {
-  if (bps >= 1e9) return `${(bps / 1e9).toFixed(0)}G`;
-  if (bps >= 1e6) return `${(bps / 1e6).toFixed(0)}M`;
-  if (bps >= 1e3) return `${(bps / 1e3).toFixed(0)}K`;
-  return `${bps}`;
+  return `${(bps / 1e9).toFixed(0)}G`;
 }
 
 function TopLinkUtilization({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1212,6 +1212,7 @@ export interface LinkIssue {
   side_z_metro: string
   since: string
   is_down: boolean
+  bandwidth_bps: number
 }
 
 export interface LinkMetric {
@@ -1300,6 +1301,7 @@ export interface NonActivatedLink {
   status: string
   since: string
   active_incident_types?: string[]
+  bandwidth_bps: number
 }
 
 export interface ISISDeviceIssue {


### PR DESCRIPTION
## Summary of Changes
* Add `bandwidth_bps` field to `LinkIssue` and `NonActivatedLink` API responses by including `l.bandwidth_bps` in the no_data, missing_adjacency, and drained/provisioning ClickHouse queries
* Display link speed as a compact suffix (e.g. `100G`) on link labels in the expandable issue box and Link Status History timeline on the status page
* Gracefully skip the speed suffix when `bandwidth_bps` is 0 (e.g. newly provisioned links)
* Fixes #523

## Testing Verification
* Go API builds and lints cleanly (`go build ./api/...`, `golangci-lint run ./api/...` — 0 issues)
* TypeScript type check passes for all changed files (no new errors in `status-page.tsx`, `link-status-timelines.tsx`, or `api.ts`)
* Bandwidth suffix only renders when `bandwidth_bps > 0`, so links without bandwidth data display unchanged
* Label format verified across all 5 render locations: mobile + desktop for LinkIssue items, mobile + desktop for NonActivatedLink items, and LinkRow in Link Status History