### PR TITLE
api: fix nested If combinator in multi-link latency raw query

### DIFF
--- a/api/handlers/link_latency.go
+++ b/api/handlers/link_latency.go
@@ -523,10 +523,10 @@ func (a *API) GetMultiLinkLatencyHistory(w http.ResponseWriter, r *http.Request)
 					formatDateTime(toStartOfInterval(f.event_ts, INTERVAL %s), '%%Y-%%m-%%dT%%H:%%i:%%SZ') AS time_bucket,
 					f.link_pk,
 					l.code AS link_code,
-					%sIf(f.rtt_us, f.origin_device_pk = l.side_a_pk) / 1000.0 AS rtt_a_to_z_ms,
-					%sIf(f.rtt_us, f.origin_device_pk != l.side_a_pk) / 1000.0 AS rtt_z_to_a_ms,
-					%sIf(abs(f.ipdv_us), f.origin_device_pk = l.side_a_pk) / 1000.0 AS jitter_a_to_z_ms,
-					%sIf(abs(f.ipdv_us), f.origin_device_pk != l.side_a_pk) / 1000.0 AS jitter_z_to_a_ms,
+					%s(f.rtt_us, f.origin_device_pk = l.side_a_pk) / 1000.0 AS rtt_a_to_z_ms,
+					%s(f.rtt_us, f.origin_device_pk != l.side_a_pk) / 1000.0 AS rtt_z_to_a_ms,
+					%s(abs(f.ipdv_us), f.origin_device_pk = l.side_a_pk) / 1000.0 AS jitter_a_to_z_ms,
+					%s(abs(f.ipdv_us), f.origin_device_pk != l.side_a_pk) / 1000.0 AS jitter_z_to_a_ms,
 					countIf(f.loss = true OR f.rtt_us = 0) * 100.0 / greatest(count(*), 1) AS loss_pct
 				FROM fact_dz_device_link_latency f
 				JOIN dz_links_current l ON f.link_pk = l.pk


### PR DESCRIPTION
## Summary of Changes
- Fixed multi-link latency history endpoint failing with ClickHouse error 184 (`Nested identical combinator 'If' is not supported`) in per-link mode on raw fact table queries
- The query template appended `If` to a function name that already ended in `If` (e.g. `avgIf` → `avgIfIf(...)`, `quantileIf(0.95)` → `quantileIf(0.95)If(...)`), producing invalid SQL
- Removed the duplicate `If` from the template so `rawAggIfFunc` stands alone as the full aggregate-with-combinator call

## Testing Verification
- Reproduced against `https://data.malbeclabs.com/performance/link-latency` with a 35-minute window and multi-PK selection (the path that routes to the raw fact table in per-link mode) — before the fix the API logged `code: 184, message: Nested identical combinator 'If' is not supported`; after the fix the substituted SQL is valid ClickHouse (`avgIf(X, cond)`, `quantileIf(0.95)(X, cond)`)
- Ran `go test ./api/handlers/ -run Latency` — passes