### PR TITLE
api: fix shred epoch revenue query understating USDC

### DIFF
--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -868,18 +868,22 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	start := time.Now()
+	// Sum fund inflows bucketed by the on-chain Solana epoch when the deposit
+	// landed (slot / 432000). The stored epoch column on batch_allocate events
+	// is the tenure's active_epoch, so summing by it attributes prepaid USDC
+	// to a future tenure and understates what users actually paid this epoch.
 	query := `
 		SELECT
-			epoch,
+			toUInt64(intDiv(slot, 432000)) AS tx_epoch,
 			sum(amount_usdc) / 1000000 AS total_usdc,
 			sum(amount_usdc) / 1000000 AS total_dollars,
 			count() AS payment_count
 		FROM fact_dz_shred_escrow_events FINAL
-		WHERE event_type IN ('payment', 'batch_allocate')
-		  AND epoch IS NOT NULL
+		WHERE event_type = 'fund'
 		  AND amount_usdc IS NOT NULL
-		GROUP BY epoch
-		ORDER BY epoch DESC
+		  AND status = 'ok'
+		GROUP BY tx_epoch
+		ORDER BY tx_epoch DESC
 		LIMIT ?
 	`
 


### PR DESCRIPTION
## Summary of Changes

- Switches `GetShredEpochRevenue` to sum `fund` event amounts bucketed by the on-chain Solana epoch (`intDiv(slot, 432000)`) instead of summing `batch_allocate` amounts grouped by the stored `epoch` column.
- The stored `epoch` is the tenure's `active_epoch`, so prepaid USDC was being attributed to a future tenure epoch and was missing from the wall-clock collection epoch on the Shreds Economics chart.
- Drops the dead `'payment'` event_type filter — no parser path emits that type, so the previous query was effectively `event_type = 'batch_allocate'`.

Resolves https://github.com/malbeclabs/infra/issues/1212.

## Diff Breakdown

| Category    | Files | Lines (+/-) | Net |
|-------------|-------|-------------|-----|
| Core logic  |     1 | +9 / -5     |  +4 |

A single SQL handler change in the API.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/shreds.go` — replace the revenue query: sum `fund` events bucketed by `intDiv(slot, 432000)`, drop the unused `'payment'` filter, add `status = 'ok'` guard.

</details>

## Testing Verification

- Existing `api/handlers` shred tests pass (`go test ./api/handlers/ -run TestGetShred`).
- Validated against prod ClickHouse: epoch 964 went from $4,890 (old query) → $13,630 across 114 fund events (new query); the delta matches USDC sitting in escrow as prepayment for future tenures.