### PR TITLE
web: fix
  Interface Errors & Discards x-axis range for sparse data

### DIFF
--- a/web/src/components/traffic-chart-uplot.tsx
+++ b/web/src/components/traffic-chart-uplot.tsx
@@ -30,6 +30,8 @@ interface TrafficChartProps {
   loading?: boolean
   /** Time range in seconds — extends x-axis to show full range even with sparse data */
   timeRangeSeconds?: number
+  /** Right edge of the requested window (unix seconds). Anchors the x-axis when data is sparse. */
+  rangeEnd?: number
   /** Custom labels for bidirectional directions (default: { in: 'Rx', out: 'Tx' }) */
   directionLabels?: { in: string; out: string }
   /** Override legend header text (e.g. "Summary of 42 interfaces") */
@@ -116,7 +118,7 @@ function formatPctAxis(pct: number): string {
   return pct.toFixed(1) + '%'
 }
 
-function TrafficChartImpl({ title, data, series, stacked = false, linkLookup, bidirectional = false, onTimeRangeSelect, metric = 'throughput', loading = false, timeRangeSeconds, directionLabels: dirLabels, legendHeader }: TrafficChartProps) {
+function TrafficChartImpl({ title, data, series, stacked = false, linkLookup, bidirectional = false, onTimeRangeSelect, metric = 'throughput', loading = false, timeRangeSeconds, rangeEnd, directionLabels: dirLabels, legendHeader }: TrafficChartProps) {
   const inLabel = dirLabels?.in ?? 'Rx'
   const outLabel = dirLabels?.out ?? 'Tx'
   const { resolvedTheme } = useTheme()
@@ -582,10 +584,18 @@ function TrafficChartImpl({ title, data, series, stacked = false, linkLookup, bi
       scales: {
         x: {
           time: true,
+          auto: !timeRangeSeconds,
+          // uPlot pads single-point data by ~1000 days in the x direction, so we can't trust
+          // the dataMin/dataMax it hands us. Anchor the window to rangeEnd (or dataMax when no
+          // explicit rangeEnd), and extend backward only if real data precedes the window.
           range: timeRangeSeconds
             ? (_u: uPlot, dataMin: number, dataMax: number) => {
-                const rangeMin = dataMax - timeRangeSeconds
-                return [Math.min(dataMin, rangeMin), dataMax]
+                const end = rangeEnd != null ? rangeEnd : (Number.isFinite(dataMax) ? dataMax : 0)
+                const start = end - timeRangeSeconds
+                const leftEdge = Number.isFinite(dataMin) && dataMin < start && rangeEnd == null
+                  ? dataMin
+                  : start
+                return [leftEdge, end]
               }
             : undefined,
         },

--- a/web/src/pages/traffic-page.tsx
+++ b/web/src/pages/traffic-page.tsx
@@ -456,6 +456,12 @@ function TrafficPageContent() {
     refetchInterval: dashboardState.refetchInterval,
   })
 
+  const rangeEnd = useMemo(() => {
+    if (customEnd) return customEnd
+    return Math.floor(Date.now() / 1000)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customEnd, allTrafficData])
+
   // Build a lookup from series metadata to classify each device+intf pair
   const intfCategoryMap = useMemo(() => {
     const map = new Map<string, IntfCategory>()
@@ -759,6 +765,7 @@ function TrafficPageContent() {
               metric="counters"
               loading={countersFetching}
               timeRangeSeconds={timeRangeSeconds}
+              rangeEnd={rangeEnd}
             />
           </LazyChart>
         </div>
@@ -816,6 +823,7 @@ function TrafficPageContent() {
               metric={metric}
               loading={fetching}
               timeRangeSeconds={timeRangeSeconds}
+              rangeEnd={rangeEnd}
               legendHeader={
                 catAggregated ? `Summary of ${originalIntfCount} interfaces` : undefined
               }


### PR DESCRIPTION
## Summary of Changes
- The Interface Errors & Discards panel now renders its x-axis as the selected window (e.g. the last 3 hours), matching the other charts on the page, instead of a spurious 2–3 year span.
- Root cause: uPlot pads single-point time-series data by `86,400,000` (its "1 day in ms" constant applied verbatim to a seconds-based scale = 1000 days). The counters chart filters to non-zero buckets and routinely has only one point, so uPlot produced a phantom `dataMax` far in the future.
- Fix: `TrafficChart` now accepts an explicit `rangeEnd` prop and anchors the x-scale to it (with `auto: false`) when `timeRangeSeconds` is set, ignoring the padded `dataMax` uPlot supplies.

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net  |
|-------------|-------|-------------|------|
| Core logic  |     2 | +21 / -3    |  +18 |

Small surgical fix contained to the shared chart component and its caller.

<details>
<summary>Key files</summary>

- `web/src/components/traffic-chart-uplot.tsx` — new `rangeEnd` prop; x-scale `range` callback anchors to `rangeEnd` instead of trusting uPlot's `dataMax`; `auto: false` when a window is specified.
- `web/src/pages/traffic-page.tsx` — computes `rangeEnd` (`customEnd ?? now`) memoized against the fetched data; passed to both `<TrafficChart>` instances.

</details>

## Testing Verification
- Verified against prod data on `/traffic/interfaces?time_range=3h` — the Errors & Discards panel correctly shows a 3-hour window ending at "now" with the sparse data points plotted inside it (previously rendered an axis spanning May 2026 → Dec 2028).
- Confirmed other panels (Tunnel / Link / CYOA / Other) still render identically, since their data is dense and `Math.max(dataMax, rangeEnd) ≈ rangeEnd`.
