### PR TITLE
api, web: don't flag transient one-sided reporting as no_data

### DIFF
--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -604,13 +604,11 @@ func buildLinkMetricsStatus(
 	statusStr := health.ClassifyLinkStatus(avgLatency, lossPct, committedRtt)
 
 	// One-sided reporting — one side sends probes, the other doesn't.
-	// Don't upgrade to unhealthy; transient one-sided is common at bucket
-	// boundaries. Keep whatever status the latency/loss classification gave.
-	if drainStatus != "hard-drained" && (rollup.ASamples == 0) != (rollup.ZSamples == 0) {
-		if isCollecting {
-			statusStr = "no_data"
-		}
-	}
+	// Don't upgrade to unhealthy or no_data; transient one-sided is common at
+	// bucket boundaries (especially the collecting bucket, where one reporter
+	// may simply be a few seconds behind the other). Keep whatever status the
+	// latency/loss classification gave; the "One-sided reporting" reason
+	// below preserves the signal for tooltips and details.
 
 	// Upgrade status based on interface issues (same thresholds as status_rollup_handlers)
 	const interfaceUnhealthyThreshold = uint64(100)

--- a/web/src/components/link-status-timelines.tsx
+++ b/web/src/components/link-status-timelines.tsx
@@ -325,7 +325,10 @@ function addBucketIssues(b: LinkMetricsBucket, issues: Set<string>) {
       if (r.includes('interface error')) issues.add('interface_errors')
       if (r.includes('discard')) issues.add('discards')
       if (r.includes('carrier')) issues.add('carrier_transitions')
-      if (r.includes('One-sided')) issues.add('no_data')
+      // Skip one-sided on the collecting bucket: side reporters write probes
+      // independently and being a few seconds out of sync at the bucket
+      // boundary is normal, not an outage signal.
+      if (r.includes('One-sided') && !b.status.collecting) issues.add('no_data')
     }
   }
   // Also check traffic data directly (for FCS errors and utilization not in reasons)


### PR DESCRIPTION
## Summary

- Link scoreboard "No Data" badge was firing pink/active on virtually every healthy link in production because the collecting (in-progress) bucket emits a "One-sided reporting" signal whenever one side's probe reporter is a few seconds behind the other at the bucket boundary — a normal, transient condition.
- Backend (`link_metrics.go`): stop forcing the collecting bucket to `health=no_data` on one-sided reporting. The existing comment already acknowledged transient one-sided is expected at bucket boundaries; the code is now consistent with that intent. The "One-sided reporting" reason is still appended for tooltips/details.
- Frontend (`link-status-timelines.tsx`): when mapping server reasons to badge issue tags, only treat "One-sided reporting" as `no_data` for non-collecting buckets. Persistent historical one-sided still flags as a partial outage (matches the design intent in the status appendix); transient collecting one-sided does not.

## Scope

The parallel logic in `status_rollup_handlers.go` (powering the `/status` page) has the same shape and is intentionally left alone here to keep scope tight to the scoreboard issue captured in the screenshot. Happy to do a follow-up if we want to align the two paths.

## Testing Verification

- `go test ./api/handlers/...` passes (full handler suite, ~25s).
- `tsc -b --noEmit` clean on the web package.
- Walked through the badge state machine for each combination of {collecting, historical} × {fully missing, one-sided, both-sided}: only the transient collecting one-sided case loses its badge; all other no-data and partial-outage signals continue to flag as before.