### PR TITLE
api: page-cache instrumentation and quiet client-cancel warns

### DIFF
--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -34,15 +34,31 @@ func isClientDisconnect(err error) bool {
 
 // logError logs at ERROR level, silently skipping client disconnects.
 func logError(msg string, args ...any) {
-	// Extract the error from args to check for client disconnect.
+	if hasClientDisconnect(args) {
+		return
+	}
+	slog.Error(msg, args...)
+}
+
+// logWarn logs at WARN level, silently skipping client disconnects.
+func logWarn(msg string, args ...any) {
+	if hasClientDisconnect(args) {
+		return
+	}
+	slog.Warn(msg, args...)
+}
+
+// hasClientDisconnect reports whether args contains an "error" key whose
+// value is a client-disconnect error (context cancellation, broken pipe, etc.).
+func hasClientDisconnect(args []any) bool {
 	for i := 0; i+1 < len(args); i += 2 {
 		if args[i] == "error" {
 			if err, ok := args[i+1].(error); ok && isClientDisconnect(err) {
-				return
+				return true
 			}
 		}
 	}
-	slog.Error(msg, args...)
+	return false
 }
 
 // internalError logs the full error internally and returns a user-safe message.

--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -493,12 +493,12 @@ func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {
 	metrics.RecordClickHouseQuery("multicast", duration, cr.err)
 
 	if cr.err != nil {
-		slog.Warn("multicast group members count query failed", "error", cr.err)
+		logWarn("multicast group members count query failed", "error", cr.err)
 		http.Error(w, cr.err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if dr.err != nil {
-		slog.Warn("multicast group members data query failed", "error", dr.err)
+		logWarn("multicast group members data query failed", "error", dr.err)
 		http.Error(w, dr.err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -649,7 +649,7 @@ func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {
 		lr := <-leaderCh
 
 		if tr.err != nil {
-			slog.Warn("multicast group members traffic query error", "error", tr.err)
+			logWarn("multicast group members traffic query error", "error", tr.err)
 		} else {
 			for key, vals := range tr.data {
 				if indices, ok := tunnelToMembers[key]; ok {
@@ -667,7 +667,7 @@ func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if lr.err != nil {
-			slog.Warn("multicast group members leader query error", "error", lr.err)
+			logWarn("multicast group members leader query error", "error", lr.err)
 		} else {
 			for clientIP, vals := range lr.data {
 				if indices, ok := clientIPToMembers[clientIP]; ok {

--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -95,7 +95,20 @@ func newTemporalLogger(log *slog.Logger) *temporalLogger {
 }
 
 func (l *temporalLogger) Debug(msg string, keyvals ...any) {} // suppress to avoid noisy workflow logs
-func (l *temporalLogger) Info(msg string, keyvals ...any)  { l.log.Info(msg, keyvals...) }
+func (l *temporalLogger) Info(msg string, keyvals ...any) {
+	// Temporal logs this at INFO when an activity's StartToCloseTimeout
+	// expires before the activity returns. Our activities handle ctx
+	// cancellation cleanly and always return nil, so the message is
+	// non-actionable in steady state. The Error= keyval also trips
+	// cloud-log heuristics that promote the line to ERROR severity.
+	// Demote to Debug so it stays suppressed in prod but is recoverable
+	// by flipping verbose logging on during an incident.
+	if msg == "Task processing failed with client side error" {
+		l.log.Debug(msg, keyvals...)
+		return
+	}
+	l.log.Info(msg, keyvals...)
+}
 func (l *temporalLogger) Warn(msg string, keyvals ...any)  { l.log.Warn(msg, keyvals...) }
 func (l *temporalLogger) Error(msg string, keyvals ...any) { l.log.Error(msg, keyvals...) }
 

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -21,6 +21,12 @@ const (
 	fastRefreshInterval    = 3 * time.Second
 	continueAsNewThreshold = 60 // ~30 min at 30s intervals
 	errorAfterFailures     = 3  // log WARN for transient failures, ERROR after this many consecutive failures
+
+	// slowRefreshThreshold surfaces per-entry duration at INFO when a single
+	// cache refresh (query + write) takes at least this long. Normal entries
+	// finish in well under a second; anything above this is worth flagging
+	// when the activity is running close to its StartToCloseTimeout budget.
+	slowRefreshThreshold = 10 * time.Second
 )
 
 // cacheEntry defines a single cache key to refresh.
@@ -192,6 +198,9 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 }
 
 func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error)) {
+	start := time.Now()
+	var queryDuration, writeDuration time.Duration
+
 	const maxAttempts = 2
 	for attempt := range maxAttempts {
 		if parentCtx.Err() != nil {
@@ -200,7 +209,9 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 		}
 
 		ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
+		queryStart := time.Now()
 		result, err := fn(ctx)
+		queryDuration = time.Since(queryStart)
 		cancel()
 
 		if err != nil {
@@ -225,9 +236,11 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 
 		a.failures.Delete(key)
 
+		writeStart := time.Now()
 		a.writeMu.Lock()
 		err = a.API.WritePageCache(parentCtx, key, result)
 		a.writeMu.Unlock()
+		writeDuration = time.Since(writeStart)
 		if err != nil {
 			if parentCtx.Err() != nil {
 				return
@@ -236,7 +249,21 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 			return
 		}
 
-		a.Log.Debug("cache refreshed", "cache", name)
+		// Surface slow entries at INFO so we can spot the outlier that's
+		// eating the activity's StartToCloseTimeout budget. Normal entries
+		// log at DEBUG (suppressed in prod).
+		total := time.Since(start)
+		args := []any{
+			"cache", name,
+			"duration", total.Round(time.Millisecond),
+			"query_duration", queryDuration.Round(time.Millisecond),
+			"write_duration", writeDuration.Round(time.Millisecond),
+		}
+		if total >= slowRefreshThreshold {
+			a.Log.Info("slow cache refresh", args...)
+		} else {
+			a.Log.Debug("cache refreshed", args...)
+		}
 		return
 	}
 }
@@ -263,8 +290,13 @@ func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	}
 	ctx = temporalworkflow.WithActivityOptions(ctx, actOpts)
 
+	// RefreshLatestCaches runs every 3s and only hits edge_scoreboard:latest
+	// queries, but those occasionally take >30s under ClickHouse contention
+	// from the heavier RefreshCaches queries running in parallel. A 60s
+	// budget absorbs that variance without being wide enough to mask a real
+	// regression.
 	fastActOpts := temporalworkflow.ActivityOptions{
-		StartToCloseTimeout: 30 * time.Second,
+		StartToCloseTimeout: 60 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},


### PR DESCRIPTION
## Summary
Four changes, grouped because they all reduce log noise on the page-cache / handler error paths:

1. **Suppress Temporal's `"Task processing failed with client side error"` INFO log.** Route it to `slog.Debug` via the `temporalLogger` adapter. Activities handle ctx cancellation cleanly and always return nil, so the message is non-actionable in steady state. The `Error=` keyval was tripping cloud-log heuristics that promoted the line to ERROR. Flipping the API's verbose flag (`-v`) brings it back during an incident.

2. **Bump `RefreshLatestCaches` `StartToCloseTimeout` from 30s → 60s.** Loki shows `RefreshCaches` durations max around 2 min, well under its 3 min budget — so the timeouts aren't coming from there. They're coming from the fast activity, which runs every 3s and only hits `edge_scoreboard:latest` queries; those occasionally exceed 30s under ClickHouse contention from heavier parallel `RefreshCaches` queries.

3. **Per-entry duration instrumentation in `refresh()`.** Tracks query and write times separately. Entries under `slowRefreshThreshold` (10s) log at DEBUG; at/above log `"slow cache refresh"` at INFO with cache name, total duration, query/write split. Surfaces which entry is close to budget without flooding logs in steady state.

4. **`logWarn` helper + apply at multicast handler.** Mirrors `logError`: silently skips logs whose `"error"` arg is a client disconnect. Removes occasional `"multicast group members ... query error error=context canceled"` lines that fire when the browser cancels mid-fetch. Same pattern as #571 for device/link metrics, just for `slog.Warn` sites.

## Why grouped
Originally just (1)–(3) on the page-cache worker; (4) came up while testing and shares the same "stop logging things triggered by client cancel" theme.

## Testing Verification
- `go build ./api/...` clean; targeted handler tests pass.
- Post-deploy: `"Task processing failed"` lines should drop to zero (or to DEBUG-only if verbose is on). Watch for `"slow cache refresh"` entries — those flag the actual outlier queries if the underlying contention persists.