### PR TITLE
web/api: split metro detail stats into separate endpoint

### DIFF
--- a/api/handlers/metros.go
+++ b/api/handlers/metros.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/api/metrics"
+	"golang.org/x/sync/errgroup"
 )
 
 type MetroListItem struct {
@@ -331,10 +332,13 @@ type MetroDetail struct {
 	RawMaxUnicastUsers         uint64  `json:"raw_max_unicast_users"`
 	RawMaxMulticastSubscribers uint64  `json:"raw_max_multicast_subscribers"`
 	RawMaxMulticastPublishers  uint64  `json:"raw_max_multicast_publishers"`
-	ValidatorCount             uint64  `json:"validator_count"`
-	StakeSol                   float64 `json:"stake_sol"`
-	InBps                      float64 `json:"in_bps"`
-	OutBps                     float64 `json:"out_bps"`
+}
+
+type MetroStats struct {
+	ValidatorCount uint64  `json:"validator_count"`
+	StakeSol       float64 `json:"stake_sol"`
+	InBps          float64 `json:"in_bps"`
+	OutBps         float64 `json:"out_bps"`
 }
 
 func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
@@ -406,32 +410,6 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 			FROM dz_devices_current
 			WHERE metro_pk = ? AND location_pk != ''
 			GROUP BY metro_pk
-		),
-		validator_stats AS (
-			SELECT
-				d.metro_pk,
-				count(DISTINCT v.vote_pubkey) as validator_count,
-				sum(v.activated_stake_lamports) / 1e9 as stake_sol
-			FROM dz_users_current u
-			JOIN dz_devices_current d ON u.device_pk = d.pk
-			JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip
-			JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey
-			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true'
-				AND d.metro_pk = ?
-			GROUP BY d.metro_pk
-		),
-		traffic_rates AS (
-			SELECT
-				d.metro_pk,
-				SUM(f.avg_in_bps) as in_bps,
-				SUM(f.avg_out_bps) as out_bps
-			FROM device_interface_rollup_5m f
-			JOIN dz_devices_current d ON f.device_pk = d.pk
-			WHERE f.bucket_ts >= now() - INTERVAL 15 MINUTE
-				AND f.user_tunnel_id IS NULL
-				AND f.link_pk = ''
-				AND d.metro_pk = ?
-			GROUP BY d.metro_pk
 		)
 		SELECT
 			m.pk,
@@ -452,24 +430,18 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 			COALESCE(ouc.max_multicast_publishers, 0) as max_multicast_publishers,
 			COALESCE(ouc.raw_max_unicast_users, 0) as raw_max_unicast_users,
 			COALESCE(ouc.raw_max_multicast_subscribers, 0) as raw_max_multicast_subscribers,
-			COALESCE(ouc.raw_max_multicast_publishers, 0) as raw_max_multicast_publishers,
-			COALESCE(vs.validator_count, 0) as validator_count,
-			COALESCE(vs.stake_sol, 0) as stake_sol,
-			COALESCE(tr.in_bps, 0) as in_bps,
-			COALESCE(tr.out_bps, 0) as out_bps
+			COALESCE(ouc.raw_max_multicast_publishers, 0) as raw_max_multicast_publishers
 		FROM dz_metros_current m
 		LEFT JOIN device_counts dc ON m.pk = dc.metro_pk
 		LEFT JOIN user_counts uc ON m.pk = uc.metro_pk
 		LEFT JOIN onchain_user_counts ouc ON m.pk = ouc.metro_pk
 		LEFT JOIN country_info ci ON m.pk = ci.metro_pk
 		LEFT JOIN facility_counts lc ON m.pk = lc.metro_pk
