### PR TITLE
shreds: prorate epoch revenue chart by per-seat charged USDC

### DIFF
--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -868,18 +868,27 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	start := time.Now()
-	// Revenue per epoch is the sum of per-seat USDC actually charged. The
-	// on-chain protocol prorates instant-allocated seats by remaining slots in
-	// the epoch (eab207d/onchain: compute prorated service), so
-	// `last_usdc_price_dollars` and `subscription_start_slot` on ClientSeat are
-	// the authoritative inputs for the charged amount:
+	// Revenue per epoch is the sum of per-seat USDC actually charged, net of
+	// prorated refunds. The on-chain protocol prorates instant-allocated seats
+	// by remaining slots in the epoch (doublezero-shreds#243) and refunds the
+	// unused portion when withdrawn via RequestProratedInstantSeatWithdrawal,
+	// so `last_usdc_price_dollars` and `subscription_start_slot` on ClientSeat
+	// are the inputs for the gross charge:
 	//
 	//     charged = last_price_dollars * (epoch_end_slot - start_slot) / SLOTS_PER_EPOCH
 	//
 	// where epoch_end_slot = (active_epoch + 1) * SLOTS_PER_EPOCH. For
-	// batch-allocated seats, start_slot = epoch_start, so this collapses to the
+	// batch-allocated seats start_slot = epoch_start, so this collapses to the
 	// full epoch price; for instant-allocated seats it captures the actual
 	// prorated charge.
+	//
+	// Refunds are subtracted from the gross charge per (seat, active_epoch).
+	// The prorated withdrawal log emits "Refunded N USDC" (in micro-USDC) and
+	// the parser stores N in fact_dz_shred_escrow_events.amount_usdc on the
+	// withdraw_seat row; the non-prorated withdrawal variant leaves amount_usdc
+	// null, so `event_type='withdraw_seat' AND amount_usdc IS NOT NULL` selects
+	// only refunds. The active_epoch the refund applies to is derived from the
+	// withdrawal slot via slot/SLOTS_PER_EPOCH.
 	//
 	// Pre-upgrade seats (or post-deactivation snapshots) have last_price = 0
 	// and start_slot = 0; we fall back to the legacy
@@ -890,6 +899,7 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 	// allocation-time values rather than the deactivation snapshot (which
 	// zeroes both fields).
 	const slotsPerEpoch = 432000
