### PR TITLE
indexer: fix isis_down false positive after device hostname renames

### DIFF
--- a/indexer/pkg/rollup/activities.go
+++ b/indexer/pkg/rollup/activities.go
@@ -355,10 +355,18 @@ func (a *Activities) resolveLinkState(ctx context.Context, linkPKs map[string]st
 // resolveISISAdjacency queries dim_isis_adjacencies_history to determine if each
 // (link, bucket) pair has an ISIS adjacency. For each bucket, it finds the latest
 // adjacency state as of the bucket's end time (bucket + 5min).
+//
+// A link is UP only when both sides independently confirm the adjacency is healthy
+// (activeCount >= 2). This guards against false positives from hostname renames,
+// where the old entity gets is_deleted=1 alongside a new is_deleted=0 entity for
+// the same link_pk at the same snapshot_ts. Because ClickHouse row ordering for
+// same-timestamp entries is nondeterministic, a single carry-forward variable could
+// flip to "deleted" and never recover. Per-entity tracking and evaluating state
+// after each timestamp group (not after each individual row) avoids this.
 func (a *Activities) resolveISISAdjacency(ctx context.Context, linkPKs map[string]struct{}, bucketTimes map[time.Time]struct{}, _, windowEnd time.Time, sourceDB string) (map[bucketKey]bool, error) {
-	// Query all adjacency entries up to windowEnd
+	// Include entity_id so we can carry forward state per entity independently.
 	query := `
-		SELECT link_pk, snapshot_ts, is_deleted
+		SELECT link_pk, entity_id, snapshot_ts, is_deleted
 		FROM ` + tableRef(sourceDB, "dim_isis_adjacencies_history") + `
 		WHERE snapshot_ts <= $1 AND link_pk != ''
 		ORDER BY link_pk, snapshot_ts
@@ -370,19 +378,21 @@ func (a *Activities) resolveISISAdjacency(ctx context.Context, linkPKs map[strin
 	defer rows.Close()
 
 	type entry struct {
+		entityID  string
 		ts        time.Time
 		isDeleted bool
 	}
 	entriesByLink := make(map[string][]entry)
 	for rows.Next() {
-		var linkPK string
+		var linkPK, entityID string
 		var ts time.Time
 		var isDeleted uint8
-		if err := rows.Scan(&linkPK, &ts, &isDeleted); err != nil {
+		if err := rows.Scan(&linkPK, &entityID, &ts, &isDeleted); err != nil {
 			return nil, fmt.Errorf("ISIS adjacency scan: %w", err)
 		}
 		if _, ok := linkPKs[linkPK]; ok {
 			entriesByLink[linkPK] = append(entriesByLink[linkPK], entry{
+				entityID:  entityID,
 				ts:        ts.UTC(),
 				isDeleted: isDeleted == 1,
 			})
@@ -392,12 +402,38 @@ func (a *Activities) resolveISISAdjacency(ctx context.Context, linkPKs map[strin
 		return nil, fmt.Errorf("ISIS adjacency rows: %w", err)
 	}
 
-	// For each (link, bucket), check if ISIS was down at any point during the
-	// bucket. A bucket is marked isis_down=true if the carry-forward state
-	// entering the bucket is deleted, OR if any snapshot within the bucket
-	// window [bucket_start, bucket_end] has is_deleted=1. Historical entries
-	// from before the bucket only contribute via the carry-forward state
-	// (the latest value), not by marking the bucket as "was down".
+	// consumeGroup advances entryIdx past all entries sharing the same timestamp,
+	// applying each to entityState. Returns true if any entries were consumed.
+	activeCount := func(entityState map[string]bool) int {
+		n := 0
+		for _, deleted := range entityState {
+			if !deleted {
+				n++
+			}
+		}
+		return n
+	}
+	consumeGroup := func(entries []entry, entryIdx *int, entityState map[string]bool, until func(time.Time) bool) bool {
+		if *entryIdx >= len(entries) || !until(entries[*entryIdx].ts) {
+			return false
+		}
+		consumed := false
+		for *entryIdx < len(entries) && until(entries[*entryIdx].ts) {
+			ts := entries[*entryIdx].ts
+			for *entryIdx < len(entries) && entries[*entryIdx].ts.Equal(ts) {
+				entityState[entries[*entryIdx].entityID] = entries[*entryIdx].isDeleted
+				*entryIdx++
+			}
+			consumed = true
+		}
+		return consumed
+	}
+
+	// For each (link, bucket), determine isis_down using per-entity carry-forward.
+	// Each entity (one per side of the link) tracks its own is_deleted independently.
+	// A link is UP only when at least 2 entities are active (both sides confirm UP).
+	// State is evaluated after each full same-timestamp group so that a rename's
+	// simultaneous delete+create doesn't cause a momentary false down.
 	const bucketWidth = 5 * time.Minute
 	result := make(map[bucketKey]bool)
 	sortedBuckets := sortedTimes(bucketTimes)
@@ -406,26 +442,29 @@ func (a *Activities) resolveISISAdjacency(ctx context.Context, linkPKs map[strin
 		if len(entries) == 0 {
 			continue // not an ISIS link
 		}
+		entityState := make(map[string]bool) // entity_id → isDeleted
 		entryIdx := 0
 		seenEntry := false
-		current := false // carry-forward state at bucket boundary
+
 		for _, bt := range sortedBuckets {
 			bucketEnd := bt.Add(bucketWidth)
-			// Consume entries before this bucket — they update the carry-forward state.
-			for entryIdx < len(entries) && entries[entryIdx].ts.Before(bt) {
-				current = entries[entryIdx].isDeleted
+			// Consume timestamp groups before this bucket to update carry-forward.
+			if consumeGroup(entries, &entryIdx, entityState, func(ts time.Time) bool { return ts.Before(bt) }) {
 				seenEntry = true
-				entryIdx++
 			}
-			wasDown := current // carry-forward: was down entering this bucket
-			// Consume entries within the bucket window [bt, bucketEnd].
+			// Initial wasDown from carry-forward. If no entities seen yet, default UP.
+			wasDown := len(entityState) > 0 && activeCount(entityState) < 2
+			// Consume timestamp groups within [bt, bucketEnd], checking after each group.
 			for entryIdx < len(entries) && !entries[entryIdx].ts.After(bucketEnd) {
-				current = entries[entryIdx].isDeleted
-				if current {
-					wasDown = true // went down during this bucket
+				ts := entries[entryIdx].ts
+				for entryIdx < len(entries) && entries[entryIdx].ts.Equal(ts) {
+					entityState[entries[entryIdx].entityID] = entries[entryIdx].isDeleted
+					entryIdx++
+				}
+				if activeCount(entityState) < 2 {
+					wasDown = true
 				}
 				seenEntry = true
-				entryIdx++
 			}
 			if seenEntry {
 				result[bucketKey{linkPK: pk, bucket: bt}] = wasDown

--- a/indexer/pkg/rollup/activities_test.go
+++ b/indexer/pkg/rollup/activities_test.go
@@ -125,9 +125,12 @@ func TestComputeLinkRollup_WithData(t *testing.T) {
 		"link-entity-1", now, now, "00000000-0000-0000-0000-000000000001", uint8(0), "link-1", "activated", "device-a", "device-z", int64(10_000_000_000), int64(500_000))
 	require.NoError(t, err)
 
-	// Seed ISIS adjacency (link has adjacency = not ISIS down)
+	// Seed ISIS adjacencies for both sides of the link (both sides must be UP for isis_down=false)
 	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		"isis-adj-1", now, now, "00000000-0000-0000-0000-000000000002", uint8(0), "link-1", "device-a", "sys-1", "sys-2")
+	require.NoError(t, err)
+	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		"isis-adj-2", now, now, "00000000-0000-0000-0000-000000000003", uint8(0), "link-1", "device-z", "sys-2", "sys-1")
 	require.NoError(t, err)
 
 	// Seed latency samples for both sides within the same 5m bucket

--- a/indexer/pkg/rollup/activities_test.go
+++ b/indexer/pkg/rollup/activities_test.go
@@ -247,6 +247,55 @@ func TestComputeLinkRollup_ISISDown(t *testing.T) {
 	assert.False(t, buckets[0].ISISDown)
 }
 
+// TestComputeLinkRollup_ISISHostnameRename verifies that a device hostname rename —
+// which emits a simultaneous is_deleted=1 (old entity) and is_deleted=0 (new entity)
+// at the same snapshot_ts — does not cause a false isis_down=true.
+func TestComputeLinkRollup_ISISHostnameRename(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+	initialTS := now.Add(-20 * time.Minute)
+	renameTS := now.Add(-15 * time.Minute) // before window start, processed as carry-forward
+
+	err := conn.Exec(ctx, `INSERT INTO dim_dz_links_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, pk, status, side_a_pk, side_z_pk, bandwidth_bps, committed_rtt_ns) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		"link-entity-rename", now, now, "00000000-0000-0000-0000-000000000020", uint8(0), "link-rename", "activated", "device-a", "device-z", int64(10_000_000_000), int64(500_000))
+	require.NoError(t, err)
+
+	// Initial state: both sides active
+	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		"isis-adj-a-old", initialTS, initialTS, "00000000-0000-0000-0000-000000000021", uint8(0), "link-rename", "device-a", "sys-a", "sys-z")
+	require.NoError(t, err)
+	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		"isis-adj-z", initialTS, initialTS, "00000000-0000-0000-0000-000000000022", uint8(0), "link-rename", "device-z", "sys-z", "sys-a")
+	require.NoError(t, err)
+
+	// Hostname rename: delete old entity AND create new entity at the same snapshot_ts.
+	// Nondeterministic row ordering in ClickHouse previously caused this to mark the link down.
+	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		"isis-adj-a-old", renameTS, renameTS, "00000000-0000-0000-0000-000000000023", uint8(1), "link-rename", "device-a", "sys-a", "sys-z")
+	require.NoError(t, err)
+	err = conn.Exec(ctx, `INSERT INTO dim_isis_adjacencies_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, link_pk, device_pk, system_id, neighbor_system_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		"isis-adj-a-new", renameTS, renameTS, "00000000-0000-0000-0000-000000000024", uint8(0), "link-rename", "device-a-renamed", "sys-a-new", "sys-z")
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `INSERT INTO fact_dz_device_link_latency (event_ts, ingested_at, epoch, sample_index, origin_device_pk, target_device_pk, link_pk, rtt_us, loss) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		bucketStart, bucketStart, int64(1), int32(0), "device-a", "device-z", "link-rename", int64(100), false)
+	require.NoError(t, err)
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeLinkRollup(ctx, BackfillChunkInput{
+		WindowStart: now.Add(-10 * time.Minute),
+		WindowEnd:   now.Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+	// After rename, old entity is deleted but new entity is active alongside the Z side — link is UP.
+	assert.False(t, buckets[0].ISISDown)
+}
+
 // --- Device interface rollup tests ---
 
 func TestWriteDeviceInterfaceBuckets(t *testing.T) {


### PR DESCRIPTION
Resolves: #540

## Summary of Changes
- Replace single carry-forward `bool` per link in `resolveISISAdjacency` with per-entity state tracking (`map[entity_id]bool`). A link is only UP when ≥ 2 entities are non-deleted — both sides of the link must independently confirm the adjacency is healthy.
- Evaluate state after each full same-timestamp group rather than after each individual row, so a rename's simultaneous `is_deleted=1` (old entity) and `is_deleted=0` (new entity) at the same `snapshot_ts` is resolved atomically.
- Add regression test `TestComputeLinkRollup_ISISHostnameRename` that seeds a simultaneous delete+create at the same timestamp and asserts the link stays UP.

## Diff Breakdown
| Category   | Files | Lines (+/-)  | Net  |
|------------|-------|--------------|------|
| Core logic |     1 | +60 / -21    |  +39 |
| Tests      |     1 | +53 / -1     |  +52 |
| **Total**  |     2 | +113 / -22   |  +91 |

Small, focused algorithm fix with targeted regression test.

<details>
<summary>Key files (click to expand)</summary>

- `indexer/pkg/rollup/activities.go` — rewrites `resolveISISAdjacency` to use per-entity carry-forward and timestamp-group evaluation
- `indexer/pkg/rollup/activities_test.go` — seeds both sides of the IS-IS adjacency and adds a dedicated rename regression test

</details>

## Testing Verification
- `TestComputeLinkRollup_ISISHostnameRename`: seeds a simultaneous `is_deleted=1` (old entity) + `is_deleted=0` (new entity) at the same `snapshot_ts`, confirms `isis_down=false`
- All rollup tests pass (`go test ./indexer/pkg/rollup/...`) and full test suite passes (`make test`)
- Fix self-heals automatically on deploy: `link_rollup_5m` uses `ReplacingMergeTree` and the live rollup rewrites the last 30 minutes every 30 seconds; once recent buckets get `isis_down=false`, the ongoing incident in `link_incidents_v` closes on its own