-		LEFT JOIN validator_stats vs ON m.pk = vs.metro_pk
-		LEFT JOIN traffic_rates tr ON m.pk = tr.metro_pk
 		WHERE m.pk = ?
 	`
 
 	var metro MetroDetail
-	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk, pk, pk).Scan(
+	err := a.envDB(ctx).QueryRow(ctx, query, pk, pk, pk, pk, pk).Scan(
 		&metro.PK,
 		&metro.Code,
 		&metro.Name,
@@ -489,10 +461,6 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 		&metro.RawMaxUnicastUsers,
 		&metro.RawMaxMulticastSubscribers,
 		&metro.RawMaxMulticastPublishers,
-		&metro.ValidatorCount,
-		&metro.StakeSol,
-		&metro.InBps,
-		&metro.OutBps,
 	)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
@@ -509,6 +477,74 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(metro); err != nil {
+		logError("failed to encode response", "error", err)
+	}
+}
+
+func (a *API) GetMetroStats(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	pk := chi.URLParam(r, "pk")
+	if pk == "" {
+		http.Error(w, "missing metro pk", http.StatusBadRequest)
+		return
+	}
+
+	start := time.Now()
+	db := a.envDB(ctx)
+
+	var stats MetroStats
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		const query = `
+			SELECT
+				count(DISTINCT v.vote_pubkey) as validator_count,
+				COALESCE(sum(v.activated_stake_lamports) / 1e9, 0) as stake_sol
+			FROM dz_users_current u
+			JOIN dz_devices_current d ON u.device_pk = d.pk
+			JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip
+			JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey
+			WHERE u.status = 'activated' AND u.client_ip != '' AND v.epoch_vote_account = 'true'
+				AND d.metro_pk = ?
+		`
+		err := db.QueryRow(gctx, query, pk).Scan(&stats.ValidatorCount, &stats.StakeSol)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		const query = `
+			SELECT
+				COALESCE(SUM(f.avg_in_bps), 0) as in_bps,
+				COALESCE(SUM(f.avg_out_bps), 0) as out_bps
+			FROM device_interface_rollup_5m f
+			JOIN dz_devices_current d ON f.device_pk = d.pk
+			WHERE f.bucket_ts >= now() - INTERVAL 15 MINUTE
+				AND f.user_tunnel_id IS NULL
+				AND f.link_pk = ''
+				AND d.metro_pk = ?
+		`
+		err := db.QueryRow(gctx, query, pk).Scan(&stats.InBps, &stats.OutBps)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+
+	err := g.Wait()
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+	if err != nil {
+		logError("metro stats query failed", "error", err, "pk", pk)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stats); err != nil {
 		logError("failed to encode response", "error", err)
 	}
 }

--- a/api/main.go
+++ b/api/main.go
@@ -545,6 +545,7 @@ func main() {
 		r.Get("/api/dz/links-health", api.GetLinkHealth)
 		r.Get("/api/dz/metros", api.GetMetros)
 		r.Get("/api/dz/metros/{pk}", api.GetMetro)
+		r.Get("/api/dz/metros/{pk}/stats", api.GetMetroStats)
 		r.Get("/api/dz/facilities", api.GetFacilities)
 		r.Get("/api/dz/facilities/{pk}", api.GetFacility)
 		r.Get("/api/peeringdb/fac/{loc_id}", api.GetPeeringDBFacility)

--- a/web/src/components/metro-detail-page.tsx
+++ b/web/src/components/metro-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2, MapPin, AlertCircle, ArrowLeft, ChevronUp, ChevronDown } from 'lucide-react'
-import { fetchMetro, fetchDevicesByMetro, fetchFacilitiesByMetro } from '@/lib/api'
+import { fetchMetro, fetchMetroStats, fetchDevicesByMetro, fetchFacilitiesByMetro } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
 import { handleRowClick } from '@/lib/utils'
@@ -52,6 +52,12 @@ export function MetroDetailPage() {
   const { data: metro, isLoading, error } = useQuery({
     queryKey: ['metro', pk],
     queryFn: () => fetchMetro(pk!),
+    enabled: !!pk,
+  })
+
+  const { data: stats } = useQuery({
+    queryKey: ['metro-stats', pk],
+    queryFn: () => fetchMetroStats(pk!),
     enabled: !!pk,
   })
 
@@ -220,7 +226,7 @@ export function MetroDetailPage() {
             <div className="text-xs text-muted-foreground">Users</div>
           </div>
           <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
-            <div className="text-sm font-medium">{metro.validator_count}</div>
+            <div className="text-sm font-medium">{stats ? stats.validator_count : '—'}</div>
             <div className="text-xs text-muted-foreground">Validators</div>
           </div>
           {/* Map — spans both rows */}
@@ -233,15 +239,15 @@ export function MetroDetailPage() {
           </div>
           {/* Row 2 */}
           <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
-            <div className="text-sm font-medium">{formatBps(metro.in_bps)}</div>
+            <div className="text-sm font-medium">{stats ? formatBps(stats.in_bps) : '—'}</div>
             <div className="text-xs text-muted-foreground">Inbound</div>
           </div>
           <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center">
-            <div className="text-sm font-medium">{formatBps(metro.out_bps)}</div>
+            <div className="text-sm font-medium">{stats ? formatBps(stats.out_bps) : '—'}</div>
             <div className="text-xs text-muted-foreground">Outbound</div>
           </div>
           <div className="bg-muted/30 rounded-lg px-2 py-2.5 text-center" style={{ gridColumn: 'span 2' }}>
-            <div className="text-sm font-medium">{formatStake(metro.stake_sol)}</div>
+            <div className="text-sm font-medium">{stats ? formatStake(stats.stake_sol) : '—'}</div>
             <div className="text-xs text-muted-foreground">Total Stake</div>
           </div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3033,17 +3033,27 @@ export async function fetchMetros(
   return res.json()
 }
 
-export interface MetroDetail extends Metro {
+export interface MetroDetail extends Metro {}
+
+export async function fetchMetro(pk: string): Promise<MetroDetail> {
+  const res = await fetchWithRetry(`/api/dz/metros/${encodeURIComponent(pk)}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch metro')
+  }
+  return res.json()
+}
+
+export interface MetroStats {
   validator_count: number
   stake_sol: number
   in_bps: number
   out_bps: number
 }
 
