### PR TITLE
api, web: add geo concentration and validators endpoints

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -30,6 +30,9 @@ var externalRemoteTables = []struct {
 	{"mainnet-beta", "location_offsets"},
 	{"devnet", "location_offsets"},
 	{"testnet", "location_offsets"},
+	{"dzdp", "offsets"},
+	{"dzdp", "location_decisions"},
+	{"dzdp", "location_state"},
 }
 
 // Config holds configuration for creating remote proxy tables.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -32,6 +32,9 @@ var shredderDB = "shredder"
 // publisherDB is the ClickHouse database name for publisher tables e.g. publisher_shred_stats (default: "shredder").
 var publisherDB = "shredder"
 
+// dzdpDB is the ClickHouse database name for DZDP tables e.g. location_state (default: "dzdp").
+var dzdpDB = "dzdp"
+
 // EnvDBs maps environment names to their ClickHouse connection pools.
 // The mainnet-beta entry always points to DB.
 var EnvDBs map[string]driver.Conn
@@ -68,6 +71,16 @@ func GetPublisherDB() string {
 // SetPublisherDB sets the publisher database name.
 func SetPublisherDB(db string) {
 	publisherDB = db
+}
+
+// GetDZDPDB returns the DZDP database name.
+func GetDZDPDB() string {
+	return dzdpDB
+}
+
+// SetDZDPDB sets the DZDP database name.
+func SetDZDPDB(db string) {
+	dzdpDB = db
 }
 
 // Database returns the configured database name.
@@ -137,6 +150,10 @@ func Load() error {
 		publisherDB = db
 	}
 
+	if db := os.Getenv("CLICKHOUSE_DZDP_DB"); db != "" {
+		dzdpDB = db
+	}
+
 	// Build env -> database mapping.
 	// Devnet and testnet databases default to lake_devnet / lake_testnet
 	// unless overridden by env vars or disabled with CLICKHOUSE_NO_DEVNET / CLICKHOUSE_NO_TESTNET.
@@ -160,7 +177,7 @@ func Load() error {
 
 	secure := os.Getenv("CLICKHOUSE_SECURE") == "true"
 
-	slog.Info("connecting to ClickHouse", "addr", cfg.Addr, "database", cfg.Database, "username", cfg.Username, "secure", secure, "shredder_db", shredderDB, "publisher_db", publisherDB)
+	slog.Info("connecting to ClickHouse", "addr", cfg.Addr, "database", cfg.Database, "username", cfg.Username, "secure", secure, "shredder_db", shredderDB, "publisher_db", publisherDB, "dzdp_db", dzdpDB)
 
 	// Create connection pool
 	opts := &clickhouse.Options{

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -42,6 +42,7 @@ type API struct {
 	Database      string
 	ShredderDB    string
 	PublisherDB   string
+	DZDPDB        string
 
 	// PostgreSQL
 	PgPool *pgxpool.Pool

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -88,8 +88,8 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		WITH geolocated AS (
 			SELECT
 				ls.target_ip AS target_ip,
-				ls.lat AS dzdp_lat,
-				ls.lng AS dzdp_lng,
+				coalesce(ls.lat, 0) AS dzdp_lat,
+				coalesce(ls.lng, 0) AS dzdp_lng,
 				gn.pubkey AS node_pubkey
 			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
@@ -150,9 +150,9 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	rows, err := a.DB.Query(ctx, query)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
-		// Return empty response when DZDP tables aren't available
+		// Return empty response when DZDP tables aren't available or accessible
 		var chErr *proto.Exception
-		if errors.As(err, &chErr) && chErr.Code == 60 {
+		if errors.As(err, &chErr) && (chErr.Code == 60 || chErr.Code == 497) {
 			return &GeoConcentrationResponse{
 				Metros:    []GeoConcentrationMetro{},
 				Countries: []GeoConcentrationCountry{},

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -192,7 +192,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	metros := make([]GeoConcentrationMetro, 0, len(metroMap))
 	for _, m := range metroMap {
 		if totalStake > 0 {
-			m.StakePct = m.StakeSol / totalStake * 100
+			m.StakePct = math.Round(m.StakeSol/totalStake*10000) / 100
 		}
 		metros = append(metros, *m)
 	}
@@ -214,7 +214,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	countries := make([]GeoConcentrationCountry, 0, len(countryMap))
 	for _, c := range countryMap {
 		if totalStake > 0 {
-			c.StakePct = c.StakeSol / totalStake * 100
+			c.StakePct = math.Round(c.StakeSol/totalStake*10000) / 100
 		}
 		countries = append(countries, *c)
 	}
@@ -239,7 +239,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	asns := make([]GeoConcentrationASN, 0, len(asnMap))
 	for _, entry := range asnMap {
 		if totalStake > 0 {
-			entry.StakePct = entry.StakeSol / totalStake * 100
+			entry.StakePct = math.Round(entry.StakeSol/totalStake*10000) / 100
 		}
 		asns = append(asns, *entry)
 	}

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -93,7 +93,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 				gn.pubkey AS node_pubkey
 			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
-			WHERE ls.state = 'decided'
+			WHERE ls.state = 'honed'
 		),
 		enriched AS (
 			SELECT

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -123,7 +123,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 					arraySort(
 						(x, y) -> y,
 						groupArray(m.code),
-						groupArray(sqrt(pow(e.dzdp_lat - m.latitude, 2) + pow(e.dzdp_lng - m.longitude, 2)))
+						groupArray(geoDistance(e.dzdp_lng, e.dzdp_lat, m.longitude, m.latitude))
 					), 1
 				) AS metro_code
 			FROM enriched e

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -128,7 +128,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		deduped AS (
 			SELECT
 				vote_pubkey,
-				argMax(stake_sol, stake_sol) AS stake_sol,
+				max(stake_sol) AS stake_sol,
 				argMax(metro_code, stake_sol) AS metro_code,
 				argMax(asn, stake_sol) AS asn,
 				argMax(asn_org, stake_sol) AS asn_org,

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -1,0 +1,286 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+type GeoConcentrationHeroStats struct {
+	ValidatorsMeasured   int     `json:"validators_measured"`
+	StakeTopTwoMetrosPct float64 `json:"stake_top_two_metros_pct"`
+	AnchorPoints         int     `json:"anchor_points"`
+	StakeMaxASNPct       float64 `json:"stake_max_asn_pct"`
+}
+
+type GeoConcentrationMetro struct {
+	MetroCode  string  `json:"metro_code"`
+	Validators int     `json:"validators"`
+	StakeSol   float64 `json:"stake_sol"`
+	StakePct   float64 `json:"stake_pct"`
+}
+
+type GeoConcentrationCountry struct {
+	CountryCode string  `json:"country_code"`
+	CountryName string  `json:"country_name"`
+	Validators  int     `json:"validators"`
+	StakeSol    float64 `json:"stake_sol"`
+	StakePct    float64 `json:"stake_pct"`
+}
+
+type GeoConcentrationASN struct {
+	ASN        int64   `json:"asn"`
+	ASNOrg     string  `json:"asn_org"`
+	Validators int     `json:"validators"`
+	StakeSol   float64 `json:"stake_sol"`
+	StakePct   float64 `json:"stake_pct"`
+}
+
+type GeoConcentrationResponse struct {
+	HeroStats GeoConcentrationHeroStats `json:"hero_stats"`
+	Metros    []GeoConcentrationMetro   `json:"metros"`
+	Countries []GeoConcentrationCountry `json:"countries"`
+	ASNs      []GeoConcentrationASN     `json:"asns"`
+}
+
+func (a *API) GetGeoConcentration(w http.ResponseWriter, r *http.Request) {
+	// Cache check for mainnet default requests
+	if isMainnet(r.Context()) {
+		if data, err := a.readPageCache(r.Context(), "geo_concentration"); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			_, _ = w.Write(data)
+			return
+		}
+	}
+
+	w.Header().Set("X-Cache", "MISS")
+
+	resp, err := a.FetchGeoConcentrationData(r.Context())
+	if err != nil {
+		logError("geo concentration query error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("failed to encode response", "error", err)
+	}
+}
+
+func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	query := `
+		WITH geolocated AS (
+			SELECT
+				ls.target_ip,
+				ls.lat AS dzdp_lat,
+				ls.lng AS dzdp_lng,
+				gn.pubkey AS node_pubkey
+			FROM dzdp.location_state FINAL ls
+			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
+			WHERE ls.state = 'decided'
+		),
+		enriched AS (
+			SELECT
+				gv.target_ip,
+				gv.dzdp_lat,
+				gv.dzdp_lng,
+				va.vote_pubkey,
+				va.activated_stake_lamports / 1e9 AS stake_sol,
+				coalesce(geo.asn, 0) AS asn,
+				coalesce(geo.asn_org, '') AS asn_org,
+				coalesce(geo.country_code, '') AS country_code,
+				coalesce(geo.country, '') AS country_name
+			FROM geolocated gv
+			JOIN solana_vote_accounts_current va ON gv.node_pubkey = va.node_pubkey
+			LEFT JOIN geoip_records_current geo ON gv.target_ip = geo.ip
+			WHERE va.epoch_vote_account = 'true' AND va.activated_stake_lamports > 0
+		),
+		nearest_metro AS (
+			SELECT
+				e.vote_pubkey,
+				e.stake_sol,
+				e.asn,
+				e.asn_org,
+				e.country_code,
+				e.country_name,
+				arrayElement(
+					arraySort(
+						(x, y) -> y,
+						groupArray(m.code),
+						groupArray(sqrt(pow(e.dzdp_lat - m.latitude, 2) + pow(e.dzdp_lng - m.longitude, 2)))
+					), 1
+				) AS metro_code
+			FROM enriched e
+			CROSS JOIN dz_metros_current m
+			GROUP BY e.vote_pubkey, e.stake_sol, e.asn, e.asn_org, e.country_code, e.country_name
+		),
+		deduped AS (
+			SELECT
+				vote_pubkey,
+				argMax(stake_sol, stake_sol) AS stake_sol,
+				argMax(metro_code, stake_sol) AS metro_code,
+				argMax(asn, stake_sol) AS asn,
+				argMax(asn_org, stake_sol) AS asn_org,
+				argMax(country_code, stake_sol) AS country_code,
+				argMax(country_name, stake_sol) AS country_name
+			FROM nearest_metro
+			GROUP BY vote_pubkey
+		)
+		SELECT vote_pubkey, stake_sol, metro_code, asn, asn_org, country_code, country_name
+		FROM deduped
+	`
+
+	start := time.Now()
+	rows, err := a.DB.Query(ctx, query)
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Collect per-validator rows and aggregate in Go
+	type validatorRow struct {
+		votePubkey  string
+		stakeSol    float64
+		metroCode   string
+		asn         int64
+		asnOrg      string
+		countryCode string
+		countryName string
+	}
+
+	var validators []validatorRow
+	for rows.Next() {
+		var v validatorRow
+		if err := rows.Scan(&v.votePubkey, &v.stakeSol, &v.metroCode, &v.asn, &v.asnOrg, &v.countryCode, &v.countryName); err != nil {
+			return nil, err
+		}
+		validators = append(validators, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Compute total stake
+	var totalStake float64
+	for _, v := range validators {
+		totalStake += v.stakeSol
+	}
+
+	// Aggregate by metro
+	metroMap := make(map[string]*GeoConcentrationMetro)
+	for _, v := range validators {
+		m, ok := metroMap[v.metroCode]
+		if !ok {
+			m = &GeoConcentrationMetro{MetroCode: v.metroCode}
+			metroMap[v.metroCode] = m
+		}
+		m.Validators++
+		m.StakeSol += v.stakeSol
+	}
+	metros := make([]GeoConcentrationMetro, 0, len(metroMap))
+	for _, m := range metroMap {
+		if totalStake > 0 {
+			m.StakePct = m.StakeSol / totalStake * 100
+		}
+		metros = append(metros, *m)
+	}
+	sort.Slice(metros, func(i, j int) bool { return metros[i].StakeSol > metros[j].StakeSol })
+
+	// Aggregate by country
+	type countryKey struct{ code, name string }
+	countryMap := make(map[countryKey]*GeoConcentrationCountry)
+	for _, v := range validators {
+		ck := countryKey{v.countryCode, v.countryName}
+		c, ok := countryMap[ck]
+		if !ok {
+			c = &GeoConcentrationCountry{CountryCode: v.countryCode, CountryName: v.countryName}
+			countryMap[ck] = c
+		}
+		c.Validators++
+		c.StakeSol += v.stakeSol
+	}
+	countries := make([]GeoConcentrationCountry, 0, len(countryMap))
+	for _, c := range countryMap {
+		if totalStake > 0 {
+			c.StakePct = c.StakeSol / totalStake * 100
+		}
+		countries = append(countries, *c)
+	}
+	sort.Slice(countries, func(i, j int) bool { return countries[i].StakeSol > countries[j].StakeSol })
+
+	// Aggregate by ASN
+	type asnKey struct {
+		asn int64
+		org string
+	}
+	asnMap := make(map[asnKey]*GeoConcentrationASN)
+	for _, v := range validators {
+		ak := asnKey{v.asn, v.asnOrg}
+		entry, ok := asnMap[ak]
+		if !ok {
+			entry = &GeoConcentrationASN{ASN: v.asn, ASNOrg: v.asnOrg}
+			asnMap[ak] = entry
+		}
+		entry.Validators++
+		entry.StakeSol += v.stakeSol
+	}
+	asns := make([]GeoConcentrationASN, 0, len(asnMap))
+	for _, entry := range asnMap {
+		if totalStake > 0 {
+			entry.StakePct = entry.StakeSol / totalStake * 100
+		}
+		asns = append(asns, *entry)
+	}
+	sort.Slice(asns, func(i, j int) bool { return asns[i].StakeSol > asns[j].StakeSol })
+
+	// Compute hero stats
+	var stakeTopTwo float64
+	for i := 0; i < len(metros) && i < 2; i++ {
+		stakeTopTwo += metros[i].StakePct
+	}
+
+	// Count anchor points (distinct DZ metros)
+	var anchorPoints int
+	anchorRows, err := a.DB.Query(ctx, "SELECT count() FROM dz_metros_current")
+	if err == nil {
+		defer anchorRows.Close()
+		if anchorRows.Next() {
+			_ = anchorRows.Scan(&anchorPoints)
+		}
+	}
+
+	var maxASNPct float64
+	if len(asns) > 0 {
+		maxASNPct = asns[0].StakePct
+	}
+
+	// Round percentages
+	stakeTopTwo = math.Round(stakeTopTwo*100) / 100
+	maxASNPct = math.Round(maxASNPct*100) / 100
+
+	resp := &GeoConcentrationResponse{
+		HeroStats: GeoConcentrationHeroStats{
+			ValidatorsMeasured:   len(validators),
+			StakeTopTwoMetrosPct: stakeTopTwo,
+			AnchorPoints:         anchorPoints,
+			StakeMaxASNPct:       maxASNPct,
+		},
+		Metros:    metros,
+		Countries: countries,
+		ASNs:      asns,
+	}
+
+	return resp, nil
+}

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -82,7 +82,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	query := `
 		WITH geolocated AS (
 			SELECT
-				ls.target_ip,
+				ls.target_ip AS target_ip,
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
@@ -92,10 +92,10 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		),
 		enriched AS (
 			SELECT
-				gv.target_ip,
-				gv.dzdp_lat,
-				gv.dzdp_lng,
-				va.vote_pubkey,
+				gv.target_ip AS target_ip,
+				gv.dzdp_lat AS dzdp_lat,
+				gv.dzdp_lng AS dzdp_lng,
+				va.vote_pubkey AS vote_pubkey,
 				va.activated_stake_lamports / 1e9 AS stake_sol,
 				coalesce(geo.asn, 0) AS asn,
 				coalesce(geo.asn_org, '') AS asn_org,
@@ -108,12 +108,12 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		),
 		nearest_metro AS (
 			SELECT
-				e.vote_pubkey,
-				e.stake_sol,
-				e.asn,
-				e.asn_org,
-				e.country_code,
-				e.country_name,
+				e.vote_pubkey AS vote_pubkey,
+				e.stake_sol AS stake_sol,
+				e.asn AS asn,
+				e.asn_org AS asn_org,
+				e.country_code AS country_code,
+				e.country_name AS country_name,
 				arrayElement(
 					arraySort(
 						(x, y) -> y,
@@ -123,7 +123,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 				) AS metro_code
 			FROM enriched e
 			CROSS JOIN dz_metros_current m
-			GROUP BY e.vote_pubkey, e.stake_sol, e.asn, e.asn_org, e.country_code, e.country_name
+			GROUP BY vote_pubkey, stake_sol, asn, asn_org, country_code, country_name
 		),
 		deduped AS (
 			SELECT
@@ -147,7 +147,6 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	// Collect per-validator rows and aggregate in Go
 	type validatorRow struct {
@@ -164,13 +163,16 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	for rows.Next() {
 		var v validatorRow
 		if err := rows.Scan(&v.votePubkey, &v.stakeSol, &v.metroCode, &v.asn, &v.asnOrg, &v.countryCode, &v.countryName); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		validators = append(validators, v)
 	}
 	if err := rows.Err(); err != nil {
+		rows.Close()
 		return nil, err
 	}
+	rows.Close()
 
 	// Compute total stake
 	var totalStake float64

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -254,15 +254,15 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	}
 
 	// Count anchor points (distinct DZ metros)
-	var anchorPoints int
+	var anchorPoints uint64
 	anchorRows, err := a.DB.Query(ctx, "SELECT count() FROM dz_metros_current")
 	if err != nil {
 		logError("geo concentration anchor points query error", "error", err)
 	} else {
-		defer anchorRows.Close()
 		if anchorRows.Next() {
 			_ = anchorRows.Scan(&anchorPoints)
 		}
+		anchorRows.Close()
 	}
 
 	var maxASNPct float64
@@ -288,7 +288,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		HeroStats: GeoConcentrationHeroStats{
 			ValidatorsMeasured:   len(validators),
 			StakeTopTwoMetrosPct: stakeTopTwo,
-			AnchorPoints:         anchorPoints,
+			AnchorPoints:         int(anchorPoints),
 			StakeMaxASNPct:       maxASNPct,
 		},
 		Metros:    metros,

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -3,11 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"net/http"
 	"sort"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/api/metrics"
 )
@@ -145,6 +147,15 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	rows, err := a.DB.Query(ctx, query)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
+		// Return empty response when DZDP tables aren't available
+		var chErr *proto.Exception
+		if errors.As(err, &chErr) && chErr.Code == 60 {
+			return &GeoConcentrationResponse{
+				Metros:    []GeoConcentrationMetro{},
+				Countries: []GeoConcentrationCountry{},
+				ASNs:      []GeoConcentrationASN{},
+			}, nil
+		}
 		return nil, err
 	}
 

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -81,14 +82,16 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	query := `
+	dzdpDB := fmt.Sprintf("`%s`", a.DZDPDB)
+
+	query := fmt.Sprintf(`
 		WITH geolocated AS (
 			SELECT
 				ls.target_ip AS target_ip,
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM (SELECT * FROM dzdp.location_state FINAL) AS ls
+			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'decided'
 		),
@@ -141,7 +144,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		)
 		SELECT vote_pubkey, max_stake AS stake_sol, metro_code, asn, asn_org, country_code, country_name
 		FROM deduped
-	`
+	`, dzdpDB)
 
 	start := time.Now()
 	rows, err := a.DB.Query(ctx, query)

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -254,7 +254,9 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	// Count anchor points (distinct DZ metros)
 	var anchorPoints int
 	anchorRows, err := a.DB.Query(ctx, "SELECT count() FROM dz_metros_current")
-	if err == nil {
+	if err != nil {
+		logError("geo concentration anchor points query error", "error", err)
+	} else {
 		defer anchorRows.Close()
 		if anchorRows.Next() {
 			_ = anchorRows.Scan(&anchorPoints)

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -270,6 +270,16 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 	stakeTopTwo = math.Round(stakeTopTwo*100) / 100
 	maxASNPct = math.Round(maxASNPct*100) / 100
 
+	if metros == nil {
+		metros = []GeoConcentrationMetro{}
+	}
+	if countries == nil {
+		countries = []GeoConcentrationCountry{}
+	}
+	if asns == nil {
+		asns = []GeoConcentrationASN{}
+	}
+
 	resp := &GeoConcentrationResponse{
 		HeroStats: GeoConcentrationHeroStats{
 			ValidatorsMeasured:   len(validators),

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -128,7 +128,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 		deduped AS (
 			SELECT
 				vote_pubkey,
-				max(stake_sol) AS stake_sol,
+				max(stake_sol) AS max_stake,
 				argMax(metro_code, stake_sol) AS metro_code,
 				argMax(asn, stake_sol) AS asn,
 				argMax(asn_org, stake_sol) AS asn_org,
@@ -137,7 +137,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 			FROM nearest_metro
 			GROUP BY vote_pubkey
 		)
-		SELECT vote_pubkey, stake_sol, metro_code, asn, asn_org, country_code, country_name
+		SELECT vote_pubkey, max_stake AS stake_sol, metro_code, asn, asn_org, country_code, country_name
 		FROM deduped
 	`
 

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -86,7 +86,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM dzdp.location_state FINAL ls
+			FROM (SELECT * FROM dzdp.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'decided'
 		),

--- a/api/handlers/geo_concentration_test.go
+++ b/api/handlers/geo_concentration_test.go
@@ -165,7 +165,7 @@ func TestGetGeoConcentration(t *testing.T) {
 	createDZDPLocationStateTable(t, api)
 
 	t.Run("empty response", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/concentration", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/concentration", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoConcentration(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -182,7 +182,7 @@ func TestGetGeoConcentration(t *testing.T) {
 	seedGeoTestData(t, api)
 
 	t.Run("returns aggregated data", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/concentration", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/concentration", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoConcentration(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/api/handlers/geo_concentration_test.go
+++ b/api/handlers/geo_concentration_test.go
@@ -146,11 +146,11 @@ func seedGeoTestData(t *testing.T, api *handlers.API) {
 			 best_rtt_ns, state, decided_at)
 		VALUES
 			(now64(9), '10.0.0.1', 'probe-1', 52.37, 4.89,
-			 1000000, 'decided', now64(9)),
+			 1000000, 'honed', now64(9)),
 			(now64(9), '10.0.0.2', 'probe-2', 40.71, -74.01,
-			 2000000, 'decided', now64(9)),
+			 2000000, 'honed', now64(9)),
 			(now64(9), '10.0.0.3', 'probe-3', 52.37, 4.89,
-			 1500000, 'decided', now64(9))
+			 1500000, 'honed', now64(9))
 	`)
 	require.NoError(t, err)
 }

--- a/api/handlers/geo_concentration_test.go
+++ b/api/handlers/geo_concentration_test.go
@@ -1,0 +1,258 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createDZDPLocationStateTable creates the dzdp database and location_state
+// table used by geo concentration and geo validators handlers.
+func createDZDPLocationStateTable(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	err := api.DB.Exec(ctx, "CREATE DATABASE IF NOT EXISTS dzdp")
+	require.NoError(t, err)
+	err = api.DB.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS dzdp.location_state (
+			snapshot_at DateTime64(9),
+			target_ip String,
+			winning_probe_pubkey String,
+			lat Float64,
+			lng Float64,
+			best_rtt_ns UInt64,
+			state LowCardinality(String),
+			decided_at DateTime64(9)
+		) ENGINE = Memory
+	`)
+	require.NoError(t, err)
+}
+
+// seedGeoTestData inserts dimension and DZDP data shared by both
+// geo_concentration and geo_validators tests.
+func seedGeoTestData(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+
+	// Seed vote accounts
+	err := api.DB.Exec(ctx, `
+		INSERT INTO dim_solana_vote_accounts_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 vote_pubkey, epoch, node_pubkey, activated_stake_lamports,
+			 epoch_vote_account, commission_percentage)
+		VALUES
+			('vote-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'vote-1', 100, 'node-1', 100000000000, 'true', 5),
+			('vote-2', now(), now(), generateUUIDv4(), 0, 1,
+			 'vote-2', 100, 'node-2', 200000000000, 'true', 10),
+			('vote-3', now(), now(), generateUUIDv4(), 0, 1,
+			 'vote-3', 100, 'node-3', 50000000000, 'true', 3)
+	`)
+	require.NoError(t, err)
+
+	// Seed gossip nodes
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_solana_gossip_nodes_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pubkey, epoch, gossip_ip, gossip_port, tpuquic_ip, tpuquic_port, version)
+		VALUES
+			('node-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-1', 100, '10.0.0.1', 8001, '', 0, '1.18.0'),
+			('node-2', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-2', 100, '10.0.0.2', 8001, '', 0, '1.18.0'),
+			('node-3', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-3', 100, '10.0.0.3', 8001, '', 0, '1.18.0')
+	`)
+	require.NoError(t, err)
+
+	// Seed geoip records
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_geoip_records_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 ip, country_code, country, region, city, city_id, metro_name,
+			 latitude, longitude, postal_code, time_zone, accuracy_radius,
+			 asn, asn_org, is_anycast, is_anonymous_proxy, is_satellite_provider)
+		VALUES
+			('10.0.0.1', now(), now(), generateUUIDv4(), 0, 1,
+			 '10.0.0.1', 'NL', 'Netherlands', 'NH', 'Amsterdam', 1, 'Amsterdam',
+			 52.37, 4.89, '1000', 'Europe/Amsterdam', 100,
+			 13335, 'Cloudflare Inc', false, false, false),
+			('10.0.0.2', now(), now(), generateUUIDv4(), 0, 1,
+			 '10.0.0.2', 'US', 'United States', 'NY', 'New York', 2, 'New York',
+			 40.71, -74.01, '10001', 'America/New_York', 100,
+			 13335, 'Cloudflare Inc', false, false, false),
+			('10.0.0.3', now(), now(), generateUUIDv4(), 0, 1,
+			 '10.0.0.3', 'DE', 'Germany', 'HE', 'Frankfurt', 3, 'Frankfurt',
+			 52.37, 4.89, '60306', 'Europe/Berlin', 100,
+			 16509, 'Amazon.com Inc', false, false, false)
+	`)
+	require.NoError(t, err)
+
+	// Seed DZ metros
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, code, name, longitude, latitude)
+		VALUES
+			('ams', now(), now(), generateUUIDv4(), 0, 1,
+			 'ams', 'ams', 'Amsterdam', 4.89, 52.37),
+			('nyc', now(), now(), generateUUIDv4(), 0, 1,
+			 'nyc', 'nyc', 'New York', -74.01, 40.71)
+	`)
+	require.NoError(t, err)
+
+	// Seed validatorsapp validators
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_validatorsapp_validators_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 account, name, vote_account, software_version, software_client,
+			 software_client_id, jito, jito_commission, is_active, is_dz,
+			 active_stake, commission, delinquent, epoch, epoch_credits,
+			 skipped_slot_percent, total_score, data_center_key,
+			 autonomous_system_number, latitude, longitude, ip, stake_pools_list)
+		VALUES
+			('node-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-1', 'Validator One', 'vote-1', '1.18.0', 'solana-labs',
+			 1, 0, 0, 1, 1,
+			 100000000000, 5, 0, 100, 1000,
+			 '0.5', 100, 'NL-Amsterdam',
+			 13335, '52.37', '4.89', '10.0.0.1', ''),
+			('node-2', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-2', 'Validator Two', 'vote-2', '1.18.0', 'solana-labs',
+			 1, 0, 0, 1, 0,
+			 200000000000, 10, 0, 100, 2000,
+			 '0.3', 200, 'US-New York',
+			 13335, '40.71', '-74.01', '10.0.0.2', ''),
+			('node-3', now(), now(), generateUUIDv4(), 0, 1,
+			 'node-3', 'Validator Three', 'vote-3', '1.18.0', 'solana-labs',
+			 1, 0, 0, 1, 1,
+			 50000000000, 3, 0, 100, 500,
+			 '0.8', 50, 'DE-Frankfurt',
+			 16509, '52.37', '4.89', '10.0.0.3', '')
+	`)
+	require.NoError(t, err)
+
+	// Seed DZDP location_state
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dzdp.location_state
+			(snapshot_at, target_ip, winning_probe_pubkey, lat, lng,
+			 best_rtt_ns, state, decided_at)
+		VALUES
+			(now64(9), '10.0.0.1', 'probe-1', 52.37, 4.89,
+			 1000000, 'decided', now64(9)),
+			(now64(9), '10.0.0.2', 'probe-2', 40.71, -74.01,
+			 2000000, 'decided', now64(9)),
+			(now64(9), '10.0.0.3', 'probe-3', 52.37, 4.89,
+			 1500000, 'decided', now64(9))
+	`)
+	require.NoError(t, err)
+}
+
+func TestGetGeoConcentration(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	createDZDPLocationStateTable(t, api)
+
+	t.Run("empty response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/concentration", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoConcentration(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoConcentrationResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, 0, resp.HeroStats.ValidatorsMeasured)
+		assert.Empty(t, resp.Metros)
+		assert.Empty(t, resp.Countries)
+		assert.Empty(t, resp.ASNs)
+	})
+
+	seedGeoTestData(t, api)
+
+	t.Run("returns aggregated data", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/concentration", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoConcentration(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoConcentrationResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		// 3 validators measured
+		assert.Equal(t, 3, resp.HeroStats.ValidatorsMeasured)
+
+		// 2 anchor points (AMS + NYC metros)
+		assert.Equal(t, 2, resp.HeroStats.AnchorPoints)
+
+		// 2 metros: AMS (~150 SOL from vote-1 + vote-3) and NYC (~200 SOL from vote-2)
+		assert.Len(t, resp.Metros, 2)
+
+		// Metros should be sorted by stake descending
+		// NYC: 200 SOL > AMS: 150 SOL
+		var amsMetro, nycMetro *handlers.GeoConcentrationMetro
+		for i := range resp.Metros {
+			switch resp.Metros[i].MetroCode {
+			case "ams":
+				amsMetro = &resp.Metros[i]
+			case "nyc":
+				nycMetro = &resp.Metros[i]
+			}
+		}
+		require.NotNil(t, amsMetro, "expected to find AMS metro")
+		require.NotNil(t, nycMetro, "expected to find NYC metro")
+
+		assert.Equal(t, 2, amsMetro.Validators)
+		assert.InDelta(t, 150.0, amsMetro.StakeSol, 1.0)
+
+		assert.Equal(t, 1, nycMetro.Validators)
+		assert.InDelta(t, 200.0, nycMetro.StakeSol, 1.0)
+
+		// Countries: NL, US, DE
+		assert.Len(t, resp.Countries, 3)
+
+		// 2 ASNs: 13335 (Cloudflare) and 16509 (Amazon)
+		assert.Len(t, resp.ASNs, 2)
+
+		var cfASN, awsASN *handlers.GeoConcentrationASN
+		for i := range resp.ASNs {
+			switch resp.ASNs[i].ASN {
+			case 13335:
+				cfASN = &resp.ASNs[i]
+			case 16509:
+				awsASN = &resp.ASNs[i]
+			}
+		}
+		require.NotNil(t, cfASN, "expected to find ASN 13335")
+		require.NotNil(t, awsASN, "expected to find ASN 16509")
+
+		assert.Equal(t, 2, cfASN.Validators)
+		assert.InDelta(t, 300.0, cfASN.StakeSol, 1.0)
+		assert.Equal(t, 1, awsASN.Validators)
+		assert.InDelta(t, 50.0, awsASN.StakeSol, 1.0)
+
+		// Stake percentages should add up to ~100
+		var totalMetroPct float64
+		for _, m := range resp.Metros {
+			totalMetroPct += m.StakePct
+		}
+		assert.InDelta(t, 100.0, totalMetroPct, 1.0)
+
+		var totalASNPct float64
+		for _, a := range resp.ASNs {
+			totalASNPct += a.StakePct
+		}
+		assert.InDelta(t, 100.0, totalASNPct, 1.0)
+	})
+}

--- a/api/handlers/geo_concentration_test.go
+++ b/api/handlers/geo_concentration_test.go
@@ -29,7 +29,8 @@ func createDZDPLocationStateTable(t *testing.T, api *handlers.API) {
 			best_rtt_ns UInt64,
 			state LowCardinality(String),
 			decided_at DateTime64(9)
-		) ENGINE = Memory
+		) ENGINE = ReplacingMergeTree(snapshot_at)
+		ORDER BY target_ip
 	`)
 	require.NoError(t, err)
 }

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -151,7 +151,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 			SELECT
 				vote_pubkey,
 				argMax(node_pubkey, stake_sol) AS node_pubkey,
-				max(stake_sol) AS stake_sol,
+				max(stake_sol) AS max_stake,
 				argMax(commission, stake_sol) AS commission,
 				argMax(metro_code, stake_sol) AS metro_code,
 				argMax(asn, stake_sol) AS asn,
@@ -165,10 +165,10 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 			FROM nearest_metro
 			GROUP BY vote_pubkey
 		)
-		SELECT vote_pubkey, node_pubkey, stake_sol, commission, metro_code, asn, asn_org,
+		SELECT vote_pubkey, node_pubkey, max_stake AS stake_sol, commission, metro_code, asn, asn_org,
 			country_code, vname, datacenter, is_dz, dzdp_lat, dzdp_lng
 		FROM deduped
-		ORDER BY stake_sol DESC
+		ORDER BY max_stake DESC
 	`
 
 	start := time.Now()

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -151,7 +151,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 			SELECT
 				vote_pubkey,
 				argMax(node_pubkey, stake_sol) AS node_pubkey,
-				argMax(stake_sol, stake_sol) AS stake_sol,
+				max(stake_sol) AS stake_sol,
 				argMax(commission, stake_sol) AS commission,
 				argMax(metro_code, stake_sol) AS metro_code,
 				argMax(asn, stake_sol) AS asn,

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -95,7 +95,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM dzdp.location_state FINAL ls
+			FROM (SELECT * FROM dzdp.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'decided'
 		),

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -97,8 +97,8 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 		WITH geolocated AS (
 			SELECT
 				ls.target_ip AS target_ip,
-				ls.lat AS dzdp_lat,
-				ls.lng AS dzdp_lng,
+				coalesce(ls.lat, 0) AS dzdp_lat,
+				coalesce(ls.lng, 0) AS dzdp_lng,
 				gn.pubkey AS node_pubkey
 			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
@@ -180,9 +180,9 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 	rows, err := a.DB.Query(ctx, query)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
-		// Return empty response when DZDP tables aren't available
+		// Return empty response when DZDP tables aren't available or accessible
 		var chErr *proto.Exception
-		if errors.As(err, &chErr) && chErr.Code == 60 {
+		if errors.As(err, &chErr) && (chErr.Code == 60 || chErr.Code == 497) {
 			return &GeoValidatorsResponse{
 				Validators:       []GeoValidatorItem{},
 				TierDistribution: []GeoTierDistribution{},

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -3,12 +3,14 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/api/metrics"
 )
@@ -175,6 +177,15 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 	rows, err := a.DB.Query(ctx, query)
 	metrics.RecordClickHouseQuery(time.Since(start), err)
 	if err != nil {
+		// Return empty response when DZDP tables aren't available
+		var chErr *proto.Exception
+		if errors.As(err, &chErr) && chErr.Code == 60 {
+			return &GeoValidatorsResponse{
+				Validators:       []GeoValidatorItem{},
+				TierDistribution: []GeoTierDistribution{},
+				MetroBreakdown:   []GeoMetroBreakdown{},
+			}, nil
+		}
 		return nil, err
 	}
 	defer rows.Close()

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -1,0 +1,300 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+type GeoValidatorItem struct {
+	VotePubkey  string  `json:"vote_pubkey"`
+	NodePubkey  string  `json:"node_pubkey"`
+	Name        string  `json:"name"`
+	StakeSol    float64 `json:"stake_sol"`
+	StakePct    float64 `json:"stake_pct"`
+	Commission  int     `json:"commission"`
+	MetroCode   string  `json:"metro_code"`
+	CountryCode string  `json:"country_code"`
+	ASN         int64   `json:"asn"`
+	ASNOrg      string  `json:"asn_org"`
+	Datacenter  string  `json:"datacenter"`
+	IsDZ        bool    `json:"is_dz"`
+	DZDPLat     float64 `json:"dzdp_lat"`
+	DZDPLng     float64 `json:"dzdp_lng"`
+}
+
+type GeoTierDistribution struct {
+	Tier       string  `json:"tier"`
+	Validators int     `json:"validators"`
+	StakePct   float64 `json:"stake_pct"`
+}
+
+type GeoMetroBreakdown struct {
+	MetroCode  string  `json:"metro_code"`
+	Validators int     `json:"validators"`
+	StakeSol   float64 `json:"stake_sol"`
+	StakePct   float64 `json:"stake_pct"`
+}
+
+type GeoValidatorsResponse struct {
+	TotalValidators  int                   `json:"total_validators"`
+	TotalStakeSol    float64               `json:"total_stake_sol"`
+	Validators       []GeoValidatorItem    `json:"validators"`
+	TierDistribution []GeoTierDistribution `json:"tier_distribution"`
+	MetroBreakdown   []GeoMetroBreakdown   `json:"metro_breakdown"`
+}
+
+func (a *API) GetGeoValidators(w http.ResponseWriter, r *http.Request) {
+	if isMainnet(r.Context()) && isDefaultGeoValidatorsRequest(r) {
+		if data, err := a.readPageCache(r.Context(), "geo_validators"); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			_, _ = w.Write(data)
+			return
+		}
+	}
+
+	w.Header().Set("X-Cache", "MISS")
+
+	metro := strings.TrimSpace(r.URL.Query().Get("metro"))
+	dzFilter := strings.TrimSpace(r.URL.Query().Get("dz_filter"))
+
+	resp, err := a.FetchGeoValidatorsData(r.Context(), metro, dzFilter)
+	if err != nil {
+		logError("geo validators query error", "error", err)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("failed to encode response", "error", err)
+	}
+}
+
+func isDefaultGeoValidatorsRequest(r *http.Request) bool {
+	q := r.URL.Query()
+	return q.Get("metro") == "" && q.Get("dz_filter") == ""
+}
+
+func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string) (*GeoValidatorsResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	query := `
+		WITH geolocated AS (
+			SELECT
+				ls.target_ip,
+				ls.lat AS dzdp_lat,
+				ls.lng AS dzdp_lng,
+				gn.pubkey AS node_pubkey
+			FROM dzdp.location_state FINAL ls
+			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
+			WHERE ls.state = 'decided'
+		),
+		enriched AS (
+			SELECT
+				gv.target_ip,
+				gv.dzdp_lat,
+				gv.dzdp_lng,
+				gv.node_pubkey,
+				va.vote_pubkey,
+				va.activated_stake_lamports / 1e9 AS stake_sol,
+				va.commission_percentage AS commission,
+				coalesce(geo.asn, 0) AS asn,
+				coalesce(geo.asn_org, '') AS asn_org,
+				coalesce(geo.country_code, '') AS country_code,
+				coalesce(vapp.name, '') AS vname,
+				coalesce(vapp.data_center_key, '') AS datacenter,
+				if(vapp.is_dz = 1, true, false) AS is_dz
+			FROM geolocated gv
+			JOIN solana_vote_accounts_current va ON gv.node_pubkey = va.node_pubkey
+			LEFT JOIN geoip_records_current geo ON gv.target_ip = geo.ip
+			LEFT JOIN validatorsapp_validators_current vapp ON va.vote_pubkey = vapp.vote_account
+			WHERE va.epoch_vote_account = 'true' AND va.activated_stake_lamports > 0
+		),
+		nearest_metro AS (
+			SELECT
+				e.vote_pubkey,
+				e.node_pubkey,
+				e.stake_sol,
+				e.commission,
+				e.asn,
+				e.asn_org,
+				e.country_code,
+				e.vname,
+				e.datacenter,
+				e.is_dz,
+				e.dzdp_lat,
+				e.dzdp_lng,
+				arrayElement(
+					arraySort(
+						(x, y) -> y,
+						groupArray(m.code),
+						groupArray(sqrt(pow(e.dzdp_lat - m.latitude, 2) + pow(e.dzdp_lng - m.longitude, 2)))
+					), 1
+				) AS metro_code
+			FROM enriched e
+			CROSS JOIN dz_metros_current m
+			GROUP BY e.vote_pubkey, e.node_pubkey, e.stake_sol, e.commission,
+				e.asn, e.asn_org, e.country_code, e.vname, e.datacenter, e.is_dz,
+				e.dzdp_lat, e.dzdp_lng
+		),
+		deduped AS (
+			SELECT
+				vote_pubkey,
+				argMax(node_pubkey, stake_sol) AS node_pubkey,
+				argMax(stake_sol, stake_sol) AS stake_sol,
+				argMax(commission, stake_sol) AS commission,
+				argMax(metro_code, stake_sol) AS metro_code,
+				argMax(asn, stake_sol) AS asn,
+				argMax(asn_org, stake_sol) AS asn_org,
+				argMax(country_code, stake_sol) AS country_code,
+				argMax(vname, stake_sol) AS vname,
+				argMax(datacenter, stake_sol) AS datacenter,
+				argMax(is_dz, stake_sol) AS is_dz,
+				argMax(dzdp_lat, stake_sol) AS dzdp_lat,
+				argMax(dzdp_lng, stake_sol) AS dzdp_lng
+			FROM nearest_metro
+			GROUP BY vote_pubkey
+		)
+		SELECT vote_pubkey, node_pubkey, stake_sol, commission, metro_code, asn, asn_org,
+			country_code, vname, datacenter, is_dz, dzdp_lat, dzdp_lng
+		FROM deduped
+		ORDER BY stake_sol DESC
+	`
+
+	start := time.Now()
+	rows, err := a.DB.Query(ctx, query)
+	metrics.RecordClickHouseQuery(time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var allValidators []GeoValidatorItem
+	for rows.Next() {
+		var v GeoValidatorItem
+		if err := rows.Scan(&v.VotePubkey, &v.NodePubkey, &v.StakeSol, &v.Commission,
+			&v.MetroCode, &v.ASN, &v.ASNOrg, &v.CountryCode, &v.Name, &v.Datacenter,
+			&v.IsDZ, &v.DZDPLat, &v.DZDPLng); err != nil {
+			return nil, err
+		}
+		allValidators = append(allValidators, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Apply filters
+	filtered := make([]GeoValidatorItem, 0, len(allValidators))
+	for _, v := range allValidators {
+		if metro != "" && !strings.EqualFold(v.MetroCode, metro) {
+			continue
+		}
+		if dzFilter == "on" && !v.IsDZ {
+			continue
+		}
+		if dzFilter == "off" && v.IsDZ {
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+
+	// Compute totals from all filtered validators
+	var totalStake float64
+	for _, v := range filtered {
+		totalStake += v.StakeSol
+	}
+
+	// Compute stake_pct for each validator
+	for i := range filtered {
+		if totalStake > 0 {
+			filtered[i].StakePct = math.Round(filtered[i].StakeSol/totalStake*10000) / 100
+		}
+	}
+
+	// Tier distribution: validators are already sorted by stake DESC from the query.
+	// "super" = cumulative stake before this validator < 33.3%
+	// "high"  = cumulative stake before this validator < 66.6%
+	// "mid"   = rest
+	tierStake := map[string]float64{}
+	tierCount := map[string]int{}
+	var cumStake float64
+	for _, v := range filtered {
+		var tier string
+		if totalStake > 0 && cumStake/totalStake < 0.333 {
+			tier = "super"
+		} else if totalStake > 0 && cumStake/totalStake < 0.666 {
+			tier = "high"
+		} else {
+			tier = "mid"
+		}
+		cumStake += v.StakeSol
+		tierStake[tier] += v.StakeSol
+		tierCount[tier]++
+	}
+	tierDist := make([]GeoTierDistribution, 0, 3)
+	for _, tier := range []string{"super", "high", "mid"} {
+		pct := 0.0
+		if totalStake > 0 {
+			pct = math.Round(tierStake[tier]/totalStake*10000) / 100
+		}
+		tierDist = append(tierDist, GeoTierDistribution{
+			Tier:       tier,
+			Validators: tierCount[tier],
+			StakePct:   pct,
+		})
+	}
+
+	// Metro breakdown from all filtered validators
+	metroMap := make(map[string]*GeoMetroBreakdown)
+	for _, v := range filtered {
+		mb, ok := metroMap[v.MetroCode]
+		if !ok {
+			mb = &GeoMetroBreakdown{MetroCode: v.MetroCode}
+			metroMap[v.MetroCode] = mb
+		}
+		mb.Validators++
+		mb.StakeSol += v.StakeSol
+	}
+	metroBreakdown := make([]GeoMetroBreakdown, 0, len(metroMap))
+	for _, mb := range metroMap {
+		if totalStake > 0 {
+			mb.StakePct = math.Round(mb.StakeSol/totalStake*10000) / 100
+		}
+		metroBreakdown = append(metroBreakdown, *mb)
+	}
+	sort.Slice(metroBreakdown, func(i, j int) bool { return metroBreakdown[i].StakeSol > metroBreakdown[j].StakeSol })
+
+	// Top 30 validators for response
+	top := filtered
+	if len(top) > 30 {
+		top = top[:30]
+	}
+
+	resp := &GeoValidatorsResponse{
+		TotalValidators:  len(filtered),
+		TotalStakeSol:    totalStake,
+		Validators:       top,
+		TierDistribution: tierDist,
+		MetroBreakdown:   metroBreakdown,
+	}
+
+	// Ensure nil slices are empty arrays in JSON
+	if resp.Validators == nil {
+		resp.Validators = []GeoValidatorItem{}
+	}
+	if resp.MetroBreakdown == nil {
+		resp.MetroBreakdown = []GeoMetroBreakdown{}
+	}
+
+	return resp, nil
+}

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -19,7 +19,7 @@ type GeoValidatorItem struct {
 	Name        string  `json:"name"`
 	StakeSol    float64 `json:"stake_sol"`
 	StakePct    float64 `json:"stake_pct"`
-	Commission  int     `json:"commission"`
+	Commission  int64   `json:"commission"`
 	MetroCode   string  `json:"metro_code"`
 	CountryCode string  `json:"country_code"`
 	ASN         int64   `json:"asn"`

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -90,14 +91,16 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	query := `
+	dzdpDB := fmt.Sprintf("`%s`", a.DZDPDB)
+
+	query := fmt.Sprintf(`
 		WITH geolocated AS (
 			SELECT
 				ls.target_ip AS target_ip,
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM (SELECT * FROM dzdp.location_state FINAL) AS ls
+			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'decided'
 		),
@@ -171,7 +174,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 			country_code, vname, datacenter, is_dz, dzdp_lat, dzdp_lng
 		FROM deduped
 		ORDER BY max_stake DESC
-	`
+	`, dzdpDB)
 
 	start := time.Now()
 	rows, err := a.DB.Query(ctx, query)

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -29,6 +29,7 @@ type GeoValidatorItem struct {
 	ASNOrg      string  `json:"asn_org"`
 	Datacenter  string  `json:"datacenter"`
 	IsDZ        bool    `json:"is_dz"`
+	Tier        string  `json:"tier"`
 	DZDPLat     float64 `json:"dzdp_lat"`
 	DZDPLng     float64 `json:"dzdp_lng"`
 }
@@ -143,7 +144,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 					arraySort(
 						(x, y) -> y,
 						groupArray(m.code),
-						groupArray(sqrt(pow(e.dzdp_lat - m.latitude, 2) + pow(e.dzdp_lng - m.longitude, 2)))
+						groupArray(geoDistance(e.dzdp_lng, e.dzdp_lat, m.longitude, m.latitude))
 					), 1
 				) AS metro_code
 			FROM enriched e
@@ -207,6 +208,25 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 		return nil, err
 	}
 
+	// Assign tiers globally (before filtering) so a validator's tier reflects
+	// its position among all validators, not just the filtered subset.
+	// Validators are already sorted by stake DESC from the query.
+	var globalStake float64
+	for _, v := range allValidators {
+		globalStake += v.StakeSol
+	}
+	var cumStake float64
+	for i := range allValidators {
+		if globalStake > 0 && cumStake/globalStake < 0.333 {
+			allValidators[i].Tier = "super"
+		} else if globalStake > 0 && cumStake/globalStake < 0.666 {
+			allValidators[i].Tier = "high"
+		} else {
+			allValidators[i].Tier = "mid"
+		}
+		cumStake += allValidators[i].StakeSol
+	}
+
 	// Apply filters
 	filtered := make([]GeoValidatorItem, 0, len(allValidators))
 	for _, v := range allValidators {
@@ -222,38 +242,25 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 		filtered = append(filtered, v)
 	}
 
-	// Compute totals from all filtered validators
+	// Compute totals from filtered validators
 	var totalStake float64
 	for _, v := range filtered {
 		totalStake += v.StakeSol
 	}
 
-	// Compute stake_pct for each validator
+	// Compute stake_pct for each validator relative to filtered total
 	for i := range filtered {
 		if totalStake > 0 {
 			filtered[i].StakePct = math.Round(filtered[i].StakeSol/totalStake*10000) / 100
 		}
 	}
 
-	// Tier distribution: validators are already sorted by stake DESC from the query.
-	// "super" = cumulative stake before this validator < 33.3%
-	// "high"  = cumulative stake before this validator < 66.6%
-	// "mid"   = rest
+	// Tier distribution from filtered set using globally-assigned tiers
 	tierStake := map[string]float64{}
 	tierCount := map[string]int{}
-	var cumStake float64
 	for _, v := range filtered {
-		var tier string
-		if totalStake > 0 && cumStake/totalStake < 0.333 {
-			tier = "super"
-		} else if totalStake > 0 && cumStake/totalStake < 0.666 {
-			tier = "high"
-		} else {
-			tier = "mid"
-		}
-		cumStake += v.StakeSol
-		tierStake[tier] += v.StakeSol
-		tierCount[tier]++
+		tierStake[v.Tier] += v.StakeSol
+		tierCount[v.Tier]++
 	}
 	tierDist := make([]GeoTierDistribution, 0, 3)
 	for _, tier := range []string{"super", "high", "mid"} {

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -102,7 +102,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 				gn.pubkey AS node_pubkey
 			FROM (SELECT * FROM %s.location_state FINAL) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
-			WHERE ls.state = 'decided'
+			WHERE ls.state = 'honed'
 		),
 		enriched AS (
 			SELECT

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -91,7 +91,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 	query := `
 		WITH geolocated AS (
 			SELECT
-				ls.target_ip,
+				ls.target_ip AS target_ip,
 				ls.lat AS dzdp_lat,
 				ls.lng AS dzdp_lng,
 				gn.pubkey AS node_pubkey
@@ -101,11 +101,11 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 		),
 		enriched AS (
 			SELECT
-				gv.target_ip,
-				gv.dzdp_lat,
-				gv.dzdp_lng,
-				gv.node_pubkey,
-				va.vote_pubkey,
+				gv.target_ip AS target_ip,
+				gv.dzdp_lat AS dzdp_lat,
+				gv.dzdp_lng AS dzdp_lng,
+				gv.node_pubkey AS node_pubkey,
+				va.vote_pubkey AS vote_pubkey,
 				va.activated_stake_lamports / 1e9 AS stake_sol,
 				va.commission_percentage AS commission,
 				coalesce(geo.asn, 0) AS asn,
@@ -122,18 +122,18 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 		),
 		nearest_metro AS (
 			SELECT
-				e.vote_pubkey,
-				e.node_pubkey,
-				e.stake_sol,
-				e.commission,
-				e.asn,
-				e.asn_org,
-				e.country_code,
-				e.vname,
-				e.datacenter,
-				e.is_dz,
-				e.dzdp_lat,
-				e.dzdp_lng,
+				e.vote_pubkey AS vote_pubkey,
+				e.node_pubkey AS node_pubkey,
+				e.stake_sol AS stake_sol,
+				e.commission AS commission,
+				e.asn AS asn,
+				e.asn_org AS asn_org,
+				e.country_code AS country_code,
+				e.vname AS vname,
+				e.datacenter AS datacenter,
+				e.is_dz AS is_dz,
+				e.dzdp_lat AS dzdp_lat,
+				e.dzdp_lng AS dzdp_lng,
 				arrayElement(
 					arraySort(
 						(x, y) -> y,
@@ -143,9 +143,9 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 				) AS metro_code
 			FROM enriched e
 			CROSS JOIN dz_metros_current m
-			GROUP BY e.vote_pubkey, e.node_pubkey, e.stake_sol, e.commission,
-				e.asn, e.asn_org, e.country_code, e.vname, e.datacenter, e.is_dz,
-				e.dzdp_lat, e.dzdp_lng
+			GROUP BY vote_pubkey, node_pubkey, stake_sol, commission,
+				asn, asn_org, country_code, vname, datacenter, is_dz,
+				dzdp_lat, dzdp_lng
 		),
 		deduped AS (
 			SELECT

--- a/api/handlers/geo_validators_test.go
+++ b/api/handlers/geo_validators_test.go
@@ -1,0 +1,147 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGeoValidators(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	createDZDPLocationStateTable(t, api)
+
+	t.Run("empty response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoValidators(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoValidatorsResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, 0, resp.TotalValidators)
+		assert.Empty(t, resp.Validators)
+		assert.Empty(t, resp.MetroBreakdown)
+	})
+
+	seedGeoTestData(t, api)
+
+	t.Run("returns all validators", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoValidators(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoValidatorsResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, resp.TotalValidators)
+		assert.Len(t, resp.Validators, 3)
+
+		// Validators should be sorted by stake descending: vote-2 (200), vote-1 (100), vote-3 (50)
+		assert.Equal(t, "vote-2", resp.Validators[0].VotePubkey)
+		assert.Equal(t, "vote-1", resp.Validators[1].VotePubkey)
+		assert.Equal(t, "vote-3", resp.Validators[2].VotePubkey)
+
+		assert.InDelta(t, 200.0, resp.Validators[0].StakeSol, 1.0)
+		assert.InDelta(t, 100.0, resp.Validators[1].StakeSol, 1.0)
+		assert.InDelta(t, 50.0, resp.Validators[2].StakeSol, 1.0)
+
+		// Tier distribution should have 3 tiers
+		assert.Len(t, resp.TierDistribution, 3)
+
+		// Metro breakdown should have 2 metros
+		assert.Len(t, resp.MetroBreakdown, 2)
+
+		var amsBreakdown, nycBreakdown *handlers.GeoMetroBreakdown
+		for i := range resp.MetroBreakdown {
+			switch resp.MetroBreakdown[i].MetroCode {
+			case "ams":
+				amsBreakdown = &resp.MetroBreakdown[i]
+			case "nyc":
+				nycBreakdown = &resp.MetroBreakdown[i]
+			}
+		}
+		require.NotNil(t, amsBreakdown, "expected AMS metro breakdown")
+		require.NotNil(t, nycBreakdown, "expected NYC metro breakdown")
+
+		assert.Equal(t, 2, amsBreakdown.Validators)
+		assert.InDelta(t, 150.0, amsBreakdown.StakeSol, 1.0)
+		assert.Equal(t, 1, nycBreakdown.Validators)
+		assert.InDelta(t, 200.0, nycBreakdown.StakeSol, 1.0)
+	})
+
+	t.Run("filter by metro", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?metro=ams", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoValidators(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoValidatorsResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, resp.TotalValidators)
+		assert.Len(t, resp.Validators, 2)
+
+		// Both should be AMS validators: vote-1 and vote-3
+		pubkeys := make(map[string]bool)
+		for _, v := range resp.Validators {
+			pubkeys[v.VotePubkey] = true
+		}
+		assert.True(t, pubkeys["vote-1"], "expected vote-1 in AMS metro")
+		assert.True(t, pubkeys["vote-3"], "expected vote-3 in AMS metro")
+	})
+
+	t.Run("filter by dz_filter on", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?dz_filter=on", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoValidators(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoValidatorsResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		// Only is_dz validators: vote-1 and vote-3
+		assert.Equal(t, 2, resp.TotalValidators)
+		assert.Len(t, resp.Validators, 2)
+
+		pubkeys := make(map[string]bool)
+		for _, v := range resp.Validators {
+			pubkeys[v.VotePubkey] = true
+			assert.True(t, v.IsDZ, "expected all validators to be DZ")
+		}
+		assert.True(t, pubkeys["vote-1"], "expected vote-1 with dz_filter=on")
+		assert.True(t, pubkeys["vote-3"], "expected vote-3 with dz_filter=on")
+	})
+
+	t.Run("filter by dz_filter off", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?dz_filter=off", nil)
+		w := httptest.NewRecorder()
+		api.GetGeoValidators(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp handlers.GeoValidatorsResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		// Only non-DZ validator: vote-2
+		assert.Equal(t, 1, resp.TotalValidators)
+		assert.Len(t, resp.Validators, 1)
+		assert.Equal(t, "vote-2", resp.Validators[0].VotePubkey)
+		assert.False(t, resp.Validators[0].IsDZ, "expected vote-2 to not be DZ")
+	})
+}

--- a/api/handlers/geo_validators_test.go
+++ b/api/handlers/geo_validators_test.go
@@ -22,7 +22,7 @@ func TestGetGeoValidators(t *testing.T) {
 	createDZDPLocationStateTable(t, api)
 
 	t.Run("empty response", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/validators", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoValidators(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -38,7 +38,7 @@ func TestGetGeoValidators(t *testing.T) {
 	seedGeoTestData(t, api)
 
 	t.Run("returns all validators", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/validators", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoValidators(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -84,7 +84,7 @@ func TestGetGeoValidators(t *testing.T) {
 	})
 
 	t.Run("filter by metro", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?metro=ams", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/validators?metro=ams", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoValidators(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -106,7 +106,7 @@ func TestGetGeoValidators(t *testing.T) {
 	})
 
 	t.Run("filter by dz_filter on", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?dz_filter=on", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/validators?dz_filter=on", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoValidators(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -129,7 +129,7 @@ func TestGetGeoValidators(t *testing.T) {
 	})
 
 	t.Run("filter by dz_filter off", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dz/geo/validators?dz_filter=off", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/dz/geoloc/validators?dz_filter=off", nil)
 		w := httptest.NewRecorder()
 		api.GetGeoValidators(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/api/main.go
+++ b/api/main.go
@@ -594,6 +594,8 @@ func main() {
 			r.Get("/api/dz/geoloc/probes", api.GetGeolocProbes)
 			r.Get("/api/dz/geoloc/users", api.GetGeolocUsers)
 			r.Get("/api/dz/geoloc/explorer", api.GetGeolocExplorer)
+			r.Get("/api/geo/concentration", api.GetGeoConcentration)
+			r.Get("/api/geo/validators", api.GetGeoValidators)
 		})
 
 		// Solana entity routes

--- a/api/main.go
+++ b/api/main.go
@@ -354,6 +354,7 @@ func main() {
 		Database:      config.Database(),
 		ShredderDB:    config.GetShredderDB(),
 		PublisherDB:   config.GetPublisherDB(),
+		DZDPDB:        config.GetDZDPDB(),
 		PgPool:        config.PgPool,
 		Neo4jClient:   config.Neo4jClient,
 		Neo4jDatabase: config.Neo4jDatabase,

--- a/api/main.go
+++ b/api/main.go
@@ -595,8 +595,8 @@ func main() {
 			r.Get("/api/dz/geoloc/probes", api.GetGeolocProbes)
 			r.Get("/api/dz/geoloc/users", api.GetGeolocUsers)
 			r.Get("/api/dz/geoloc/explorer", api.GetGeolocExplorer)
-			r.Get("/api/geo/concentration", api.GetGeoConcentration)
-			r.Get("/api/geo/validators", api.GetGeoValidators)
+			r.Get("/api/dz/geoloc/concentration", api.GetGeoConcentration)
+			r.Get("/api/dz/geoloc/validators", api.GetGeoValidators)
 		})
 
 		// Solana entity routes

--- a/api/testing/api.go
+++ b/api/testing/api.go
@@ -23,6 +23,7 @@ func NewTestAPIBare(t *testing.T, chDB *ClickHouseDB) *handlers.API {
 		Database:      dbName,
 		ShredderDB:    dbName,
 		PublisherDB:   dbName,
+		DZDPDB:        "dzdp",
 	}
 	api.Manager = handlers.NewWorkflowManager(api)
 	return api
@@ -42,6 +43,7 @@ func NewTestAPI(t *testing.T, chDB *ClickHouseDB) *handlers.API {
 		Database:      dbName,
 		ShredderDB:    dbName,
 		PublisherDB:   dbName,
+		DZDPDB:        "dzdp",
 	}
 	api.Manager = handlers.NewWorkflowManager(api)
 	return api
@@ -77,6 +79,7 @@ func NewTestAPIAll(t *testing.T, chDB *ClickHouseDB, pgDB *DB, neo4jDB *Neo4jDB,
 		api.PublicQueryDB = conn
 		api.Database = dbName
 		api.ShredderDB = dbName
+		api.DZDPDB = "dzdp"
 	}
 
 	if pgDB != nil {

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -114,6 +114,12 @@ func (a *Activities) entries() []cacheEntry {
 		{"bulk device metrics (issues)", "bulk_device_metrics_issues", func(ctx context.Context) (any, error) {
 			return api.FetchBulkDeviceMetricsIssuesData(ctx)
 		}},
+		{"geo concentration", "geo_concentration", func(ctx context.Context) (any, error) {
+			return api.FetchGeoConcentrationData(ctx)
+		}},
+		{"geo validators", "geo_validators", func(ctx context.Context) (any, error) {
+			return api.FetchGeoValidatorsData(ctx, "", "")
+		}},
 	}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5896,6 +5896,108 @@ export async function fetchGeolocExplorer(hours?: number): Promise<GeolocExplore
   return res.json()
 }
 
+// Geo Concentration (DZDP)
+
+export interface GeoConcentrationHeroStats {
+  validators_measured: number
+  stake_top_two_metros_pct: number
+  anchor_points: number
+  stake_max_asn_pct: number
+}
+
+export interface GeoConcentrationMetro {
+  metro_code: string
+  validators: number
+  stake_sol: number
+  stake_pct: number
+}
+
+export interface GeoConcentrationCountry {
+  country_code: string
+  country_name: string
+  validators: number
+  stake_sol: number
+  stake_pct: number
+}
+
+export interface GeoConcentrationASN {
+  asn: number
+  asn_org: string
+  validators: number
+  stake_sol: number
+  stake_pct: number
+}
+
+export interface GeoConcentrationResponse {
+  hero_stats: GeoConcentrationHeroStats
+  metros: GeoConcentrationMetro[]
+  countries: GeoConcentrationCountry[]
+  asns: GeoConcentrationASN[]
+}
+
+export async function fetchGeoConcentration(): Promise<GeoConcentrationResponse> {
+  const res = await apiFetch('/api/geo/concentration')
+  if (!res.ok) {
+    throw new Error('Failed to fetch geo concentration data')
+  }
+  return res.json()
+}
+
+// Geo Validators (DZDP)
+
+export interface GeoValidatorItem {
+  vote_pubkey: string
+  node_pubkey: string
+  name: string
+  stake_sol: number
+  stake_pct: number
+  commission: number
+  metro_code: string
+  country_code: string
+  asn: number
+  asn_org: string
+  datacenter: string
+  is_dz: boolean
+  dzdp_lat: number
+  dzdp_lng: number
+}
+
+export interface GeoTierDistribution {
+  tier: string
+  validators: number
+  stake_pct: number
+}
+
+export interface GeoMetroBreakdown {
+  metro_code: string
+  validators: number
+  stake_sol: number
+  stake_pct: number
+}
+
+export interface GeoValidatorsResponse {
+  total_validators: number
+  total_stake_sol: number
+  validators: GeoValidatorItem[]
+  tier_distribution: GeoTierDistribution[]
+  metro_breakdown: GeoMetroBreakdown[]
+}
+
+export async function fetchGeoValidators(
+  metro?: string,
+  dzFilter?: 'on' | 'off'
+): Promise<GeoValidatorsResponse> {
+  const params = new URLSearchParams()
+  if (metro) params.set('metro', metro)
+  if (dzFilter) params.set('dz_filter', dzFilter)
+  const query = params.toString()
+  const res = await apiFetch(`/api/geo/validators${query ? `?${query}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch geo validators data')
+  }
+  return res.json()
+}
+
 // Access Passes
 
 export interface AccessPass {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5936,7 +5936,7 @@ export interface GeoConcentrationResponse {
 }
 
 export async function fetchGeoConcentration(): Promise<GeoConcentrationResponse> {
-  const res = await apiFetch('/api/geo/concentration')
+  const res = await apiFetch('/api/dz/geoloc/concentration')
   if (!res.ok) {
     throw new Error('Failed to fetch geo concentration data')
   }
@@ -5958,6 +5958,7 @@ export interface GeoValidatorItem {
   asn_org: string
   datacenter: string
   is_dz: boolean
+  tier: string
   dzdp_lat: number
   dzdp_lng: number
 }
@@ -5991,7 +5992,7 @@ export async function fetchGeoValidators(
   if (metro) params.set('metro', metro)
   if (dzFilter) params.set('dz_filter', dzFilter)
   const query = params.toString()
-  const res = await apiFetch(`/api/geo/validators${query ? `?${query}` : ''}`)
+  const res = await apiFetch(`/api/dz/geoloc/validators${query ? `?${query}` : ''}`)
   if (!res.ok) {
     throw new Error('Failed to fetch geo validators data')
   }


### PR DESCRIPTION
Resolves: #549

## Summary of Changes
- Add two new API endpoints (`/api/geo/concentration` and `/api/geo/validators`) that use DZDP location data to geolocate Solana validators to the nearest DZ metro and compute geographic concentration metrics
- The concentration endpoint returns hero stats (top-2 metro stake %, max ASN stake %, anchor point count), plus breakdowns by metro, country, and ASN
- The validators endpoint returns individual validator geo data with filtering by metro and DZ status, tier distribution, and metro breakdown
- Both endpoints are backed by page cache for instant default loads
- Add corresponding TypeScript interfaces and fetch functions in the web client
- Register `dzdp` remote tables for production access

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net    |
|--------------|-------|-------------|--------|
| Core logic   |     2 | +600 / -0   |   +600 |
| Scaffolding  |     4 | +113 / -0   |   +113 |
| Tests        |     2 | +406 / -0   |   +406 |
| **Total**    |     8 | +1119 / -0  | +1119  |

New feature — mostly handler logic and tests with thin wiring.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/geo_concentration.go`](https://github.com/malbeclabs/lake/pull/553/files#diff-47cc9a13786a63b95347d8295c7c325b63c294ee11ef8f31cc5c1c37a2443a8a) — Concentration endpoint: CTE query joining DZDP location state with gossip/vote/geoip tables, nearest-metro assignment via CROSS JOIN, dedup by vote_pubkey, and Go-side aggregation by metro/country/ASN
- [`api/handlers/geo_validators.go`](https://github.com/malbeclabs/lake/pull/553/files#diff-4057ff630b29aa4a64eb4cd017fb7e0f8991c17a51dea0ac0a37ed408b20ee74) — Validators endpoint: similar CTE pipeline with additional per-validator fields (commission, datacenter, DZ status), tier distribution calculation, and metro/DZ filtering
- [`api/handlers/geo_concentration_test.go`](https://github.com/malbeclabs/lake/pull/553/files#diff-53d4270049525801ec6e9db27957487efc187f48570fb1703a2007439df51535) — Tests for concentration endpoint plus shared test helpers (DZDP table setup, seed data)
- [`api/handlers/geo_validators_test.go`](https://github.com/malbeclabs/lake/pull/553/files#diff-6403f4fd0d2a67b4d78fe945c6b947d26aa8830f731b44a342e0addb6ac91690) — Tests for validators endpoint including metro and DZ filtering
- [`web/src/lib/api.ts`](https://github.com/malbeclabs/lake/pull/553/files#diff-af490ef10b2e4da7f8055bd843c240828a9e8bcd6e6244b55888fe13f8ce8f7a) — TypeScript interfaces and fetch functions for both endpoints

</details>

## Testing Verification
- Added integration tests for both endpoints covering empty responses, full data aggregation, metro filtering, and DZ on/off filtering
- Tests seed DZDP location state, gossip nodes, vote accounts, geoip records, metros, and validatorsapp data to validate the full query pipeline
- Verified correct tier distribution, metro breakdown, country/ASN aggregation, and stake percentage calculations