+	const usdcMicroPerDollar = 1_000_000
 	query := `
 		WITH seat_per_epoch AS (
 			SELECT
@@ -923,6 +933,17 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 			WHERE is_deleted = 0
 			GROUP BY exchange_key, current_epoch
 		),
+		seat_refunds AS (
+			SELECT
+				client_seat_pk AS pk,
+				intDiv(slot, ?) AS active_epoch,
+				sum(coalesce(amount_usdc, 0)) / ? AS refund_dollars
+			FROM fact_dz_shred_escrow_events
+			WHERE event_type = 'withdraw_seat'
+			  AND amount_usdc IS NOT NULL
+			  AND status = 'ok'
+			GROUP BY pk, active_epoch
+		),
 		seat_charges AS (
 			SELECT
 				s.active_epoch AS epoch,
@@ -939,12 +960,14 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 					-- Legacy fallback: full epoch price.
 					WHEN s.has_override = 1 THEN toFloat64(s.override_price)
 					ELSE toFloat64(coalesce(m.price, 0)) + toFloat64(coalesce(d.premium, 0))
-				END AS charged_dollars
+				END - coalesce(r.refund_dollars, 0) AS charged_dollars
 			FROM seat_per_epoch s
 			LEFT JOIN device_per_epoch d
 				ON s.device_key = d.device_key AND d.epoch = s.active_epoch
 			LEFT JOIN metro_per_epoch m
 				ON d.metro_key = m.exchange_key AND m.epoch = s.active_epoch
+			LEFT JOIN seat_refunds r
+				ON r.pk = s.pk AND r.active_epoch = s.active_epoch
 		)
 		SELECT
 			epoch,
@@ -957,7 +980,11 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 		LIMIT ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, slotsPerEpoch, slotsPerEpoch, slotsPerEpoch, limit)
+	rows, err := a.envDB(ctx).Query(ctx, query,
+		slotsPerEpoch, usdcMicroPerDollar, // seat_refunds
+		slotsPerEpoch, slotsPerEpoch, slotsPerEpoch, // seat_charges
+		limit,
+	)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -868,13 +868,28 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	start := time.Now()
-	// Revenue per epoch is the sum of per-seat prices for every seat allocated
-	// for that active_epoch. Summing batch_allocate.amount_usdc directly misses
-	// seats that get allocated via instant `allocate_seat` (no Charged log) and
-	// pre-new-style `batch_allocate` events (parser doesn't extract amount).
-	// Joining seats history with metro/device price history at each
-	// active_epoch reconstructs the charge using the same price formula the
-	// list endpoint uses (override, else metro_price + device_premium).
+	// Revenue per epoch is the sum of per-seat USDC actually charged. The
+	// on-chain protocol prorates instant-allocated seats by remaining slots in
+	// the epoch (eab207d/onchain: compute prorated service), so
+	// `last_usdc_price_dollars` and `subscription_start_slot` on ClientSeat are
+	// the authoritative inputs for the charged amount:
+	//
+	//     charged = last_price_dollars * (epoch_end_slot - start_slot) / SLOTS_PER_EPOCH
+	//
+	// where epoch_end_slot = (active_epoch + 1) * SLOTS_PER_EPOCH. For
+	// batch-allocated seats, start_slot = epoch_start, so this collapses to the
+	// full epoch price; for instant-allocated seats it captures the actual
+	// prorated charge.
+	//
+	// Pre-upgrade seats (or post-deactivation snapshots) have last_price = 0
+	// and start_slot = 0; we fall back to the legacy
+	// override-or-metro+device-premium formula, which matches what those seats
+	// were actually charged before the on-chain proration upgrade.
+	//
+	// Note: max() over snapshots for a given (pk, active_epoch) selects the
+	// allocation-time values rather than the deactivation snapshot (which
+	// zeroes both fields).
+	const slotsPerEpoch = 432000
 	query := `
 		WITH seat_per_epoch AS (
 			SELECT
@@ -882,7 +897,9 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 				active_epoch,
 				argMax(device_key, snapshot_ts) AS device_key,
 				argMax(has_price_override, snapshot_ts) AS has_override,
-				argMax(override_usdc_price_dollars, snapshot_ts) AS override_price
+				argMax(override_usdc_price_dollars, snapshot_ts) AS override_price,
+				max(subscription_start_slot) AS start_slot,
+				max(last_usdc_price_dollars) AS last_price
 			FROM dim_dz_shred_client_seats_history
 			WHERE is_deleted = 0 AND active_epoch > 0
 			GROUP BY pk, active_epoch
@@ -905,33 +922,42 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 			FROM dim_dz_shred_metro_histories_history
 			WHERE is_deleted = 0
 			GROUP BY exchange_key, current_epoch
+		),
+		seat_charges AS (
+			SELECT
+				s.active_epoch AS epoch,
+				CASE
+					-- Prorated path: stored on-chain price scaled by slots active.
+					WHEN s.last_price > 0 AND s.start_slot > 0 THEN
+						toFloat64(s.last_price) * greatest(
+							least(
+								toInt64((s.active_epoch + 1) * ?) - toInt64(s.start_slot),
+								toInt64(?)
+							),
+							toInt64(0)
+						) / ?
+					-- Legacy fallback: full epoch price.
+					WHEN s.has_override = 1 THEN toFloat64(s.override_price)
+					ELSE toFloat64(coalesce(m.price, 0)) + toFloat64(coalesce(d.premium, 0))
+				END AS charged_dollars
+			FROM seat_per_epoch s
+			LEFT JOIN device_per_epoch d
+				ON s.device_key = d.device_key AND d.epoch = s.active_epoch
+			LEFT JOIN metro_per_epoch m
+				ON d.metro_key = m.exchange_key AND m.epoch = s.active_epoch
 		)
 		SELECT
