### PR TITLE
api: don't log client-cancel as ERROR for edge scoreboard

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -312,7 +312,7 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := a.FetchEdgeScoreboardData(ctx, window, leadersOnly, sinceSlot, beforeSlot, slotLimit)
 	if err != nil {
-		log.Printf("EdgeScoreboard error: %v", err)
+		logError("EdgeScoreboard error", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- Switch the top-level `GetEdgeScoreboard` error log from `log.Printf` to `logError` (`api/handlers/errors.go:36`), which silently skips errors caused by client disconnects (context cancellation, deadline exceeded, broken pipe, connection reset, unexpected EOF).
- Same pattern as #571 for device_metrics and link_metrics.

## Why
Recurring ERROR log line:
```
EdgeScoreboard error: max slot: context canceled
```
The 60s context in `GetEdgeScoreboard` derives from `r.Context()`. When a browser cancels an in-flight request (tab navigation, newer poll superseding an older one), `r.Context()` cancels and the cancellation propagates straight through to the ClickHouse driver. The `max slot` preamble query is usually the first to error out, surfacing as the line above.

Inner errgroup logs (`query4`, `query7`, etc.) already check `gctx.Err()` before logging, so they don't generate noise on client-cancel. The top-level handler path didn't — this fixes that.

## Testing Verification
- `go build ./api/...` clean.
- Post-deploy verify in Loki:
  ```
  count_over_time({app="lake-api", namespace="lake-prod"}
    |= "EdgeScoreboard error" |= "context canceled" [24h])
  ```
  Should drop close to zero. Genuine query errors still log at ERROR.