### PR TITLE
api/v1: add link latency listing endpoint

### DIFF
--- a/api/handlers/link_metrics.go
+++ b/api/handlers/link_metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -903,6 +904,250 @@ func filterBulkLinkMetricsIssuesOnly(resp *BulkLinkMetricsResponse) {
 			}
 		}
 	}
+}
+
+// LinkLatencyFilter narrows the set of links returned by FetchLinkLatency.
+// Values within a category are OR'd; non-empty categories are AND'd together.
+// All string comparisons are case-insensitive exact matches. Contributor and
+// metro filters match either side of the link.
+type LinkLatencyFilter struct {
+	LinkPKs          []string
+	LinkCodes        []string
+	ContributorCodes []string
+	MetroCodes       []string
+}
+
+// LinkLatencyOptions configures FetchLinkLatency: time window, bucket
+// granularity, and which links to include.
+type LinkLatencyOptions struct {
+	// TimeRange is a preset like "24h" or "7d". Used when StartTime/EndTime are nil.
+	// Empty defaults to "24h".
+	TimeRange string
+	// StartTime/EndTime, if both set, override TimeRange.
+	StartTime *time.Time
+	EndTime   *time.Time
+	// Bucket is one of "auto", "10s", "30s", "1m", "5m", "10m", "15m", "30m",
+	// "1h", "4h", "12h", "1d". Empty or "auto" picks based on the window.
+	Bucket string
+	// Filter narrows the set of links returned. Empty Filter returns all
+	// active links.
+	Filter LinkLatencyFilter
+}
+
+// LinkLatencyResult is the response from FetchLinkLatency.
+type LinkLatencyResult struct {
+	TimeRange     string
+	BucketSeconds int
+	BucketCount   int
+	// Links is sorted by link code. status/traffic fields on each bucket
+	// are nil — only latency is populated.
+	Links []*LinkMetricsResponse
+}
+
+// FetchLinkLatency returns latency time-series for all active links matching
+// the filter. An empty filter returns every active link.
+func (a *API) FetchLinkLatency(ctx context.Context, opts LinkLatencyOptions) (*LinkLatencyResult, error) {
+	params, err := resolveLinkLatencyParams(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	db := a.envDB(ctx)
+	metaMap, err := queryStatusLinkMeta(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("link latency metadata: %w", err)
+	}
+
+	filtered := filterLinkMeta(metaMap, opts.Filter)
+
+	bucketSecs := params.BucketSeconds
+	if bucketSecs == 0 {
+		bucketSecs = params.BucketMinutes * 60
+	}
+
+	if len(filtered) == 0 {
+		return &LinkLatencyResult{
+			TimeRange:     params.TimeRange,
+			BucketSeconds: bucketSecs,
+			BucketCount:   params.BucketCount,
+			Links:         []*LinkMetricsResponse{},
+		}, nil
+	}
+
+	pks := make([]string, 0, len(filtered))
+	for pk := range filtered {
+		pks = append(pks, pk)
+	}
+	rollupMap, err := queryLinkRollup(ctx, db, params, pks...)
+	if err != nil {
+		return nil, fmt.Errorf("link latency rollup: %w", err)
+	}
+
+	bucketDuration := time.Duration(bucketSecs) * time.Second
+	now := time.Now().UTC()
+	if params.EndTime != nil {
+		now = *params.EndTime
+	}
+
+	links := make([]*LinkMetricsResponse, 0, len(filtered))
+	for pk, meta := range filtered {
+		buckets := make([]LinkMetricsBucket, 0, params.BucketCount)
+		for i := params.BucketCount - 1; i >= 0; i-- {
+			var bucketStart time.Time
+			if params.StartTime != nil {
+				bucketStart = params.StartTime.Truncate(bucketDuration).Add(time.Duration(params.BucketCount-1-i) * bucketDuration)
+			} else {
+				bucketStart = now.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
+			}
+			bk := linkBucketKey{LinkPK: pk, BucketTS: bucketStart}
+			rollup := rollupMap[bk]
+			bucket := LinkMetricsBucket{TS: bucketStart.Format(time.RFC3339)}
+			if rollup != nil && (rollup.ASamples > 0 || rollup.ZSamples > 0) {
+				bucket.Latency = &LinkMetricsLatency{
+					AAvgRttUs: rollup.AAvgRttUs, AMinRttUs: rollup.AMinRttUs,
+					AP50RttUs: rollup.AP50RttUs, AP90RttUs: rollup.AP90RttUs,
+					AP95RttUs: rollup.AP95RttUs, AP99RttUs: rollup.AP99RttUs,
+					AMaxRttUs: rollup.AMaxRttUs, ALossPct: rollup.ALossPct, ASamples: rollup.ASamples,
+					ZAvgRttUs: rollup.ZAvgRttUs, ZMinRttUs: rollup.ZMinRttUs,
+					ZP50RttUs: rollup.ZP50RttUs, ZP90RttUs: rollup.ZP90RttUs,
+					ZP95RttUs: rollup.ZP95RttUs, ZP99RttUs: rollup.ZP99RttUs,
+					ZMaxRttUs: rollup.ZMaxRttUs, ZLossPct: rollup.ZLossPct, ZSamples: rollup.ZSamples,
+					AAvgJitterUs: rollup.AAvgJitterUs, AMinJitterUs: rollup.AMinJitterUs,
+					AP50JitterUs: rollup.AP50JitterUs, AP90JitterUs: rollup.AP90JitterUs,
+					AP95JitterUs: rollup.AP95JitterUs, AP99JitterUs: rollup.AP99JitterUs,
+					AMaxJitterUs: rollup.AMaxJitterUs,
+					ZAvgJitterUs: rollup.ZAvgJitterUs, ZMinJitterUs: rollup.ZMinJitterUs,
+					ZP50JitterUs: rollup.ZP50JitterUs, ZP90JitterUs: rollup.ZP90JitterUs,
+					ZP95JitterUs: rollup.ZP95JitterUs, ZP99JitterUs: rollup.ZP99JitterUs,
+					ZMaxJitterUs: rollup.ZMaxJitterUs,
+				}
+			}
+			buckets = append(buckets, bucket)
+		}
+		links = append(links, &LinkMetricsResponse{
+			LinkPK:               meta.PK,
+			LinkCode:             meta.Code,
+			LinkType:             meta.LinkType,
+			ContributorCode:      meta.Contributor,
+			ContributorPK:        meta.ContributorPK,
+			SideZContributorCode: meta.SideZContributor,
+			SideAMetro:           meta.SideAMetro,
+			SideZMetro:           meta.SideZMetro,
+			SideADevice:          meta.SideADevice,
+			SideZDevice:          meta.SideZDevice,
+			SideAIfaceName:       meta.SideAIfaceName,
+			SideZIfaceName:       meta.SideZIfaceName,
+			CommittedRttUs:       meta.CommittedRttUs,
+			CommittedJitterUs:    meta.CommittedJitterUs,
+			BandwidthBps:         meta.BandwidthBps,
+			TimeRange:            params.TimeRange,
+			BucketSeconds:        bucketSecs,
+			BucketCount:          params.BucketCount,
+			Buckets:              buckets,
+		})
+	}
+
+	sort.Slice(links, func(i, j int) bool { return links[i].LinkCode < links[j].LinkCode })
+
+	return &LinkLatencyResult{
+		TimeRange:     params.TimeRange,
+		BucketSeconds: bucketSecs,
+		BucketCount:   params.BucketCount,
+		Links:         links,
+	}, nil
+}
+
+// resolveLinkLatencyParams turns LinkLatencyOptions into bucketParams,
+// applying defaults and validating the bucket spec.
+func resolveLinkLatencyParams(opts LinkLatencyOptions) (bucketParams, error) {
+	timeRange := opts.TimeRange
+	if timeRange == "" {
+		timeRange = "24h"
+	}
+
+	var params bucketParams
+	if opts.StartTime != nil && opts.EndTime != nil {
+		params = parseBucketParamsCustom(*opts.StartTime, *opts.EndTime, 24)
+	} else {
+		now := time.Now().UTC()
+		duration := presetToDuration(timeRange)
+		startTime := now.Add(-duration)
+		params = parseBucketParamsCustom(startTime, now, 24)
+		params.TimeRange = timeRange
+	}
+
+	if opts.Bucket != "" && opts.Bucket != "auto" {
+		interval, ok := parseBucketString(opts.Bucket)
+		if !ok {
+			return params, fmt.Errorf("invalid bucket %q", opts.Bucket)
+		}
+		secs := intervalToSeconds(interval)
+		var totalSecs int
+		if params.StartTime != nil && params.EndTime != nil {
+			totalSecs = int(params.EndTime.Sub(*params.StartTime).Seconds())
+		} else {
+			totalSecs = params.TotalMinutes * 60
+		}
+		count := totalSecs / secs
+		if count < 1 {
+			count = 1
+		}
+		params.BucketSeconds = secs
+		params.BucketMinutes = secs / 60
+		params.BucketInterval = interval
+		params.BucketCount = count
+		params.UseRaw = isRawBucket(interval)
+	}
+
+	return params, nil
+}
+
+// filterLinkMeta applies LinkLatencyFilter to a metadata map. An empty filter
+// returns the input unchanged.
+func filterLinkMeta(metaMap map[string]*statusLinkMeta, f LinkLatencyFilter) map[string]*statusLinkMeta {
+	if len(f.LinkPKs) == 0 && len(f.LinkCodes) == 0 && len(f.ContributorCodes) == 0 && len(f.MetroCodes) == 0 {
+		return metaMap
+	}
+	pkSet := lowerSet(f.LinkPKs)
+	codeSet := lowerSet(f.LinkCodes)
+	contribSet := lowerSet(f.ContributorCodes)
+	metroSet := lowerSet(f.MetroCodes)
+
+	result := make(map[string]*statusLinkMeta)
+	for pk, m := range metaMap {
+		if len(pkSet) > 0 && !pkSet[strings.ToLower(pk)] {
+			continue
+		}
+		if len(codeSet) > 0 && !codeSet[strings.ToLower(m.Code)] {
+			continue
+		}
+		if len(contribSet) > 0 {
+			if !contribSet[strings.ToLower(m.Contributor)] && !contribSet[strings.ToLower(m.SideZContributor)] {
+				continue
+			}
+		}
+		if len(metroSet) > 0 {
+			if !metroSet[strings.ToLower(m.SideAMetro)] && !metroSet[strings.ToLower(m.SideZMetro)] {
+				continue
+			}
+		}
+		result[pk] = m
+	}
+	return result
+}
+
+func lowerSet(values []string) map[string]bool {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		out[strings.ToLower(v)] = true
+	}
+	return out
 }
 
 // FetchBulkLinkMetricsData is the exported entry point for the page cache worker.