-			s.active_epoch AS epoch,
-			toFloat64(sum(
-				CASE
-					WHEN s.has_override = 1 THEN toInt64(s.override_price)
-					ELSE toInt64(coalesce(m.price, 0)) + toInt64(coalesce(d.premium, 0))
-				END
-			)) AS total_usdc,
-			toFloat64(sum(
-				CASE
-					WHEN s.has_override = 1 THEN toInt64(s.override_price)
-					ELSE toInt64(coalesce(m.price, 0)) + toInt64(coalesce(d.premium, 0))
-				END
-			)) AS total_dollars,
+			epoch,
+			sum(charged_dollars) AS total_usdc,
+			sum(charged_dollars) AS total_dollars,
 			toUInt64(count()) AS payment_count
-		FROM seat_per_epoch s
-		LEFT JOIN device_per_epoch d
-			ON s.device_key = d.device_key AND d.epoch = s.active_epoch
-		LEFT JOIN metro_per_epoch m
-			ON d.metro_key = m.exchange_key AND m.epoch = s.active_epoch
+		FROM seat_charges
 		GROUP BY epoch
 		ORDER BY epoch DESC
 		LIMIT ?
 	`
 
-	rows, err := a.envDB(ctx).Query(ctx, query, limit)
+	rows, err := a.envDB(ctx).Query(ctx, query, slotsPerEpoch, slotsPerEpoch, slotsPerEpoch, limit)
 	duration := time.Since(start)
 	metrics.RecordClickHouseQuery(duration, err)
 

--- a/api/handlers/shreds_test.go
+++ b/api/handlers/shreds_test.go
@@ -678,6 +678,66 @@ func TestGetShredEpochRevenue_Prorated(t *testing.T) {
 	assert.Equal(t, uint64(4), items[0].PaymentCount)
 }
 
+// A seat that withdrew mid-epoch via the prorated instruction emits
+// "Refunded N USDC", which the parser stores in
+// fact_dz_shred_escrow_events.amount_usdc on the withdraw_seat row. The
+// revenue query subtracts those refunds from the gross charge per
+// (seat, active_epoch). Non-prorated withdrawals leave amount_usdc null and
+// are ignored.
+func TestGetShredEpochRevenue_NetsOutProratedRefund(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	// active_epoch=300: epoch_start=129_600_000, epoch_end=130_032_000.
+	//   seat-refund: batch-allocated at epoch_start, last_price=40 → gross=40.
+	//                Prorated withdrawal at slot 129_816_000 (halfway through),
+	//                refund=20 USDC = 20_000_000 micro. Net=20.
+	//   seat-old-withdraw: identical allocation, but withdrawn via the old
+	//                non-prorated instruction (amount_usdc NULL) → no refund
+	//                applied, full 40 charged.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_client_seats_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pk, device_key, client_ip, tenure_epochs, funded_epoch, active_epoch,
+		 has_price_override, override_usdc_price_dollars, escrow_count, funding_authority_key,
+		 subscription_start_slot, last_usdc_price_dollars)
+		VALUES
+		('seat-refund', now(), now(), generateUUIDv4(), 0, 1,
+		 'seat-refund', 'dev-x', '10.0.0.6', 1, 299, 300,
+		 0, 0, 1, 'funder-6',
+		 129600000, 40),
+		('seat-old-withdraw', now(), now(), generateUUIDv4(), 0, 2,
+		 'seat-old-withdraw', 'dev-x', '10.0.0.7', 1, 299, 300,
+		 0, 0, 1, 'funder-7',
+		 129600000, 40)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO fact_dz_shred_escrow_events
+		(event_ts, ingested_at, escrow_pk, client_seat_pk, tx_signature, slot,
+		 event_type, amount_usdc, balance_after_usdc, epoch, status, signer)
+		VALUES
+		(now(), now(), 'esc-refund', 'seat-refund', 'tx-refund', 129816000,
+		 'withdraw_seat', 20000000, NULL, NULL, 'ok', 'signer-1'),
+		(now(), now(), 'esc-old',    'seat-old-withdraw', 'tx-old', 129816000,
+		 'withdraw_seat', NULL, NULL, NULL, 'ok', 'signer-1')
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/epoch-revenue", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredEpochRevenue(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var items []handlers.ShredEpochRevenueItem
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&items))
+	require.Len(t, items, 1)
+	assert.Equal(t, uint64(300), items[0].Epoch)
+	// 40 (seat-refund gross) - 20 (refund) + 40 (seat-old-withdraw, no refund) = 60.
+	assert.InDelta(t, 60.0, items[0].TotalDollars, 1e-6)
+	assert.Equal(t, uint64(2), items[0].PaymentCount)
+}
+
 // Sanity-check that a seat which deactivated mid-epoch (last_price/start_slot
 // zeroed in its latest snapshot) still contributes the original prorated
 // charge — max() over snapshots picks the allocation-time values, not the

--- a/api/handlers/shreds_test.go
+++ b/api/handlers/shreds_test.go
@@ -602,3 +602,121 @@ func findSeat(items []handlers.ShredClientSeatItem, pk string) *handlers.ShredCl
 	}
 	return nil
 }
+
+func TestGetShredEpochRevenue_Prorated(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	// Devices and metros for the legacy-fallback path.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_metro_histories_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pk, exchange_key, is_current_price_finalized, total_initialized_devices,
+		 current_epoch, current_usdc_price_dollars)
+		VALUES
+		('mh-100', now(), now(), generateUUIDv4(), 0, 1,
+		 'mh-100', 'metro-x', 1, 1, 100, 10)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_device_histories_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pk, device_key, is_enabled, has_settled_seats, metro_exchange_key,
+		 active_granted_seats, active_total_available_seats,
+		 current_epoch, current_requested_seat_count, current_granted_seat_count,
+		 current_total_available_seats, current_usdc_metro_premium_dollars)
+		VALUES
+		('dh-100', now(), now(), generateUUIDv4(), 0, 1,
+		 'dh-100', 'dev-x', 1, 1, 'metro-x',
+		 4, 10, 100, 4, 4, 10, -2)
+	`))
+
+	// Four seats in active_epoch 100 with slots_per_epoch = 432000 (epoch start
+	// at 43_200_000, epoch end at 43_632_000):
+	//   batch:    start = epoch_start, last_price=15  → charged = 15.0  (full epoch)
+	//   instant:  start = epoch_start+216000, last_price=20 → charged = 10.0 (half epoch)
+	//   legacy:   start=0, last_price=0, no override     → charged = 10 + (-2) = 8.0
+	//   override: start=0, last_price=0, override=25      → charged = 25.0
+	// Expected total: 58.0, payment_count = 4.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_client_seats_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pk, device_key, client_ip, tenure_epochs, funded_epoch, active_epoch,
+		 has_price_override, override_usdc_price_dollars, escrow_count, funding_authority_key,
+		 subscription_start_slot, last_usdc_price_dollars)
+		VALUES
+		('seat-batch', now(), now(), generateUUIDv4(), 0, 1,
+		 'seat-batch', 'dev-x', '10.0.0.1', 1, 99, 100,
+		 0, 0, 1, 'funder-1',
+		 43200000, 15),
+		('seat-instant', now(), now(), generateUUIDv4(), 0, 2,
+		 'seat-instant', 'dev-x', '10.0.0.2', 1, 100, 100,
+		 0, 0, 1, 'funder-2',
+		 43416000, 20),
+		('seat-legacy', now(), now(), generateUUIDv4(), 0, 3,
+		 'seat-legacy', 'dev-x', '10.0.0.3', 1, 100, 100,
+		 0, 0, 1, 'funder-3',
+		 0, 0),
+		('seat-override', now(), now(), generateUUIDv4(), 0, 4,
+		 'seat-override', 'dev-x', '10.0.0.4', 1, 100, 100,
+		 1, 25, 1, 'funder-4',
+		 0, 0)
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/epoch-revenue", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredEpochRevenue(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var items []handlers.ShredEpochRevenueItem
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&items))
+	require.Len(t, items, 1)
+	assert.Equal(t, uint64(100), items[0].Epoch)
+	assert.InDelta(t, 58.0, items[0].TotalDollars, 1e-6)
+	assert.InDelta(t, 58.0, items[0].TotalUSDC, 1e-6)
+	assert.Equal(t, uint64(4), items[0].PaymentCount)
+}
+
+// Sanity-check that a seat which deactivated mid-epoch (last_price/start_slot
+// zeroed in its latest snapshot) still contributes the original prorated
+// charge — max() over snapshots picks the allocation-time values, not the
+// post-deactivation zeros.
+func TestGetShredEpochRevenue_DeactivatedSeatChargeRetained(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	// Seat allocated at epoch start (full price), then deactivated. Two
+	// snapshots: allocation-time with values, then a later snapshot with
+	// zeros. Both rows have active_epoch=200 and is_deleted=0.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_client_seats_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 pk, device_key, client_ip, tenure_epochs, funded_epoch, active_epoch,
+		 has_price_override, override_usdc_price_dollars, escrow_count, funding_authority_key,
+		 subscription_start_slot, last_usdc_price_dollars)
+		VALUES
+		('seat-cycled', toDateTime('2026-01-01 00:00:00'), now(), generateUUIDv4(), 0, 1,
+		 'seat-cycled', 'dev-x', '10.0.0.5', 1, 199, 200,
+		 0, 0, 1, 'funder-5',
+		 86400000, 30),
+		('seat-cycled', toDateTime('2026-01-02 00:00:00'), now(), generateUUIDv4(), 0, 2,
+		 'seat-cycled', 'dev-x', '10.0.0.5', 1, 199, 200,
+		 0, 0, 1, 'funder-5',
+		 0, 0)
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/epoch-revenue", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredEpochRevenue(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var items []handlers.ShredEpochRevenueItem
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&items))
+	require.Len(t, items, 1)
+	assert.Equal(t, uint64(200), items[0].Epoch)
+	// Allocated at epoch_start=200*432000=86400000, full epoch → 30.0.
+	assert.InDelta(t, 30.0, items[0].TotalDollars, 1e-6)
+}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/lmittmann/tint v1.1.3
-	github.com/malbeclabs/doublezero v0.8.1-0.20260501211405-1221a05e001c
+	github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/lmittmann/tint v1.1.3
-	github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368
+	github.com/malbeclabs/doublezero v0.8.1-0.20260508135840-334398de8bad
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4

