### PR TITLE
utils, api: redact RPC URL credentials in logs and errors

### DIFF
--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 
 	"github.com/getsentry/sentry-go"
+
+	"github.com/malbeclabs/lake/utils/pkg/redact"
 )
 
 // isClientDisconnect returns true if the error is caused by the client
@@ -64,39 +66,9 @@ func internalError(operation string, err error) string {
 	return operation
 }
 
-// SanitizeError removes sensitive information from error messages.
-// Use this when you need to include some error context but want to
-// strip credentials and internal details.
+// SanitizeError removes sensitive information from error messages by
+// redacting basic-auth credentials, sensitive query-param values, and
+// token-shaped path segments in any URLs the message contains.
 func SanitizeError(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	msg := err.Error()
-
-	// Remove anything that looks like credentials in URLs
-	// Pattern: protocol://user:pass@host or protocol://user@host
-	if idx := strings.Index(msg, "://"); idx != -1 {
-		// Find the @ symbol that separates credentials from host
-		atIdx := strings.Index(msg[idx:], "@")
-		if atIdx != -1 {
-			// Replace credentials with ***
-			endOfProto := idx + 3 // len("://")
-			msg = msg[:endOfProto] + "***@" + msg[idx+atIdx+1:]
-		}
-	}
-
-	// Remove query parameters which may contain SQL
-	if idx := strings.Index(msg, "?"); idx != -1 {
-		// Find the end of the URL (next space or quote)
-		endIdx := len(msg)
-		for _, delim := range []string{" ", "'", "\""} {
-			if i := strings.Index(msg[idx:], delim); i != -1 && idx+i < endIdx {
-				endIdx = idx + i
-			}
-		}
-		msg = msg[:idx] + "?..." + msg[endIdx:]
-	}
-
-	return msg
+	return redact.Error(err)
 }

--- a/api/handlers/errors_test.go
+++ b/api/handlers/errors_test.go
@@ -21,7 +21,7 @@ func TestSanitizeError_PlainError(t *testing.T) {
 	assert.Equal(t, "something went wrong", result)
 }
 
