### PR TITLE
api: don't log client-cancel as ERROR for metric fetches

### DIFF
--- a/api/handlers/device_metrics.go
+++ b/api/handlers/device_metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -225,7 +224,7 @@ func (a *API) GetDeviceMetrics(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := a.fetchDeviceMetrics(ctx, devicePK, params, include)
 	if err != nil {
-		slog.Error("error fetching device metrics", "error", err, "device_pk", devicePK)
+		logError("error fetching device metrics", "error", err, "device_pk", devicePK)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -815,7 +814,7 @@ func (a *API) GetBulkDeviceMetrics(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := a.fetchBulkDeviceMetrics(ctx, params, include)
 	if err != nil {
-		slog.Error("error fetching bulk device metrics", "error", err)
+		logError("error fetching bulk device metrics", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -841,7 +841,7 @@ func (a *API) GetBulkLinkMetrics(w http.ResponseWriter, r *http.Request) {
 	issuesOnly := q.Get("has_issues") == "true"
 	resp, err := a.fetchBulkLinkMetrics(ctx, params, include, issuesOnly)
 	if err != nil {
-		slog.Error("error fetching bulk link metrics", "error", err)
+		logError("error fetching bulk link metrics", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- Switch three `slog.Error` sites in `device_metrics` and `link_metrics` handlers to the existing `logError` helper (`api/handlers/errors.go:34`), which silently skips errors caused by client disconnects (context cancellation, deadline exceeded, broken pipe, connection reset, unexpected EOF).
- `GetLinkMetrics` already used `logError`; this brings `GetDeviceMetrics`, `GetBulkDeviceMetrics`, and `GetBulkLinkMetrics` in line with it.

## Why
Recurring ERROR log lines like:
```
ERROR error fetching device metrics error="device interface rollup: interface rollup query: context canceled" device_pk=...
```
fire whenever a browser cancels an in-flight metrics request — typical when navigating away from a detail page or when a newer poll supersedes an older one. The 15s `statusContext` budget derives from `r.Context()`, so client cancellations propagate straight through to the ClickHouse driver and surface as `context canceled`. Nobody is waiting for the response — these aren't actionable errors and shouldn't page anyone.

## Testing Verification
- `go test ./api/handlers/...` passes.
- Post-deploy verify in Loki:
  ```
  count_over_time({app="lake-api", namespace="lake-prod"} |= "error fetching device metrics" |= "context canceled" [24h])
  ```
  Should drop to ~0. Genuine non-cancel errors still log at ERROR.