--- a/go.sum
+++ b/go.sum
@@ -238,10 +238,8 @@ github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr32
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/malbeclabs/doublezero v0.8.1-0.20260501211405-1221a05e001c h1:qWhkAOq4gOLhmHF2xt60A6O+S9/hm4OvAaV+moZkz00=
-github.com/malbeclabs/doublezero v0.8.1-0.20260501211405-1221a05e001c/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
-github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368 h1:Uq9ER+cP81Ywk0sXLMS5zbAeLIGeHi1H0RntRKICvfg=
-github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
+github.com/malbeclabs/doublezero v0.8.1-0.20260508135840-334398de8bad h1:0NEd/Xj0xryw8deWYNskBK0MWYri3KCZKAcRuau5STE=
+github.com/malbeclabs/doublezero v0.8.1-0.20260508135840-334398de8bad/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/malbeclabs/doublezero v0.8.1-0.20260501211405-1221a05e001c h1:qWhkAOq4gOLhmHF2xt60A6O+S9/hm4OvAaV+moZkz00=
 github.com/malbeclabs/doublezero v0.8.1-0.20260501211405-1221a05e001c/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
+github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368 h1:Uq9ER+cP81Ywk0sXLMS5zbAeLIGeHi1H0RntRKICvfg=
+github.com/malbeclabs/doublezero v0.8.1-0.20260506223126-a1590a94d368/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/indexer/db/clickhouse/migrations/20260506000001_shred_client_seat_prorated_fields.sql
+++ b/indexer/db/clickhouse/migrations/20260506000001_shred_client_seat_prorated_fields.sql
@@ -1,0 +1,106 @@
+-- +goose Up
+
+-- Add SubscriptionStartSlot and LastUSDCPriceDollars to dim_dz_shred_client_seats.
+-- These were added to the on-chain ClientSeat for prorated service support and
+-- are needed to compute prorated USDC charges per epoch.
+
+-- +goose StatementBegin
+ALTER TABLE dim_dz_shred_client_seats_history
+    ADD COLUMN IF NOT EXISTS subscription_start_slot UInt64 DEFAULT 0 AFTER funding_authority_key,
+    ADD COLUMN IF NOT EXISTS last_usdc_price_dollars UInt16 DEFAULT 0 AFTER subscription_start_slot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_shred_client_seats_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE stg_dim_dz_shred_client_seats_snapshot (
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    device_key String,
+    client_ip String,
+    tenure_epochs UInt16,
+    funded_epoch UInt64,
+    active_epoch UInt64,
+    has_price_override UInt8,
+    override_usdc_price_dollars UInt16,
+    escrow_count UInt32,
+    funding_authority_key String,
+    subscription_start_slot UInt64 DEFAULT 0,
+    last_usdc_price_dollars UInt16 DEFAULT 0
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_client_seats_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_client_seats_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash,
+    pk, device_key, client_ip, tenure_epochs, funded_epoch, active_epoch,
+    has_price_override, override_usdc_price_dollars, escrow_count, funding_authority_key,
+    subscription_start_slot, last_usdc_price_dollars
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_client_seats_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_client_seats_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash,
+    pk, device_key, client_ip, tenure_epochs, funded_epoch, active_epoch,
+    has_price_override, override_usdc_price_dollars, escrow_count, funding_authority_key
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_shred_client_seats_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE stg_dim_dz_shred_client_seats_snapshot (
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    pk String,
+    device_key String,
+    client_ip String,
+    tenure_epochs UInt16,
+    funded_epoch UInt64,
+    active_epoch UInt64,
+    has_price_override UInt8,
+    override_usdc_price_dollars UInt16,
+    escrow_count UInt32,
+    funding_authority_key String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dim_dz_shred_client_seats_history
+    DROP COLUMN IF EXISTS last_usdc_price_dollars,
+    DROP COLUMN IF EXISTS subscription_start_slot;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/shreds/escrowevents/parser.go
+++ b/indexer/pkg/dz/shreds/escrowevents/parser.go
@@ -124,6 +124,8 @@ func parseInstructionGroup(action string, details []string, clientSeatPK string)
 		return parseInstantAllocate(details)
 	case "Request instant seat withdrawal":
 		return &parsedEvent{EventType: EventTypeWithdrawSeat}
+	case "Request prorated instant seat withdrawal":
+		return parseProratedWithdraw(details)
 	case "Close payment escrow":
 		return parseClose(details)
 	case "Batch allocate seats":
@@ -197,6 +199,27 @@ func parseClose(details []string) *parsedEvent {
 			parts := strings.SplitN(after, " ", 2)
 			if n, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
 				pe.Amount = &n
+			}
+		}
+	}
+
+	return pe
+}
+
+// parseProratedWithdraw parses logs from RequestProratedInstantSeatWithdrawal.
+// We keep EventType=withdraw_seat so the unique key matches the older
+// non-prorated variant (dedup replaces on re-ingest); the discriminator at
+// query time is amount_usdc IS NOT NULL, which only the prorated path sets.
+// The prorated variant emits "Refunded {N} USDC" — N is in micro-USDC.
+func parseProratedWithdraw(details []string) *parsedEvent {
+	pe := &parsedEvent{EventType: EventTypeWithdrawSeat}
+
+	for _, d := range details {
+		if after, ok := strings.CutPrefix(d, "Refunded "); ok {
+			if before, ok := strings.CutSuffix(after, " USDC"); ok {
+				if n, err := strconv.ParseInt(before, 10, 64); err == nil {
+					pe.Amount = &n
+				}
 			}
 		}
 	}

--- a/indexer/pkg/dz/shreds/escrowevents/parser_test.go
+++ b/indexer/pkg/dz/shreds/escrowevents/parser_test.go
@@ -97,6 +97,55 @@ func TestParseInstantWithdrawEvent(t *testing.T) {
 	}
 }
 
