### PR TITLE
api: move geo_validators timeout to call sites

### DIFF
--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -70,7 +70,10 @@ func (a *API) GetGeoValidators(w http.ResponseWriter, r *http.Request) {
 	metro := strings.TrimSpace(r.URL.Query().Get("metro"))
 	dzFilter := strings.TrimSpace(r.URL.Query().Get("dz_filter"))
 
-	resp, err := a.FetchGeoValidatorsData(r.Context(), metro, dzFilter)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	resp, err := a.FetchGeoValidatorsData(ctx, metro, dzFilter)
 	if err != nil {
 		logError("geo validators query error", "error", err)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -89,9 +92,6 @@ func isDefaultGeoValidatorsRequest(r *http.Request) bool {
 }
 
 func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string) (*GeoValidatorsResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
 	dzdpDB := fmt.Sprintf("`%s`", a.DZDPDB)
 
 	query := fmt.Sprintf(`


### PR DESCRIPTION
## Summary
- Drop the hardcoded 15s `context.WithTimeout` inside `FetchGeoValidatorsData` (`api/handlers/geo_validators.go:92`).
- Add a 30s timeout in `GetGeoValidators` (HTTP handler) around `r.Context()`, matching the pattern used by other handlers.

## Why
`page-cache cache="geo validators" consecutive_failures=3 error="context deadline exceeded"` recurring in `lake-prod`.

The fetcher set its own 15s timeout that clamped every caller's budget — even though #570 bumped the page-cache worker's per-entry budget to 60s, this fetcher was still giving up at 15s. The query is genuinely heavy:
- `location_state FINAL` ⨝ `solana_gossip_nodes_current` ⨝ `solana_vote_accounts_current`
- LEFT JOIN `geoip_records_current` + `validatorsapp_validators_current`
- `CROSS JOIN dz_metros_current` for nearest-metro computation per validator (~1000 × ~50 = 50k pairs)
- `argMax` aggregation over the result

After this change:
- Worker calls (`FetchGeoValidatorsData(ctx, "", "")` via `RefreshCaches`) are governed by the 60s per-entry budget.
- HTTP requests are bounded by a fresh 30s timeout at the handler.

## Testing Verification
- `go test ./api/handlers/...` passes.
- Post-deploy verify in Loki:
  ```
  count_over_time({app="lake-api", namespace="lake-prod"} |= "cache=\"geo validators\"" |= "context deadline exceeded" [24h])
  ```
  Should drop close to zero.