### PR TITLE
api: reduce edge scoreboard query timeouts

### DIFF
--- a/api/handlers/access_passes.go
+++ b/api/handlers/access_passes.go
@@ -171,7 +171,7 @@ func (a *API) GetAccessPasses(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("access_passes", duration, err)
 
 	if err != nil {
 		logError("access passes query error", "error", err)
@@ -264,7 +264,7 @@ func (a *API) GetAccessPass(w http.ResponseWriter, r *http.Request) {
 		&subAllowlistJSON,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("access_passes", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -438,7 +438,7 @@ func (a *API) GetAccessPassConnections(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, connQuery, connArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("access_passes", duration, err)
 
 	if err != nil {
 		logError("access pass connections query error", "error", err)

--- a/api/handlers/catalog.go
+++ b/api/handlers/catalog.go
@@ -45,7 +45,7 @@ func (a *API) GetCatalog(w http.ResponseWriter, r *http.Request) {
 
 	duration := time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("catalog", duration, err)
 		http.Error(w, internalError("Failed to query database", err), http.StatusInternalServerError)
 		return
 	}
@@ -55,7 +55,7 @@ func (a *API) GetCatalog(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var t TableInfo
 		if err := rows.Scan(&t.Name, &t.Database, &t.Engine, &t.Type); err != nil {
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("catalog", duration, err)
 			http.Error(w, internalError("Failed to scan row", err), http.StatusInternalServerError)
 			return
 		}
@@ -63,12 +63,12 @@ func (a *API) GetCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rows.Err(); err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("catalog", duration, err)
 		http.Error(w, internalError("Failed to read rows", err), http.StatusInternalServerError)
 		return
 	}
 
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("catalog", duration, nil)
 
 	// Fetch columns for each table
 	colStart := time.Now()
@@ -81,7 +81,7 @@ func (a *API) GetCatalog(w http.ResponseWriter, r *http.Request) {
 
 	colDuration := time.Since(colStart)
 	if err != nil {
-		metrics.RecordClickHouseQuery(colDuration, err)
+		metrics.RecordClickHouseQuery("catalog", colDuration, err)
 		// Non-fatal: return tables without columns
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(CatalogResponse{Tables: tables})
@@ -94,18 +94,18 @@ func (a *API) GetCatalog(w http.ResponseWriter, r *http.Request) {
 	for colRows.Next() {
 		var tableName, colName string
 		if err := colRows.Scan(&tableName, &colName); err != nil {
-			metrics.RecordClickHouseQuery(colDuration, err)
+			metrics.RecordClickHouseQuery("catalog", colDuration, err)
 			http.Error(w, internalError("Failed to scan column row", err), http.StatusInternalServerError)
 			return
 		}
 		tableColumns[tableName] = append(tableColumns[tableName], colName)
 	}
 	if err := colRows.Err(); err != nil {
-		metrics.RecordClickHouseQuery(colDuration, err)
+		metrics.RecordClickHouseQuery("catalog", colDuration, err)
 		http.Error(w, internalError("Failed to iterate column rows", err), http.StatusInternalServerError)
 		return
 	}
-	metrics.RecordClickHouseQuery(colDuration, nil)
+	metrics.RecordClickHouseQuery("catalog", colDuration, nil)
 
 	// Attach columns to tables
 	for i := range tables {

--- a/api/handlers/contributors.go
+++ b/api/handlers/contributors.go
@@ -158,7 +158,7 @@ func (a *API) GetContributors(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("contributors", duration, err)
 
 	if err != nil {
 		logError("contributors query failed", "error", err)
@@ -384,7 +384,7 @@ func (a *API) GetContributor(w http.ResponseWriter, r *http.Request) {
 		&contributor.OutBps,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("contributors", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/api/handlers/db.go
+++ b/api/handlers/db.go
@@ -42,7 +42,7 @@ func (q *DBQuerier) Query(ctx context.Context, sql string) (workflow.QueryResult
 	rows, err := q.db.Query(ctx, sql)
 	duration := time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("db", duration, err)
 		return workflow.QueryResult{SQL: sql, Error: err.Error()}, nil
 	}
 	defer rows.Close()
@@ -64,7 +64,7 @@ func (q *DBQuerier) Query(ctx context.Context, sql string) (workflow.QueryResult
 		}
 
 		if err := rows.Scan(values...); err != nil {
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("db", duration, err)
 			return workflow.QueryResult{SQL: sql, Error: fmt.Sprintf("scan error: %v", err)}, nil
 		}
 
@@ -77,11 +77,11 @@ func (q *DBQuerier) Query(ctx context.Context, sql string) (workflow.QueryResult
 	}
 
 	if err := rows.Err(); err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("db", duration, err)
 		return workflow.QueryResult{SQL: sql, Error: err.Error()}, nil
 	}
 
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("db", duration, nil)
 
 	// Sanitize rows to replace NaN/Inf values with nil (JSON-safe)
 	workflow.SanitizeRows(resultRows)
@@ -171,11 +171,11 @@ func (f *DBSchemaFetcher) FetchSchema(ctx context.Context) (string, error) {
 	`, f.database)
 	duration := time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("db", duration, err)
 		return "", fmt.Errorf("failed to fetch columns: %w", err)
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("db", duration, nil)
 
 	type columnInfo struct {
 		Table string
@@ -203,11 +203,11 @@ func (f *DBSchemaFetcher) FetchSchema(ctx context.Context) (string, error) {
 	`, f.database)
 	duration = time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("db", duration, err)
 		return "", fmt.Errorf("failed to fetch views: %w", err)
 	}
 	defer viewRows.Close()
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("db", duration, nil)
 
 	views := make(map[string]bool)
 	for viewRows.Next() {

--- a/api/handlers/devices.go
+++ b/api/handlers/devices.go
@@ -211,11 +211,11 @@ func (a *API) GetDevices(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("devices", duration, err)
 
 	if err != nil && isUnknownIdentifierError(err) {
 		rows, err = a.envDB(ctx).Query(ctx, queryFallback, args...)
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("devices", time.Since(start), err)
 	}
 
 	if err != nil {
@@ -457,7 +457,7 @@ func (a *API) GetDevice(w http.ResponseWriter, r *http.Request) {
 		&interfacesJSON,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("devices", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -573,7 +573,7 @@ func (a *API) GetDeviceValidatorStats(w http.ResponseWriter, r *http.Request) {
 		&stats.StakeSol,
 		&stats.StakeShare,
 	)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("devices", time.Since(start), err)
 
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		logError("device validator stats query failed", "error", err, "pk", pk)

--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -590,47 +590,6 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			}
 		}
 
-		// Query 1d: Publisher stats using the same method as the publisher check page.
-		// publisher_count = activated DZ users with publishers and matched gossip+stake (same as total_publishers).
-		// publishing_count / publishing_stake_pct = subset with leader_slots > 0 (same as "Publishing Shreds").
-		{
-			shredStatsTable := fmt.Sprintf("`%s`.publisher_shred_stats", a.PublisherDB)
-			start = time.Now()
-			err = a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(`
-			WITH current_epoch AS (
-				SELECT max(epoch) AS epoch FROM %s
-			),
-			leader_pubkeys AS (
-				SELECT DISTINCT dz_user_pubkey
-				FROM %s
-				WHERE epoch >= (SELECT epoch FROM current_epoch) - 1
-				  AND is_scheduled_leader = true
-			),
-			total_network_stake AS (
-				SELECT sum(activated_stake_lamports) AS stake
-				FROM solana_vote_accounts_current
-				WHERE epoch_vote_account = 'true' AND activated_stake_lamports > 0
-			)
-			SELECT
-				countIf(v.vote_pubkey != '' AND g.pubkey != '') AS publisher_count,
-				countIf(v.vote_pubkey != '' AND g.pubkey != '' AND l.dz_user_pubkey != '') AS publishing_count,
-				COALESCE(sumIf(v.activated_stake_lamports, v.vote_pubkey != '' AND g.pubkey != '' AND l.dz_user_pubkey != ''), 0)
-					/ greatest(COALESCE((SELECT stake FROM total_network_stake), 0), 1) * 100 AS publishing_stake_pct
-			FROM dz_users_current u
-			LEFT JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip AND u.client_ip != ''
-			LEFT JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey AND v.epoch_vote_account = 'true'
-			LEFT JOIN leader_pubkeys l ON u.pk = l.dz_user_pubkey
-			WHERE u.status = 'activated'
-			  AND JSONLength(u.publishers) > 0
-		`, shredStatsTable, shredStatsTable),
-			).Scan(&publisherCount, &publishingCount, &publishingStakePct)
-			duration = time.Since(start)
-			metrics.RecordClickHouseQuery(duration, err)
-			if err != nil {
-				log.Printf("EdgeScoreboard query1d error: %v", err)
-			}
-		}
-
 	} // end !cursorMode aggregate queries
 
 	// Build node ID list and location codes for parallel queries below.
@@ -701,6 +660,39 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 	// Groups A–C and E–F are skipped in cursor mode (sinceSlot > 0 or beforeSlot > 0) since the caller
 	// only needs recent_slots and those queries are expensive.
 	if !cursorMode {
+
+		// Group P: publisher / publishing-shred / stake-% headline numbers.
+		// Reads the publisher_check page-cache entry (refreshed by the worker every 30s)
+		// and derives the three values from it. The previous in-place query (q1d) ran
+		// sequentially before this errgroup and consumed most of the deadline budget in
+		// prod, surfacing as "context deadline exceeded" on q1d / q8 in the worker.
+		g.Go(func() error {
+			data, err := a.readPageCache(gctx, "publisher_check")
+			if err != nil {
+				log.Printf("EdgeScoreboard publisher_check cache read error: %v", err)
+				return nil
+			}
+			var pc PublisherCheckResponse
+			if err := json.Unmarshal(data, &pc); err != nil {
+				log.Printf("EdgeScoreboard publisher_check unmarshal error: %v", err)
+				return nil
+			}
+			if pc.TotalNetworkStake <= 0 {
+				return nil
+			}
+			publisherCount = pc.TotalPublishers
+			var publishingStake int64
+			var pubCount uint64
+			for _, p := range pc.Publishers {
+				if p.LeaderSlots > 0 && p.VotePubkey != "" && p.NodePubkey != "" {
+					pubCount++
+					publishingStake += int64(p.ActivatedStake)
+				}
+			}
+			publishingCount = pubCount
+			publishingStakePct = float64(publishingStake) / float64(pc.TotalNetworkStake) * 100
+			return nil
+		})
 
 		// Group A: feed win rates → lead times
 		g.Go(func() error {

--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -355,7 +355,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary_v2 WHERE slot < %d`,
 			shredderDB, maxValidSlot,
 		)).Scan(&maxSlot, &lagSec)
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("edge_scoreboard:max_slot", time.Since(start), err)
 		if err != nil {
 			return nil, fmt.Errorf("max slot: %w", err)
 		}
@@ -428,7 +428,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		start := time.Now()
 		rows1, err := a.envDB(ctx).Query(ctx, query1)
 		duration := time.Since(start)
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("edge_scoreboard:q1", duration, err)
 		if err != nil {
 			return nil, fmt.Errorf("query1: %w", err)
 		}
@@ -525,7 +525,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			start = time.Now()
 			rows1b, err := a.envDB(ctx).Query(ctx, query1b)
 			duration = time.Since(start)
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q1b", duration, err)
 			if err != nil {
 				return nil, fmt.Errorf("query1b: %w", err)
 			}
@@ -574,7 +574,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			start = time.Now()
 			rows1c, err := a.envDB(ctx).Query(ctx, query1c)
 			duration = time.Since(start)
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q1c", duration, err)
 			if err != nil {
 				return nil, fmt.Errorf("query1c: %w", err)
 			}
@@ -767,7 +767,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 
 			t := time.Now()
 			rows, err := a.envDB(gctx).Query(gctx, q2)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q2", time.Since(t), err)
 			if err != nil {
 				return fmt.Errorf("query2: %w", err)
 			}
@@ -870,7 +870,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			}
 			t := time.Now()
 			rows2b, err := a.envDB(gctx).Query(gctx, q2b)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q2b", time.Since(t), err)
 			if err != nil {
 				return fmt.Errorf("query2b: %w", err)
 			}
@@ -909,7 +909,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			}
 			t := time.Now()
 			rows, err := a.envDB(gctx).Query(gctx, `SELECT code, name, latitude, longitude FROM dz_metros_current WHERE code IN (?)`, codes)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q3", time.Since(t), err)
 			if err != nil {
 				return fmt.Errorf("query3: %w", err)
 			}
@@ -966,7 +966,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			GROUP BY metro_code`
 			t := time.Now()
 			rows, err := a.envDB(gctx).Query(gctx, query4)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q4", time.Since(t), err)
 			if err != nil && gctx.Err() == nil {
 				log.Printf("EdgeScoreboard query4 error: %v", err)
 				return nil
@@ -1123,7 +1123,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		}
 		t := time.Now()
 		rows5, err := a.envDB(gctx).Query(gctx, query5)
-		metrics.RecordClickHouseQuery(time.Since(t), err)
+		metrics.RecordClickHouseQuery("edge_scoreboard:q5", time.Since(t), err)
 		if err != nil {
 			if gctx.Err() != nil {
 				return nil
@@ -1179,7 +1179,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 
 				t = time.Now()
 				rows6a, err := a.envDB(gctx).Query(gctx, query6a, relSlots)
-				metrics.RecordClickHouseQuery(time.Since(t), err)
+				metrics.RecordClickHouseQuery("edge_scoreboard:q6a", time.Since(t), err)
 				if err != nil {
 					if gctx.Err() != nil {
 						return nil
@@ -1223,7 +1223,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				`
 				t = time.Now()
 				rows6b, err := a.envDB(gctx).Query(gctx, query6b, pubkeys)
-				metrics.RecordClickHouseQuery(time.Since(t), err)
+				metrics.RecordClickHouseQuery("edge_scoreboard:q6b", time.Since(t), err)
 				if err != nil {
 					if gctx.Err() != nil {
 						return nil
@@ -1368,7 +1368,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 
 			t := time.Now()
 			rows7, err := a.envDB(gctx).Query(gctx, query7)
-			metrics.RecordClickHouseQuery(time.Since(t), err)
+			metrics.RecordClickHouseQuery("edge_scoreboard:q7", time.Since(t), err)
 			if err != nil && gctx.Err() == nil {
 				log.Printf("EdgeScoreboard query7 error: %v", err)
 				return nil
@@ -1556,7 +1556,7 @@ func (a *API) FetchEdgeScoreboardLatest(ctx context.Context, leadersOnly bool, s
 		`SELECT max(slot), toFloat64(toUnixTimestamp(now()) - toUnixTimestamp(max(event_ts))) FROM %s.slot_feed_race_summary_v2 WHERE slot < %d`,
 		shredderDB, maxValidSlot,
 	)).Scan(&maxSlot, &lagSec)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("edge_scoreboard:max_slot", time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("max slot: %w", err)
 	}

--- a/api/handlers/facilities.go
+++ b/api/handlers/facilities.go
@@ -197,12 +197,12 @@ func (a *API) GetFacilities(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, facilitiesEnrichedCTE+listSuffix, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("facilities", duration, err)
 
 	if err != nil && isUnknownIdentifierError(err) {
 		// location_pk not yet in dz_devices_current — fall back to simple query without join
 		rows, err = a.envDB(ctx).Query(ctx, facilitiesSimpleCTE+listSuffix, args...)
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("facilities", time.Since(start), err)
 	}
 
 	if err != nil {
@@ -285,11 +285,11 @@ func (a *API) GetFacility(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, facilitiesEnrichedCTE+detailSuffix, pk)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("facilities", duration, err)
 
 	if err != nil && isUnknownIdentifierError(err) {
 		rows, err = a.envDB(ctx).Query(ctx, facilitiesSimpleCTE+detailSuffix, pk)
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("facilities", time.Since(start), err)
 	}
 
 	if err != nil {

--- a/api/handlers/field_values.go
+++ b/api/handlers/field_values.go
@@ -319,7 +319,7 @@ func (a *API) GetFieldValues(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("field_values", duration, err)
 
 	if err != nil {
 		logError("field values query failed", "error", err, "query", query)

--- a/api/handlers/generate.go
+++ b/api/handlers/generate.go
@@ -353,7 +353,7 @@ func (a *API) validateQuery(sql string) string {
 	rows, err := a.DB.Query(ctx, explainQuery)
 	duration := time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("generate", duration, err)
 		// ClickHouse error messages are safe to show and useful for LLM retry
 		errMsg := err.Error()
 		if len(errMsg) > 500 {
@@ -362,7 +362,7 @@ func (a *API) validateQuery(sql string) string {
 		return errMsg
 	}
 	rows.Close()
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("generate", duration, nil)
 
 	return "" // Valid query
 }

--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -148,7 +148,7 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 
 	start := time.Now()
 	rows, err := a.DB.Query(ctx, query)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("geo_concentration", time.Since(start), err)
 	if err != nil {
 		// Return empty response when DZDP tables aren't available or accessible
 		var chErr *proto.Exception

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -179,7 +179,7 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 
 	start := time.Now()
 	rows, err := a.DB.Query(ctx, query)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("geo_validators", time.Since(start), err)
 	if err != nil {
 		// Return empty response when DZDP tables aren't available or accessible
 		var chErr *proto.Exception

--- a/api/handlers/geoloc_explorer.go
+++ b/api/handlers/geoloc_explorer.go
@@ -76,7 +76,7 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	deviceRows, err := a.envDB(ctx).Query(ctx, deviceQuery)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("geoloc_explorer", duration, err)
 	if err != nil {
 		logError("geoloc explorer device query error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -118,7 +118,7 @@ func (a *API) GetGeolocExplorer(w http.ResponseWriter, r *http.Request) {
 	start = time.Now()
 	targetRows, err := a.envDB(ctx).Query(ctx, targetQuery)
 	duration = time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("geoloc_explorer", duration, err)
 	if err != nil {
 		logError("geoloc explorer target query error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)

--- a/api/handlers/geoloc_probes.go
+++ b/api/handlers/geoloc_probes.go
@@ -70,7 +70,7 @@ func (a *API) GetGeolocProbes(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("geoloc_probes", duration, err)
 
 	if err != nil {
 		logError("geoloc probes query error", "error", err)

--- a/api/handlers/geoloc_users.go
+++ b/api/handlers/geoloc_users.go
@@ -69,7 +69,7 @@ func (a *API) GetGeolocUsers(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("geoloc_users", duration, err)
 
 	if err != nil {
 		logError("geoloc users query error", "error", err)

--- a/api/handlers/gossip_nodes.go
+++ b/api/handlers/gossip_nodes.go
@@ -131,7 +131,7 @@ func (a *API) GetGossipNodes(w http.ResponseWriter, r *http.Request) {
 	queryArgs := append(filterArgs, pagination.Limit, pagination.Offset)
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("gossip_nodes", duration, err)
 
 	if err != nil {
 		logError("gossip nodes query failed", "error", err)
@@ -295,7 +295,7 @@ func (a *API) GetGossipNode(w http.ResponseWriter, r *http.Request) {
 		&node.VotePubkey,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("gossip_nodes", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -160,7 +160,7 @@ func (a *API) GetISISTopology(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	writeJSON(w, response)
 }
@@ -292,7 +292,7 @@ func (a *API) GetISISPath(w http.ResponseWriter, r *http.Request) {
 	path := parsePathHops(devicesVal)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	writeJSON(w, PathResponse{
 		Path:        path,
@@ -557,7 +557,7 @@ func (a *API) GetTopologyCompare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	writeJSON(w, response)
 }
@@ -867,7 +867,7 @@ func (a *API) GetFailureImpact(w http.ResponseWriter, r *http.Request) {
 	response.AffectedPathCount = len(response.AffectedPaths)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	slog.Info("failure impact", "device", response.DeviceCode, "unreachable", response.UnreachableCount, "affected_paths", response.AffectedPathCount, "metros_impacted", len(response.MetroImpact), "duration", duration)
 
@@ -966,7 +966,7 @@ func (a *API) GetISISPaths(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 	slog.Info("ISIS KSP completed", "paths", len(response.Paths), "duration", duration)
 
 	writeJSON(w, response)
@@ -1175,7 +1175,7 @@ func (a *API) GetCriticalLinks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	criticalCount := 0
 	importantCount := 0
@@ -1441,7 +1441,7 @@ func (a *API) GetRedundancyReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	slog.Info("redundancy report completed", "issues", len(response.Issues), "critical", criticalCount, "warning", warningCount, "info", infoCount, "duration", duration)
 
@@ -1672,7 +1672,7 @@ func (a *API) GetMetroConnectivity(w http.ResponseWriter, r *http.Request) {
 	response.Metros = filtered
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil) // Reuse existing metric for now
+	metrics.RecordClickHouseQuery("isis", duration, nil) // Reuse existing metric for now
 
 	slog.Info("metro connectivity completed", "metros", len(response.Metros), "connections", len(response.Connectivity), "duration", duration)
 
@@ -1988,7 +1988,7 @@ func (a *API) GetMetroPathDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	writeJSON(w, response)
 }
@@ -2277,7 +2277,7 @@ func (a *API) PostMaintenanceImpact(w http.ResponseWriter, r *http.Request) {
 	response.AffectedMetros = computeAffectedMetrosFast(ctx, session, offlineDevicePKs)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	slog.Info("maintenance impact analyzed", "devices", len(req.Devices), "links", len(req.Links), "duration", duration)
 
@@ -3158,7 +3158,7 @@ func (a *API) GetMetroDevicePaths(w http.ResponseWriter, r *http.Request) {
 	})
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("isis", duration, nil)
 
 	slog.Info("GetMetroDevicePaths completed", "from", response.FromMetroCode, "to", response.ToMetroCode, "pairs", response.TotalPairs, "duration", duration)
 

--- a/api/handlers/isis_ksp.go
+++ b/api/handlers/isis_ksp.go
@@ -78,7 +78,7 @@ func (a *API) loadTopologyGraph(ctx context.Context) (*kspGraph, error) {
 
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("isis_ksp", time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("loading topology graph: %w", err)
 	}

--- a/api/handlers/link_latency.go
+++ b/api/handlers/link_latency.go
@@ -290,7 +290,7 @@ func (a *API) GetLinkLatencyData(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("link_latency", duration, err)
 
 	if err != nil {
 		logError("link latency query error", "error", err, "duration", duration)
@@ -446,7 +446,7 @@ func (a *API) GetMultiLinkLatencyHistory(w http.ResponseWriter, r *http.Request)
 
 		rows, err := a.envDB(ctx).Query(ctx, query)
 		duration := time.Since(start)
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("link_latency", duration, err)
 
 		if err != nil {
 			logError("aggregate latency query error", "error", err, "duration", duration)
@@ -578,7 +578,7 @@ func (a *API) GetMultiLinkLatencyHistory(w http.ResponseWriter, r *http.Request)
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("link_latency", duration, err)
 
 	if err != nil {
 		logError("multi-link latency query error", "error", err, "duration", duration)

--- a/api/handlers/links.go
+++ b/api/handlers/links.go
@@ -170,7 +170,7 @@ func (a *API) GetLinks(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("links", duration, err)
 
 	if err != nil {
 		logError("links query failed", "error", err)
@@ -351,7 +351,7 @@ func (a *API) GetLinkHealth(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, committedRttProvisioningNs)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("links", duration, err)
 
 	if err != nil {
 		logError("link health query failed", "error", err)
@@ -514,7 +514,7 @@ func (a *API) GetLink(w http.ResponseWriter, r *http.Request) {
 		&link.ISISDelayOverrideNs,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("links", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/api/handlers/mcp.go
+++ b/api/handlers/mcp.go
@@ -140,7 +140,7 @@ func (a *API) registerExecuteSQLTool(server *mcp.Server, r *http.Request) {
 		rows, err := db.Query(queryCtx, query)
 		duration := time.Since(start)
 		if err != nil {
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("mcp", duration, err)
 			return nil, ExecuteSQLOutput{}, fmt.Errorf("query failed: %w", err)
 		}
 		defer rows.Close()
@@ -161,7 +161,7 @@ func (a *API) registerExecuteSQLTool(server *mcp.Server, r *http.Request) {
 			}
 
 			if err := rows.Scan(values...); err != nil {
-				metrics.RecordClickHouseQuery(duration, err)
+				metrics.RecordClickHouseQuery("mcp", duration, err)
 				return nil, ExecuteSQLOutput{}, fmt.Errorf("scan failed: %w", err)
 			}
 
@@ -173,11 +173,11 @@ func (a *API) registerExecuteSQLTool(server *mcp.Server, r *http.Request) {
 		}
 
 		if err := rows.Err(); err != nil {
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("mcp", duration, err)
 			return nil, ExecuteSQLOutput{}, fmt.Errorf("rows error: %w", err)
 		}
 
-		metrics.RecordClickHouseQuery(duration, nil)
+		metrics.RecordClickHouseQuery("mcp", duration, nil)
 
 		// Convert to JSON-safe values
 		safeRows := make([][]any, len(resultRows))

--- a/api/handlers/metros.go
+++ b/api/handlers/metros.go
@@ -241,11 +241,11 @@ func (a *API) GetMetros(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, queryWithLocations, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("metros", duration, err)
 
 	if err != nil && isUnknownIdentifierError(err) {
 		rows, err = a.envDB(ctx).Query(ctx, queryWithoutLocations, args...)
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("metros", time.Since(start), err)
 	}
 
 	if err != nil {
@@ -463,7 +463,7 @@ func (a *API) GetMetro(w http.ResponseWriter, r *http.Request) {
 		&metro.RawMaxMulticastPublishers,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("metros", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -536,7 +536,7 @@ func (a *API) GetMetroStats(w http.ResponseWriter, r *http.Request) {
 	})
 
 	err := g.Wait()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("metros", time.Since(start), err)
 	if err != nil {
 		logError("metro stats query failed", "error", err, "pk", pk)
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -99,7 +99,7 @@ func (a *API) GetMulticastGroups(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast groups query error", "error", err)
@@ -227,7 +227,7 @@ func (a *API) GetMulticastGroup(w http.ResponseWriter, r *http.Request) {
 		&group.SubscriberCount,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -490,7 +490,7 @@ func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {
 	cr := <-countCh
 	dr := <-dataCh
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, cr.err)
+	metrics.RecordClickHouseQuery("multicast", duration, cr.err)
 
 	if cr.err != nil {
 		slog.Warn("multicast group members count query failed", "error", cr.err)
@@ -865,7 +865,7 @@ func (a *API) GetMulticastGroupTraffic(w http.ResponseWriter, r *http.Request) {
 	}
 	trafficRows, err := a.envDB(ctx).Query(ctx, trafficQuery, filterIDs, devicePKs)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast group traffic query error", "error", err)
@@ -1037,7 +1037,7 @@ func (a *API) GetMulticastGroupMemberCounts(w http.ResponseWriter, r *http.Reque
 
 	rows, err := a.envDB(ctx).Query(ctx, query, groupPK, groupPK, groupPK, groupPK)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast group member counts query error", "error", err)
@@ -1194,7 +1194,7 @@ func (a *API) GetMulticastTreePaths(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, membersQuery, response.GroupPK, response.GroupPK, response.GroupPK, response.GroupPK, response.GroupPK)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast tree paths members query error", "error", err)
@@ -1413,7 +1413,7 @@ func (a *API) GetMulticastTreeSegments(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, membersQuery, response.GroupPK, response.GroupPK, response.GroupPK, response.GroupPK, response.GroupPK)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast tree segments members query error", "error", err)
@@ -1656,7 +1656,7 @@ func (a *API) GetMulticastGroupShredStats(w http.ResponseWriter, r *http.Request
 
 	rows, err := a.envDB(ctx).Query(ctx, query, userPKs)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("multicast", duration, err)
 
 	if err != nil {
 		logError("multicast group shred stats query error", "error", err, "duration", duration)

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -254,7 +254,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("publisher_check", duration, err)
 
 	if err != nil {
 		return nil, err

--- a/api/handlers/query.go
+++ b/api/handlers/query.go
@@ -116,7 +116,7 @@ func (a *API) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 	rows, err := a.PublicQueryDB.Query(ctx, query)
 	duration := time.Since(start)
 	if err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("query", duration, err)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(QueryResponse{
 			Error:     err.Error(),
@@ -143,7 +143,7 @@ func (a *API) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := rows.Scan(values...); err != nil {
-			metrics.RecordClickHouseQuery(duration, err)
+			metrics.RecordClickHouseQuery("query", duration, err)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(QueryResponse{
 				Error:     err.Error(),
@@ -161,7 +161,7 @@ func (a *API) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rows.Err(); err != nil {
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("query", duration, err)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(QueryResponse{
 			Error:     err.Error(),
@@ -170,7 +170,7 @@ func (a *API) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("query", duration, nil)
 
 	// Convert rows to JSON-safe values
 	safeRows := make([][]any, len(resultRows))

--- a/api/handlers/search.go
+++ b/api/handlers/search.go
@@ -637,7 +637,7 @@ func (a *API) SearchAutocomplete(w http.ResponseWriter, r *http.Request) {
 		allSuggestions = allSuggestions[:limit]
 	}
 
-	metrics.RecordClickHouseQuery(time.Since(start), nil)
+	metrics.RecordClickHouseQuery("search", time.Since(start), nil)
 
 	w.Header().Set("Content-Type", "application/json")
 	if allSuggestions == nil {
@@ -751,7 +751,7 @@ func (a *API) Search(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	metrics.RecordClickHouseQuery(time.Since(start), nil)
+	metrics.RecordClickHouseQuery("search", time.Since(start), nil)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(SearchResponse{Query: q, Results: results})

--- a/api/handlers/shred_subscribers.go
+++ b/api/handlers/shred_subscribers.go
@@ -47,7 +47,7 @@ func (a *API) fetchShredSeatByClientIP(ctx context.Context, clientIP string) (*S
 		WHERE s.client_ip = ?
 		LIMIT 1
 	`, clientIP)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("shred_subscribers", time.Since(start), err)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (a *API) FetchShredSubscribers(ctx context.Context, funder string, limit, o
 
 	var total uint64
 	if err := a.envDB(ctx).QueryRow(ctx, countQuery, whereArgs...).Scan(&total); err != nil {
-		metrics.RecordClickHouseQuery(time.Since(start), err)
+		metrics.RecordClickHouseQuery("shred_subscribers", time.Since(start), err)
 		return nil, 0, err
 	}
 
@@ -158,7 +158,7 @@ func (a *API) FetchShredSubscribers(ctx context.Context, funder string, limit, o
 	queryArgs := append(whereArgs, limit, offset)
 
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("shred_subscribers", time.Since(start), err)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -68,7 +68,7 @@ func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
 		&overview.NextSeatFundingIndex,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		// If no execution controller exists yet, return empty overview.
@@ -316,7 +316,7 @@ func (a *API) GetShredClientSeats(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred client seats query failed", "error", err)
@@ -409,7 +409,7 @@ func (a *API) GetShredDeviceHistories(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred device histories query failed", "error", err)
@@ -485,7 +485,7 @@ func (a *API) GetShredMetroHistories(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, pagination.Limit, pagination.Offset)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred metro histories query failed", "error", err)
@@ -557,7 +557,7 @@ func (a *API) GetShredFunders(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred funders query failed", "error", err)
@@ -744,7 +744,7 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred escrow events query failed", "error", err)
@@ -816,7 +816,7 @@ func (a *API) GetShredSubscriberHistory(w http.ResponseWriter, r *http.Request) 
 
 	rows, err := a.envDB(ctx).Query(ctx, query, limit)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred subscriber history query failed", "error", err)
@@ -933,7 +933,7 @@ func (a *API) GetShredEpochRevenue(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, limit)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds", duration, err)
 
 	if err != nil {
 		logError("shred epoch revenue query failed", "error", err)

--- a/api/handlers/shreds_devices.go
+++ b/api/handlers/shreds_devices.go
@@ -96,7 +96,7 @@ func (a *API) GetShredDevices(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("shreds_devices", duration, err)
 
 	if err != nil {
 		logError("shred devices query failed", "error", err)

--- a/api/handlers/stake.go
+++ b/api/handlers/stake.go
@@ -211,7 +211,7 @@ func (a *API) FetchStakeOverviewData(ctx context.Context) (*StakeOverview, error
 
 	err := g.Wait()
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("stake", duration, err)
 
 	if err != nil {
 		return nil, err
@@ -329,7 +329,7 @@ func (a *API) GetStakeHistory(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("stake", duration, err)
 
 	if err != nil {
 		logError("stake history query error", "error", err)
@@ -564,7 +564,7 @@ func (a *API) GetStakeChanges(w http.ResponseWriter, r *http.Request) {
 
 	err := g.Wait()
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("stake", duration, err)
 
 	if err != nil {
 		logError("stake changes query error", "error", err)
@@ -752,7 +752,7 @@ func (a *API) GetStakeValidators(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("stake", duration, err)
 
 	if err != nil {
 		logError("stake validators query error", "error", err)

--- a/api/handlers/stats.go
+++ b/api/handlers/stats.go
@@ -179,7 +179,7 @@ func (a *API) GetStats(w http.ResponseWriter, r *http.Request) {
 
 	err := g.Wait()
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("stats", duration, err)
 
 	if err != nil {
 		logError("stats query failed", "error", err)

--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -1354,7 +1354,7 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 	}
 	resp.Links.Issues = append(resp.Links.Issues, missingAdjIssues...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("status", duration, err)
 
 	if err != nil {
 		resp.Error = err.Error()

--- a/api/handlers/tenants.go
+++ b/api/handlers/tenants.go
@@ -74,7 +74,7 @@ func (a *API) GetTenants(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("tenants", duration, err)
 
 	if err != nil {
 		logError("tenants query failed", "error", err)
@@ -165,7 +165,7 @@ func (a *API) GetTenant(w http.ResponseWriter, r *http.Request) {
 		&t.BillingRate,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("tenants", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/api/handlers/timeline.go
+++ b/api/handlers/timeline.go
@@ -933,7 +933,7 @@ func (a *API) GetTimeline(w http.ResponseWriter, r *http.Request) {
 	histogram := computeHistogram(allEvents, params.StartTime, params.EndTime)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("timeline", duration, nil)
 
 	resp := TimelineResponse{
 		Events: paginatedEvents,
@@ -1038,7 +1038,7 @@ func (a *API) queryEntityChanges(ctx context.Context, startTime, endTime time.Ti
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var result []entityChangeRow
 	for rows.Next() {
@@ -1106,7 +1106,7 @@ func (a *API) fetchDeviceChangeDetails(ctx context.Context, rows []entityChangeR
 		return nil, err
 	}
 	defer dbRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	// Build a set of requested (entityID, snapshotTS) for fast lookup
 	type rowKey struct {
@@ -1261,7 +1261,7 @@ func (a *API) fetchLinkChangeDetails(ctx context.Context, rows []entityChangeRow
 		return nil, err
 	}
 	defer dbRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	type rowKey struct {
 		entityID   string
@@ -1432,7 +1432,7 @@ func (a *API) fetchMetroChangeDetails(ctx context.Context, rows []entityChangeRo
 		return nil, err
 	}
 	defer dbRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	type rowKey struct {
 		entityID   string
@@ -1536,7 +1536,7 @@ func (a *API) fetchContributorChangeDetails(ctx context.Context, rows []entityCh
 		return nil, err
 	}
 	defer dbRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	type rowKey struct {
 		entityID   string
@@ -1642,7 +1642,7 @@ func (a *API) fetchUserChangeDetails(ctx context.Context, rows []entityChangeRow
 		return nil, err
 	}
 	defer dbRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	type rowKey struct {
 		entityID   string
@@ -2010,7 +2010,7 @@ func (a *API) queryIncidentEvents(ctx context.Context, startTime, endTime time.T
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var events []TimelineEvent
 	for rows.Next() {
@@ -2255,7 +2255,7 @@ func (a *API) queryValidatorEvents(ctx context.Context, startTime, endTime time.
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var events []TimelineEvent
 	for rows.Next() {
@@ -2418,7 +2418,7 @@ func (a *API) queryGossipNetworkChanges(ctx context.Context, startTime, endTime 
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var events []TimelineEvent
 	for rows.Next() {
@@ -2598,7 +2598,7 @@ func (a *API) queryVoteAccountChanges(ctx context.Context, startTime, endTime ti
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var events []TimelineEvent
 	for rows.Next() {
@@ -2746,7 +2746,7 @@ func (a *API) queryStakeChanges(ctx context.Context, startTime, endTime time.Tim
 		return nil, err
 	}
 	defer rows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	var events []TimelineEvent
 	for rows.Next() {
@@ -2883,7 +2883,7 @@ func (a *API) queryDZStakeAttribution(ctx context.Context, startTime, endTime ti
 		return nil, err
 	}
 	defer snapRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start), err)
 
 	type snapshotPair struct {
 		currTS         time.Time
@@ -2948,7 +2948,7 @@ func (a *API) queryDZStakeAttribution(ctx context.Context, startTime, endTime ti
 		return nil, err
 	}
 	defer valRows.Close()
-	metrics.RecordClickHouseQuery(time.Since(start2), err)
+	metrics.RecordClickHouseQuery("timeline", time.Since(start2), err)
 
 	// Index validators by (snapshot_ts, vote_pubkey)
 	type valData struct {

--- a/api/handlers/topology.go
+++ b/api/handlers/topology.go
@@ -302,7 +302,7 @@ func (a *API) FetchTopologyData(ctx context.Context) (TopologyResponse, error) {
 
 	err := g.Wait()
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	return TopologyResponse{
 		Metros:  metros,
@@ -467,7 +467,7 @@ func (a *API) fetchTopologyLinkMetrics(ctx context.Context) (TopologyLinkMetrics
 
 	err := g.Wait()
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	result := make(map[string]TopologyLinkMetricsEntry, len(latencyRows))
 	for _, r := range latencyRows {
@@ -597,7 +597,7 @@ func (a *API) fetchTopologyValidators(ctx context.Context) (TopologyValidatorsRe
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	if err != nil {
 		duration := time.Since(start)
-		metrics.RecordClickHouseQuery(duration, err)
+		metrics.RecordClickHouseQuery("topology", duration, err)
 		return TopologyValidatorsResponse{}, err
 	}
 	defer rows.Close()
@@ -615,7 +615,7 @@ func (a *API) fetchTopologyValidators(ctx context.Context) (TopologyValidatorsRe
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	return TopologyValidatorsResponse{Validators: validators}, nil
 }
@@ -853,7 +853,7 @@ func (a *API) GetEntityTraffic(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("topology", duration, nil)
 
 	if points == nil {
 		points = []TrafficDataPoint{}
@@ -1011,7 +1011,7 @@ func (a *API) GetLatencyComparison(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	if err != nil {
 		logError("latency comparison query error", "error", err)
@@ -1124,7 +1124,7 @@ func (a *API) FetchLatencyComparisonData(ctx context.Context) (*LatencyCompariso
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	if err != nil {
 		return nil, err
@@ -1301,7 +1301,7 @@ func (a *API) GetLatencyHistory(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, metro1, metro2)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("topology", duration, err)
 
 	if err != nil {
 		logError("latency history query error", "error", err)

--- a/api/handlers/traffic.go
+++ b/api/handlers/traffic.go
@@ -361,7 +361,7 @@ func (a *API) GetTrafficData(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -375,7 +375,7 @@ func (a *API) GetTrafficData(w http.ResponseWriter, r *http.Request) {
 
 	meanRows, err := a.envDB(ctx).Query(ctx, meanQuery)
 	meanDuration := time.Since(start) - duration
-	metrics.RecordClickHouseQuery(meanDuration, err)
+	metrics.RecordClickHouseQuery("traffic", meanDuration, err)
 	if err != nil {
 		if ctx.Err() != nil {
 			return
@@ -606,7 +606,7 @@ func (a *API) GetDiscardsData(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {

--- a/api/handlers/traffic_dashboard.go
+++ b/api/handlers/traffic_dashboard.go
@@ -1147,7 +1147,7 @@ func (a *API) GetTrafficDashboardHealth(w http.ResponseWriter, r *http.Request) 
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic_dashboard", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1239,7 +1239,7 @@ func (a *API) GetTrafficDashboardStress(w http.ResponseWriter, r *http.Request) 
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic_dashboard", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1435,7 +1435,7 @@ func (a *API) GetTrafficDashboardTop(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic_dashboard", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1524,7 +1524,7 @@ func (a *API) GetTrafficDashboardDrilldown(w http.ResponseWriter, r *http.Reques
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic_dashboard", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1686,7 +1686,7 @@ func (a *API) GetTrafficDashboardBurstiness(w http.ResponseWriter, r *http.Reque
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("traffic_dashboard", duration, err)
 
 	if err != nil {
 		if ctx.Err() != nil {

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -166,7 +166,7 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 	queryArgs := append(filterArgs, pagination.Limit, pagination.Offset)
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("users", duration, err)
 
 	if err != nil {
 		logError("users query failed", "error", err)
@@ -384,7 +384,7 @@ func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
 		&user.IsDeleted,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("users", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -532,7 +532,7 @@ func (a *API) GetUserTraffic(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, pk)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("users", duration, err)
 
 	if err != nil {
 		logError("user traffic query failed", "error", err, "pk", pk)
@@ -647,7 +647,7 @@ func (a *API) GetUserMulticastGroups(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := a.envDB(ctx).Query(ctx, query, pk, pk)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("users", duration, err)
 
 	if err != nil {
 		logError("user multicast groups query failed", "error", err, "pk", pk)

--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -226,7 +226,7 @@ func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
 	queryArgs := append(filterArgs, pagination.Limit, pagination.Offset)
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("validators", duration, err)
 
 	if err != nil {
 		logError("validators query failed", "error", err)
@@ -315,7 +315,7 @@ func (a *API) FetchValidatorsMetadata(ctx context.Context) ([]ValidatorMetadataR
 	`
 
 	rows, err := a.envDB(ctx).Query(ctx, query)
-	metrics.RecordClickHouseQuery(time.Since(start), err)
+	metrics.RecordClickHouseQuery("validators", time.Since(start), err)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +486,7 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 		&validator.SoftwareVersion,
 	)
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, err)
+	metrics.RecordClickHouseQuery("validators", duration, err)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/api/handlers/whatif.go
+++ b/api/handlers/whatif.go
@@ -248,7 +248,7 @@ func (a *API) GetSimulateLinkRemoval(w http.ResponseWriter, r *http.Request) {
 	response.AffectedPathCount = len(response.AffectedPaths)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("whatif", duration, nil)
 
 	slog.Debug("simulate link removal complete",
 		"source", response.SourceCode, "target", response.TargetCode,
@@ -535,7 +535,7 @@ func (a *API) GetSimulateLinkAddition(w http.ResponseWriter, r *http.Request) {
 	response.ImprovedPathCount = len(response.ImprovedPaths)
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("whatif", duration, nil)
 
 	slog.Debug("simulate link addition complete",
 		"source", response.SourceCode, "target", response.TargetCode, "metric", metric,
@@ -639,7 +639,7 @@ func (a *API) PostWhatIfRemoval(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := time.Since(start)
-	metrics.RecordClickHouseQuery(duration, nil)
+	metrics.RecordClickHouseQuery("whatif", duration, nil)
 
 	slog.Debug("what-if removal complete",
 		"devices", len(req.Devices), "links", len(req.Links),

--- a/api/metrics/metrics.go
+++ b/api/metrics/metrics.go
@@ -77,15 +77,19 @@ var (
 			Name: "doublezero_lake_api_clickhouse_queries_total",
 			Help: "Total number of ClickHouse queries",
 		},
-		[]string{"status"}, // "success", "error", "timeout", "cancelled"
+		[]string{"name", "status"}, // status: "success", "error", "timeout", "cancelled"
 	)
 
-	ClickHouseQueryDuration = promauto.NewHistogram(
+	// Bucket boundaries are aligned to our deadline budgets (30s handler default,
+	// 45s page-cache worker, 60s edge_scoreboard handler) so p95/p99 against the
+	// deadline is readable in Grafana.
+	ClickHouseQueryDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "doublezero_lake_api_clickhouse_query_duration_seconds",
 			Help:    "Duration of ClickHouse queries in seconds",
-			Buckets: prometheus.ExponentialBuckets(0.01, 2, 12), // 10ms to ~41s
+			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90},
 		},
+		[]string{"name"},
 	)
 
 	// Anthropic API metrics
@@ -217,8 +221,10 @@ func Middleware(next http.Handler) http.Handler {
 	})
 }
 
-// RecordClickHouseQuery records metrics for a ClickHouse query.
-func RecordClickHouseQuery(duration time.Duration, err error) {
+// RecordClickHouseQuery records metrics for a ClickHouse query. The name should
+// be a stable, low-cardinality identifier for the query (e.g. "edge_scoreboard:q1d",
+// "publisher_check:totals") so per-query latency and error rate are visible in Grafana.
+func RecordClickHouseQuery(name string, duration time.Duration, err error) {
 	status := "success"
 	if err != nil {
 		switch {
@@ -230,8 +236,8 @@ func RecordClickHouseQuery(duration time.Duration, err error) {
 			status = "error"
 		}
 	}
-	ClickHouseQueriesTotal.WithLabelValues(status).Inc()
-	ClickHouseQueryDuration.Observe(duration.Seconds())
+	ClickHouseQueriesTotal.WithLabelValues(name, status).Inc()
+	ClickHouseQueryDuration.WithLabelValues(name).Observe(duration.Seconds())
 }
 
 func isDeadlineExceeded(err error) bool {


### PR DESCRIPTION
Resolves: #568

## Summary of Changes
- Replace edge_scoreboard's q1d (publisher / publishing-shred / stake-% query) with a read of the `publisher_check` page-cache entry, deriving the three headline values from the response. Move it into the existing errgroup so it no longer runs sequentially before the parallel queries.
- Should clear the recurring `EdgeScoreboard query1d / query8 (geoip) error: context deadline exceeded` log lines from the page-cache refresh worker (~79 q1d errors / 24h in lake-prod) — q1d was the slow sequential step eating the 45 s budget.
- Add a `name` label to `ClickHouseQueriesTotal` and `ClickHouseQueryDuration` so per-query latency and error rate are visible in Grafana (today they're emitted as a single unlabeled aggregate). edge_scoreboard's queries get individual names (`edge_scoreboard:q1` ... `:q7`, `:max_slot`); other handlers default to file-basename.
- Widen the duration histogram buckets from a 12-bucket exponential series capped at 20.48 s to a hand-tuned set covering 10ms..90s with extra resolution at 30s/45s/60s — the deadline budgets we actually care about. Previously p99 above 20 s disappeared into the +Inf bucket.
- Numbers verified equivalent to the previous query locally (446 / 419 / 49.80% from both sources).

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net |
|-------------|-------|-------------|-----|
| Core logic  |     2 | +59 / -61   |  -2 |
| Scaffolding |    38 | +141 / -141 |   0 |
| **Total**   |    40 | +200 / -202 |  -2 |

The two core-logic files carry the actual change (q1d swap + metrics labels/buckets). The 38 scaffolding files are mechanical 1-for-1 updates passing the new `name` argument to `metrics.RecordClickHouseQuery` — no behavior change.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/edge_scoreboard.go`](https://github.com/malbeclabs/lake/pull/567/files#diff-f2de81cc68fddae2ed6afe695d4f530031f72f07dbe5455fcc329bd0246abaf0) — drop sequential q1d block; add new errgroup goroutine ("Group P") that reads `publisher_check` page-cache and computes the three headline numbers. Cache-miss / unmarshal failure leaves them at 0 (matches the prior non-fatal semantics). Each existing query also gets a per-query metric name (`edge_scoreboard:q1` ... `:q7`, `:max_slot`).
- [`api/metrics/metrics.go`](https://github.com/malbeclabs/lake/pull/567/files#diff-5208557f25b71e10429097f2e8e70b5ba5d63406cda7587b009a1af93cf12e86) — add `name` label to both ClickHouse query metrics; convert `ClickHouseQueryDuration` from `Histogram` to `HistogramVec`; widen buckets to `[10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 15s, 30s, 45s, 60s, 90s]`.

</details>

## Caveats
- On cold start (worker hasn't populated `publisher_check` yet) the three headline numbers read 0 for ~30s. Same window as any cache-backed page on cold start.
- Envs that run the API without the cache-refresh worker will read 0 indefinitely for these three numbers.
- Heavier handlers (`timeline` 14 calls, `isis` 11, `topology` / `shreds` / `multicast` / `db` / `catalog` 8 each) currently share a single label per file; refining those to per-query names is a cheap follow-up if the file-level visibility turns out insufficient.

## Verification
- Local: `/api/dz/edge/scoreboard` returns identical `publisher_count` / `publishing_count` / `publishing_stake_pct` (446 / 419 / 49.80431200287905%) to the values derived from `/api/dz/publisher-check`.
- Post-deploy verification (Loki):
```
count_over_time({app="lake-api", namespace="lake-prod"} |= "EdgeScoreboard query1d error" [24h])
count_over_time({app="lake-api", namespace="lake-prod"} |= "EdgeScoreboard query8" [24h])
```
Both should drop to ~0.