--- a/api/handlers/v1_dz_links_latency_test.go
+++ b/api/handlers/v1_dz_links_latency_test.go
@@ -1,0 +1,376 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1DZLinkLatencyContractFields locks down the public JSON shape. Renaming or
+// removing a field is a breaking change — bump the API version instead.
+var v1DZLinkLatencyContractFields = struct {
+	top    []string
+	link   []string
+	bucket []string
+}{
+	top: []string{
+		"$schema",
+		"time_range",
+		"bucket_seconds",
+		"bucket_count",
+		"total_links",
+		"link_limit",
+		"link_offset",
+		"links",
+	},
+	link: []string{
+		"link_pk",
+		"link_code",
+		"link_type",
+		"contributor_code",
+		"side_z_contributor_code",
+		"side_a_device",
+		"side_z_device",
+		"side_a_metro",
+		"side_z_metro",
+		"committed_rtt_us",
+		"committed_jitter_us",
+		"buckets",
+	},
+	bucket: []string{
+		"ts",
+		"a_samples", "a_loss_pct",
+		"a_avg_rtt_us", "a_min_rtt_us", "a_p50_rtt_us", "a_p90_rtt_us", "a_p95_rtt_us", "a_p99_rtt_us", "a_max_rtt_us",
+		"a_avg_jitter_us", "a_min_jitter_us", "a_p50_jitter_us", "a_p90_jitter_us", "a_p95_jitter_us", "a_p99_jitter_us", "a_max_jitter_us",
+		"z_samples", "z_loss_pct",
+		"z_avg_rtt_us", "z_min_rtt_us", "z_p50_rtt_us", "z_p90_rtt_us", "z_p95_rtt_us", "z_p99_rtt_us", "z_max_rtt_us",
+		"z_avg_jitter_us", "z_min_jitter_us", "z_p50_jitter_us", "z_p90_jitter_us", "z_p95_jitter_us", "z_p99_jitter_us", "z_max_jitter_us",
+	},
+}
+
+// seedTwoLinksWithLatency seeds two contributor/metro pairs with one link each
+// and a single recent rollup bucket per link, returning the truncated "now"
+// used for bucket alignment.
+func seedTwoLinksWithLatency(t *testing.T, api *handlers.API) time.Time {
+	t.Helper()
+	seedMetro(t, api, "metro-nyc", "NYC")
+	seedMetro(t, api, "metro-lax", "LAX")
+	seedMetro(t, api, "metro-fra", "FRA")
+	seedContributor(t, api, "contrib-acme", "acme")
+	seedContributor(t, api, "contrib-zenith", "zenith")
+	seedDeviceMetadata(t, api, "dev-nyc-acme", "DEV-NYC-ACME", "router", "contrib-acme", "metro-nyc", 10, "activated")
+	seedDeviceMetadata(t, api, "dev-lax-acme", "DEV-LAX-ACME", "router", "contrib-acme", "metro-lax", 10, "activated")
+	seedDeviceMetadata(t, api, "dev-fra-zen", "DEV-FRA-ZEN", "router", "contrib-zenith", "metro-fra", 10, "activated")
+
+	seedLinkMetadata(t, api, "link-1", "NYC-LAX-1", "WAN", "contrib-acme", "dev-nyc-acme", "dev-lax-acme", 10_000_000_000, 500_000, "activated")
+	seedLinkMetadata(t, api, "link-2", "NYC-FRA-1", "WAN", "contrib-zenith", "dev-nyc-acme", "dev-fra-zen", 10_000_000_000, 700_000, "activated")
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	seedLinkRollup(t, api, now.Add(-time.Hour), "link-1", 50_000, 51_000, 0.5, 0.25, 3600, 3600, "activated", false, false)
+	seedLinkRollup(t, api, now.Add(-time.Hour), "link-2", 70_000, 71_000, 0, 0, 3600, 3600, "activated", false, false)
+	return now
+}
+
+func TestV1DZLinkLatency_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1DZLinkLatencyContractFields.top, "response")
+
+	links, ok := raw["links"].([]any)
+	require.True(t, ok, "links must be a JSON array")
+	require.NotEmpty(t, links, "response should include links")
+	for i, l := range links {
+		obj, ok := l.(map[string]any)
+		require.True(t, ok, "links[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1DZLinkLatencyContractFields.link, "links[i]")
+		buckets, ok := obj["buckets"].([]any)
+		require.True(t, ok, "links[%d].buckets must be a JSON array", i)
+		require.NotEmpty(t, buckets, "links[%d] should have at least one bucket", i)
+		for j, b := range buckets {
+			bobj, ok := b.(map[string]any)
+			require.True(t, ok, "links[%d].buckets[%d] must be a JSON object", i, j)
+			assertJSONKeys(t, bobj, v1DZLinkLatencyContractFields.bucket, "links[i].buckets[j]")
+		}
+	}
+}
+
+func TestV1DZLinkLatency_AllLinks(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	assert.Equal(t, 2, resp.TotalLinks)
+	assert.Equal(t, 100, resp.LinkLimit)
+	assert.Equal(t, 0, resp.LinkOffset)
+	require.Len(t, resp.Links, 2)
+	// Sorted by link_code → NYC-FRA-1 before NYC-LAX-1.
+	assert.Equal(t, "NYC-FRA-1", resp.Links[0].LinkCode)
+	assert.Equal(t, "NYC-LAX-1", resp.Links[1].LinkCode)
+
+	laxLink := resp.Links[1]
+	assert.Equal(t, "link-1", laxLink.LinkPK)
+	assert.Equal(t, "acme", laxLink.ContributorCode)
+	assert.Equal(t, "WAN", laxLink.LinkType)
+	assert.Equal(t, "DEV-NYC-ACME", laxLink.SideADevice)
+	assert.Equal(t, "DEV-LAX-ACME", laxLink.SideZDevice)
+	assert.Equal(t, "NYC", laxLink.SideAMetro)
+	assert.Equal(t, "LAX", laxLink.SideZMetro)
+	assert.InDelta(t, 500.0, laxLink.CommittedRttUs, 0.01)
+	require.NotEmpty(t, laxLink.Buckets)
+
+	// Find populated bucket and verify the seeded values.
+	var populated *v1.DZLinkLatencyBucket
+	for i := range laxLink.Buckets {
+		if laxLink.Buckets[i].ASamples > 0 {
+			populated = &laxLink.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, populated)
+	assert.InDelta(t, 50_000.0, populated.AAvgRttUs, 0.01)
+	assert.InDelta(t, 51_000.0, populated.ZAvgRttUs, 0.01)
+	assert.InDelta(t, 0.5, populated.ALossPct, 0.01)
+}
+
+func TestV1DZLinkLatency_FilterByLinkPK(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?link_pk=link-2", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	assert.Equal(t, "link-2", resp.Links[0].LinkPK)
+}
+
+func TestV1DZLinkLatency_FilterByLinkCode(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	// Case-insensitive exact match.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?link_code=nyc-lax-1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	assert.Equal(t, "NYC-LAX-1", resp.Links[0].LinkCode)
+}
+
+func TestV1DZLinkLatency_FilterByContributor(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?contributor_code=zenith", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	assert.Equal(t, "link-2", resp.Links[0].LinkPK)
+}
+
+func TestV1DZLinkLatency_FilterByMetro(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	// FRA only appears on link-2 (NYC↔FRA); should not match link-1 (NYC↔LAX).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?metro_code=FRA", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	assert.Equal(t, "link-2", resp.Links[0].LinkPK)
+}
+
+func TestV1DZLinkLatency_FilterMultipleValues(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	// Repeated query params OR within a filter.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?metro_code=LAX&metro_code=FRA", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Len(t, resp.Links, 2)
+}
+
+func TestV1DZLinkLatency_FilterNoMatches(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?metro_code=does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.TotalLinks)
+	assert.Empty(t, resp.Links)
+}
+
+func TestV1DZLinkLatency_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedTwoLinksWithLatency(t, api)
+
+	r := newV1Router(t, api)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?link_limit=1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZLinkLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.TotalLinks)
+	assert.Equal(t, 1, resp.LinkLimit)
+	require.Len(t, resp.Links, 1)
+	first := resp.Links[0].LinkCode
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?link_limit=1&link_offset=1", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	assert.NotEqual(t, first, resp.Links[0].LinkCode)
+
+	// Offset past total returns empty page; total still reflects full match count.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?link_offset=10", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.TotalLinks)
+	assert.Empty(t, resp.Links)
+}
+
+func TestV1DZLinkLatency_InvalidParams(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+
+	for _, url := range []string{
+		"/api/v1/dz/links/latency?range=99h",
+		"/api/v1/dz/links/latency?bucket=2s",
+		"/api/v1/dz/links/latency?start_time=-1",
+		"/api/v1/dz/links/latency?link_limit=0",
+		"/api/v1/dz/links/latency?link_limit=9999",
+		"/api/v1/dz/links/latency?link_offset=-1",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+}
+
+func TestV1DZLinkLatency_RawBucketWindowCap(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+
+	// Reject: raw-mode bucket combined with too-wide a window.
+	for _, url := range []string{
+		"/api/v1/dz/links/latency?bucket=10s&range=24h",
+		"/api/v1/dz/links/latency?bucket=30s&range=24h",
+		"/api/v1/dz/links/latency?bucket=1m&range=24h",
+		// Custom window: 10s bucket over 6h is too wide.
+		"/api/v1/dz/links/latency?bucket=10s&start_time=1000000000&end_time=1000021600",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+
+	// Accept: raw-mode bucket inside its allowed window. No data is fine —
+	// the response is just an empty link list.
+	for _, url := range []string{
+		"/api/v1/dz/links/latency?bucket=10s&range=1h",
+		"/api/v1/dz/links/latency?bucket=30s&range=3h",
+		"/api/v1/dz/links/latency?bucket=1m&range=6h",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+}
+
+func TestV1DZLinkLatency_InvertedCustomWindow(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/links/latency?start_time=2000&end_time=1000", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "body: %s", rr.Body.String())
+}

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -98,6 +98,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 		registerEdgeShredsPublishers(humaAPI, api)
 		registerEdgeShredsSubscribers(humaAPI, api)
 		registerValidatorsMetadata(humaAPI, api)
+		registerDZLinksLatency(humaAPI, api)
 
 		// Register 308 redirects from deprecated paths to their current
 		// canonical paths. These keep existing consumers working while the

--- a/api/v1/dz_links_latency.go
+++ b/api/v1/dz_links_latency.go
@@ -1,0 +1,291 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// DZLinkLatencyBucket is a single time-bucketed latency measurement for one
+// link. The bucket covers the response envelope's BucketSeconds starting at
+// TS. Zero values for samples + RTT + jitter + loss indicate the bucket had
+// no probe data.
+type DZLinkLatencyBucket struct {
+	TS string `json:"ts" doc:"RFC3339 bucket start timestamp (UTC)" example:"2026-05-12T00:00:00Z"`
+
+	ASamples     uint64  `json:"a_samples" doc:"Probe samples observed on the A side"`
+	ALossPct     float64 `json:"a_loss_pct" doc:"Packet loss percent on the A side"`
+	AAvgRttUs    float64 `json:"a_avg_rtt_us" doc:"Average RTT, A side, microseconds"`
+	AMinRttUs    float64 `json:"a_min_rtt_us" doc:"Min RTT, A side, microseconds"`
+	AP50RttUs    float64 `json:"a_p50_rtt_us" doc:"P50 RTT, A side, microseconds"`
+	AP90RttUs    float64 `json:"a_p90_rtt_us" doc:"P90 RTT, A side, microseconds"`
+	AP95RttUs    float64 `json:"a_p95_rtt_us" doc:"P95 RTT, A side, microseconds"`
+	AP99RttUs    float64 `json:"a_p99_rtt_us" doc:"P99 RTT, A side, microseconds"`
+	AMaxRttUs    float64 `json:"a_max_rtt_us" doc:"Max RTT, A side, microseconds"`
+	AAvgJitterUs float64 `json:"a_avg_jitter_us" doc:"Average jitter, A side, microseconds"`
+	AMinJitterUs float64 `json:"a_min_jitter_us" doc:"Min jitter, A side, microseconds"`
+	AP50JitterUs float64 `json:"a_p50_jitter_us" doc:"P50 jitter, A side, microseconds"`
+	AP90JitterUs float64 `json:"a_p90_jitter_us" doc:"P90 jitter, A side, microseconds"`
+	AP95JitterUs float64 `json:"a_p95_jitter_us" doc:"P95 jitter, A side, microseconds"`
+	AP99JitterUs float64 `json:"a_p99_jitter_us" doc:"P99 jitter, A side, microseconds"`
+	AMaxJitterUs float64 `json:"a_max_jitter_us" doc:"Max jitter, A side, microseconds"`
+
+	ZSamples     uint64  `json:"z_samples" doc:"Probe samples observed on the Z side"`
+	ZLossPct     float64 `json:"z_loss_pct" doc:"Packet loss percent on the Z side"`
+	ZAvgRttUs    float64 `json:"z_avg_rtt_us" doc:"Average RTT, Z side, microseconds"`
+	ZMinRttUs    float64 `json:"z_min_rtt_us" doc:"Min RTT, Z side, microseconds"`
+	ZP50RttUs    float64 `json:"z_p50_rtt_us" doc:"P50 RTT, Z side, microseconds"`
+	ZP90RttUs    float64 `json:"z_p90_rtt_us" doc:"P90 RTT, Z side, microseconds"`
+	ZP95RttUs    float64 `json:"z_p95_rtt_us" doc:"P95 RTT, Z side, microseconds"`
+	ZP99RttUs    float64 `json:"z_p99_rtt_us" doc:"P99 RTT, Z side, microseconds"`
+	ZMaxRttUs    float64 `json:"z_max_rtt_us" doc:"Max RTT, Z side, microseconds"`
+	ZAvgJitterUs float64 `json:"z_avg_jitter_us" doc:"Average jitter, Z side, microseconds"`
+	ZMinJitterUs float64 `json:"z_min_jitter_us" doc:"Min jitter, Z side, microseconds"`
+	ZP50JitterUs float64 `json:"z_p50_jitter_us" doc:"P50 jitter, Z side, microseconds"`
+	ZP90JitterUs float64 `json:"z_p90_jitter_us" doc:"P90 jitter, Z side, microseconds"`
+	ZP95JitterUs float64 `json:"z_p95_jitter_us" doc:"P95 jitter, Z side, microseconds"`
+	ZP99JitterUs float64 `json:"z_p99_jitter_us" doc:"P99 jitter, Z side, microseconds"`
+	ZMaxJitterUs float64 `json:"z_max_jitter_us" doc:"Max jitter, Z side, microseconds"`
+}
+
+// DZLinkLatency is the per-link entry in the latency listing response.
+type DZLinkLatency struct {
+	LinkPK               string                `json:"link_pk" doc:"Link pubkey (PDA)"`
+	LinkCode             string                `json:"link_code" doc:"Link code"`
+	LinkType             string                `json:"link_type" doc:"Link type (e.g. WAN, DZX)"`
+	ContributorCode      string                `json:"contributor_code" doc:"Contributor code (A side)"`
+	SideZContributorCode string                `json:"side_z_contributor_code" doc:"Contributor code on the Z side"`
+	SideADevice          string                `json:"side_a_device" doc:"Device code on the A side"`
+	SideZDevice          string                `json:"side_z_device" doc:"Device code on the Z side"`
+	SideAMetro           string                `json:"side_a_metro" doc:"Metro code on the A side"`
+	SideZMetro           string                `json:"side_z_metro" doc:"Metro code on the Z side"`
+	CommittedRttUs       float64               `json:"committed_rtt_us" doc:"Committed RTT SLO, microseconds"`
+	CommittedJitterUs    float64               `json:"committed_jitter_us" doc:"Committed jitter SLO, microseconds"`
+	Buckets              []DZLinkLatencyBucket `json:"buckets" doc:"Time-ordered buckets (oldest first)"`
+}
+
+// DZLinkLatencyResponse is the body returned by the link latency endpoint.
+type DZLinkLatencyResponse struct {
+	TimeRange     string          `json:"time_range" doc:"Resolved time range preset, when not using an explicit window"`
+	BucketSeconds int             `json:"bucket_seconds" doc:"Bucket width in seconds"`
+	BucketCount   int             `json:"bucket_count" doc:"Number of buckets per link"`
+	TotalLinks    int             `json:"total_links" doc:"Total links matching the filter (before pagination)"`
+	LinkLimit     int             `json:"link_limit" doc:"Maximum links returned per page"`
+	LinkOffset    int             `json:"link_offset" doc:"Offset into the filtered link set"`
+	Links         []DZLinkLatency `json:"links" doc:"Links sorted by link_code"`
+}
+
+// DZLinkLatencyInput is the request for the link latency endpoint.
+// Multi-value filters accept repeated query params, e.g.
+// `?metro_code=NYC&metro_code=LAX`. Within a filter, values are OR'd; across
+// filters, AND'd. Contributor and metro filters match either side of the link.
+type DZLinkLatencyInput struct {
+	LinkPK          []string `query:"link_pk,explode" doc:"Filter to specific link pubkeys"`
+	LinkCode        []string `query:"link_code,explode" doc:"Filter by link code (case-insensitive exact)"`
+	ContributorCode []string `query:"contributor_code,explode" doc:"Filter by contributor code (case-insensitive exact); matches either side"`
+	MetroCode       []string `query:"metro_code,explode" doc:"Filter by metro code (case-insensitive exact); matches either side"`
+	Range           string   `query:"range" enum:"1h,3h,6h,12h,24h,3d,7d,14d,30d" default:"24h" doc:"Time range preset. Ignored if start_time and end_time are both set."`
+	StartTime       int64    `query:"start_time" minimum:"0" default:"0" doc:"Custom window start (unix seconds). If set together with end_time, overrides range."`
+	EndTime         int64    `query:"end_time" minimum:"0" default:"0" doc:"Custom window end (unix seconds)."`
+	Bucket          string   `query:"bucket" enum:"auto,10s,30s,1m,5m,10m,15m,30m,1h,4h,12h,1d" default:"auto" doc:"Bucket size. 'auto' picks granularity based on the window. Sub-5-minute buckets are capped to short windows."`
+	LinkLimit       int      `query:"link_limit" minimum:"1" maximum:"500" default:"100" doc:"Maximum links returned per page. Each link includes the full bucket window."`
+	LinkOffset      int      `query:"link_offset" minimum:"0" default:"0" doc:"Offset into the filtered, sorted link set"`
+}
+
+// DZLinkLatencyOutput wraps the response body for huma.
+type DZLinkLatencyOutput struct {
+	Body DZLinkLatencyResponse
+}
+
+func registerDZLinksLatency(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-dz-links-latency",
+		Method:      "GET",
+		Path:        "/dz/links/latency",
+		Summary:     "List latency time-series for DZ network links",
+		Description: "Returns per-bucket A-side and Z-side RTT percentiles, jitter percentiles, packet loss, and sample counts for DoubleZero network links. Use the filter query params to narrow to specific links, contributors, or metros — within a filter values are OR'd; across filters AND'd.",
+		Tags:        []string{"DZ/Links"},
+	}, func(ctx context.Context, input *DZLinkLatencyInput) (*DZLinkLatencyOutput, error) {
+		opts := handlers.LinkLatencyOptions{
+			TimeRange: input.Range,
+			Bucket:    input.Bucket,
+			Filter: handlers.LinkLatencyFilter{
+				LinkPKs:          input.LinkPK,
+				LinkCodes:        input.LinkCode,
+				ContributorCodes: input.ContributorCode,
+				MetroCodes:       input.MetroCode,
+			},
+		}
+
+		var windowDur time.Duration
+		if input.StartTime > 0 && input.EndTime > 0 {
+			st := time.Unix(input.StartTime, 0).UTC()
+			et := time.Unix(input.EndTime, 0).UTC()
+			if !et.After(st) {
+				return nil, huma.Error422UnprocessableEntity("end_time must be after start_time")
+			}
+			opts.StartTime = &st
+			opts.EndTime = &et
+			windowDur = et.Sub(st)
+		} else {
+			windowDur = rangePresetToDuration(input.Range)
+		}
+
+		// Sub-5-minute buckets query the raw fact table. We cap them at the
+		// same windows `bucket=auto` would have chosen, so callers can't ask
+		// for `bucket=10s&range=30d` and pull 259k buckets per link out of
+		// raw facts.
+		if err := validateRawBucketWindow(input.Bucket, windowDur); err != nil {
+			return nil, huma.Error422UnprocessableEntity(err.Error())
+		}
+
+		result, err := api.FetchLinkLatency(ctx, opts)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch link latency", err)
+		}
+
+		total := len(result.Links)
+		start := input.LinkOffset
+		if start > total {
+			start = total
+		}
+		end := start + input.LinkLimit
+		if end > total {
+			end = total
+		}
+		page := result.Links[start:end]
+
+		links := make([]DZLinkLatency, len(page))
+		for i, link := range page {
+			links[i] = toDZLinkLatency(link)
+		}
+
+		return &DZLinkLatencyOutput{Body: DZLinkLatencyResponse{
+			TimeRange:     result.TimeRange,
+			BucketSeconds: result.BucketSeconds,
+			BucketCount:   result.BucketCount,
+			TotalLinks:    total,
+			LinkLimit:     input.LinkLimit,
+			LinkOffset:    input.LinkOffset,
+			Links:         links,
+		}}, nil
+	})
+}
+
+func toDZLinkLatency(r *handlers.LinkMetricsResponse) DZLinkLatency {
+	buckets := make([]DZLinkLatencyBucket, len(r.Buckets))
+	for i, b := range r.Buckets {
+		buckets[i] = DZLinkLatencyBucket{TS: b.TS}
+		if b.Latency == nil {
+			continue
+		}
+		buckets[i].ASamples = b.Latency.ASamples
+		buckets[i].ALossPct = b.Latency.ALossPct
+		buckets[i].AAvgRttUs = b.Latency.AAvgRttUs
+		buckets[i].AMinRttUs = b.Latency.AMinRttUs
+		buckets[i].AP50RttUs = b.Latency.AP50RttUs
+		buckets[i].AP90RttUs = b.Latency.AP90RttUs
+		buckets[i].AP95RttUs = b.Latency.AP95RttUs
+		buckets[i].AP99RttUs = b.Latency.AP99RttUs
+		buckets[i].AMaxRttUs = b.Latency.AMaxRttUs
+		buckets[i].AAvgJitterUs = b.Latency.AAvgJitterUs
+		buckets[i].AMinJitterUs = b.Latency.AMinJitterUs
+		buckets[i].AP50JitterUs = b.Latency.AP50JitterUs
+		buckets[i].AP90JitterUs = b.Latency.AP90JitterUs
+		buckets[i].AP95JitterUs = b.Latency.AP95JitterUs
+		buckets[i].AP99JitterUs = b.Latency.AP99JitterUs
+		buckets[i].AMaxJitterUs = b.Latency.AMaxJitterUs
+
+		buckets[i].ZSamples = b.Latency.ZSamples
+		buckets[i].ZLossPct = b.Latency.ZLossPct
+		buckets[i].ZAvgRttUs = b.Latency.ZAvgRttUs
+		buckets[i].ZMinRttUs = b.Latency.ZMinRttUs
+		buckets[i].ZP50RttUs = b.Latency.ZP50RttUs
+		buckets[i].ZP90RttUs = b.Latency.ZP90RttUs
+		buckets[i].ZP95RttUs = b.Latency.ZP95RttUs
+		buckets[i].ZP99RttUs = b.Latency.ZP99RttUs
+		buckets[i].ZMaxRttUs = b.Latency.ZMaxRttUs
+		buckets[i].ZAvgJitterUs = b.Latency.ZAvgJitterUs
+		buckets[i].ZMinJitterUs = b.Latency.ZMinJitterUs
+		buckets[i].ZP50JitterUs = b.Latency.ZP50JitterUs
+		buckets[i].ZP90JitterUs = b.Latency.ZP90JitterUs
+		buckets[i].ZP95JitterUs = b.Latency.ZP95JitterUs
+		buckets[i].ZP99JitterUs = b.Latency.ZP99JitterUs
+		buckets[i].ZMaxJitterUs = b.Latency.ZMaxJitterUs
+	}
+
+	return DZLinkLatency{
+		LinkPK:               r.LinkPK,
+		LinkCode:             r.LinkCode,
+		LinkType:             r.LinkType,
+		ContributorCode:      r.ContributorCode,
+		SideZContributorCode: r.SideZContributorCode,
+		SideADevice:          r.SideADevice,
+		SideZDevice:          r.SideZDevice,
+		SideAMetro:           r.SideAMetro,
+		SideZMetro:           r.SideZMetro,
+		CommittedRttUs:       r.CommittedRttUs,
+		CommittedJitterUs:    r.CommittedJitterUs,
+		Buckets:              buckets,
+	}
+}
+
+// rangePresetToDuration mirrors the enum on DZLinkLatencyInput.Range.
+func rangePresetToDuration(preset string) time.Duration {
+	switch preset {
+	case "1h":
+		return time.Hour
+	case "3h":
+		return 3 * time.Hour
+	case "6h":
+		return 6 * time.Hour
+	case "12h":
+		return 12 * time.Hour
+	case "3d":
+		return 3 * 24 * time.Hour
+	case "7d":
+		return 7 * 24 * time.Hour
+	case "14d":
+		return 14 * 24 * time.Hour
+	case "30d":
+		return 30 * 24 * time.Hour
+	default:
+		return 24 * time.Hour
+	}
+}
+
+// validateRawBucketWindow caps sub-5-minute buckets to the same window sizes
+// that `bucket=auto` would pick. Without this, a caller could combine a
+// fine-grained bucket with a multi-day window and force a heavy raw fact-table
+// scan returning tens of thousands of buckets per link.
+func validateRawBucketWindow(bucket string, window time.Duration) error {
+	var maxWindow time.Duration
+	switch bucket {
+	case "10s":
+		maxWindow = time.Hour
+	case "30s":
+		maxWindow = 3 * time.Hour
+	case "1m":
+		maxWindow = 6 * time.Hour
+	default:
+		return nil
+	}
+	if window > maxWindow {
+		return fmt.Errorf("bucket=%s is only allowed for windows up to %s", bucket, formatHumanDuration(maxWindow))
+	}
+	return nil
+}
+
+func formatHumanDuration(d time.Duration) string {
+	if d >= 24*time.Hour && d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+	if d >= time.Hour && d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	return d.String()
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/dz/links/latency` returning per-bucket A-side and Z-side RTT percentiles, jitter percentiles, packet loss, and sample counts for DZ network links.
- Supports repeatable filters on `link_pk`, `link_code`, `contributor_code`, and `metro_code` (OR within a filter, AND across); contributor and metro match either side of the link.
- Paginated (`limit`/`offset`, max 500/page), sorted by `link_code`.
- Sub-5-minute buckets (`10s`/`30s`/`1m`) are capped to the same windows that `bucket=auto` would pick, preventing accidental tens-of-thousands-of-buckets raw fact-table scans.

## Testing Verification
- [x] Contract test: response top-level keys, per-link keys, per-bucket keys
- [x] Each filter exercised individually (link_pk, link_code, contributor_code, metro_code)
- [x] Multi-value within a filter (\`?metro_code=LAX&metro_code=FRA\` returns links touching either)
- [x] Empty-filter result and zero-match filter case
- [x] Pagination including offset past the total
- [x] Raw-bucket window cap accepts within-limit combos and rejects out-of-bounds with 422
- [x] Inverted custom window (end_time <= start_time) rejected with 422