### PR TITLE
api, indexer: quiet temporal deploy-time grpc-closing log

### DIFF
--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -118,14 +118,17 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) { l.log.Error(msg, ke
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing
 // failed with error" keyvals carry an error that's expected during deploys
 // (activity completes after the workflow has already finished or been
-// continue-as-newed).
+// continue-as-newed; in-flight RPC observes the gRPC client connection
+// closing as the pod shuts down).
 func hasBenignTaskProcessingError(keyvals []any) bool {
 	for i := 0; i+1 < len(keyvals); i += 2 {
 		if keyvals[i] != "Error" {
 			continue
 		}
 		if err, ok := keyvals[i+1].(error); ok {
-			if strings.Contains(err.Error(), "workflow execution already completed") {
+			msg := err.Error()
+			if strings.Contains(msg, "workflow execution already completed") ||
+				strings.Contains(msg, "grpc: the client connection is closing") {
 				return true
 			}
 		}

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -167,14 +167,19 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 }
 
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing
-// failed with error" keyvals carry an error that's expected during deploys.
+// failed with error" keyvals carry an error that's expected during deploys
+// (activity reports back after the workflow has already finished or been
+// continue-as-newed; in-flight RPC observes the gRPC client connection
+// closing as the pod shuts down).
 func hasBenignTaskProcessingError(keyvals []any) bool {
 	for i := 0; i+1 < len(keyvals); i += 2 {
 		if keyvals[i] != "Error" {
 			continue
 		}
 		if err, ok := keyvals[i+1].(error); ok {
-			if strings.Contains(err.Error(), "workflow execution already completed") {
+			msg := err.Error()
+			if strings.Contains(msg, "workflow execution already completed") ||
+				strings.Contains(msg, "grpc: the client connection is closing") {
 				return true
 			}
 		}

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -178,14 +178,19 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 }
 
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing
-// failed with error" keyvals carry an error that's expected during deploys.
+// failed with error" keyvals carry an error that's expected during deploys
+// (activity reports back after the workflow has already finished or been
+// continue-as-newed; in-flight RPC observes the gRPC client connection
+// closing as the pod shuts down).
 func hasBenignTaskProcessingError(keyvals []any) bool {
 	for i := 0; i+1 < len(keyvals); i += 2 {
 		if keyvals[i] != "Error" {
 			continue
 		}
 		if err, ok := keyvals[i+1].(error); ok {
-			if strings.Contains(err.Error(), "workflow execution already completed") {
+			msg := err.Error()
+			if strings.Contains(msg, "workflow execution already completed") ||
+				strings.Contains(msg, "grpc: the client connection is closing") {
 				return true
 			}
 		}

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -147,14 +147,19 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 }
 
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing
-// failed with error" keyvals carry an error that's expected during deploys.
+// failed with error" keyvals carry an error that's expected during deploys
+// (activity reports back after the workflow has already finished or been
+// continue-as-newed; in-flight RPC observes the gRPC client connection
+// closing as the pod shuts down).
 func hasBenignTaskProcessingError(keyvals []any) bool {
 	for i := 0; i+1 < len(keyvals); i += 2 {
 		if keyvals[i] != "Error" {
 			continue
 		}
 		if err, ok := keyvals[i+1].(error); ok {
-			if strings.Contains(err.Error(), "workflow execution already completed") {
+			msg := err.Error()
+			if strings.Contains(msg, "workflow execution already completed") ||
+				strings.Contains(msg, "grpc: the client connection is closing") {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

- Extend `hasBenignTaskProcessingError` in all four `temporalLogger` adapters (`api/worker`, `indexer/pkg/dzingest`, `indexer/pkg/rollup`, `indexer/pkg/solingest`) to also match `"grpc: the client connection is closing"`, demoting the line to Debug.
- Same pattern as the existing `"workflow execution already completed"` suppression added in #581.

These are benign deploy-time noise, identical in nature to the workflow-already-completed case.

## Testing Verification

- Post-deploy, verify in Loki that `{app="lake-api"} |= "Task processing failed with error" |= "grpc: the client connection is closing"` drops to zero during rollouts.