-func TestSanitizeError_RemovesCredentialsFromURL(t *testing.T) {
+func TestSanitizeError_RedactsCredentialsInURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
@@ -31,17 +31,17 @@ func TestSanitizeError_RemovesCredentialsFromURL(t *testing.T) {
 		{
 			name:     "URL with user:pass",
 			input:    "failed to connect: postgres://user:secretpass@localhost:5432/db",
-			expected: "failed to connect: postgres://***@localhost:5432/db",
+			expected: "failed to connect: postgres://redacted@localhost:5432/db",
 		},
 		{
 			name:     "URL with just user",
 			input:    "error at: postgres://admin@localhost:5432/db",
-			expected: "error at: postgres://***@localhost:5432/db",
+			expected: "error at: postgres://redacted@localhost:5432/db",
 		},
 		{
 			name:     "HTTPS URL with credentials",
 			input:    "cannot reach: https://api_key:secret123@api.example.com/v1",
-			expected: "cannot reach: https://***@api.example.com/v1",
+			expected: "cannot reach: https://redacted@api.example.com/v1",
 		},
 		{
 			name:     "URL without credentials",
@@ -59,7 +59,7 @@ func TestSanitizeError_RemovesCredentialsFromURL(t *testing.T) {
 	}
 }
 
-func TestSanitizeError_RemovesQueryParameters(t *testing.T) {
+func TestSanitizeError_RedactsSensitiveQueryParameters(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
@@ -67,19 +67,19 @@ func TestSanitizeError_RemovesQueryParameters(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "URL with query params",
+			name:     "token in query is redacted, other params preserved",
 			input:    "error fetching: https://api.example.com/data?token=secret123&foo=bar",
-			expected: "error fetching: https://api.example.com/data?...",
+			expected: "error fetching: https://api.example.com/data?foo=bar&token=redacted",
 		},
 		{
-			name:     "URL with query ending in space",
-			input:    "GET https://api.example.com?key=secret failed",
-			expected: "GET https://api.example.com?... failed",
+			name:     "non-sensitive query is preserved",
+			input:    "GET https://api.example.com?retries=3 failed",
+			expected: "GET https://api.example.com?retries=3 failed",
 		},
 		{
-			name:     "URL with query in quotes",
-			input:    "requesting 'https://api.example.com?pass=xxx' returned error",
-			expected: "requesting 'https://api.example.com?...' returned error",
+			name:     "api-key in query is redacted",
+			input:    "requesting 'https://api.example.com?api-key=xxx' returned error",
+			expected: "requesting 'https://api.example.com?api-key=redacted' returned error",
 		},
 	}
 
@@ -94,31 +94,37 @@ func TestSanitizeError_RemovesQueryParameters(t *testing.T) {
 
 func TestSanitizeError_CombinedCredentialsAndQuery(t *testing.T) {
 	t.Parallel()
-	err := errors.New("connect to: postgres://user:pass@localhost:5432/db?sslmode=disable")
+	err := errors.New("connect to: postgres://user:pass@localhost:5432/db?token=secret&sslmode=disable")
 	result := handlers.SanitizeError(err)
 
-	// Should remove credentials first, then query params
-	assert.Contains(t, result, "***@localhost")
-	assert.Contains(t, result, "?...")
+	assert.Contains(t, result, "redacted@localhost")
+	assert.Contains(t, result, "token=redacted")
+	assert.Contains(t, result, "sslmode=disable")
 	assert.NotContains(t, result, "user:pass")
-	assert.NotContains(t, result, "sslmode")
+	assert.NotContains(t, result, "secret")
 }
 
 func TestSanitizeError_NoProtocol(t *testing.T) {
 	t.Parallel()
-	// Error without :// should not be modified for credentials
 	err := errors.New("failed: user@host denied")
 	result := handlers.SanitizeError(err)
-	// The @ without :// protocol shouldn't trigger credential removal
 	assert.Equal(t, "failed: user@host denied", result)
 }
 
 func TestSanitizeError_MultipleURLs(t *testing.T) {
 	t.Parallel()
-	// Only the first URL is processed
 	err := errors.New("from https://user:pass@a.com to https://user2:pass2@b.com")
 	result := handlers.SanitizeError(err)
 
-	// First URL should have credentials removed
-	assert.Contains(t, result, "https://***@a.com")
+	assert.Contains(t, result, "https://redacted@a.com")
+	assert.Contains(t, result, "https://redacted@b.com")
+	assert.NotContains(t, result, "user:pass")
+	assert.NotContains(t, result, "user2:pass2")
+}
+
+func TestSanitizeError_PathEmbeddedToken(t *testing.T) {
+	t.Parallel()
+	err := errors.New("GET https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab failed")
+	result := handlers.SanitizeError(err)
+	assert.Equal(t, "GET https://doublezero-mainnet-beta.rpcpool.com/redacted failed", result)
 }

--- a/api/handlers/ledger.go
+++ b/api/handlers/ledger.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/malbeclabs/lake/api/solana"
+	"github.com/malbeclabs/lake/utils/pkg/redact"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -203,7 +204,7 @@ func (a *API) GetDZLedger(w http.ResponseWriter, r *http.Request) {
 		logError("DZ ledger RPC request failed", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
-		_ = json.NewEncoder(w).Encode(LedgerResponse{Error: err.Error()})
+		_ = json.NewEncoder(w).Encode(LedgerResponse{Error: redact.Error(err)})
 		return
 	}
 
@@ -227,7 +228,7 @@ func (a *API) GetSolanaLedger(w http.ResponseWriter, r *http.Request) {
 		logError("Solana ledger RPC request failed", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
-		_ = json.NewEncoder(w).Encode(LedgerResponse{Error: err.Error()})
+		_ = json.NewEncoder(w).Encode(LedgerResponse{Error: redact.Error(err)})
 		return
 	}
 
@@ -319,7 +320,7 @@ func (a *API) GetValidatorPerformance(w http.ResponseWriter, r *http.Request) {
 		logError("validator performance query failed", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(ValidatorPerfResponse{Error: err.Error()})
+		_ = json.NewEncoder(w).Encode(ValidatorPerfResponse{Error: redact.Error(err)})
 		return
 	}
 

--- a/api/main.go
+++ b/api/main.go
@@ -30,6 +30,7 @@ import (
 	v1 "github.com/malbeclabs/lake/api/v1"
 	"github.com/malbeclabs/lake/api/worker"
 	slackbot "github.com/malbeclabs/lake/slack/bot"
+	"github.com/malbeclabs/lake/utils/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/slack-go/slack/socketmode"
 )
@@ -221,7 +222,12 @@ func main() {
 	noWorkerFlag := flag.Bool("no-worker", false, "Disable embedded page cache worker (for prod where it runs standalone)")
 	noDevnetFlag := flag.Bool("no-devnet", false, "Disable devnet database connection")
 	noTestnetFlag := flag.Bool("no-testnet", false, "Disable testnet database connection")
+	verboseFlag := flag.Bool("v", false, "Verbose logging (debug level)")
 	flag.Parse()
+
+	// Install the shared logger as the slog default. The handler redacts
+	// credentials embedded in URLs so api logs match indexer/admin behavior.
+	slog.SetDefault(logger.New(*verboseFlag))
 
 	// Set env vars so config.Load() picks them up (flags take precedence over env)
 	if *useRemoteFlag {

--- a/utils/pkg/logger/logger.go
+++ b/utils/pkg/logger/logger.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/lmittmann/tint"
+
+	"github.com/malbeclabs/lake/utils/pkg/redact"
 )
 
 func New(verbose bool) *slog.Logger {
@@ -20,9 +22,24 @@ func New(verbose bool) *slog.Logger {
 			if a.Key == slog.TimeKey {
 				t := a.Value.Time().UTC()
 				a.Value = slog.StringValue(formatRFC3339Millis(t))
+				return a
 			}
-			if s, ok := a.Value.Any().(string); ok && s == "" {
-				return slog.Attr{}
+			// Redact credentials embedded in URLs from string and error values.
+			// Catches both direct URL fields (logger.Info("...", "url", rpcURL))
+			// and URLs that bubble up inside *url.Error / wrapped error messages.
+			switch a.Value.Kind() {
+			case slog.KindString:
+				s := a.Value.String()
+				if s == "" {
+					return slog.Attr{}
+				}
+				if r := redact.String(s); r != s {
+					a.Value = slog.StringValue(r)
+				}
+			case slog.KindAny:
+				if err, ok := a.Value.Any().(error); ok && err != nil {
+					a.Value = slog.StringValue(redact.Error(err))
+				}
 			}
 			return a
 		},

--- a/utils/pkg/redact/url.go
+++ b/utils/pkg/redact/url.go
@@ -1,0 +1,131 @@
+// Package redact removes credentials from URLs in logs and error messages.
+//
+// It targets three credential shapes that show up in RPC URLs:
+//   - basic auth: https://user:pass@host/path
+//   - sensitive query params: ?api-key=xxx, ?token=xxx, ?key=xxx, etc.
+//   - path-embedded tokens: https://host/db336024-e7a8-46b1-80e5-352dd77060ab
+//     (Triton/RPCPool style UUID, QuickNode-style long alphanumeric, etc.)
+//
+// Use [URL] for a single URL string, [String] for arbitrary text that may
+// contain URLs (error messages, log lines), and [Error] as a convenience
+// wrapper for errors.
+package redact
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// sensitiveQueryKeys are query-parameter names whose values are redacted.
+// Compared case-insensitively.
+var sensitiveQueryKeys = map[string]struct{}{
+	"api-key":   {},
+	"api_key":   {},
+	"apikey":    {},
+	"auth":      {},
+	"authkey":   {},
+	"key":       {},
+	"pass":      {},
+	"password":  {},
+	"secret":    {},
+	"sig":       {},
+	"signature": {},
+	"token":     {},
+	"x-api-key": {},
+}
+
+// tokenSegment matches path segments that look like API tokens. The intent is
+// to catch UUIDs and long opaque hex/alphanumeric blobs while leaving normal
+// path components (api, v1, mainnet-beta, getValidators) alone.
+//
+// Patterns:
+//   - UUID:           [hex]{8}-[hex]{4}-[hex]{4}-[hex]{4}-[hex]{12}
+//   - long hex:       [hex]{16,}      (no other characters)
+//   - long alphanum:  [a-zA-Z0-9]{24,} (no dashes, underscores, or dots)
+var tokenSegment = regexp.MustCompile(
+	`^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{16,}|[A-Za-z0-9]{24,})$`,
+)
+
+// urlFinder finds URL-shaped substrings inside arbitrary text. The scheme
+// pattern matches anything URL-shaped (http, https, postgres, redis, mongodb,
+// etc.), since credentials can ride on any of them. Trailing sentence
+// punctuation is trimmed by the caller.
+var urlFinder = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.\-]*://[^\s'"<>\\\[\]]+`)
+
+// trailingPunct is stripped from the tail of regex matches before they are
+// fed to [URL]. urlFinder accepts these characters mid-URL but they are
+// almost always sentence punctuation when at the end.
+const trailingPunct = ".,;:!?)]}>\"'"
+
+// URL redacts credentials from a single URL string. Inputs that don't parse
+// as a URL with a scheme and host are returned unchanged.
+func URL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return raw
+	}
+
+	// Strip any user info (basic auth).
+	if u.User != nil {
+		u.User = url.User("redacted")
+	}
+
+	// Redact known-sensitive query parameters in place.
+	if u.RawQuery != "" {
+		q := u.Query()
+		changed := false
+		for k, vs := range q {
+			if _, ok := sensitiveQueryKeys[strings.ToLower(k)]; !ok {
+				continue
+			}
+			for i := range vs {
+				if vs[i] != "" {
+					vs[i] = "redacted"
+					changed = true
+				}
+			}
+		}
+		if changed {
+			u.RawQuery = q.Encode()
+		}
+	}
+
+	// Redact token-shaped path segments (UUIDs, long opaque blobs).
+	if u.Path != "" && u.Path != "/" {
+		parts := strings.Split(u.Path, "/")
+		for i, p := range parts {
+			if p != "" && tokenSegment.MatchString(p) {
+				parts[i] = "redacted"
+			}
+		}
+		u.Path = strings.Join(parts, "/")
+	}
+
+	return u.String()
+}
+
+// String finds URLs in s and redacts credentials from each. Non-URL text is
+// returned unchanged.
+func String(s string) string {
+	if !strings.Contains(s, "://") {
+		return s
+	}
+	return urlFinder.ReplaceAllStringFunc(s, func(match string) string {
+		// Peel off trailing sentence punctuation so it survives unredacted.
+		tail := ""
+		for len(match) > 0 && strings.ContainsRune(trailingPunct, rune(match[len(match)-1])) {
+			tail = string(match[len(match)-1]) + tail
+			match = match[:len(match)-1]
+		}
+		return URL(match) + tail
+	})
+}
+
+// Error returns String(err.Error()) or "" if err is nil.
+func Error(err error) string {
+	if err == nil {
+		return ""
+	}
+	return String(err.Error())
+}

--- a/utils/pkg/redact/url_test.go
+++ b/utils/pkg/redact/url_test.go
@@ -1,0 +1,160 @@
+package redact_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/malbeclabs/lake/utils/pkg/redact"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "basic auth user:pass",
+			in:   "https://user:secret@api.example.com/v1",
+			want: "https://redacted@api.example.com/v1",
+		},
+		{
+			name: "basic auth user only",
+			in:   "https://admin@api.example.com/v1",
+			want: "https://redacted@api.example.com/v1",
+		},
+		{
+			name: "api-key query param",
+			in:   "https://mainnet.helius-rpc.com/?api-key=abc123secret",
+			want: "https://mainnet.helius-rpc.com/?api-key=redacted",
+		},
+		{
+			name: "token query param case-insensitive",
+			in:   "https://api.example.com/v1?Token=secret&foo=bar",
+			want: "https://api.example.com/v1?Token=redacted&foo=bar",
+		},
+		{
+			name: "non-sensitive query params preserved",
+			in:   "postgres://host:5432/db?sslmode=disable&pool_max=10",
+			want: "postgres://host:5432/db?sslmode=disable&pool_max=10",
+		},
+		{
+			name: "path-embedded UUID token",
+			in:   "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab",
+			want: "https://doublezero-mainnet-beta.rpcpool.com/redacted",
+		},
+		{
+			name: "path-embedded long hex token",
+			in:   "https://api.example.com/abc123def456abc123def456abc123def456",
+			want: "https://api.example.com/redacted",
+		},
+		{
+			name: "path-embedded long alphanumeric token",
+			in:   "https://name.solana.quiknode.pro/abc123def456ghi789jkl012/",
+			want: "https://name.solana.quiknode.pro/redacted/",
+		},
+		{
+			name: "normal path components preserved",
+			in:   "https://api.example.com/v1/getValidators/mainnet-beta",
+			want: "https://api.example.com/v1/getValidators/mainnet-beta",
+		},
+		{
+			name: "path with both normal and token segments",
+			in:   "https://api.example.com/v1/db336024-e7a8-46b1-80e5-352dd77060ab/data",
+			want: "https://api.example.com/v1/redacted/data",
+		},
+		{
+			name: "all three forms combined",
+			in:   "https://user:pass@api.example.com/abc123def456abc123def456abc123def456?token=xxx&keep=yes",
+			want: "https://redacted@api.example.com/redacted?keep=yes&token=redacted",
+		},
+		{
+			name: "url with no credentials passes through",
+			in:   "https://api.mainnet-beta.solana.com",
+			want: "https://api.mainnet-beta.solana.com",
+		},
+		{
+			name: "non-url returned unchanged",
+			in:   "not a url",
+			want: "not a url",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, redact.URL(tt.in))
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no url",
+			in:   "something went wrong",
+			want: "something went wrong",
+		},
+		{
+			name: "url in error message",
+			in:   `Get "https://mainnet.helius-rpc.com/?api-key=secret123": connection refused`,
+			want: `Get "https://mainnet.helius-rpc.com/?api-key=redacted": connection refused`,
+		},
+		{
+			name: "url at end of sentence with period",
+			in:   "see https://api.example.com/?token=secret.",
+			want: "see https://api.example.com/?token=redacted.",
+		},
+		{
+			name: "url with path token in error",
+			in:   "failed: GET https://x.com/db336024-e7a8-46b1-80e5-352dd77060ab returned 500",
+			want: "failed: GET https://x.com/redacted returned 500",
+		},
+		{
+			name: "multiple urls in one string",
+			in:   "from https://a.com/?key=secret1 to https://b.com/?token=secret2",
+			want: "from https://a.com/?key=redacted to https://b.com/?token=redacted",
+		},
+		{
+			name: "basic auth in error",
+			in:   "failed to connect: postgres://user:pass@localhost:5432/db",
+			want: "failed to connect: postgres://redacted@localhost:5432/db",
+		},
+		{
+			name: "non-sensitive query preserved in error",
+			in:   "connect: postgres://localhost:5432/db?sslmode=disable",
+			want: "connect: postgres://localhost:5432/db?sslmode=disable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, redact.String(tt.in))
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+	t.Run("nil", func(t *testing.T) {
+		assert.Equal(t, "", redact.Error(nil))
+	})
+	t.Run("non-nil with url", func(t *testing.T) {
+		err := errors.New("connection failed: https://api.example.com/?api-key=secret")
+		assert.Equal(t,
+			"connection failed: https://api.example.com/?api-key=redacted",
+			redact.Error(err),
+		)
+	})
+}


### PR DESCRIPTION
## Summary
- New `utils/pkg/redact` package: strips basic-auth, sensitive query-param values (`api-key`, `token`, `secret`, etc.), and token-shaped path segments (UUIDs, long opaque hex/alphanumeric — Triton/RPCPool, QuickNode-style) from URL strings.
- Wired into `utils/pkg/logger` via slog `ReplaceAttr` so any log produced through `logger.New` (indexer, admin, controlcenter, dev/controlcenter) automatically redacts URLs found in string attributes and error values.
- API binary now installs the shared logger as the slog default (`api/main.go`), gaining the same coverage. Previously logged via Go's bare default handler with no redaction.
- `api/handlers/errors.go:SanitizeError` delegates to `redact.Error`. Picks up path-embedded token redaction it previously missed. Existing tests updated.
- `api/handlers/ledger.go`: redact errors before they go into JSON response bodies (these bypass slog).

## Why
RPC URLs in this codebase commonly carry credentials in three forms:
1. **Basic auth** — `https://user:pass@host`.
2. **Query param** — `https://mainnet.helius-rpc.com/?api-key=xxx`.
3. **Path-embedded token** — `https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab` (Triton).

Form (3) was not redacted by the previous `SanitizeError`, and the rest only got redacted if explicitly invoked by hand. Errors that bubble up from HTTP clients via Go's `*url.Error` (`Get "https://...": connection refused`) routinely carry the raw URL, so any log line that captures an error is a potential leak.

The slog handler approach catches this universally: scanning string and error values at the handler boundary, before anything is written. New log call sites are protected automatically.

## Behavior change worth flagging
`SanitizeError` previously stripped entire query strings (`?...`); it now selectively redacts only known-sensitive keys and preserves the rest. So `?sslmode=disable&token=secret` becomes `?sslmode=disable&token=redacted` instead of `?...`. Strictly more useful for debugging while still safe.

## Testing Verification
- `go test ./...` passes (full suite ran clean).
- `utils/pkg/redact` covers UUID-path tokens, long hex, long alphanumeric, query params, basic auth, multiple URLs in one string, trailing punctuation, and non-URL passthrough.
- `api/handlers/errors_test.go` updated for the new behavior, including a new test for path-embedded UUID tokens.

## Follow-ups (out of scope)
- Several handlers still write `err.Error()` directly into JSON response bodies (e.g. `query.go`, `stake.go`, `gossip_nodes.go`). Those bypass the slog handler and could leak URLs into client responses. Not addressed here — the inventory was log-first, and these would benefit from a sweep but the pattern matches what `ledger.go` already adopted.
- `defaultDZLedgerRPCURL` in `api/handlers/ledger.go:53` is a hardcoded production URL with an embedded token. Pre-existing — not in scope, but worth moving to env-var-only.