### PR TITLE
web/api: label shreds economics in USDC and show 2Z equivalents

### DIFF
--- a/api/handlers/swap_rate.go
+++ b/api/handlers/swap_rate.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	swapRateCacheTTL      = 60 * time.Second
+	defaultTwoZOracleURL  = "https://sol-2z-oracle-api-v1.mainnet-beta.doublezero.xyz"
+	twoZOracleURLEnvVar   = "TWOZ_ORACLE_URL"
+	twoZOracleSwapRateKey = "/swap-rate"
+	swapRateMaxAttempts   = 3
+)
+
+var swapRateRetryBackoffs = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+
+type swapRateResponse struct {
+	SOLPriceUSD  float64 `json:"sol_price_usd"`
+	TwoZPriceUSD float64 `json:"twoz_price_usd"`
+	SwapRate     float64 `json:"swap_rate"`
+	FetchedAt    int64   `json:"fetched_at"`
+}
+
+type swapRateCacheEntry struct {
+	resp      swapRateResponse
+	fetchedAt time.Time
+}
+
+var (
+	swapRateHTTPClient = &http.Client{Timeout: 10 * time.Second}
+	swapRateMu         sync.Mutex
+	swapRateCache      *swapRateCacheEntry
+)
+
+func twoZOracleURL() string {
+	if u := os.Getenv(twoZOracleURLEnvVar); u != "" {
+		return u
+	}
+	return defaultTwoZOracleURL
+}
+
+func (a *API) GetSwapRate(w http.ResponseWriter, r *http.Request) {
+	swapRateMu.Lock()
+	entry := swapRateCache
+	swapRateMu.Unlock()
+
+	if entry != nil && time.Since(entry.fetchedAt) < swapRateCacheTTL {
+		writeSwapRateJSON(w, entry.resp, true)
+		return
+	}
+
+	out, err := fetchSwapRateWithRetry(r.Context())
+	if err != nil {
+		if entry != nil {
+			logError("swap rate: oracle fetch failed, serving stale cache", "error", err)
+			writeSwapRateJSON(w, entry.resp, true)
+			return
+		}
+		logError("swap rate: oracle fetch failed with no cached fallback", "error", err)
+		http.Error(w, "failed to fetch from oracle", http.StatusBadGateway)
+		return
+	}
+
+	swapRateMu.Lock()
+	swapRateCache = &swapRateCacheEntry{resp: out, fetchedAt: time.Now()}
+	swapRateMu.Unlock()
+
+	writeSwapRateJSON(w, out, false)
+}
+
+func fetchSwapRateWithRetry(ctx context.Context) (swapRateResponse, error) {
+	var lastErr error
+	for attempt := range swapRateMaxAttempts {
+		if attempt > 0 {
+			backoff := swapRateRetryBackoffs[attempt-1]
+			select {
+			case <-ctx.Done():
+				return swapRateResponse{}, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		out, retry, err := fetchSwapRateOnce(ctx)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		if !retry {
+			return swapRateResponse{}, err
+		}
+	}
+	return swapRateResponse{}, lastErr
+}
+
+func fetchSwapRateOnce(ctx context.Context) (swapRateResponse, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, twoZOracleURL()+twoZOracleSwapRateKey, nil)
+	if err != nil {
+		return swapRateResponse{}, false, fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := swapRateHTTPClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return swapRateResponse{}, false, err
+		}
+		return swapRateResponse{}, true, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		return swapRateResponse{}, true, fmt.Errorf("oracle status %d", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return swapRateResponse{}, false, fmt.Errorf("oracle status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return swapRateResponse{}, true, fmt.Errorf("read body: %w", err)
+	}
+
+	var raw struct {
+		SwapRate     float64 `json:"swapRate"`
+		SOLPriceUSD  string  `json:"solPriceUsd"`
+		TwoZPriceUSD string  `json:"twozPriceUsd"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return swapRateResponse{}, false, fmt.Errorf("parse body: %w", err)
+	}
+
+	solUSD, _ := strconv.ParseFloat(raw.SOLPriceUSD, 64)
+	twozUSD, _ := strconv.ParseFloat(raw.TwoZPriceUSD, 64)
+	return swapRateResponse{
+		SOLPriceUSD:  solUSD,
+		TwoZPriceUSD: twozUSD,
+		SwapRate:     raw.SwapRate,
+		FetchedAt:    time.Now().Unix(),
+	}, false, nil
+}
+
+func writeSwapRateJSON(w http.ResponseWriter, p swapRateResponse, cached bool) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=60")
+	if cached {
+		w.Header().Set("X-Cache", "HIT")
+	} else {
+		w.Header().Set("X-Cache", "MISS")
+	}
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		logError("failed to encode swap rate response", "error", err)
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -573,6 +573,7 @@ func main() {
 		r.Get("/api/dz/shreds/devices", api.GetShredDevices)
 		r.Get("/api/dz/shreds/epoch-revenue", api.GetShredEpochRevenue)
 		r.Get("/api/dz/shreds/subscriber-history", api.GetShredSubscriberHistory)
+		r.Get("/api/dz/swap-rate", api.GetSwapRate)
 		r.Get("/api/dz/field-values", api.GetFieldValues)
 		r.Get("/api/dz/ledger", api.GetDZLedger)
 

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -101,10 +101,10 @@ function useRefreshButton(
 
 function formatUSDC(n: number, compact = false): string {
   if (compact) {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M USDC`;
-    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K USDC`;
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
   }
-  return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`;
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 function format2Z(n: number, compact = false): string {
@@ -141,18 +141,27 @@ function Skeleton({ className = "w-20" }: { className?: string }) {
 function SectionTitle({
   children,
   className = "mb-4",
+  hint,
 }: {
   children: React.ReactNode;
   className?: string;
+  hint?: React.ReactNode;
 }) {
   return (
     <div
       className={`text-xs font-medium text-muted-foreground/70 uppercase tracking-widest ${className}`}
     >
       {children}
+      {hint && (
+        <span className="ml-2 normal-case tracking-normal text-muted-foreground/50 font-normal">
+          {hint}
+        </span>
+      )}
     </div>
   );
 }
+
+const USDC_HINT = "($ = USDC)";
 
 function TwoZHint({
   usdc,
@@ -589,7 +598,7 @@ export function ShredsEconomicsPage() {
         <div className="space-y-8">
           {/* Revenue Overview */}
           <section>
-            <SectionTitle>Revenue Overview</SectionTitle>
+            <SectionTitle hint={USDC_HINT}>Revenue Overview</SectionTitle>
             <StatGroup
               stats={[
                 {
@@ -649,7 +658,7 @@ export function ShredsEconomicsPage() {
 
           {/* Next Epoch Forecast */}
           <section>
-            <SectionTitle>Next Epoch Forecast</SectionTitle>
+            <SectionTitle hint={USDC_HINT}>Next Epoch Forecast</SectionTitle>
             <StatGroup
               stats={[
                 {
@@ -762,7 +771,7 @@ export function ShredsEconomicsPage() {
                       };
               return (
                 <section>
-                  <SectionTitle>Retention Signal</SectionTitle>
+                  <SectionTitle hint={USDC_HINT}>Retention Signal</SectionTitle>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     {/* Seats Funded */}
                     <div className="relative rounded-lg bg-card border border-border overflow-hidden p-5">
@@ -880,8 +889,8 @@ export function ShredsEconomicsPage() {
             {/* Revenue per Epoch */}
             <section>
               <div className="flex items-center justify-between mb-4">
-                <SectionTitle className="">
-                  Revenue per Epoch — USDC
+                <SectionTitle className="" hint={USDC_HINT}>
+                  Revenue per Epoch
                 </SectionTitle>
                 <div>
                   <SmallDropdown
@@ -923,7 +932,7 @@ export function ShredsEconomicsPage() {
                         <div className="flex items-center gap-4 px-2 mb-3">
                           <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                             <span className="inline-block h-2 w-2 rounded-sm bg-blue-400/80" />
-                            USDC collected
+                            $ collected
                           </span>
                         </div>
                         <ResponsiveContainer width="100%" height={192}>
@@ -976,7 +985,7 @@ export function ShredsEconomicsPage() {
                                 fontSize: 11,
                                 fill: "var(--muted-foreground)",
                               }}
-                              tickFormatter={(v: number) => `${v}`}
+                              tickFormatter={(v: number) => `$${v}`}
                               width={52}
                             />
                             <Tooltip
@@ -1019,7 +1028,7 @@ export function ShredsEconomicsPage() {
                           </AreaChart>
                         </ResponsiveContainer>
                         <p className="text-xs text-muted-foreground px-2 pt-2">
-                          Historical USDC collected per epoch.
+                          Historical revenue collected per epoch.
                         </p>
                       </>
                     );
@@ -1200,8 +1209,8 @@ export function ShredsEconomicsPage() {
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
             {/* Predicted Revenue */}
             <section>
-              <SectionTitle>
-                Predicted Revenue (USDC) — Next{" "}
+              <SectionTitle hint={USDC_HINT}>
+                Predicted Revenue — Next{" "}
                 {econ ? econ.revenueProjection.length : 0} Epochs
               </SectionTitle>
               <div className="border border-border rounded-lg bg-card px-2 pt-5 pb-2">
@@ -1476,10 +1485,10 @@ export function ShredsEconomicsPage() {
                         Metro
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Price / Epoch
+                        Price / Epoch (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Monthly Equiv
+                        Monthly Equiv (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         Devices
@@ -1576,10 +1585,10 @@ export function ShredsEconomicsPage() {
                         USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        MRR
+                        MRR (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Escrow
+                        Escrow (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         % Rev
@@ -1662,19 +1671,19 @@ export function ShredsEconomicsPage() {
                     <thead>
                       <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
                         <th className="px-4 py-3 text-left font-medium uppercase tracking-wider">
-                          Price / Epoch
+                          Price / Epoch (USDC)
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                           Seats
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Epoch Rev
+                          Epoch Rev (USDC)
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Monthly
+                          Monthly (USDC)
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Annual
+                          Annual (USDC)
                         </th>
                       </tr>
                     </thead>
@@ -1786,10 +1795,10 @@ export function ShredsEconomicsPage() {
                         USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        MRR
+                        MRR (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Escrow
+                        Escrow (USDC)
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         Min Runway

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -25,6 +25,7 @@ import {
   fetchShredsOverview,
   fetchShredEpochRevenue,
   fetchShredSubscriberHistory,
+  fetchSwapRate,
   type ShredClientSeat,
 } from "@/lib/api";
 import { PageHeader } from "./page-header";
@@ -106,6 +107,19 @@ function formatUSDC(n: number, compact = false): string {
   return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`;
 }
 
+function format2Z(n: number, compact = false): string {
+  if (compact) {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M 2Z`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K 2Z`;
+  }
+  return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} 2Z`;
+}
+
+function usdcTo2Z(usdc: number, twoZPriceUSD: number | undefined): number | null {
+  if (!twoZPriceUSD || twoZPriceUSD <= 0) return null;
+  return usdc / twoZPriceUSD;
+}
+
 function truncatePK(pk: string, head = 6, tail = 4): string {
   if (pk.length <= head + tail + 3) return pk;
   return `${pk.slice(0, head)}...${pk.slice(-tail)}`;
@@ -136,6 +150,24 @@ function SectionTitle({
       className={`text-xs font-medium text-muted-foreground/70 uppercase tracking-widest ${className}`}
     >
       {children}
+    </div>
+  );
+}
+
+function TwoZHint({
+  usdc,
+  twoZPriceUSD,
+  compact = false,
+}: {
+  usdc: number;
+  twoZPriceUSD: number | undefined;
+  compact?: boolean;
+}) {
+  const twoZ = usdcTo2Z(usdc, twoZPriceUSD);
+  if (twoZ == null) return null;
+  return (
+    <div className="text-xs font-normal text-muted-foreground/50 tabular-nums mt-0.5">
+      ≈ {format2Z(twoZ, compact)}
     </div>
   );
 }
@@ -479,6 +511,14 @@ export function ShredsEconomicsPage() {
     refetchInterval: 60_000,
   });
 
+  const { data: swapRate } = useQuery({
+    queryKey: ["swap-rate"],
+    queryFn: fetchSwapRate,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+  const twoZPriceUSD = swapRate?.twoz_price_usd;
+
   const [subscriberRange, setSubscriberRange] = useState<1 | 5 | 10 | "all">(
     "all",
   );
@@ -554,25 +594,53 @@ export function ShredsEconomicsPage() {
               stats={[
                 {
                   label: "Epoch Revenue",
-                  value: econ ? formatUSDC(econ.epochRevenue) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.epochRevenue)}
+                      <TwoZHint usdc={econ.epochRevenue} twoZPriceUSD={twoZPriceUSD} />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: "current epoch",
                   accent: "blue",
                 },
                 {
                   label: "MRR",
-                  value: econ ? formatUSDC(econ.mrr) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.mrr)}
+                      <TwoZHint usdc={econ.mrr} twoZPriceUSD={twoZPriceUSD} />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: `${EPOCHS_PER_MONTH} epochs/mo`,
                   accent: "green",
                 },
                 {
                   label: "ARR",
-                  value: econ ? formatUSDC(econ.arr, true) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.arr, true)}
+                      <TwoZHint usdc={econ.arr} twoZPriceUSD={twoZPriceUSD} compact />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: "annualized",
                   accent: "green",
                 },
                 {
                   label: "Total Escrow",
-                  value: econ ? formatUSDC(econ.totalEscrow) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.totalEscrow)}
+                      <TwoZHint usdc={econ.totalEscrow} twoZPriceUSD={twoZPriceUSD} />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: "locked balance",
                 },
               ]}
@@ -586,7 +654,14 @@ export function ShredsEconomicsPage() {
               stats={[
                 {
                   label: "Predicted Revenue",
-                  value: econ ? formatUSDC(econ.nextEpochRevenue) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.nextEpochRevenue)}
+                      <TwoZHint usdc={econ.nextEpochRevenue} twoZPriceUSD={twoZPriceUSD} />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: "seats with sufficient balance",
                   accent: "green",
                 },
@@ -613,7 +688,14 @@ export function ShredsEconomicsPage() {
                 },
                 {
                   label: "Revenue at Risk",
-                  value: econ ? formatUSDC(econ.revenueAtRisk) : <Skeleton />,
+                  value: econ ? (
+                    <>
+                      {formatUSDC(econ.revenueAtRisk)}
+                      <TwoZHint usdc={econ.revenueAtRisk} twoZPriceUSD={twoZPriceUSD} />
+                    </>
+                  ) : (
+                    <Skeleton />
+                  ),
                   sub: "may not renew",
                   accent: econ && econ.revenueAtRisk > 0 ? "amber" : undefined,
                 },
@@ -727,10 +809,19 @@ export function ShredsEconomicsPage() {
                           className={`h-3.5 w-3.5 mt-0.5 ${riskColor.icon}`}
                         />
                       </div>
-                      <div className="flex items-baseline gap-1 mb-4">
+                      <div className="flex flex-col gap-0.5 mb-4">
                         <span className="text-4xl font-bold tabular-nums tracking-tight">
                           {formatUSDC(econ.revenueAtRisk, true)}
                         </span>
+                        {(() => {
+                          const twoZ = usdcTo2Z(econ.revenueAtRisk, twoZPriceUSD);
+                          if (twoZ == null) return null;
+                          return (
+                            <span className="text-xs text-muted-foreground/50 tabular-nums">
+                              ≈ {format2Z(twoZ, true)}
+                            </span>
+                          );
+                        })()}
                       </div>
                       <div className="h-0.5 rounded-full bg-muted/40 overflow-hidden mb-3">
                         <div

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -98,12 +98,12 @@ function useRefreshButton(
   return { spinning: spinning || isFetching, onClick };
 }
 
-function formatUSD(n: number, compact = false): string {
+function formatUSDC(n: number, compact = false): string {
   if (compact) {
-    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
-    if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M USDC`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K USDC`;
   }
-  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`;
 }
 
 function truncatePK(pk: string, head = 6, tail = 4): string {
@@ -521,6 +521,8 @@ export function ShredsEconomicsPage() {
           subtitle={
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               {currentEpoch != null && <span>Epoch {currentEpoch}</span>}
+              {currentEpoch != null && <span className="text-muted-foreground/40">·</span>}
+              <span>Fees are in USDC, protocol revenue in 2Z</span>
             </div>
           }
           actions={
@@ -552,26 +554,26 @@ export function ShredsEconomicsPage() {
               stats={[
                 {
                   label: "Epoch Revenue",
-                  value: econ ? formatUSD(econ.epochRevenue) : <Skeleton />,
+                  value: econ ? formatUSDC(econ.epochRevenue) : <Skeleton />,
                   sub: "current epoch",
                   accent: "blue",
                 },
                 {
                   label: "MRR",
-                  value: econ ? formatUSD(econ.mrr) : <Skeleton />,
+                  value: econ ? formatUSDC(econ.mrr) : <Skeleton />,
                   sub: `${EPOCHS_PER_MONTH} epochs/mo`,
                   accent: "green",
                 },
                 {
                   label: "ARR",
-                  value: econ ? formatUSD(econ.arr, true) : <Skeleton />,
+                  value: econ ? formatUSDC(econ.arr, true) : <Skeleton />,
                   sub: "annualized",
                   accent: "green",
                 },
                 {
                   label: "Total Escrow",
-                  value: econ ? formatUSD(econ.totalEscrow) : <Skeleton />,
-                  sub: "USDC locked",
+                  value: econ ? formatUSDC(econ.totalEscrow) : <Skeleton />,
+                  sub: "locked balance",
                 },
               ]}
             />
@@ -584,7 +586,7 @@ export function ShredsEconomicsPage() {
               stats={[
                 {
                   label: "Predicted Revenue",
-                  value: econ ? formatUSD(econ.nextEpochRevenue) : <Skeleton />,
+                  value: econ ? formatUSDC(econ.nextEpochRevenue) : <Skeleton />,
                   sub: "seats with sufficient balance",
                   accent: "green",
                 },
@@ -611,7 +613,7 @@ export function ShredsEconomicsPage() {
                 },
                 {
                   label: "Revenue at Risk",
-                  value: econ ? formatUSD(econ.revenueAtRisk) : <Skeleton />,
+                  value: econ ? formatUSDC(econ.revenueAtRisk) : <Skeleton />,
                   sub: "may not renew",
                   accent: econ && econ.revenueAtRisk > 0 ? "amber" : undefined,
                 },
@@ -727,7 +729,7 @@ export function ShredsEconomicsPage() {
                       </div>
                       <div className="flex items-baseline gap-1 mb-4">
                         <span className="text-4xl font-bold tabular-nums tracking-tight">
-                          {formatUSD(econ.revenueAtRisk, true)}
+                          {formatUSDC(econ.revenueAtRisk, true)}
                         </span>
                       </div>
                       <div className="h-0.5 rounded-full bg-muted/40 overflow-hidden mb-3">
@@ -883,7 +885,7 @@ export function ShredsEconomicsPage() {
                                 fontSize: 11,
                                 fill: "var(--muted-foreground)",
                               }}
-                              tickFormatter={(v: number) => `$${v}`}
+                              tickFormatter={(v: number) => `${v}`}
                               width={52}
                             />
                             <Tooltip
@@ -904,7 +906,7 @@ export function ShredsEconomicsPage() {
                                       Epoch {label}
                                     </div>
                                     <div className="font-semibold text-foreground">
-                                      {formatUSD(Number(payload[0].value))}
+                                      {formatUSDC(Number(payload[0].value))}
                                     </div>
                                   </div>
                                 );
@@ -1108,7 +1110,7 @@ export function ShredsEconomicsPage() {
             {/* Predicted Revenue */}
             <section>
               <SectionTitle>
-                Predicted Revenue — Next{" "}
+                Predicted Revenue (USDC) — Next{" "}
                 {econ ? econ.revenueProjection.length : 0} Epochs
               </SectionTitle>
               <div className="border border-border rounded-lg bg-card px-2 pt-5 pb-2">
@@ -1224,7 +1226,7 @@ export function ShredsEconomicsPage() {
                                       Confirmed
                                     </span>
                                     <span className="ml-auto font-semibold">
-                                      {formatUSD(Number(confirmed.value))}
+                                      {formatUSDC(Number(confirmed.value))}
                                     </span>
                                   </div>
                                 )}
@@ -1235,7 +1237,7 @@ export function ShredsEconomicsPage() {
                                       At-risk
                                     </span>
                                     <span className="ml-auto font-semibold">
-                                      {formatUSD(Number(atRisk.value))}
+                                      {formatUSDC(Number(atRisk.value))}
                                     </span>
                                   </div>
                                 )}
@@ -1414,10 +1416,10 @@ export function ShredsEconomicsPage() {
                                 {m.metro}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(m.price)} USDC
+                                {formatUSDC(m.price)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right text-muted-foreground">
-                                ~{formatUSD(m.monthlyEquiv)}
+                                ~{formatUSDC(m.monthlyEquiv)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
                                 {m.devices}
@@ -1480,7 +1482,7 @@ export function ShredsEconomicsPage() {
                         Seats
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        $/Epoch
+                        USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         MRR
@@ -1510,13 +1512,13 @@ export function ShredsEconomicsPage() {
                               {m.seats}
                             </td>
                             <td className="px-4 py-3 tabular-nums text-right">
-                              {formatUSD(m.epochRevenue)}
+                              {formatUSDC(m.epochRevenue)}
                             </td>
                             <td className="px-4 py-3 tabular-nums text-right">
-                              {formatUSD(m.mrr)}
+                              {formatUSDC(m.mrr)}
                             </td>
                             <td className="px-4 py-3 tabular-nums text-right">
-                              {formatUSD(m.escrow)}
+                              {formatUSDC(m.escrow)}
                             </td>
                             <td className="px-4 py-3 tabular-nums text-right text-muted-foreground">
                               {m.revenuePct.toFixed(1)}%
@@ -1593,7 +1595,7 @@ export function ShredsEconomicsPage() {
                               className={`border-b border-border last:border-0 ${i % 2 === 0 ? "" : "bg-muted/10"}`}
                             >
                               <td className="px-4 py-3 font-medium tabular-nums">
-                                {formatUSD(t.price)}
+                                {formatUSDC(t.price)}
                                 <span className="text-xs text-muted-foreground font-normal ml-1.5">
                                   ({t.seatsPct.toFixed(0)}%)
                                 </span>
@@ -1602,13 +1604,13 @@ export function ShredsEconomicsPage() {
                                 {t.seats}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(t.epochRevenue)}
+                                {formatUSDC(t.epochRevenue)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(t.monthlyRevenue)}
+                                {formatUSDC(t.monthlyRevenue)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right text-muted-foreground">
-                                {formatUSD(t.monthlyRevenue * 12, true)}
+                                {formatUSDC(t.monthlyRevenue * 12, true)}
                               </td>
                             </tr>
                           ))
@@ -1645,13 +1647,13 @@ export function ShredsEconomicsPage() {
                             {econ.totalSeats}
                           </td>
                           <td className="px-4 py-3 tabular-nums text-right">
-                            {formatUSD(econ.epochRevenue)}
+                            {formatUSDC(econ.epochRevenue)}
                           </td>
                           <td className="px-4 py-3 tabular-nums text-right">
-                            {formatUSD(econ.mrr)}
+                            {formatUSDC(econ.mrr)}
                           </td>
                           <td className="px-4 py-3 tabular-nums text-right">
-                            {formatUSD(econ.arr, true)}
+                            {formatUSDC(econ.arr, true)}
                           </td>
                         </tr>
                       </tfoot>
@@ -1690,7 +1692,7 @@ export function ShredsEconomicsPage() {
                         Seats
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        $/Epoch
+                        USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         MRR
@@ -1726,13 +1728,13 @@ export function ShredsEconomicsPage() {
                                 {f.seats}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(f.epochRevenue)}
+                                {formatUSDC(f.epochRevenue)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(f.epochRevenue * EPOCHS_PER_MONTH)}
+                                {formatUSDC(f.epochRevenue * EPOCHS_PER_MONTH)}
                               </td>
                               <td className="px-4 py-3 tabular-nums text-right">
-                                {formatUSD(f.escrow)}
+                                {formatUSDC(f.escrow)}
                               </td>
                               <td
                                 className={`px-4 py-3 tabular-nums text-right font-medium ${runwayColor}`}

--- a/web/src/components/shreds-economics-page.tsx
+++ b/web/src/components/shreds-economics-page.tsx
@@ -101,10 +101,10 @@ function useRefreshButton(
 
 function formatUSDC(n: number, compact = false): string {
   if (compact) {
-    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
-    if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M USDC`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K USDC`;
   }
-  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`;
 }
 
 function format2Z(n: number, compact = false): string {
@@ -141,27 +141,18 @@ function Skeleton({ className = "w-20" }: { className?: string }) {
 function SectionTitle({
   children,
   className = "mb-4",
-  hint,
 }: {
   children: React.ReactNode;
   className?: string;
-  hint?: React.ReactNode;
 }) {
   return (
     <div
       className={`text-xs font-medium text-muted-foreground/70 uppercase tracking-widest ${className}`}
     >
       {children}
-      {hint && (
-        <span className="ml-2 normal-case tracking-normal text-muted-foreground/50 font-normal">
-          {hint}
-        </span>
-      )}
     </div>
   );
 }
-
-const USDC_HINT = "($ = USDC)";
 
 function TwoZHint({
   usdc,
@@ -598,7 +589,7 @@ export function ShredsEconomicsPage() {
         <div className="space-y-8">
           {/* Revenue Overview */}
           <section>
-            <SectionTitle hint={USDC_HINT}>Revenue Overview</SectionTitle>
+            <SectionTitle>Revenue Overview</SectionTitle>
             <StatGroup
               stats={[
                 {
@@ -658,7 +649,7 @@ export function ShredsEconomicsPage() {
 
           {/* Next Epoch Forecast */}
           <section>
-            <SectionTitle hint={USDC_HINT}>Next Epoch Forecast</SectionTitle>
+            <SectionTitle>Next Epoch Forecast</SectionTitle>
             <StatGroup
               stats={[
                 {
@@ -771,7 +762,7 @@ export function ShredsEconomicsPage() {
                       };
               return (
                 <section>
-                  <SectionTitle hint={USDC_HINT}>Retention Signal</SectionTitle>
+                  <SectionTitle>Retention Signal</SectionTitle>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     {/* Seats Funded */}
                     <div className="relative rounded-lg bg-card border border-border overflow-hidden p-5">
@@ -889,8 +880,8 @@ export function ShredsEconomicsPage() {
             {/* Revenue per Epoch */}
             <section>
               <div className="flex items-center justify-between mb-4">
-                <SectionTitle className="" hint={USDC_HINT}>
-                  Revenue per Epoch
+                <SectionTitle className="">
+                  Revenue per Epoch — USDC
                 </SectionTitle>
                 <div>
                   <SmallDropdown
@@ -932,7 +923,7 @@ export function ShredsEconomicsPage() {
                         <div className="flex items-center gap-4 px-2 mb-3">
                           <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                             <span className="inline-block h-2 w-2 rounded-sm bg-blue-400/80" />
-                            $ collected
+                            USDC collected
                           </span>
                         </div>
                         <ResponsiveContainer width="100%" height={192}>
@@ -985,7 +976,7 @@ export function ShredsEconomicsPage() {
                                 fontSize: 11,
                                 fill: "var(--muted-foreground)",
                               }}
-                              tickFormatter={(v: number) => `$${v}`}
+                              tickFormatter={(v: number) => `${v}`}
                               width={52}
                             />
                             <Tooltip
@@ -1028,7 +1019,7 @@ export function ShredsEconomicsPage() {
                           </AreaChart>
                         </ResponsiveContainer>
                         <p className="text-xs text-muted-foreground px-2 pt-2">
-                          Historical revenue collected per epoch.
+                          Historical USDC collected per epoch.
                         </p>
                       </>
                     );
@@ -1209,8 +1200,8 @@ export function ShredsEconomicsPage() {
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
             {/* Predicted Revenue */}
             <section>
-              <SectionTitle hint={USDC_HINT}>
-                Predicted Revenue — Next{" "}
+              <SectionTitle>
+                Predicted Revenue (USDC) — Next{" "}
                 {econ ? econ.revenueProjection.length : 0} Epochs
               </SectionTitle>
               <div className="border border-border rounded-lg bg-card px-2 pt-5 pb-2">
@@ -1485,10 +1476,10 @@ export function ShredsEconomicsPage() {
                         Metro
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Price / Epoch (USDC)
+                        Price / Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Monthly Equiv (USDC)
+                        Monthly Equiv
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         Devices
@@ -1585,10 +1576,10 @@ export function ShredsEconomicsPage() {
                         USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        MRR (USDC)
+                        MRR
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Escrow (USDC)
+                        Escrow
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         % Rev
@@ -1671,19 +1662,19 @@ export function ShredsEconomicsPage() {
                     <thead>
                       <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
                         <th className="px-4 py-3 text-left font-medium uppercase tracking-wider">
-                          Price / Epoch (USDC)
+                          Price / Epoch
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                           Seats
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Epoch Rev (USDC)
+                          Epoch Rev
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Monthly (USDC)
+                          Monthly
                         </th>
                         <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                          Annual (USDC)
+                          Annual
                         </th>
                       </tr>
                     </thead>
@@ -1795,10 +1786,10 @@ export function ShredsEconomicsPage() {
                         USDC/Epoch
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        MRR (USDC)
+                        MRR
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                        Escrow (USDC)
+                        Escrow
                       </th>
                       <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
                         Min Runway

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5183,6 +5183,19 @@ export async function fetchShredSubscriberHistory(limit = 50): Promise<ShredSubs
   return res.json()
 }
 
+export interface SwapRate {
+  sol_price_usd: number
+  twoz_price_usd: number
+  swap_rate: number
+  fetched_at: number
+}
+
+export async function fetchSwapRate(): Promise<SwapRate> {
+  const res = await fetchWithRetry('/api/dz/swap-rate')
+  if (!res.ok) throw new Error('Failed to fetch swap rate')
+  return res.json()
+}
+
 // Publisher Check
 export interface PublisherCheckItem {
   publisher_ip: string


### PR DESCRIPTION
## Summary
- Relabel shreds economics values with a `USDC` suffix to avoid implying fiat (column headers, chart titles, Y-axis ticks updated in kind)
- Add `GET /api/dz/swap-rate` that proxies the SOL/2Z oracle with 60s caching, retry-on-5xx/429/network, and stale-while-error fallback
- Render live 2Z equivalents (`≈ N 2Z`) beneath key revenue stats (Epoch Revenue, MRR, ARR, Total Escrow, Predicted Revenue, Revenue at Risk)
- Add a subtitle clarifying "Fees are in USDC, protocol revenue in 2Z"

## Why
Mari flagged that `$` on the shreds economics page is misleading — the protocol doesn't support fiat; subscriber fees are denominated in USDC and protocol revenue is in 2Z. Suffixing with `USDC` removes the fiat implication, and showing a 2Z equivalent next to each revenue stat gives a protocol-native reading for anyone who thinks in 2Z.