### PR TITLE
worker, indexer: quiet temporal deploy-time task-failure log

### DIFF
--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -96,14 +96,17 @@ func newTemporalLogger(log *slog.Logger) *temporalLogger {
 
 func (l *temporalLogger) Debug(msg string, keyvals ...any) {} // suppress to avoid noisy workflow logs
 func (l *temporalLogger) Info(msg string, keyvals ...any) {
-	// Temporal logs this at INFO when an activity's StartToCloseTimeout
-	// expires before the activity returns. Our activities handle ctx
-	// cancellation cleanly and always return nil, so the message is
-	// non-actionable in steady state. The Error= keyval also trips
-	// cloud-log heuristics that promote the line to ERROR severity.
-	// Demote to Debug so it stays suppressed in prod but is recoverable
-	// by flipping verbose logging on during an incident.
+	// Temporal logs these at INFO during normal lifecycle events
+	// (StartToCloseTimeout expiry; activity reporting back to a workflow
+	// that already completed/continued-as-new during a deploy). The Error=
+	// keyval trips cloud-log heuristics that promote the line to ERROR
+	// severity. Demote to Debug so it stays suppressed in prod but is
+	// recoverable by flipping verbose logging on during an incident.
 	if msg == "Task processing failed with client side error" {
+		l.log.Debug(msg, keyvals...)
+		return
+	}
+	if msg == "Task processing failed with error" && hasBenignTaskProcessingError(keyvals) {
 		l.log.Debug(msg, keyvals...)
 		return
 	}
@@ -111,6 +114,24 @@ func (l *temporalLogger) Info(msg string, keyvals ...any) {
 }
 func (l *temporalLogger) Warn(msg string, keyvals ...any)  { l.log.Warn(msg, keyvals...) }
 func (l *temporalLogger) Error(msg string, keyvals ...any) { l.log.Error(msg, keyvals...) }
+
+// hasBenignTaskProcessingError reports whether Temporal's "Task processing
+// failed with error" keyvals carry an error that's expected during deploys
+// (activity completes after the workflow has already finished or been
+// continue-as-newed).
+func hasBenignTaskProcessingError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			if strings.Contains(err.Error(), "workflow execution already completed") {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 func isWorkflowTerminated(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "terminated")

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
@@ -144,14 +145,41 @@ func newTemporalLogger(log *slog.Logger) *temporalLogger {
 }
 
 func (l *temporalLogger) Debug(msg string, keyvals ...any) {} // suppress noisy debug logs
-func (l *temporalLogger) Info(msg string, keyvals ...any)  { l.log.Info(msg, keyvals...) }
-func (l *temporalLogger) Warn(msg string, keyvals ...any)  { l.log.Warn(msg, keyvals...) }
+func (l *temporalLogger) Info(msg string, keyvals ...any) {
+	// Temporal logs "Task processing failed with error" at INFO when an
+	// activity reports back to a workflow that's already completed or
+	// continued-as-new (typical during deploys). The Error= keyval trips
+	// cloud-log heuristics that promote the line to ERROR severity, so
+	// demote to Debug to keep prod logs quiet.
+	if msg == "Task processing failed with error" && hasBenignTaskProcessingError(keyvals) {
+		l.log.Debug(msg, keyvals...)
+		return
+	}
+	l.log.Info(msg, keyvals...)
+}
+func (l *temporalLogger) Warn(msg string, keyvals ...any) { l.log.Warn(msg, keyvals...) }
 func (l *temporalLogger) Error(msg string, keyvals ...any) {
 	if isContextCancellation(keyvals) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
 	l.log.Error(msg, keyvals...)
+}
+
+// hasBenignTaskProcessingError reports whether Temporal's "Task processing
+// failed with error" keyvals carry an error that's expected during deploys.
+func hasBenignTaskProcessingError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			if strings.Contains(err.Error(), "workflow execution already completed") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isContextCancellation checks Temporal's key-value log pairs for errors

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -155,14 +156,41 @@ func newTemporalLogger(log *slog.Logger) *temporalLogger {
 }
 
 func (l *temporalLogger) Debug(msg string, keyvals ...any) {} // no-op to avoid blocking workflow goroutine
-func (l *temporalLogger) Info(msg string, keyvals ...any)  { l.log.Info(msg, keyvals...) }
-func (l *temporalLogger) Warn(msg string, keyvals ...any)  { l.log.Warn(msg, keyvals...) }
+func (l *temporalLogger) Info(msg string, keyvals ...any) {
+	// Temporal logs "Task processing failed with error" at INFO when an
+	// activity reports back to a workflow that's already completed or
+	// continued-as-new (typical during deploys). The Error= keyval trips
+	// cloud-log heuristics that promote the line to ERROR severity, so
+	// demote to Debug to keep prod logs quiet.
+	if msg == "Task processing failed with error" && hasBenignTaskProcessingError(keyvals) {
+		l.log.Debug(msg, keyvals...)
+		return
+	}
+	l.log.Info(msg, keyvals...)
+}
+func (l *temporalLogger) Warn(msg string, keyvals ...any) { l.log.Warn(msg, keyvals...) }
 func (l *temporalLogger) Error(msg string, keyvals ...any) {
 	if isContextCancellation(keyvals) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
 	l.log.Error(msg, keyvals...)
+}
+
+// hasBenignTaskProcessingError reports whether Temporal's "Task processing
+// failed with error" keyvals carry an error that's expected during deploys.
+func hasBenignTaskProcessingError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			if strings.Contains(err.Error(), "workflow execution already completed") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isContextCancellation checks Temporal's key-value log pairs for errors

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
@@ -124,14 +125,41 @@ func newTemporalLogger(log *slog.Logger) *temporalLogger {
 }
 
 func (l *temporalLogger) Debug(msg string, keyvals ...any) {} // suppress noisy debug logs
-func (l *temporalLogger) Info(msg string, keyvals ...any)  { l.log.Info(msg, keyvals...) }
-func (l *temporalLogger) Warn(msg string, keyvals ...any)  { l.log.Warn(msg, keyvals...) }
+func (l *temporalLogger) Info(msg string, keyvals ...any) {
+	// Temporal logs "Task processing failed with error" at INFO when an
+	// activity reports back to a workflow that's already completed or
+	// continued-as-new (typical during deploys). The Error= keyval trips
+	// cloud-log heuristics that promote the line to ERROR severity, so
+	// demote to Debug to keep prod logs quiet.
+	if msg == "Task processing failed with error" && hasBenignTaskProcessingError(keyvals) {
+		l.log.Debug(msg, keyvals...)
+		return
+	}
+	l.log.Info(msg, keyvals...)
+}
+func (l *temporalLogger) Warn(msg string, keyvals ...any) { l.log.Warn(msg, keyvals...) }
 func (l *temporalLogger) Error(msg string, keyvals ...any) {
 	if isContextCancellation(keyvals) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
 	l.log.Error(msg, keyvals...)
+}
+
+// hasBenignTaskProcessingError reports whether Temporal's "Task processing
+// failed with error" keyvals carry an error that's expected during deploys.
+func hasBenignTaskProcessingError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			if strings.Contains(err.Error(), "workflow execution already completed") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isContextCancellation checks Temporal's key-value log pairs for errors


### PR DESCRIPTION
## Summary

- Demote Temporal's `Task processing failed with error` log to Debug when its `Error=` keyval is `workflow execution already completed` — a benign byproduct of rolling deploys where an activity reports back to a workflow that's already completed or continued-as-new.
- Apply to all four `temporalLogger` adapters: `api/worker` (page-cache), `indexer/pkg/rollup`, `indexer/pkg/solingest`, `indexer/pkg/dzingest`.
- Other INFO-level Temporal messages keep their existing level so genuine issues still surface.

## Why

The Temporal SDK logs this case at INFO (`sdk/internal/internal_worker_base.go`), but the `Error=` keyval trips cloud-log heuristics that promote the line to ERROR severity in Loki — so every deploy produces a scary-looking line like:

```
INF Task processing failed with error component=temporal TaskQueue=api-page-cache ... Error="workflow execution already completed"
```

The existing `client side error` variant was already demoted in `api/worker/pagecache.go`; this extends the same pattern to the `with error` variant and brings the three indexer copies into line.

## Testing Verification

- Post-deploy, verify in Loki that `{app="lake-api"} |= "Task processing failed with error" |= "workflow execution already completed"` drops to zero during rollouts.