### PR TITLE
api: bump page cache refresh timeouts

### DIFF
--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -138,7 +138,7 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 	// effectively refresh only once every few minutes. Fully parallel execution
 	// means the activity completes in max(entry_times) rather than sum/2, so the
 	// 30s sleep actually achieves a ~30s refresh cycle. Each entry has its own
-	// 45s timeout, so failures remain bounded.
+	// 60s timeout, so failures remain bounded.
 	g, gctx := errgroup.WithContext(ctx)
 
 	for _, entry := range a.entries() {
@@ -199,7 +199,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(parentCtx, 45*time.Second)
+		ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
 		result, err := fn(ctx)
 		cancel()
 
@@ -256,7 +256,7 @@ func (a *Activities) incFailures(key string) int {
 // workflow history bounded.
 func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	actOpts := temporalworkflow.ActivityOptions{
-		StartToCloseTimeout: 2 * time.Minute,
+		StartToCloseTimeout: 3 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},


### PR DESCRIPTION
## Summary
- Bump per-entry refresh timeout from 45 s to 60 s (`api/worker/workflow.go:202`).
- Bump `RefreshCaches` activity `StartToCloseTimeout` from 2 m to 3 m to keep the worst-case retry path (60 s × 2 attempts) under the activity ceiling.

## Why
Mitigation for the recurring `query2 rows: context deadline exceeded` log line on the `edge_scoreboard` cache refresh in `lake-prod`. Same shape as #568 (which fixed q1d / q8 by replacing q1d with a `publisher_check` cache read), just on a different query that #567 didn't touch — q2's per-observer share-of-wins aggregate over `slot_feed_race_summary_v2` is heavy enough at 24 h × all hosts × all feeds with `final=1` to occasionally exceed the 45 s budget under load.

This is mitigation, not a fix. q2 is genuinely heavy and will need a structural fix (materialized rollup, drop `final=1`, or similar) if growth continues to push it past the new ceiling.

## Testing Verification
- Worst-case retry budget: 60 s × `maxAttempts=2` = 120 s, comfortably under the new 3 m activity timeout.
- Post-deploy verify in Loki:
  ```
  count_over_time({app="lake-api", namespace="lake-prod"} |= "query2 rows" [24h])
  ```
  Should drop close to zero.