### PR TITLE
indexer: tolerate transient failures across dz ingest activities

### DIFF
--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
@@ -19,12 +20,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// telemUsageErrorAfterFailures is the number of consecutive failed telemetry
-// usage refreshes after which we escalate the log to ERROR. Below the
-// threshold, transient failures (InfluxDB rate limits, per-query memory
-// exhaustion) are logged at WARN. Cadence is ~60s per workflow iteration, so
-// 3 means ~3 minutes of sustained failure before we page anyone.
-const telemUsageErrorAfterFailures = 3
+// errorAfterFailures is the number of consecutive failed refreshes after
+// which we escalate the log to ERROR. Below the threshold, transient
+// failures (deploys, ClickHouse restarts, InfluxDB rate limits) log at WARN.
+// At ~60s per workflow iteration, 3 means ~3 minutes of sustained failure
+// before paging anyone.
+const errorAfterFailures = 3
 
 // Activities holds dependencies for DZ ingest activities.
 type Activities struct {
@@ -41,13 +42,57 @@ type Activities struct {
 	ISISSource     isis.Source        // nil when ISIS is not enabled
 	ISISStore      *isis.Store        // nil when ISIS is not enabled
 
-	telemUsageFailures atomic.Int32
+	// failures tracks consecutive-failure counts per activity name.
+	// map[string]*atomic.Int32; populated lazily.
+	failures sync.Map
+}
+
+// refresh runs fn under the IngestionLog wrapper and tracks consecutive
+// failures per activity. On error, increments the counter and logs at WARN
+// below errorAfterFailures, ERROR at/above. On success, resets the counter.
+//
+// Always returns nil to Temporal. Transient failures (in-flight ClickHouse
+// during a pod restart, InfluxDB rate limits, brief network blips) don't
+// benefit from immediate retries within a single iteration — the next
+// workflow iteration (~60s) is the natural retry cadence. Returning nil
+// suppresses both Temporal's per-attempt "Activity error" log and the
+// workflow-level error log; the ingestion log table still records every
+// attempt.
+func (a *Activities) refresh(ctx context.Context, name string, fn func() (ingestionlog.RefreshResult, error)) error {
+	err := a.IngestionLog.Wrap(ctx, "dzingest", name, a.Network, fn)
+	if err != nil {
+		n := a.incFailures(name)
+		args := []any{"activity", name, "consecutive_failures", n, "error", err}
+		// Annotate the well-known InfluxDB rate-limit cause for readability.
+		if status.Code(err) == codes.ResourceExhausted {
+			args = append(args, "cause", "influxdb_rate_limit")
+		}
+		if n >= errorAfterFailures {
+			a.Log.Error("activity refresh failed", args...)
+		} else {
+			a.Log.Warn("activity refresh failed", args...)
+		}
+		return nil
+	}
+	a.resetFailures(name)
+	return nil
+}
+
+func (a *Activities) incFailures(name string) int32 {
+	v, _ := a.failures.LoadOrStore(name, &atomic.Int32{})
+	return v.(*atomic.Int32).Add(1)
+}
+
+func (a *Activities) resetFailures(name string) {
+	if v, ok := a.failures.Load(name); ok {
+		v.(*atomic.Int32).Store(0)
+	}
 }
 
 // RefreshServiceability fetches the latest DZ serviceability state from RPC
 // and writes it to ClickHouse dimension tables.
 func (a *Activities) RefreshServiceability(ctx context.Context) error {
-	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshServiceability", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshServiceability", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.Serviceability.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("serviceability refresh: %w", err)
@@ -63,7 +108,7 @@ func (a *Activities) RefreshGeolocation(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshGeolocation", a.Network)
 		return nil
 	}
-	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshGeolocation", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshGeolocation", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.Geolocation.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("geolocation refresh: %w", err)
@@ -79,7 +124,7 @@ func (a *Activities) RefreshShreds(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshShreds", a.Network)
 		return nil
 	}
-	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshShreds", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshShreds", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.Shreds.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("shreds refresh: %w", err)
@@ -91,7 +136,7 @@ func (a *Activities) RefreshShreds(ctx context.Context) error {
 // RefreshTelemetryLatency fetches device link latency samples from RPC
 // and writes them to ClickHouse fact tables.
 func (a *Activities) RefreshTelemetryLatency(ctx context.Context) error {
-	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshTelemetryLatency", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshTelemetryLatency", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.TelemLatency.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("telemetry latency refresh: %w", err)
@@ -102,42 +147,18 @@ func (a *Activities) RefreshTelemetryLatency(ctx context.Context) error {
 
 // RefreshTelemetryUsage fetches device interface counters from InfluxDB
 // and writes them to ClickHouse fact tables. No-op if InfluxDB is not configured.
-//
-// Always returns nil to Temporal. Transient InfluxDB failures (rate limits,
-// per-query memory exhaustion) don't benefit from immediate retries — the next
-// workflow iteration (~60s) is the natural retry cadence. Failures are
-// recorded to the ingestion log and tracked via telemUsageFailures: WARN
-// below the threshold, ERROR after telemUsageErrorAfterFailures consecutive
-// failures so a sustained outage still surfaces.
 func (a *Activities) RefreshTelemetryUsage(ctx context.Context) error {
 	if a.TelemUsage == nil {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshTelemetryUsage", a.Network)
 		return nil
 	}
-	err := a.IngestionLog.Wrap(ctx, "dzingest", "RefreshTelemetryUsage", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshTelemetryUsage", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.TelemUsage.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("telemetry usage refresh: %w", err)
 		}
 		return result, nil
 	})
-	if err != nil {
-		n := a.telemUsageFailures.Add(1)
-		args := []any{"consecutive_failures", n, "error", err}
-		// InfluxDB rate limit: total query duration in the last 30s cannot exceed
-		// 25 minutes. Note it explicitly so the cause is obvious in logs.
-		if status.Code(err) == codes.ResourceExhausted {
-			args = append(args, "cause", "influxdb_rate_limit")
-		}
-		if n >= telemUsageErrorAfterFailures {
-			a.Log.Error("telemetry usage refresh failed", args...)
-		} else {
-			a.Log.Warn("telemetry usage refresh failed", args...)
-		}
-		return nil
-	}
-	a.telemUsageFailures.Store(0)
-	return nil
 }
 
 // SyncGraph syncs the Neo4j topology graph from ClickHouse state.
@@ -148,7 +169,7 @@ func (a *Activities) SyncGraph(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncGraph", a.Network)
 		return nil
 	}
-	return a.IngestionLog.Wrap(ctx, "dzingest", "SyncGraph", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "SyncGraph", func() (ingestionlog.RefreshResult, error) {
 		var result ingestionlog.RefreshResult
 		if a.ISISStore != nil {
 			return result, a.GraphStore.SyncWithISIS(ctx)
@@ -164,7 +185,7 @@ func (a *Activities) SyncISIS(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncISIS", a.Network)
 		return nil
 	}
-	return a.IngestionLog.Wrap(ctx, "dzingest", "SyncISIS", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "SyncISIS", func() (ingestionlog.RefreshResult, error) {
 		var result ingestionlog.RefreshResult
 		lsps, err := a.fetchISISData(ctx)
 		if err != nil {
@@ -181,7 +202,7 @@ func (a *Activities) RefreshShredEscrowEvents(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshShredEscrowEvents", a.Network)
 		return nil
 	}
-	return a.IngestionLog.Wrap(ctx, "dzingest", "RefreshShredEscrowEvents", a.Network, func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "RefreshShredEscrowEvents", func() (ingestionlog.RefreshResult, error) {
 		result, err := a.EscrowEvents.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("escrow events refresh: %w", err)


### PR DESCRIPTION
## Summary
- Generalize the per-activity failure-tracking pattern from #573 — which only covered `RefreshTelemetryUsage` — so it applies to every dzingest activity.
- Add a shared `refresh()` helper on `Activities` that wraps `IngestionLog.Wrap`, tracks consecutive failures via a `sync.Map` of atomic counters keyed by activity name, logs WARN below `errorAfterFailures` (3) and ERROR at/above, and always returns nil to Temporal.
- Refactor all 8 dzingest activities (Serviceability, Geolocation, Shreds, TelemLatency, TelemUsage, SyncGraph, SyncISIS, ShredEscrowEvents) to use the helper.
- The standalone `telemUsageFailures atomic.Int32` field is replaced by the shared map; the InfluxDB `ResourceExhausted` annotation is preserved as a `cause=influxdb_rate_limit` log attribute.

## Why
Saw two `Activity error. Attempt=1` lines for `SyncISIS` and `RefreshShreds` with `clickhouse: connection is closed` — looked like a deploy where in-flight ClickHouse writes failed mid-restart. With Temporal's `MaximumAttempts: 3` retry, every transient failure produces up to 3 ERROR lines per activity per iteration plus a workflow-level error log on retry exhaustion. ClickHouse pod restarts, InfluxDB rate limits, and brief network blips are all single-iteration transients that don't benefit from immediate retries — the next workflow tick (~60s) is the natural retry cadence.

This is the same pattern #573 introduced for telemetry usage; pulling it out means the next activity that hits a transient error gets the protection automatically rather than needing a one-off PR.

Sustained outages still surface: once a given activity has failed `errorAfterFailures` (3) iterations in a row — about 3 minutes — the log escalates to ERROR.

## Testing Verification
- `go build ./indexer/...` clean.
- The `IngestionLog` audit trail is unchanged: every attempt still records to the ingestion log table regardless of log level, since `Wrap` runs inside `refresh`.
- Post-deploy verify: a single transient failure during a ClickHouse restart should produce one WARN line per affected activity and zero ERROR lines.