### PR TITLE
deps: bump slack-go/slack to v0.23.1 via slackmd update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/slack-go/slack v0.19.0
-	github.com/snormore/slackmd v0.2.1-0.20260131222029-402e0a9c9295
+	github.com/slack-go/slack v0.23.1
+	github.com/snormore/slackmd v0.2.1-0.20260511124041-43a63bd3e119
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -159,7 +159,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.16 // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,10 +357,10 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/slack-go/slack v0.19.0 h1:J8lL/nGTsIUX53HU8YxZeI3PDkA+sxZsFrI2Dew7h44=
-github.com/slack-go/slack v0.19.0/go.mod h1:K81UmCivcYd/5Jmz8vLBfuyoZ3B4rQC2GHVXHteXiAE=
-github.com/snormore/slackmd v0.2.1-0.20260131222029-402e0a9c9295 h1:7lZfJPRfPkrgD1BU9EiAnw6MY4Q35iw/7C0Lw19Sd4c=
-github.com/snormore/slackmd v0.2.1-0.20260131222029-402e0a9c9295/go.mod h1:VURsmh+xOt6SsQbItk6nJVfTMMs0Oz+O/TlnRNFZl8k=
+github.com/slack-go/slack v0.23.1 h1:ZS5B96wxxYQRwvJ3/vJFtqtUZi3tXhsZCyT44Nv7M80=
+github.com/slack-go/slack v0.23.1/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
+github.com/snormore/slackmd v0.2.1-0.20260511124041-43a63bd3e119 h1:COcOfWGL+kSJ1Muqxwsy+7a1b6LsXDXeiDrcI7Wcj4E=
+github.com/snormore/slackmd v0.2.1-0.20260511124041-43a63bd3e119/go.mod h1:rUy+hv1+tinA1zU/mZZeFmnRFPY272pkbCQXPDpU0a8=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
@@ -417,8 +417,8 @@ github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7Jul
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
-github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/slack/bot/handler.go
+++ b/slack/bot/handler.go
@@ -430,7 +430,9 @@ func (h *EventHandler) HandleSocketMode(ctx context.Context, client *socketmode.
 					if alreadyProcessed {
 						h.log.Info("skipping duplicate event", "envelope_id", envelopeID, "retry_attempt", retryAttempt, "retry_reason", retryReason)
 						EventsDuplicateTotal.Inc()
-						client.Ack(*evt.Request)
+						if err := client.Ack(*evt.Request); err != nil {
+							h.log.Warn("failed to ack duplicate event", "envelope_id", envelopeID, "error", err)
+						}
 						continue
 					}
 
@@ -444,7 +446,9 @@ func (h *EventHandler) HandleSocketMode(ctx context.Context, client *socketmode.
 					}
 				}
 
-				client.Ack(*evt.Request)
+				if err := client.Ack(*evt.Request); err != nil {
+					h.log.Warn("failed to ack event", "envelope_id", envelopeID, "error", err)
+				}
 				// Use background context so shutdown cancellation doesn't interrupt in-flight operations
 				// The WaitGroup handles graceful shutdown coordination.
 				// Note: Socket mode is single-tenant only, so TeamID from event is used for routing.


### PR DESCRIPTION
## Summary

- Bumps `github.com/slack-go/slack` from 0.19.0 to 0.23.1 by way of a `snormore/slackmd` update to commit `43a63bd`, which adapts to the new `RichTextPreformatted`/`RichTextQuote` shape introduced in slack-go 0.23.
- Supersedes #563 (which proposed 0.23.0 directly and failed CI because the old slackmd version didn't compile against the new slack-go API).
- `goldmark` 1.7.16 → 1.8.2 comes along as a slackmd transitive bump.

## Testing Verification

- `go build ./...` and `go vet ./...` clean
- `go test ./slack/...` passes against slack-go 0.23.1