+func TestParseProratedInstantWithdrawEvent(t *testing.T) {
+	logs := []string{
+		"Program " + testProgramID + " invoke [1]",
+		"Program log: Request prorated instant seat withdrawal",
+		"Program log: Refunded 7500000 USDC",
+		"Program log: Withdraw seat request created for client seat " + testClientSeatPK,
+		"Program " + testProgramID + " success",
+	}
+
+	events := ParseTransactionLogs(nil, testEscrowPK, testClientSeatPK, testTxSig, 350, testBlockTime, logs, false, testProgramID, testSigner)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	e := events[0]
+	if e.EventType != EventTypeWithdrawSeat {
+		t.Errorf("expected event type %q, got %q", EventTypeWithdrawSeat, e.EventType)
+	}
+	if e.AmountUSDC == nil || *e.AmountUSDC != 7500000 {
+		t.Errorf("expected amount 7500000, got %v", e.AmountUSDC)
+	}
+}
+
+func TestParseProratedInstantWithdrawEvent_NoRefund(t *testing.T) {
+	// When prorated service is disabled on-chain, refund_amount is 0 but the
+	// log line is still emitted.
+	logs := []string{
+		"Program " + testProgramID + " invoke [1]",
+		"Program log: Request prorated instant seat withdrawal",
+		"Program log: Refunded 0 USDC",
+		"Program " + testProgramID + " success",
+	}
+
+	events := ParseTransactionLogs(nil, testEscrowPK, testClientSeatPK, testTxSig, 360, testBlockTime, logs, false, testProgramID, testSigner)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	e := events[0]
+	if e.EventType != EventTypeWithdrawSeat {
+		t.Errorf("expected event type %q, got %q", EventTypeWithdrawSeat, e.EventType)
+	}
+	if e.AmountUSDC == nil || *e.AmountUSDC != 0 {
+		t.Errorf("expected amount 0, got %v", e.AmountUSDC)
+	}
+}
+
 func TestParseCloseEvent(t *testing.T) {
 	logs := []string{
 		"Program " + testProgramID + " invoke [1]",

--- a/indexer/pkg/dz/shreds/schema.go
+++ b/indexer/pkg/dz/shreds/schema.go
@@ -76,6 +76,8 @@ func (s *ClientSeatSchema) PayloadColumns() []string {
 		"override_usdc_price_dollars:INTEGER",
 		"escrow_count:INTEGER",
 		"funding_authority_key:VARCHAR",
+		"subscription_start_slot:BIGINT",
+		"last_usdc_price_dollars:INTEGER",
 	}
 }
 
@@ -91,6 +93,8 @@ func (s *ClientSeatSchema) ToRow(c ClientSeatRow) []any {
 		c.OverrideUSDCPriceDollars,
 		c.EscrowCount,
 		c.FundingAuthorityKey,
+		c.SubscriptionStartSlot,
+		c.LastUSDCPriceDollars,
 	}
 }
 

