### PR TITLE
api: support brotli content-encoding alongside gzip

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/andybalholm/brotli"
 	"github.com/getsentry/sentry-go"
 	sentryhttp "github.com/getsentry/sentry-go/http"
 	"github.com/go-chi/chi/v5"
@@ -434,7 +435,11 @@ func main() {
 	}
 
 	r.Use(middleware.Recoverer)
-	r.Use(middleware.Compress(5))
+	compressor := middleware.NewCompressor(5)
+	compressor.SetEncoder("br", func(w io.Writer, level int) io.Writer {
+		return brotli.NewWriterLevel(w, level)
+	})
+	r.Use(compressor.Handler)
 	r.Use(metrics.Middleware)
 
 	// CORS configuration - origins from env or allow all

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.44.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.13.0
+	github.com/andybalholm/brotli v1.2.0
 	github.com/anthropics/anthropic-sdk-go v1.41.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
@@ -48,7 +49,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.5.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect


### PR DESCRIPTION
## Summary of Changes
- Register a brotli (`br`) encoder on the chi compression middleware so clients advertising `Accept-Encoding: br` receive brotli-compressed responses; gzip and identity remain unchanged.
- Promote `github.com/andybalholm/brotli` from a transitive to a direct dependency (no new modules pulled in).

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Scaffolding  |     1 | +6 / -1     |  +5  |
| Config/build |     1 | +1 / -1     |  +0  |
| **Total**    |     2 | +7 / -2     |  +5  |

Pure middleware wiring — no business logic touched.

<details>
<summary>Key files (click to expand)</summary>

- `api/main.go` — swap `middleware.Compress(5)` for a `NewCompressor(5)` that registers a brotli encoder via `SetEncoder("br", ...)`.

</details>

## Testing Verification
- Verified against the current deploy (`pr-583.data.malbeclabs.com/api/v1/dz/links/latency`): gzip is enabled (~266 KB vs 8.7 MB raw) but brotli falls back to identity. After this change, `Accept-Encoding: br` requests should receive `content-encoding: br`. Will reconfirm against the PR preview deploy once it's up.
- Chi negotiates the encoder based on the client's `Accept-Encoding` q-values; clients that only advertise gzip continue to receive gzip with no behavior change.