### PR TITLE
api: fix multicast members 'all' filter syntax error

### DIFF
--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -272,7 +272,6 @@ var multicastMemberFilterFields = map[string]FilterFieldConfig{
 	"device": {Column: "device_code", Type: FieldTypeText},
 	"metro":  {Column: "metro_name", Type: FieldTypeText},
 	"owner":  {Column: "owner_pubkey", Type: FieldTypeText},
-	"all":    {Column: "", Type: FieldTypeText}, // handled specially in BuildFilterClause
 }
 
 func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary of Changes
- Remove the `"all"` entry from `multicastMemberFilterFields`. With it in the map, `BuildFilterClause`'s "all" branch iterated over every `FieldTypeText` field — including `"all"` itself — and emitted a bogus `positionCaseInsensitive(, ?) > 0` clause (empty column), producing a ClickHouse syntax error on any free-text search on the multicast members page.
- The `"all"` filter is handled specially by `BuildFilterClause` and does not need a map entry; no other handler registers it.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +0 / -1     |  -1  |

One-line fix removing the malformed map entry that caused the syntax error.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/multicast.go` — drop the `"all"` field-config entry from `multicastMemberFilterFields`

</details>

## Testing Verification
- Reproduced the original error symptom from API logs (`Syntax error … Expected one of: ALL, DISTINCT, token`) by tracing a free-text query through `ParseFilters` → `BuildFilterClause`: the empty-`Column` entry produced `positionCaseInsensitive(, ?) > 0`.
- `go test ./api/handlers/ -run "TestBuildFilterClause|TestParseFilters|TestMulticast"` passes.