### PR TITLE
api: gzip-compress responses

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -427,6 +427,7 @@ func main() {
 	}
 
 	r.Use(middleware.Recoverer)
+	r.Use(middleware.Compress(5))
 	r.Use(metrics.Middleware)
 
 	// CORS configuration - origins from env or allow all


### PR DESCRIPTION
## Summary of Changes
- Adds `chi` `middleware.Compress(5)` to the API router so responses are gzip-encoded when the client accepts it.
- Status page endpoints return multi-megabyte JSON payloads (link-history ~3.7 MB, bulk-link-metrics ~7.8 MB) that pin the page tab to the network even when served from the page cache. Compression is expected to bring these down ~5–9× over the wire, materially shortening time-to-render over WAN.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Scaffolding  |     1 | +1 / -0     |   +1 |
| **Total**    |     1 | +1 / -0     |   +1 |

One-line middleware registration.

<details>
<summary>Key files (click to expand)</summary>

- `api/main.go` — register `middleware.Compress(5)` on the chi router.

</details>

## Testing Verification
- After deploy, spot-check with `curl -H 'Accept-Encoding: gzip' -I ...` against the status-page endpoints to confirm `Content-Encoding: gzip` and reduced payload sizes.