### PR TITLE
web/api: show agent versions on device detail page

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -30,6 +30,9 @@ var externalRemoteTables = []struct {
 	{"mainnet-beta", "location_offsets"},
 	{"devnet", "location_offsets"},
 	{"testnet", "location_offsets"},
+	{"mainnet-beta", "controller_agent_versions"},
+	{"devnet", "controller_agent_versions"},
+	{"testnet", "controller_agent_versions"},
 }
 
 // Config holds configuration for creating remote proxy tables.

--- a/api/handlers/devices.go
+++ b/api/handlers/devices.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -333,6 +334,12 @@ type DeviceDetail struct {
 	PeakInBps                 float64                 `json:"peak_in_bps"`
 	PeakOutBps                float64                 `json:"peak_out_bps"`
 	Interfaces                []DeviceDetailInterface `json:"interfaces"`
+	TelemetryAgentVersion     string                  `json:"telemetry_agent_version,omitempty"`
+	TelemetryAgentCommit      string                  `json:"telemetry_agent_commit,omitempty"`
+	ConfigAgentVersion        string                  `json:"config_agent_version,omitempty"`
+	ConfigAgentCommit         string                  `json:"config_agent_commit,omitempty"`
+	ControllerVersion         string                  `json:"controller_version,omitempty"`
+	ControllerCommit          string                  `json:"controller_commit,omitempty"`
 }
 
 type DeviceValidatorStats struct {
@@ -522,6 +529,35 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
+
+	// Fetch telemetry agent version from latency sample headers
+	telemetryQuery := `
+		SELECT
+			argMax(agent_version, written_at),
+			argMax(agent_commit, written_at)
+		FROM fact_dz_device_link_latency_sample_header
+		WHERE origin_device_pk = ? AND agent_version != ''
+	`
+	_ = a.envDB(ctx).QueryRow(ctx, telemetryQuery, pk).Scan(
+		&device.TelemetryAgentVersion,
+		&device.TelemetryAgentCommit,
+	)
+
+	// Fetch config agent + controller version from controller_agent_versions proxy table
+	envDB := string(EnvFromContext(r.Context()))
+	configQuery := fmt.Sprintf(`
+		SELECT
+			agent_version, agent_commit,
+			controller_version, controller_commit
+		FROM `+"`%s`"+`.controller_agent_versions FINAL
+		WHERE device_pubkey = ?
+	`, envDB)
+	_ = a.envDB(ctx).QueryRow(ctx, configQuery, pk).Scan(
+		&device.ConfigAgentVersion,
+		&device.ConfigAgentCommit,
+		&device.ControllerVersion,
+		&device.ControllerCommit,
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(device); err != nil {

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -157,6 +157,33 @@ export function DeviceDetailPage() {
           </div>
         </div>
 
+        {/* Agent versions */}
+        {(device.telemetry_agent_version || device.config_agent_version || device.controller_version) && (
+          <div className="grid grid-cols-3 gap-4 mb-6">
+            <div className="text-center p-3 bg-muted/30 rounded-lg">
+              <div className="text-sm font-medium font-mono">{device.telemetry_agent_version || '—'}</div>
+              {device.telemetry_agent_commit && (
+                <div className="text-xs text-muted-foreground font-mono">{device.telemetry_agent_commit.slice(0, 7)}</div>
+              )}
+              <div className="text-xs text-muted-foreground mt-1">Telemetry Agent</div>
+            </div>
+            <div className="text-center p-3 bg-muted/30 rounded-lg">
+              <div className="text-sm font-medium font-mono">{device.config_agent_version || '—'}</div>
+              {device.config_agent_commit && (
+                <div className="text-xs text-muted-foreground font-mono">{device.config_agent_commit.slice(0, 7)}</div>
+              )}
+              <div className="text-xs text-muted-foreground mt-1">Config Agent</div>
+            </div>
+            <div className="text-center p-3 bg-muted/30 rounded-lg">
+              <div className="text-sm font-medium font-mono">{device.controller_version || '—'}</div>
+              {device.controller_commit && (
+                <div className="text-xs text-muted-foreground font-mono">{device.controller_commit.slice(0, 7)}</div>
+              )}
+              <div className="text-xs text-muted-foreground mt-1">Controller</div>
+            </div>
+          </div>
+        )}
+
         {/* Shared device info (stats grid + interfaces) */}
         <DeviceInfoContent device={deviceInfo} hideStatusRow hideCharts />
       </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2893,6 +2893,12 @@ export async function fetchDevicesByContributor(contributorPk: string, limit = 5
 export interface DeviceDetail extends Device {
   metro_name: string
   interfaces: DeviceInterface[]
+  telemetry_agent_version?: string
+  telemetry_agent_commit?: string
+  config_agent_version?: string
+  config_agent_commit?: string
+  controller_version?: string
+  controller_commit?: string
 }
 
 export async function fetchDevice(pk: string): Promise<DeviceDetail> {


### PR DESCRIPTION
## Summary of Changes
- Register `controller_agent_versions` as external remote table proxies for mainnet-beta, devnet, and testnet environments
- Display telemetry agent, config agent, and controller versions on the device detail page (`/dz/devices/<pk>`), querying `fact_dz_device_link_latency_sample_header` for telemetry and the new `controller_agent_versions` proxy table for config agent/controller versions
- Companion to malbeclabs/doublezero#3578 which adds the `controller_agent_versions` ReplacingMergeTree table to the controller

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +69 / -0    |  +69 |
| Scaffolding  |     1 | +3 / -0     |   +3 |
| **Total**    |     4 | +72 / -0    |  +72 |

Small feature — API queries + frontend display with scaffolding for remote table registration.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/devices.go`](https://github.com/malbeclabs/lake/pull/534/files#diff-6a02d403070e752866be51fa227bbb3e8a7831e1638b35dcac7ab5a739300d38) — Add version fields to DeviceDetail struct; query telemetry agent version from latency sample headers and config agent/controller version from controller_agent_versions proxy table
- [`web/src/components/device-detail-page.tsx`](https://github.com/malbeclabs/lake/pull/534/files#diff-cfbe44a1c39bce3e66493130eed2dd5b0a1c18704db1c85af957e3cf52450e02) — Show telemetry agent, config agent, and controller version cards on device detail page
- [`web/src/lib/api.ts`](https://github.com/malbeclabs/lake/pull/534/files#diff-af490ef10b2e4da7f8055bd843c240828a9e8bcd6e6244b55888fe13f8ce8f7a) — Add version fields to DeviceDetail TypeScript interface
- [`admin/remotetables/setup.go`](https://github.com/malbeclabs/lake/pull/534/files#diff-abea27beeb63c339ca583784b0e13eed99070b407e80b7a0bf8f9c15b3584668) — Register controller_agent_versions proxy tables for all three environments

</details>

## ClickHouse Grants

The Lake remote user needs SELECT on the new table in each environment (one-time manual grant):

```sql
GRANT SELECT ON "mainnet-beta".controller_agent_versions TO <lake_remote_user>;
GRANT SELECT ON devnet.controller_agent_versions TO <lake_remote_user>;
GRANT SELECT ON testnet.controller_agent_versions TO <lake_remote_user>;
```

## Testing Verification
- All existing device handler tests pass (16/16), including `TestGetDevice_ReturnsDetails`, `TestGetDevice_IncludesContributorInfo`, `TestGetDevice_IncludesTrafficRates`
- Version queries are non-fatal — if the proxy table doesn't exist yet or the device has no version data, the fields are simply omitted from the response