-export async function fetchMetro(pk: string): Promise<MetroDetail> {
-  const res = await fetchWithRetry(`/api/dz/metros/${encodeURIComponent(pk)}`)
+export async function fetchMetroStats(pk: string): Promise<MetroStats> {
+  const res = await fetchWithRetry(`/api/dz/metros/${encodeURIComponent(pk)}/stats`)
   if (!res.ok) {
-    throw new Error('Failed to fetch metro')
+    throw new Error('Failed to fetch metro stats')
   }
   return res.json()
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3033,7 +3033,7 @@ export async function fetchMetros(
   return res.json()
 }
 
-export interface MetroDetail extends Metro {}
+export type MetroDetail = Metro
 
 export async function fetchMetro(pk: string): Promise<MetroDetail> {
   const res = await fetchWithRetry(`/api/dz/metros/${encodeURIComponent(pk)}`)


### PR DESCRIPTION
## Summary of Changes
- Split the slow `GET /api/dz/metros/{pk}` endpoint: the handler now returns only cheap metadata, and a new `GET /api/dz/metros/{pk}/stats` endpoint returns `validator_count` / `stake_sol` / `in_bps` / `out_bps`.
- The new stats handler runs the validator-join query and the traffic-rollup query concurrently via `errgroup`, so the two independent queries don't stack.
- Metro detail page fires a third parallel `useQuery` for stats; the 4 stat tiles (Validators, Inbound, Outbound, Total Stake) render an em-dash until stats resolve, so the page paints as soon as the fast metadata lands instead of blocking on the ~1.2s combined query.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +89 / -47   |  +42 |
| Scaffolding  |     2 | +15 / -4    |  +11 |
| **Total**    |     4 | +104 / -51  |  +53 |

Handler split and UI wiring dominate; the rest is route + API-client glue.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/metros.go` — drop `validator_stats` + `traffic_rates` CTEs from `GetMetro`; add `GetMetroStats` handler running both queries concurrently with `errgroup`; introduce `MetroStats` type.
- `web/src/lib/api.ts` — remove stats fields from `MetroDetail`; add `MetroStats` type and `fetchMetroStats` fetcher.
- `web/src/components/metro-detail-page.tsx` — add `useQuery` for stats; stat tiles render `—` while loading.
- `api/main.go` — register `GET /api/dz/metros/{pk}/stats`.

</details>

## Testing Verification
- `go test ./api/handlers/ -run 'TestGetMetro' -count=1 -v` — all 9 metro tests pass.
- Timed the previous endpoint locally against `localhost:8080`: `GET /api/dz/metros/{pk}` was ~1.0–1.4s across 3 runs (local ClickHouse; prod expected to be worse). After the split, the remaining metadata query is dominated by the simple `device_counts` / `facility_counts` / `country_info` CTEs and should land well under the sibling devices/facilities requests.