--- a/indexer/pkg/dz/shreds/view.go
+++ b/indexer/pkg/dz/shreds/view.go
@@ -50,6 +50,8 @@ type ClientSeatRow struct {
 	OverrideUSDCPriceDollars uint16
 	EscrowCount              uint32
 	FundingAuthorityKey      string
+	SubscriptionStartSlot    uint64
+	LastUSDCPriceDollars     uint16
 }
 
 type PaymentEscrowRow struct {
@@ -424,6 +426,8 @@ func convertClientSeats(seats []shreds.KeyedClientSeat) []ClientSeatRow {
 			OverrideUSDCPriceDollars: s.OverrideUSDCPriceDollars,
 			EscrowCount:              s.EscrowCount,
 			FundingAuthorityKey:      s.FundingAuthorityKey.String(),
+			SubscriptionStartSlot:    s.SubscriptionStartSlot,
+			LastUSDCPriceDollars:     s.LastUSDCPriceDollars,
 		}
 	}
 	return rows


### PR DESCRIPTION
## Summary

- The on-chain shred-subscription program prorates instant-allocated seats by the slots remaining in the epoch and stores `subscription_start_slot` and `last_usdc_price_dollars` on `ClientSeat`. The previous epoch-revenue query assumed every seat paid the full per-epoch price, which overstates USDC collected for any mid-epoch instant allocation.
- The new prorated withdrawal instruction also refunds the unused slot fraction; we now subtract those refunds from the gross charge per `(seat, active_epoch)`.
- **api**: rewrite `GetShredEpochRevenue` to compute charged USDC as `last_price_dollars * (epoch_end_slot − subscription_start_slot) / 432000`, minus refunds from `fact_dz_shred_escrow_events` (selected by `event_type='withdraw_seat' AND amount_usdc IS NOT NULL`). Falls back to the legacy override-or-metro+device-premium formula for pre-upgrade snapshots where `last_price = 0`.
- **indexer**: index `subscription_start_slot` and `last_usdc_price_dollars` on `dim_dz_shred_client_seats` (and history); bump the doublezero SDK to expose them.
- **escrow parser**: add a case for `"Request prorated instant seat withdrawal"` that extracts the `Refunded N USDC` amount into `amount_usdc`. The non-prorated variant continues to leave `amount_usdc` null. `EventType` is unchanged so the existing unique key on `fact_dz_shred_escrow_events` is preserved (re-ingest deduplicates rather than creating a second row).
- **migration**: add the new columns to the seat history table, refresh the staging snapshot table, and update the `_current` view.

### Migration / backfill

- ClickHouse migration auto-applies on startup. The dimension framework will repopulate the new seat columns on the next refresh (every active seat's `attrs_hash` changes once the new payload columns are non-default).
- After merge, run `admin --backfill-escrow-events --backfill-escrow-events-truncate` to reparse historical txns and populate `amount_usdc` on prior prorated withdrawals.

## Testing Verification

- `TestGetShredEpochRevenue_Prorated`: mixes batch / instant / legacy / override seats in one epoch and asserts the prorated total (58.0 across 4 seats with one half-epoch instant allocation).
- `TestGetShredEpochRevenue_NetsOutProratedRefund`: a seat with a prorated refund (40 charged, 20 refunded → 20 net) and a seat withdrawn via the old non-prorated path (40 charged, no refund) co-exist in one epoch and the totals come out to 60.
- `TestGetShredEpochRevenue_DeactivatedSeatChargeRetained`: verifies `max()` over snapshots picks the allocation-time values rather than post-deactivation zeros, so a seat that withdrew mid-epoch still contributes its original prorated charge.
- `TestParseProratedInstantWithdrawEvent` (and `_NoRefund`): cover the new parser path including the refund=0 case.