### PR TITLE
indexer: tolerate numeric clientId in getClusterNodes

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -318,7 +318,7 @@ func run() error {
 	if solanaEnabled {
 		solanaRPCClient := rpc.NewWithRetries(solanaNetworkConfig.RPCURL, nil)
 		defer solanaRPCClient.Close()
-		solanaRPC = solanaRPCClient
+		solanaRPC = sol.NewTolerantClient(solanaRPCClient)
 	}
 
 	// Initialize ClickHouse client (required)

--- a/indexer/pkg/sol/rpc.go
+++ b/indexer/pkg/sol/rpc.go
@@ -1,0 +1,94 @@
+package sol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+)
+
+// TolerantClient wraps a *solanarpc.Client and overrides GetClusterNodes to
+// accept either a string or a number for the "clientId" field. The upstream
+// gagliardetto/solana-go library types ClientID as *string (matching the Agave
+// reference implementation), but some validators (e.g. Firedancer) return a
+// numeric value, which fails strict JSON unmarshalling.
+//
+// We don't read ClientID anywhere, so we just decode it into a permissive
+// container and stringify it for callers that might.
+type TolerantClient struct {
+	*solanarpc.Client
+}
+
+// NewTolerantClient returns a SolanaRPC implementation that tolerates numeric
+// clientId values from getClusterNodes responses.
+func NewTolerantClient(c *solanarpc.Client) *TolerantClient {
+	return &TolerantClient{Client: c}
+}
+
+type clusterNodeFlex struct {
+	Pubkey          solana.PublicKey `json:"pubkey"`
+	Gossip          *string          `json:"gossip,omitempty"`
+	TPU             *string          `json:"tpu,omitempty"`
+	TPUQUIC         *string          `json:"tpuQuic,omitempty"`
+	TPUForwards     *string          `json:"tpuForwards,omitempty"`
+	TPUForwardsQUIC *string          `json:"tpuForwardsQuic,omitempty"`
+	TPUVote         *string          `json:"tpuVote,omitempty"`
+	ServeRepair     *string          `json:"serveRepair,omitempty"`
+	PubSub          *string          `json:"pubsub,omitempty"`
+	RPC             *string          `json:"rpc,omitempty"`
+	Version         *string          `json:"version,omitempty"`
+	FeatureSet      *uint32          `json:"featureSet,omitempty"`
+	ShredVersion    uint16           `json:"shredVersion,omitempty"`
+	ClientID        json.RawMessage  `json:"clientId,omitempty"`
+}
+
+func (t *TolerantClient) GetClusterNodes(ctx context.Context) ([]*solanarpc.GetClusterNodesResult, error) {
+	var raw []*clusterNodeFlex
+	if err := t.Client.RPCCallForInto(ctx, &raw, "getClusterNodes", nil); err != nil {
+		return nil, err
+	}
+	out := make([]*solanarpc.GetClusterNodesResult, 0, len(raw))
+	for _, r := range raw {
+		if r == nil {
+			continue
+		}
+		out = append(out, &solanarpc.GetClusterNodesResult{
+			Pubkey:          r.Pubkey,
+			Gossip:          r.Gossip,
+			TPU:             r.TPU,
+			TPUQUIC:         r.TPUQUIC,
+			TPUForwards:     r.TPUForwards,
+			TPUForwardsQUIC: r.TPUForwardsQUIC,
+			TPUVote:         r.TPUVote,
+			ServeRepair:     r.ServeRepair,
+			PubSub:          r.PubSub,
+			RPC:             r.RPC,
+			Version:         r.Version,
+			FeatureSet:      r.FeatureSet,
+			ShredVersion:    r.ShredVersion,
+			ClientID:        decodeClientID(r.ClientID),
+		})
+	}
+	return out, nil
+}
+
+// decodeClientID accepts either a JSON string or a JSON number and returns a
+// stringified pointer. nil/empty/JSON-null is returned as nil.
+func decodeClientID(raw json.RawMessage) *string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return &s
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		v := n.String()
+		return &v
+	}
+	v := fmt.Sprintf("%s", raw)
+	return &v
+}

--- a/indexer/pkg/sol/rpc_test.go
+++ b/indexer/pkg/sol/rpc_test.go
@@ -1,0 +1,80 @@
+package sol
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	soljsonrpc "github.com/gagliardetto/solana-go/rpc/jsonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeClientID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want *string
+	}{
+		{"empty", "", nil},
+		{"null", "null", nil},
+		{"string", `"abc123"`, ptr("abc123")},
+		{"number", `42`, ptr("42")},
+		{"large_number", `4294967295`, ptr("4294967295")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeClientID(json.RawMessage(tc.in))
+			if tc.want == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, *tc.want, *got)
+		})
+	}
+}
+
+func TestTolerantClient_GetClusterNodes_AcceptsNumericClientID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"result": [
+				{"pubkey": "11111111111111111111111111111111", "gossip": "1.2.3.4:8001", "clientId": 7, "shredVersion": 50093},
+				{"pubkey": "11111111111111111111111111111112", "gossip": "1.2.3.5:8001", "clientId": "agave", "shredVersion": 50093},
+				{"pubkey": "11111111111111111111111111111113", "gossip": "1.2.3.6:8001", "shredVersion": 50093}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	rpcClient := soljsonrpc.NewClientWithOpts(srv.URL, nil)
+	client := solanarpc.NewWithCustomRPCClient(rpcClient)
+	tc := NewTolerantClient(client)
+
+	nodes, err := tc.GetClusterNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, nodes, 3)
+
+	require.NotNil(t, nodes[0].ClientID)
+	require.Equal(t, "7", *nodes[0].ClientID)
+
+	require.NotNil(t, nodes[1].ClientID)
+	require.Equal(t, "agave", *nodes[1].ClientID)
+
+	require.Nil(t, nodes[2].ClientID)
+
+	require.NotNil(t, nodes[0].Gossip)
+	require.Equal(t, "1.2.3.4:8001", *nodes[0].Gossip)
+	require.Equal(t, uint16(50093), nodes[0].ShredVersion)
+}
+
+func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
## Summary

- Solana RPC refresh has been failing in mainnet-beta with `json: cannot unmarshal number into Go struct field GetClusterNodesResult.ClientID of type string` since the bump to `gagliardetto/solana-go` v1.19.0 in #439, which added `ClientID *string` to the result struct. Some validators (e.g. Firedancer) return `clientId` as a number, which fails strict unmarshalling and aborts the entire refresh.
- Wraps the gagliardetto client in a new `sol.TolerantClient` that overrides `GetClusterNodes` to call the raw RPC with a permissive intermediate struct (`json.RawMessage` for `clientId`), then stringifies whichever shape comes back. All other RPC methods pass through unchanged.
- We don't read `ClientID` anywhere in the codebase, so coercing numeric values to their string form is safe.

## Testing Verification

- `TestDecodeClientID` covers null/string/number/large-number cases for the permissive decoder.
- `TestTolerantClient_GetClusterNodes_AcceptsNumericClientID` exercises the full path against an `httptest` server returning a payload with one numeric `clientId`, one string `clientId`, and one missing — all three parse cleanly and other fields (gossip, shredVersion) round-trip correctly.