### PR TITLE
api/v1: add dz-vs-internet metro-pair latency endpoint

### DIFF
--- a/api/handlers/metro_pair_latency.go
+++ b/api/handlers/metro_pair_latency.go
@@ -72,13 +72,13 @@ type MetroPairLatencyBucket struct {
 }
 
 // MetroPair is the per-pair entry in the listing. Direction is normalized:
-// Metro1Code < Metro2Code lexicographically (via least/greatest), matching the
-// existing dz_vs_internet_latency_comparison view.
+// MetroACode < MetroBCode lexicographically (via least/greatest). A/B are
+// labels, not directions — the underlying samples are bidirectional.
 type MetroPair struct {
-	Metro1Code string
-	Metro1Name string
-	Metro2Code string
-	Metro2Name string
+	MetroACode string
+	MetroAName string
+	MetroBCode string
+	MetroBName string
 	Buckets    []MetroPairLatencyBucket
 }
 
@@ -129,8 +129,8 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 
 	for rows.Next() {
 		var (
-			metro1, metro2         string
-			metro1Name, metro2Name string
+			metroA, metroB         string
+			metroAName, metroBName string
 			bucketTS               time.Time
 
 			dzSamples uint64
@@ -168,7 +168,7 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 		)
 
 		if err := rows.Scan(
-			&metro1, &metro2, &metro1Name, &metro2Name, &bucketTS,
+			&metroA, &metroB, &metroAName, &metroBName, &bucketTS,
 			&dzSamples, &dzAvg, &dzMin, &dzP50, &dzP90, &dzP95, &dzP99, &dzMax,
 			&dzAvgJ, &dzMinJ, &dzP50J, &dzP90J, &dzP95J, &dzP99J, &dzMaxJ, &dzLoss,
 			&inetSamples, &inetAvg, &inetMin, &inetP50, &inetP90, &inetP95, &inetP99, &inetMax,
@@ -177,24 +177,24 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 			return nil, fmt.Errorf("metro pair latency scan: %w", err)
 		}
 
-		key := pairKey{metro1, metro2}
+		key := pairKey{metroA, metroB}
 		p, ok := pairs[key]
 		if !ok {
 			p = &MetroPair{
-				Metro1Code: metro1,
-				Metro1Name: metro1Name,
-				Metro2Code: metro2,
-				Metro2Name: metro2Name,
+				MetroACode: metroA,
+				MetroAName: metroAName,
+				MetroBCode: metroB,
+				MetroBName: metroBName,
 			}
 			pairs[key] = p
 			bucketsByPair[key] = make(map[time.Time]*MetroPairLatencyBucket)
 		}
 		// Carry forward metro names if a later row has a populated name we missed.
-		if p.Metro1Name == "" && metro1Name != "" {
-			p.Metro1Name = metro1Name
+		if p.MetroAName == "" && metroAName != "" {
+			p.MetroAName = metroAName
 		}
-		if p.Metro2Name == "" && metro2Name != "" {
-			p.Metro2Name = metro2Name
+		if p.MetroBName == "" && metroBName != "" {
+			p.MetroBName = metroBName
 		}
 
 		b := &MetroPairLatencyBucket{
@@ -269,10 +269,10 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 	}
 
 	sort.Slice(result.Pairs, func(i, j int) bool {
-		if result.Pairs[i].Metro1Code != result.Pairs[j].Metro1Code {
-			return result.Pairs[i].Metro1Code < result.Pairs[j].Metro1Code
+		if result.Pairs[i].MetroACode != result.Pairs[j].MetroACode {
+			return result.Pairs[i].MetroACode < result.Pairs[j].MetroACode
 		}
-		return result.Pairs[i].Metro2Code < result.Pairs[j].Metro2Code
+		return result.Pairs[i].MetroBCode < result.Pairs[j].MetroBCode
 	})
 
 	return result, nil
@@ -399,10 +399,10 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 		dzCTE = fmt.Sprintf(`
 		dz_data AS (
 			SELECT
-				least(ma.code, mz.code) AS metro1,
-				greatest(ma.code, mz.code) AS metro2,
-				if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
-				if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+				least(ma.code, mz.code) AS metro_a,
+				greatest(ma.code, mz.code) AS metro_b,
+				if(ma.code < mz.code, ma.name, mz.name) AS metro_a_name,
+				if(ma.code < mz.code, mz.name, ma.name) AS metro_b_name,
 				%s AS bucket_ts,
 				toUInt64(count()) AS samples,
 				avg(f.rtt_us) AS avg_rtt_us,
@@ -429,14 +429,14 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 			WHERE f.event_ts >= $1 AND f.event_ts < $2
 			  AND f.link_pk != ''
 			  AND ma.code != mz.code%s
-			GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+			GROUP BY metro_a, metro_b, metro_a_name, metro_b_name, bucket_ts
 		)`, dzBucketExpr, dzSource, metroFilterSQL)
 	} else {
 		// Rollup path: sample-weighted re-aggregation of percentiles.
 		dzCTE = fmt.Sprintf(`
 		dz_data AS (
 			SELECT
-				metro1, metro2, metro1_name, metro2_name, bucket_ts,
+				metro_a, metro_b, metro_a_name, metro_b_name, bucket_ts,
 				toUInt64(samples_total) AS samples,
 				if(samples_total > 0, w_avg / samples_total, NULL) AS avg_rtt_us,
 				if(samples_total > 0, min_rtt_us, NULL) AS min_rtt_us,
@@ -455,10 +455,10 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 				loss_pct
 			FROM (
 				SELECT
-					least(ma.code, mz.code) AS metro1,
-					greatest(ma.code, mz.code) AS metro2,
-					if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
-					if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+					least(ma.code, mz.code) AS metro_a,
+					greatest(ma.code, mz.code) AS metro_b,
+					if(ma.code < mz.code, ma.name, mz.name) AS metro_a_name,
+					if(ma.code < mz.code, mz.name, ma.name) AS metro_b_name,
 					%s AS bucket_ts,
 					sum(r.a_samples + r.z_samples) AS samples_total,
 					sumIf(r.a_avg_rtt_us * r.a_samples, r.a_samples > 0)
@@ -495,7 +495,7 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 				WHERE r.bucket_ts >= $1 AND r.bucket_ts < $2
 				  AND r.link_pk != ''
 				  AND ma.code != mz.code%s
-				GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+				GROUP BY metro_a, metro_b, metro_a_name, metro_b_name, bucket_ts
 			)
 		)`, dzBucketExpr, metroFilterSQL)
 	}
@@ -503,10 +503,10 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 	inetCTE := fmt.Sprintf(`
 		inet_data AS (
 			SELECT
-				least(ma.code, mz.code) AS metro1,
-				greatest(ma.code, mz.code) AS metro2,
-				if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
-				if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+				least(ma.code, mz.code) AS metro_a,
+				greatest(ma.code, mz.code) AS metro_b,
+				if(ma.code < mz.code, ma.name, mz.name) AS metro_a_name,
+				if(ma.code < mz.code, mz.name, ma.name) AS metro_b_name,
 				%s AS bucket_ts,
 				toUInt64(count()) AS samples,
 				avg(f.rtt_us) AS avg_rtt_us,
@@ -528,20 +528,20 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 			JOIN dz_metros_current mz ON f.target_metro_pk = mz.pk
 			WHERE f.event_ts >= $1 AND f.event_ts < $2
 			  AND ma.code != mz.code%s%s
-			GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+			GROUP BY metro_a, metro_b, metro_a_name, metro_b_name, bucket_ts
 		)`, inetBucketExpr, metroFilterSQL, inetProviderSQL)
 
 	// FULL OUTER JOIN ... USING is required here. ClickHouse's multi-column
 	// ON-clause variant does not propagate the join-key column values from the
 	// unmatched side, so rows that only exist in one CTE come back with empty
-	// metro1/metro2/bucket_ts. USING merges the join keys into a single value
+	// metro_a/metro_b/bucket_ts. USING merges the join keys into a single value
 	// per row, which is the behavior we want.
 	query := fmt.Sprintf(`
 		WITH%s,%s
 		SELECT
-			metro1, metro2,
-			COALESCE(d.metro1_name, i.metro1_name, '') AS metro1_name,
-			COALESCE(d.metro2_name, i.metro2_name, '') AS metro2_name,
+			metro_a, metro_b,
+			COALESCE(d.metro_a_name, i.metro_a_name, '') AS metro_a_name,
+			COALESCE(d.metro_b_name, i.metro_b_name, '') AS metro_b_name,
 			bucket_ts,
 			COALESCE(d.samples, toUInt64(0)) AS dz_samples,
 			d.avg_rtt_us AS dz_avg_rtt_us,
@@ -575,8 +575,8 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 			i.p99_jitter_us AS inet_p99_jitter_us,
 			i.max_jitter_us AS inet_max_jitter_us
 		FROM dz_data d
-		FULL OUTER JOIN inet_data i USING (metro1, metro2, bucket_ts)
-		ORDER BY metro1, metro2, bucket_ts
+		FULL OUTER JOIN inet_data i USING (metro_a, metro_b, bucket_ts)
+		ORDER BY metro_a, metro_b, bucket_ts
 	`, dzCTE, inetCTE)
 
 	rows, err := db.Query(ctx, query, args...)

--- a/api/handlers/metro_pair_latency.go
+++ b/api/handlers/metro_pair_latency.go
@@ -1,0 +1,584 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+// MetroPairLatencyFilter narrows the set of metro pairs returned by
+// FetchMetroPairLatency. Values within a category are OR'd; non-empty
+// categories are AND'd together. MetroCodes match either side of a pair.
+// DataProviders only apply to the internet-side samples.
+type MetroPairLatencyFilter struct {
+	MetroCodes    []string
+	DataProviders []string
+}
+
+// MetroPairLatencyOptions configures FetchMetroPairLatency: time window,
+// bucket granularity, and which metro pairs to include.
+type MetroPairLatencyOptions struct {
+	TimeRange string
+	StartTime *time.Time
+	EndTime   *time.Time
+	Bucket    string
+	Filter    MetroPairLatencyFilter
+}
+
+// MetroPairLatencyBucket is a single time-bucketed comparison row for one
+// metro pair. Zero values on a side indicate that side had no samples in the
+// bucket.
+type MetroPairLatencyBucket struct {
+	TS time.Time
+
+	DZSamples     uint64
+	DZAvgRttUs    float64
+	DZMinRttUs    float64
+	DZP50RttUs    float64
+	DZP90RttUs    float64
+	DZP95RttUs    float64
+	DZP99RttUs    float64
+	DZMaxRttUs    float64
+	DZAvgJitterUs float64
+	DZMinJitterUs float64
+	DZP50JitterUs float64
+	DZP90JitterUs float64
+	DZP95JitterUs float64
+	DZP99JitterUs float64
+	DZMaxJitterUs float64
+	DZLossPct     float64
+
+	InternetSamples     uint64
+	InternetAvgRttUs    float64
+	InternetMinRttUs    float64
+	InternetP50RttUs    float64
+	InternetP90RttUs    float64
+	InternetP95RttUs    float64
+	InternetP99RttUs    float64
+	InternetMaxRttUs    float64
+	InternetAvgJitterUs float64
+	InternetMinJitterUs float64
+	InternetP50JitterUs float64
+	InternetP90JitterUs float64
+	InternetP95JitterUs float64
+	InternetP99JitterUs float64
+	InternetMaxJitterUs float64
+}
+
+// MetroPair is the per-pair entry in the listing. Direction is normalized:
+// Metro1Code < Metro2Code lexicographically (via least/greatest), matching the
+// existing dz_vs_internet_latency_comparison view.
+type MetroPair struct {
+	Metro1Code string
+	Metro1Name string
+	Metro2Code string
+	Metro2Name string
+	Buckets    []MetroPairLatencyBucket
+}
+
+// MetroPairLatencyResult is the response from FetchMetroPairLatency.
+type MetroPairLatencyResult struct {
+	TimeRange     string
+	BucketSeconds int
+	BucketCount   int
+	Pairs         []*MetroPair
+}
+
+// FetchMetroPairLatency returns time-bucketed DZ-vs-internet latency
+// comparison data for every metro pair with samples in the window.
+//
+// DZ side: re-aggregated from link_rollup_5m (≥5m bucket) or raw
+// fact_dz_device_link_latency (sub-5m). Percentiles are re-aggregated via
+// sample-weighted averaging of the per-5m rollup percentiles in the rollup
+// path — same approximation as the link-latency endpoint.
+//
+// Internet side: always queried from raw fact_dz_internet_metro_latency
+// (no rollup table exists for it).
+//
+// Pairs are normalized direction (one row per pair, least/greatest) matching
+// the existing dz_vs_internet_latency_comparison view.
+func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOptions) (*MetroPairLatencyResult, error) {
+	params, err := resolveMetroPairLatencyParams(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketSecs := params.BucketSeconds
+	if bucketSecs == 0 {
+		bucketSecs = params.BucketMinutes * 60
+	}
+
+	start := time.Now()
+	rows, query, args, err := queryMetroPairLatency(ctx, a.envDB(ctx), params, opts.Filter)
+	duration := time.Since(start)
+	metrics.RecordClickHouseQuery("metro_pair_latency", duration, err)
+	if err != nil {
+		return nil, fmt.Errorf("metro pair latency query: %w (query=%s args=%v)", err, query, args)
+	}
+	defer rows.Close()
+
+	type pairKey struct{ m1, m2 string }
+	pairs := make(map[pairKey]*MetroPair)
+	bucketsByPair := make(map[pairKey]map[time.Time]*MetroPairLatencyBucket)
+
+	for rows.Next() {
+		var (
+			metro1, metro2         string
+			metro1Name, metro2Name string
+			bucketTS               time.Time
+
+			dzSamples uint64
+			dzAvg     *float64
+			dzMin     *float64
+			dzP50     *float64
+			dzP90     *float64
+			dzP95     *float64
+			dzP99     *float64
+			dzMax     *float64
+			dzAvgJ    *float64
+			dzMinJ    *float64
+			dzP50J    *float64
+			dzP90J    *float64
+			dzP95J    *float64
+			dzP99J    *float64
+			dzMaxJ    *float64
+			dzLoss    *float64
+
+			inetSamples uint64
+			inetAvg     *float64
+			inetMin     *float64
+			inetP50     *float64
+			inetP90     *float64
+			inetP95     *float64
+			inetP99     *float64
+			inetMax     *float64
+			inetAvgJ    *float64
+			inetMinJ    *float64
+			inetP50J    *float64
+			inetP90J    *float64
+			inetP95J    *float64
+			inetP99J    *float64
+			inetMaxJ    *float64
+		)
+
+		if err := rows.Scan(
+			&metro1, &metro2, &metro1Name, &metro2Name, &bucketTS,
+			&dzSamples, &dzAvg, &dzMin, &dzP50, &dzP90, &dzP95, &dzP99, &dzMax,
+			&dzAvgJ, &dzMinJ, &dzP50J, &dzP90J, &dzP95J, &dzP99J, &dzMaxJ, &dzLoss,
+			&inetSamples, &inetAvg, &inetMin, &inetP50, &inetP90, &inetP95, &inetP99, &inetMax,
+			&inetAvgJ, &inetMinJ, &inetP50J, &inetP90J, &inetP95J, &inetP99J, &inetMaxJ,
+		); err != nil {
+			return nil, fmt.Errorf("metro pair latency scan: %w", err)
+		}
+
+		key := pairKey{metro1, metro2}
+		p, ok := pairs[key]
+		if !ok {
+			p = &MetroPair{
+				Metro1Code: metro1,
+				Metro1Name: metro1Name,
+				Metro2Code: metro2,
+				Metro2Name: metro2Name,
+			}
+			pairs[key] = p
+			bucketsByPair[key] = make(map[time.Time]*MetroPairLatencyBucket)
+		}
+		// Carry forward metro names if a later row has a populated name we missed.
+		if p.Metro1Name == "" && metro1Name != "" {
+			p.Metro1Name = metro1Name
+		}
+		if p.Metro2Name == "" && metro2Name != "" {
+			p.Metro2Name = metro2Name
+		}
+
+		b := &MetroPairLatencyBucket{
+			TS:        bucketTS.UTC(),
+			DZSamples: dzSamples, InternetSamples: inetSamples,
+		}
+		applyFloat(&b.DZAvgRttUs, dzAvg)
+		applyFloat(&b.DZMinRttUs, dzMin)
+		applyFloat(&b.DZP50RttUs, dzP50)
+		applyFloat(&b.DZP90RttUs, dzP90)
+		applyFloat(&b.DZP95RttUs, dzP95)
+		applyFloat(&b.DZP99RttUs, dzP99)
+		applyFloat(&b.DZMaxRttUs, dzMax)
+		applyFloat(&b.DZAvgJitterUs, dzAvgJ)
+		applyFloat(&b.DZMinJitterUs, dzMinJ)
+		applyFloat(&b.DZP50JitterUs, dzP50J)
+		applyFloat(&b.DZP90JitterUs, dzP90J)
+		applyFloat(&b.DZP95JitterUs, dzP95J)
+		applyFloat(&b.DZP99JitterUs, dzP99J)
+		applyFloat(&b.DZMaxJitterUs, dzMaxJ)
+		applyFloat(&b.DZLossPct, dzLoss)
+		applyFloat(&b.InternetAvgRttUs, inetAvg)
+		applyFloat(&b.InternetMinRttUs, inetMin)
+		applyFloat(&b.InternetP50RttUs, inetP50)
+		applyFloat(&b.InternetP90RttUs, inetP90)
+		applyFloat(&b.InternetP95RttUs, inetP95)
+		applyFloat(&b.InternetP99RttUs, inetP99)
+		applyFloat(&b.InternetMaxRttUs, inetMax)
+		applyFloat(&b.InternetAvgJitterUs, inetAvgJ)
+		applyFloat(&b.InternetMinJitterUs, inetMinJ)
+		applyFloat(&b.InternetP50JitterUs, inetP50J)
+		applyFloat(&b.InternetP90JitterUs, inetP90J)
+		applyFloat(&b.InternetP95JitterUs, inetP95J)
+		applyFloat(&b.InternetP99JitterUs, inetP99J)
+		applyFloat(&b.InternetMaxJitterUs, inetMaxJ)
+		bucketsByPair[key][bucketTS.UTC()] = b
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("metro pair latency rows: %w", err)
+	}
+
+	bucketDuration := time.Duration(bucketSecs) * time.Second
+	endRef := time.Now().UTC()
+	if params.EndTime != nil {
+		endRef = *params.EndTime
+	}
+
+	result := &MetroPairLatencyResult{
+		TimeRange:     params.TimeRange,
+		BucketSeconds: bucketSecs,
+		BucketCount:   params.BucketCount,
+		Pairs:         make([]*MetroPair, 0, len(pairs)),
+	}
+
+	for key, p := range pairs {
+		buckets := make([]MetroPairLatencyBucket, 0, params.BucketCount)
+		for i := params.BucketCount - 1; i >= 0; i-- {
+			var bucketStart time.Time
+			if params.StartTime != nil {
+				bucketStart = params.StartTime.Truncate(bucketDuration).Add(time.Duration(params.BucketCount-1-i) * bucketDuration)
+			} else {
+				bucketStart = endRef.Truncate(bucketDuration).Add(-time.Duration(i) * bucketDuration)
+			}
+			if existing, ok := bucketsByPair[key][bucketStart]; ok {
+				buckets = append(buckets, *existing)
+				continue
+			}
+			buckets = append(buckets, MetroPairLatencyBucket{TS: bucketStart})
+		}
+		p.Buckets = buckets
+		result.Pairs = append(result.Pairs, p)
+	}
+
+	sort.Slice(result.Pairs, func(i, j int) bool {
+		if result.Pairs[i].Metro1Code != result.Pairs[j].Metro1Code {
+			return result.Pairs[i].Metro1Code < result.Pairs[j].Metro1Code
+		}
+		return result.Pairs[i].Metro2Code < result.Pairs[j].Metro2Code
+	})
+
+	return result, nil
+}
+
+func applyFloat(dst *float64, src *float64) {
+	if src == nil {
+		return
+	}
+	v := *src
+	if v != v { // NaN
+		return
+	}
+	*dst = v
+}
+
+// resolveMetroPairLatencyParams mirrors resolveLinkLatencyParams.
+func resolveMetroPairLatencyParams(opts MetroPairLatencyOptions) (bucketParams, error) {
+	timeRange := opts.TimeRange
+	if timeRange == "" {
+		timeRange = "24h"
+	}
+
+	var params bucketParams
+	if opts.StartTime != nil && opts.EndTime != nil {
+		params = parseBucketParamsCustom(*opts.StartTime, *opts.EndTime, 24)
+	} else {
+		now := time.Now().UTC()
+		duration := presetToDuration(timeRange)
+		startTime := now.Add(-duration)
+		params = parseBucketParamsCustom(startTime, now, 24)
+		params.TimeRange = timeRange
+	}
+
+	if opts.Bucket != "" && opts.Bucket != "auto" {
+		interval, ok := parseBucketString(opts.Bucket)
+		if !ok {
+			return params, fmt.Errorf("invalid bucket %q", opts.Bucket)
+		}
+		secs := intervalToSeconds(interval)
+		var totalSecs int
+		if params.StartTime != nil && params.EndTime != nil {
+			totalSecs = int(params.EndTime.Sub(*params.StartTime).Seconds())
+		} else {
+			totalSecs = params.TotalMinutes * 60
+		}
+		count := totalSecs / secs
+		if count < 1 {
+			count = 1
+		}
+		params.BucketSeconds = secs
+		params.BucketMinutes = secs / 60
+		params.BucketInterval = interval
+		params.BucketCount = count
+		params.UseRaw = isRawBucket(interval)
+	}
+
+	return params, nil
+}
+
+// queryMetroPairLatency runs the combined DZ + Internet bucketed query and
+// returns the open rows iterator (caller must Close).
+func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketParams, filter MetroPairLatencyFilter) (driver.Rows, string, []any, error) {
+	dzBucketCol := "r.bucket_ts"
+	dzSource := "link_rollup_5m"
+	if params.UseRaw {
+		dzBucketCol = "f.event_ts"
+		dzSource = "fact_dz_device_link_latency"
+	}
+	dzBucketExpr := bucketIntervalExprFromParams(dzBucketCol, params)
+	inetBucketExpr := bucketIntervalExprFromParams("f.event_ts", params)
+
+	var (
+		startTime time.Time
+		endTime   time.Time
+	)
+	if params.StartTime != nil {
+		startTime = *params.StartTime
+	} else {
+		startTime = time.Now().UTC().Add(-time.Duration(params.TotalMinutes) * time.Minute)
+	}
+	if params.EndTime != nil {
+		endTime = *params.EndTime
+	} else {
+		endTime = time.Now().UTC()
+	}
+
+	args := []any{startTime, endTime}
+
+	metroFilterSQL := ""
+	if len(filter.MetroCodes) > 0 {
+		quoted := make([]string, 0, len(filter.MetroCodes))
+		for _, code := range filter.MetroCodes {
+			c := strings.TrimSpace(code)
+			if c == "" {
+				continue
+			}
+			quoted = append(quoted, fmt.Sprintf("'%s'", strings.ToLower(escapeSingleQuote(c))))
+		}
+		if len(quoted) > 0 {
+			inList := strings.Join(quoted, ",")
+			metroFilterSQL = fmt.Sprintf(" AND (lower(ma.code) IN (%s) OR lower(mz.code) IN (%s))", inList, inList)
+		}
+	}
+
+	inetProviderSQL := ""
+	if len(filter.DataProviders) > 0 {
+		quoted := make([]string, 0, len(filter.DataProviders))
+		for _, p := range filter.DataProviders {
+			c := strings.TrimSpace(p)
+			if c == "" {
+				continue
+			}
+			quoted = append(quoted, fmt.Sprintf("'%s'", strings.ToLower(escapeSingleQuote(c))))
+		}
+		if len(quoted) > 0 {
+			inetProviderSQL = fmt.Sprintf(" AND lower(f.data_provider) IN (%s)", strings.Join(quoted, ","))
+		}
+	}
+
+	var dzCTE string
+	if params.UseRaw {
+		// Raw fact-table path: aggregate samples directly per metro pair + bucket.
+		dzCTE = fmt.Sprintf(`
+		dz_data AS (
+			SELECT
+				least(ma.code, mz.code) AS metro1,
+				greatest(ma.code, mz.code) AS metro2,
+				if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
+				if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+				%s AS bucket_ts,
+				toUInt64(count()) AS samples,
+				avg(f.rtt_us) AS avg_rtt_us,
+				toFloat64(min(f.rtt_us)) AS min_rtt_us,
+				quantile(0.50)(f.rtt_us) AS p50_rtt_us,
+				quantile(0.90)(f.rtt_us) AS p90_rtt_us,
+				quantile(0.95)(f.rtt_us) AS p95_rtt_us,
+				quantile(0.99)(f.rtt_us) AS p99_rtt_us,
+				toFloat64(max(f.rtt_us)) AS max_rtt_us,
+				avg(abs(f.ipdv_us)) AS avg_jitter_us,
+				toFloat64(min(abs(f.ipdv_us))) AS min_jitter_us,
+				quantile(0.50)(abs(f.ipdv_us)) AS p50_jitter_us,
+				quantile(0.90)(abs(f.ipdv_us)) AS p90_jitter_us,
+				quantile(0.95)(abs(f.ipdv_us)) AS p95_jitter_us,
+				quantile(0.99)(abs(f.ipdv_us)) AS p99_jitter_us,
+				toFloat64(max(abs(f.ipdv_us))) AS max_jitter_us,
+				countIf(f.loss = true OR f.rtt_us = 0) * 100.0 / greatest(count(), 1) AS loss_pct
+			FROM %s f
+			JOIN dz_links_current l ON f.link_pk = l.pk
+			JOIN dz_devices_current da ON l.side_a_pk = da.pk
+			JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
+			JOIN dz_metros_current ma ON da.metro_pk = ma.pk
+			JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
+			WHERE f.event_ts >= $1 AND f.event_ts < $2
+			  AND f.link_pk != ''
+			  AND ma.code != mz.code%s
+			GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+		)`, dzBucketExpr, dzSource, metroFilterSQL)
+	} else {
+		// Rollup path: sample-weighted re-aggregation of percentiles.
+		dzCTE = fmt.Sprintf(`
+		dz_data AS (
+			SELECT
+				metro1, metro2, metro1_name, metro2_name, bucket_ts,
+				toUInt64(samples_total) AS samples,
+				if(samples_total > 0, w_avg / samples_total, NULL) AS avg_rtt_us,
+				if(samples_total > 0, min_rtt_us, NULL) AS min_rtt_us,
+				if(samples_total > 0, w_p50 / samples_total, NULL) AS p50_rtt_us,
+				if(samples_total > 0, w_p90 / samples_total, NULL) AS p90_rtt_us,
+				if(samples_total > 0, w_p95 / samples_total, NULL) AS p95_rtt_us,
+				if(samples_total > 0, w_p99 / samples_total, NULL) AS p99_rtt_us,
+				if(samples_total > 0, max_rtt_us, NULL) AS max_rtt_us,
+				if(samples_total > 0, jw_avg / samples_total, NULL) AS avg_jitter_us,
+				if(samples_total > 0, min_jitter_us, NULL) AS min_jitter_us,
+				if(samples_total > 0, jw_p50 / samples_total, NULL) AS p50_jitter_us,
+				if(samples_total > 0, jw_p90 / samples_total, NULL) AS p90_jitter_us,
+				if(samples_total > 0, jw_p95 / samples_total, NULL) AS p95_jitter_us,
+				if(samples_total > 0, jw_p99 / samples_total, NULL) AS p99_jitter_us,
+				if(samples_total > 0, max_jitter_us, NULL) AS max_jitter_us,
+				loss_pct
+			FROM (
+				SELECT
+					least(ma.code, mz.code) AS metro1,
+					greatest(ma.code, mz.code) AS metro2,
+					if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
+					if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+					%s AS bucket_ts,
+					sum(r.a_samples + r.z_samples) AS samples_total,
+					sumIf(r.a_avg_rtt_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_avg_rtt_us * r.z_samples, r.z_samples > 0) AS w_avg,
+					sumIf(r.a_p50_rtt_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p50_rtt_us * r.z_samples, r.z_samples > 0) AS w_p50,
+					sumIf(r.a_p90_rtt_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p90_rtt_us * r.z_samples, r.z_samples > 0) AS w_p90,
+					sumIf(r.a_p95_rtt_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p95_rtt_us * r.z_samples, r.z_samples > 0) AS w_p95,
+					sumIf(r.a_p99_rtt_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p99_rtt_us * r.z_samples, r.z_samples > 0) AS w_p99,
+					sumIf(r.a_avg_jitter_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_avg_jitter_us * r.z_samples, r.z_samples > 0) AS jw_avg,
+					sumIf(r.a_p50_jitter_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p50_jitter_us * r.z_samples, r.z_samples > 0) AS jw_p50,
+					sumIf(r.a_p90_jitter_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p90_jitter_us * r.z_samples, r.z_samples > 0) AS jw_p90,
+					sumIf(r.a_p95_jitter_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p95_jitter_us * r.z_samples, r.z_samples > 0) AS jw_p95,
+					sumIf(r.a_p99_jitter_us * r.a_samples, r.a_samples > 0)
+						+ sumIf(r.z_p99_jitter_us * r.z_samples, r.z_samples > 0) AS jw_p99,
+					toFloat64(least(minIf(r.a_min_rtt_us, r.a_samples > 0), minIf(r.z_min_rtt_us, r.z_samples > 0))) AS min_rtt_us,
+					toFloat64(greatest(maxIf(r.a_max_rtt_us, r.a_samples > 0), maxIf(r.z_max_rtt_us, r.z_samples > 0))) AS max_rtt_us,
+					toFloat64(least(minIf(r.a_min_jitter_us, r.a_samples > 0), minIf(r.z_min_jitter_us, r.z_samples > 0))) AS min_jitter_us,
+					toFloat64(greatest(maxIf(r.a_max_jitter_us, r.a_samples > 0), maxIf(r.z_max_jitter_us, r.z_samples > 0))) AS max_jitter_us,
+					max(greatest(r.a_loss_pct, r.z_loss_pct)) AS loss_pct
+				FROM link_rollup_5m r
+				JOIN dz_links_current l ON r.link_pk = l.pk
+				JOIN dz_devices_current da ON l.side_a_pk = da.pk
+				JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
+				JOIN dz_metros_current ma ON da.metro_pk = ma.pk
+				JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
+				WHERE r.bucket_ts >= $1 AND r.bucket_ts < $2
+				  AND r.link_pk != ''
+				  AND ma.code != mz.code%s
+				GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+			)
+		)`, dzBucketExpr, metroFilterSQL)
+	}
+
+	inetCTE := fmt.Sprintf(`
+		inet_data AS (
+			SELECT
+				least(ma.code, mz.code) AS metro1,
+				greatest(ma.code, mz.code) AS metro2,
+				if(ma.code < mz.code, ma.name, mz.name) AS metro1_name,
+				if(ma.code < mz.code, mz.name, ma.name) AS metro2_name,
+				%s AS bucket_ts,
+				toUInt64(count()) AS samples,
+				avg(f.rtt_us) AS avg_rtt_us,
+				toFloat64(min(f.rtt_us)) AS min_rtt_us,
+				quantile(0.50)(f.rtt_us) AS p50_rtt_us,
+				quantile(0.90)(f.rtt_us) AS p90_rtt_us,
+				quantile(0.95)(f.rtt_us) AS p95_rtt_us,
+				quantile(0.99)(f.rtt_us) AS p99_rtt_us,
+				toFloat64(max(f.rtt_us)) AS max_rtt_us,
+				avg(abs(f.ipdv_us)) AS avg_jitter_us,
+				toFloat64(min(abs(f.ipdv_us))) AS min_jitter_us,
+				quantile(0.50)(abs(f.ipdv_us)) AS p50_jitter_us,
+				quantile(0.90)(abs(f.ipdv_us)) AS p90_jitter_us,
+				quantile(0.95)(abs(f.ipdv_us)) AS p95_jitter_us,
+				quantile(0.99)(abs(f.ipdv_us)) AS p99_jitter_us,
+				toFloat64(max(abs(f.ipdv_us))) AS max_jitter_us
+			FROM fact_dz_internet_metro_latency f
+			JOIN dz_metros_current ma ON f.origin_metro_pk = ma.pk
+			JOIN dz_metros_current mz ON f.target_metro_pk = mz.pk
+			WHERE f.event_ts >= $1 AND f.event_ts < $2
+			  AND ma.code != mz.code%s%s
+			GROUP BY metro1, metro2, metro1_name, metro2_name, bucket_ts
+		)`, inetBucketExpr, metroFilterSQL, inetProviderSQL)
+
+	// FULL OUTER JOIN ... USING is required here. ClickHouse's multi-column
+	// ON-clause variant does not propagate the join-key column values from the
+	// unmatched side, so rows that only exist in one CTE come back with empty
+	// metro1/metro2/bucket_ts. USING merges the join keys into a single value
+	// per row, which is the behavior we want.
+	query := fmt.Sprintf(`
+		WITH%s,%s
+		SELECT
+			metro1, metro2,
+			COALESCE(d.metro1_name, i.metro1_name, '') AS metro1_name,
+			COALESCE(d.metro2_name, i.metro2_name, '') AS metro2_name,
+			bucket_ts,
+			COALESCE(d.samples, toUInt64(0)) AS dz_samples,
+			d.avg_rtt_us AS dz_avg_rtt_us,
+			d.min_rtt_us AS dz_min_rtt_us,
+			d.p50_rtt_us AS dz_p50_rtt_us,
+			d.p90_rtt_us AS dz_p90_rtt_us,
+			d.p95_rtt_us AS dz_p95_rtt_us,
+			d.p99_rtt_us AS dz_p99_rtt_us,
+			d.max_rtt_us AS dz_max_rtt_us,
+			d.avg_jitter_us AS dz_avg_jitter_us,
+			d.min_jitter_us AS dz_min_jitter_us,
+			d.p50_jitter_us AS dz_p50_jitter_us,
+			d.p90_jitter_us AS dz_p90_jitter_us,
+			d.p95_jitter_us AS dz_p95_jitter_us,
+			d.p99_jitter_us AS dz_p99_jitter_us,
+			d.max_jitter_us AS dz_max_jitter_us,
+			d.loss_pct AS dz_loss_pct,
+			COALESCE(i.samples, toUInt64(0)) AS inet_samples,
+			i.avg_rtt_us AS inet_avg_rtt_us,
+			i.min_rtt_us AS inet_min_rtt_us,
+			i.p50_rtt_us AS inet_p50_rtt_us,
+			i.p90_rtt_us AS inet_p90_rtt_us,
+			i.p95_rtt_us AS inet_p95_rtt_us,
+			i.p99_rtt_us AS inet_p99_rtt_us,
+			i.max_rtt_us AS inet_max_rtt_us,
+			i.avg_jitter_us AS inet_avg_jitter_us,
+			i.min_jitter_us AS inet_min_jitter_us,
+			i.p50_jitter_us AS inet_p50_jitter_us,
+			i.p90_jitter_us AS inet_p90_jitter_us,
+			i.p95_jitter_us AS inet_p95_jitter_us,
+			i.p99_jitter_us AS inet_p99_jitter_us,
+			i.max_jitter_us AS inet_max_jitter_us
+		FROM dz_data d
+		FULL OUTER JOIN inet_data i USING (metro1, metro2, bucket_ts)
+		ORDER BY metro1, metro2, bucket_ts
+	`, dzCTE, inetCTE)
+
+	rows, err := db.Query(ctx, query, args...)
+	return rows, query, args, err
+}

--- a/api/handlers/v1_dz_metro_pairs_latency_test.go
+++ b/api/handlers/v1_dz_metro_pairs_latency_test.go
@@ -1,0 +1,376 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1DZMetroPairLatencyContractFields locks down the public JSON shape.
+// Renaming or removing a field is a breaking change — bump the API version.
+var v1DZMetroPairLatencyContractFields = struct {
+	top    []string
+	pair   []string
+	bucket []string
+}{
+	top: []string{
+		"$schema",
+		"time_range",
+		"bucket_seconds",
+		"bucket_count",
+		"total_pairs",
+		"pair_limit",
+		"pair_offset",
+		"pairs",
+	},
+	pair: []string{
+		"metro1_code",
+		"metro1_name",
+		"metro2_code",
+		"metro2_name",
+		"buckets",
+	},
+	bucket: []string{
+		"ts",
+		"dz_samples", "dz_loss_pct",
+		"dz_avg_rtt_us", "dz_min_rtt_us", "dz_p50_rtt_us", "dz_p90_rtt_us", "dz_p95_rtt_us", "dz_p99_rtt_us", "dz_max_rtt_us",
+		"dz_avg_jitter_us", "dz_min_jitter_us", "dz_p50_jitter_us", "dz_p90_jitter_us", "dz_p95_jitter_us", "dz_p99_jitter_us", "dz_max_jitter_us",
+		"internet_samples",
+		"internet_avg_rtt_us", "internet_min_rtt_us", "internet_p50_rtt_us", "internet_p90_rtt_us", "internet_p95_rtt_us", "internet_p99_rtt_us", "internet_max_rtt_us",
+		"internet_avg_jitter_us", "internet_min_jitter_us", "internet_p50_jitter_us", "internet_p90_jitter_us", "internet_p95_jitter_us", "internet_p99_jitter_us", "internet_max_jitter_us",
+	},
+}
+
+// seedInternetMetroLatency inserts a single sample into fact_dz_internet_metro_latency.
+func seedInternetMetroLatency(t *testing.T, api *handlers.API, eventTS time.Time, originMetroPK, targetMetroPK, dataProvider string, rttUs, ipdvUs int64, sampleIndex int32) {
+	t.Helper()
+	err := api.DB.Exec(t.Context(), `INSERT INTO fact_dz_internet_metro_latency (
+		event_ts, ingested_at, epoch, sample_index,
+		origin_metro_pk, target_metro_pk, data_provider, rtt_us, ipdv_us
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		eventTS, time.Now(), int64(1), sampleIndex,
+		originMetroPK, targetMetroPK, dataProvider, rttUs, ipdvUs,
+	)
+	require.NoError(t, err)
+}
+
+// seedDzVsInternetFixture sets up two metro pairs (NYC↔LAX with DZ+internet,
+// NYC↔FRA with DZ-only). Returns the truncated "now" used for bucket alignment.
+func seedDzVsInternetFixture(t *testing.T, api *handlers.API) time.Time {
+	t.Helper()
+	seedMetro(t, api, "metro-nyc", "NYC")
+	seedMetro(t, api, "metro-lax", "LAX")
+	seedMetro(t, api, "metro-fra", "FRA")
+	seedContributor(t, api, "contrib-acme", "acme")
+	seedDeviceMetadata(t, api, "dev-nyc", "DEV-NYC", "router", "contrib-acme", "metro-nyc", 10, "activated")
+	seedDeviceMetadata(t, api, "dev-lax", "DEV-LAX", "router", "contrib-acme", "metro-lax", 10, "activated")
+	seedDeviceMetadata(t, api, "dev-fra", "DEV-FRA", "router", "contrib-acme", "metro-fra", 10, "activated")
+	seedLinkMetadata(t, api, "link-nyc-lax", "NYC-LAX-1", "WAN", "contrib-acme", "dev-nyc", "dev-lax", 10_000_000_000, 500_000, "activated")
+	seedLinkMetadata(t, api, "link-nyc-fra", "NYC-FRA-1", "WAN", "contrib-acme", "dev-nyc", "dev-fra", 10_000_000_000, 700_000, "activated")
+
+	now := time.Now().UTC().Truncate(time.Hour)
+
+	// DZ samples for both pairs in the most recent rollup bucket.
+	seedLinkRollup(t, api, now.Add(-time.Hour), "link-nyc-lax", 50_000, 51_000, 0.5, 0.25, 3600, 3600, "activated", false, false)
+	seedLinkRollup(t, api, now.Add(-time.Hour), "link-nyc-fra", 70_000, 71_000, 0, 0, 3600, 3600, "activated", false, false)
+
+	// Internet samples for NYC↔LAX only (so NYC↔FRA is DZ-only). Seed at the
+	// same wall-clock time as the DZ rollup so both align into a single 10m
+	// bucket. Multiple providers so we can test data_provider filtering.
+	for i := int32(0); i < 4; i++ {
+		seedInternetMetroLatency(t, api, now.Add(-time.Hour), "metro-nyc", "metro-lax", "ripe-atlas", 80_000, 1_500, i)
+	}
+	for i := int32(0); i < 4; i++ {
+		seedInternetMetroLatency(t, api, now.Add(-time.Hour), "metro-nyc", "metro-lax", "wheresitup", 90_000, 2_000, i+10)
+	}
+	return now
+}
+
+func TestV1DZMetroPairLatency_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1DZMetroPairLatencyContractFields.top, "response")
+
+	pairs, ok := raw["pairs"].([]any)
+	require.True(t, ok, "pairs must be a JSON array")
+	require.NotEmpty(t, pairs, "response should include pairs")
+	for i, p := range pairs {
+		obj, ok := p.(map[string]any)
+		require.True(t, ok, "pairs[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1DZMetroPairLatencyContractFields.pair, "pairs[i]")
+		buckets, ok := obj["buckets"].([]any)
+		require.True(t, ok, "pairs[%d].buckets must be a JSON array", i)
+		require.NotEmpty(t, buckets, "pairs[%d] should have at least one bucket", i)
+		for j, b := range buckets {
+			bobj, ok := b.(map[string]any)
+			require.True(t, ok, "pairs[%d].buckets[%d] must be a JSON object", i, j)
+			assertJSONKeys(t, bobj, v1DZMetroPairLatencyContractFields.bucket, "pairs[i].buckets[j]")
+		}
+	}
+}
+
+func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	// Two pairs in fixture: FRA-NYC (DZ-only), LAX-NYC (DZ+internet).
+	// Sorted by (metro1_code, metro2_code) — normalized so FRA<NYC, LAX<NYC.
+	assert.Equal(t, 2, resp.TotalPairs)
+	require.Len(t, resp.Pairs, 2)
+	assert.Equal(t, "FRA", resp.Pairs[0].Metro1Code)
+	assert.Equal(t, "NYC", resp.Pairs[0].Metro2Code)
+	assert.Equal(t, "LAX", resp.Pairs[1].Metro1Code)
+	assert.Equal(t, "NYC", resp.Pairs[1].Metro2Code)
+
+	// LAX-NYC should have both DZ and internet samples in some bucket.
+	laxNyc := resp.Pairs[1]
+	var withBoth *v1.DZMetroPairLatencyBucket
+	for i := range laxNyc.Buckets {
+		if laxNyc.Buckets[i].DZSamples > 0 && laxNyc.Buckets[i].InternetSamples > 0 {
+			withBoth = &laxNyc.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, withBoth, "expected a bucket with both DZ and internet samples")
+	// 3600 a_samples + 3600 z_samples on link-nyc-lax.
+	assert.Equal(t, uint64(7200), withBoth.DZSamples)
+	// 4 ripe-atlas + 4 wheresitup.
+	assert.Equal(t, uint64(8), withBoth.InternetSamples)
+	// Sample-weighted average across both directions: (50000*3600 + 51000*3600)/7200 = 50500.
+	assert.InDelta(t, 50_500.0, withBoth.DZAvgRttUs, 1.0)
+	// Internet RTT is a mix of 80_000 and 90_000 with equal weight → 85_000 avg.
+	assert.InDelta(t, 85_000.0, withBoth.InternetAvgRttUs, 1.0)
+
+	// FRA-NYC is DZ-only: at least one bucket has DZ samples but no internet.
+	fraNyc := resp.Pairs[0]
+	var dzOnly *v1.DZMetroPairLatencyBucket
+	for i := range fraNyc.Buckets {
+		if fraNyc.Buckets[i].DZSamples > 0 {
+			dzOnly = &fraNyc.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, dzOnly, "expected a DZ-populated bucket on FRA-NYC")
+	assert.Equal(t, uint64(0), dzOnly.InternetSamples)
+}
+
+func TestV1DZMetroPairLatency_FilterByMetro(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	// FRA should only match the NYC↔FRA pair.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?metro_code=FRA", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Pairs, 1)
+	assert.Equal(t, "FRA", resp.Pairs[0].Metro1Code)
+	assert.Equal(t, "NYC", resp.Pairs[0].Metro2Code)
+}
+
+func TestV1DZMetroPairLatency_FilterMultipleMetros(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?metro_code=LAX&metro_code=FRA", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Len(t, resp.Pairs, 2)
+}
+
+func TestV1DZMetroPairLatency_FilterByDataProvider(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	// data_provider only narrows the internet side. DZ-only pairs (NYC↔FRA)
+	// should still appear because the DZ side is unaffected.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?data_provider=ripe-atlas", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, 2, resp.TotalPairs)
+
+	// LAX-NYC should now only have 4 ripe-atlas internet samples (not the
+	// 4 wheresitup ones). Internet avg = 80_000 us.
+	var laxNyc *v1.DZMetroPairLatency
+	for i := range resp.Pairs {
+		if resp.Pairs[i].Metro1Code == "LAX" && resp.Pairs[i].Metro2Code == "NYC" {
+			laxNyc = &resp.Pairs[i]
+			break
+		}
+	}
+	require.NotNil(t, laxNyc)
+	var inetBucket *v1.DZMetroPairLatencyBucket
+	for i := range laxNyc.Buckets {
+		if laxNyc.Buckets[i].InternetSamples > 0 {
+			inetBucket = &laxNyc.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, inetBucket)
+	assert.Equal(t, uint64(4), inetBucket.InternetSamples)
+	assert.InDelta(t, 80_000.0, inetBucket.InternetAvgRttUs, 1.0)
+}
+
+func TestV1DZMetroPairLatency_FilterNoMatches(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?metro_code=does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.TotalPairs)
+	assert.Empty(t, resp.Pairs)
+}
+
+func TestV1DZMetroPairLatency_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	seedDzVsInternetFixture(t, api)
+
+	r := newV1Router(t, api)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?pair_limit=1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.DZMetroPairLatencyResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.TotalPairs)
+	require.Len(t, resp.Pairs, 1)
+	first := resp.Pairs[0].Metro1Code + "-" + resp.Pairs[0].Metro2Code
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?pair_limit=1&pair_offset=1", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Pairs, 1)
+	second := resp.Pairs[0].Metro1Code + "-" + resp.Pairs[0].Metro2Code
+	assert.NotEqual(t, first, second)
+
+	// Offset past total: empty page, total unchanged.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?pair_offset=10", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.TotalPairs)
+	assert.Empty(t, resp.Pairs)
+}
+
+func TestV1DZMetroPairLatency_InvalidParams(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+
+	for _, url := range []string{
+		"/api/v1/dz/metro-pairs/latency?range=99h",
+		"/api/v1/dz/metro-pairs/latency?bucket=2s",
+		"/api/v1/dz/metro-pairs/latency?start_time=-1",
+		"/api/v1/dz/metro-pairs/latency?pair_limit=0",
+		"/api/v1/dz/metro-pairs/latency?pair_limit=9999",
+		"/api/v1/dz/metro-pairs/latency?pair_offset=-1",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+}
+
+func TestV1DZMetroPairLatency_RawBucketWindowCap(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+
+	for _, url := range []string{
+		"/api/v1/dz/metro-pairs/latency?bucket=10s&range=24h",
+		"/api/v1/dz/metro-pairs/latency?bucket=30s&range=24h",
+		"/api/v1/dz/metro-pairs/latency?bucket=1m&range=24h",
+		"/api/v1/dz/metro-pairs/latency?bucket=10s&start_time=1000000000&end_time=1000021600",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+
+	// Within-cap raw windows are accepted (empty result is fine).
+	for _, url := range []string{
+		"/api/v1/dz/metro-pairs/latency?bucket=10s&range=1h",
+		"/api/v1/dz/metro-pairs/latency?bucket=30s&range=3h",
+		"/api/v1/dz/metro-pairs/latency?bucket=1m&range=6h",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code, "url=%s body=%s", url, rr.Body.String())
+	}
+}
+
+func TestV1DZMetroPairLatency_InvertedCustomWindow(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?start_time=2000&end_time=1000", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rr.Code, "body: %s", rr.Body.String())
+}

--- a/api/handlers/v1_dz_metro_pairs_latency_test.go
+++ b/api/handlers/v1_dz_metro_pairs_latency_test.go
@@ -33,10 +33,10 @@ var v1DZMetroPairLatencyContractFields = struct {
 		"pairs",
 	},
 	pair: []string{
-		"metro1_code",
-		"metro1_name",
-		"metro2_code",
-		"metro2_name",
+		"metro_a_code",
+		"metro_a_name",
+		"metro_b_code",
+		"metro_b_name",
 		"buckets",
 	},
 	bucket: []string{
@@ -144,13 +144,13 @@ func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 
 	// Two pairs in fixture: FRA-NYC (DZ-only), LAX-NYC (DZ+internet).
-	// Sorted by (metro1_code, metro2_code) — normalized so FRA<NYC, LAX<NYC.
+	// Sorted by (metro_a_code, metro_b_code) — normalized so FRA<NYC, LAX<NYC.
 	assert.Equal(t, 2, resp.TotalPairs)
 	require.Len(t, resp.Pairs, 2)
-	assert.Equal(t, "FRA", resp.Pairs[0].Metro1Code)
-	assert.Equal(t, "NYC", resp.Pairs[0].Metro2Code)
-	assert.Equal(t, "LAX", resp.Pairs[1].Metro1Code)
-	assert.Equal(t, "NYC", resp.Pairs[1].Metro2Code)
+	assert.Equal(t, "FRA", resp.Pairs[0].MetroACode)
+	assert.Equal(t, "NYC", resp.Pairs[0].MetroBCode)
+	assert.Equal(t, "LAX", resp.Pairs[1].MetroACode)
+	assert.Equal(t, "NYC", resp.Pairs[1].MetroBCode)
 
 	// LAX-NYC should have both DZ and internet samples in some bucket.
 	laxNyc := resp.Pairs[1]
@@ -199,8 +199,8 @@ func TestV1DZMetroPairLatency_FilterByMetro(t *testing.T) {
 	var resp v1.DZMetroPairLatencyResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Pairs, 1)
-	assert.Equal(t, "FRA", resp.Pairs[0].Metro1Code)
-	assert.Equal(t, "NYC", resp.Pairs[0].Metro2Code)
+	assert.Equal(t, "FRA", resp.Pairs[0].MetroACode)
+	assert.Equal(t, "NYC", resp.Pairs[0].MetroBCode)
 }
 
 func TestV1DZMetroPairLatency_FilterMultipleMetros(t *testing.T) {
@@ -240,7 +240,7 @@ func TestV1DZMetroPairLatency_FilterByDataProvider(t *testing.T) {
 	// 4 wheresitup ones). Internet avg = 80_000 us.
 	var laxNyc *v1.DZMetroPairLatency
 	for i := range resp.Pairs {
-		if resp.Pairs[i].Metro1Code == "LAX" && resp.Pairs[i].Metro2Code == "NYC" {
+		if resp.Pairs[i].MetroACode == "LAX" && resp.Pairs[i].MetroBCode == "NYC" {
 			laxNyc = &resp.Pairs[i]
 			break
 		}
@@ -291,7 +291,7 @@ func TestV1DZMetroPairLatency_Pagination(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, 2, resp.TotalPairs)
 	require.Len(t, resp.Pairs, 1)
-	first := resp.Pairs[0].Metro1Code + "-" + resp.Pairs[0].Metro2Code
+	first := resp.Pairs[0].MetroACode + "-" + resp.Pairs[0].MetroBCode
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/dz/metro-pairs/latency?pair_limit=1&pair_offset=1", nil)
 	rr = httptest.NewRecorder()
@@ -299,7 +299,7 @@ func TestV1DZMetroPairLatency_Pagination(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Pairs, 1)
-	second := resp.Pairs[0].Metro1Code + "-" + resp.Pairs[0].Metro2Code
+	second := resp.Pairs[0].MetroACode + "-" + resp.Pairs[0].MetroBCode
 	assert.NotEqual(t, first, second)
 
 	// Offset past total: empty page, total unchanged.

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -99,6 +99,7 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 		registerEdgeShredsSubscribers(humaAPI, api)
 		registerValidatorsMetadata(humaAPI, api)
 		registerDZLinksLatency(humaAPI, api)
+		registerDZMetroPairsLatency(humaAPI, api)
 
 		// Register 308 redirects from deprecated paths to their current
 		// canonical paths. These keep existing consumers working while the

--- a/api/v1/dz_metro_pairs_latency.go
+++ b/api/v1/dz_metro_pairs_latency.go
@@ -1,0 +1,213 @@
+package v1
+
+import (
+	"context"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// DZMetroPairLatencyBucket is a single time-bucketed comparison row for one
+// normalized metro pair. Zero values on a side indicate that side had no
+// samples in the bucket.
+type DZMetroPairLatencyBucket struct {
+	TS string `json:"ts" doc:"RFC3339 bucket start timestamp (UTC)" example:"2026-05-13T00:00:00Z"`
+
+	DZSamples     uint64  `json:"dz_samples" doc:"DZ probe samples in the bucket (sum across both link directions)"`
+	DZAvgRttUs    float64 `json:"dz_avg_rtt_us" doc:"DZ average RTT, microseconds"`
+	DZMinRttUs    float64 `json:"dz_min_rtt_us" doc:"DZ min RTT, microseconds"`
+	DZP50RttUs    float64 `json:"dz_p50_rtt_us" doc:"DZ p50 RTT, microseconds"`
+	DZP90RttUs    float64 `json:"dz_p90_rtt_us" doc:"DZ p90 RTT, microseconds"`
+	DZP95RttUs    float64 `json:"dz_p95_rtt_us" doc:"DZ p95 RTT, microseconds"`
+	DZP99RttUs    float64 `json:"dz_p99_rtt_us" doc:"DZ p99 RTT, microseconds"`
+	DZMaxRttUs    float64 `json:"dz_max_rtt_us" doc:"DZ max RTT, microseconds"`
+	DZAvgJitterUs float64 `json:"dz_avg_jitter_us" doc:"DZ average jitter, microseconds"`
+	DZMinJitterUs float64 `json:"dz_min_jitter_us" doc:"DZ min jitter, microseconds"`
+	DZP50JitterUs float64 `json:"dz_p50_jitter_us" doc:"DZ p50 jitter, microseconds"`
+	DZP90JitterUs float64 `json:"dz_p90_jitter_us" doc:"DZ p90 jitter, microseconds"`
+	DZP95JitterUs float64 `json:"dz_p95_jitter_us" doc:"DZ p95 jitter, microseconds"`
+	DZP99JitterUs float64 `json:"dz_p99_jitter_us" doc:"DZ p99 jitter, microseconds"`
+	DZMaxJitterUs float64 `json:"dz_max_jitter_us" doc:"DZ max jitter, microseconds"`
+	DZLossPct     float64 `json:"dz_loss_pct" doc:"DZ packet loss percent"`
+
+	InternetSamples     uint64  `json:"internet_samples" doc:"Internet probe samples in the bucket"`
+	InternetAvgRttUs    float64 `json:"internet_avg_rtt_us" doc:"Internet average RTT, microseconds"`
+	InternetMinRttUs    float64 `json:"internet_min_rtt_us" doc:"Internet min RTT, microseconds"`
+	InternetP50RttUs    float64 `json:"internet_p50_rtt_us" doc:"Internet p50 RTT, microseconds"`
+	InternetP90RttUs    float64 `json:"internet_p90_rtt_us" doc:"Internet p90 RTT, microseconds"`
+	InternetP95RttUs    float64 `json:"internet_p95_rtt_us" doc:"Internet p95 RTT, microseconds"`
+	InternetP99RttUs    float64 `json:"internet_p99_rtt_us" doc:"Internet p99 RTT, microseconds"`
+	InternetMaxRttUs    float64 `json:"internet_max_rtt_us" doc:"Internet max RTT, microseconds"`
+	InternetAvgJitterUs float64 `json:"internet_avg_jitter_us" doc:"Internet average jitter, microseconds"`
+	InternetMinJitterUs float64 `json:"internet_min_jitter_us" doc:"Internet min jitter, microseconds"`
+	InternetP50JitterUs float64 `json:"internet_p50_jitter_us" doc:"Internet p50 jitter, microseconds"`
+	InternetP90JitterUs float64 `json:"internet_p90_jitter_us" doc:"Internet p90 jitter, microseconds"`
+	InternetP95JitterUs float64 `json:"internet_p95_jitter_us" doc:"Internet p95 jitter, microseconds"`
+	InternetP99JitterUs float64 `json:"internet_p99_jitter_us" doc:"Internet p99 jitter, microseconds"`
+	InternetMaxJitterUs float64 `json:"internet_max_jitter_us" doc:"Internet max jitter, microseconds"`
+}
+
+// DZMetroPairLatency is the per-pair entry in the listing response. Direction
+// is normalized so each pair appears once: metro1_code < metro2_code
+// lexicographically (least/greatest), matching the existing
+// dz_vs_internet_latency_comparison view.
+type DZMetroPairLatency struct {
+	Metro1Code string                     `json:"metro1_code" doc:"Lower-codepoint metro code in the normalized pair"`
+	Metro1Name string                     `json:"metro1_name" doc:"Display name for metro1"`
+	Metro2Code string                     `json:"metro2_code" doc:"Higher-codepoint metro code in the normalized pair"`
+	Metro2Name string                     `json:"metro2_name" doc:"Display name for metro2"`
+	Buckets    []DZMetroPairLatencyBucket `json:"buckets" doc:"Time-ordered buckets (oldest first)"`
+}
+
+// DZMetroPairLatencyResponse is the body returned by the metro-pair latency endpoint.
+type DZMetroPairLatencyResponse struct {
+	TimeRange     string               `json:"time_range" doc:"Resolved time range preset, when not using an explicit window"`
+	BucketSeconds int                  `json:"bucket_seconds" doc:"Bucket width in seconds"`
+	BucketCount   int                  `json:"bucket_count" doc:"Number of buckets per pair"`
+	TotalPairs    int                  `json:"total_pairs" doc:"Total metro pairs matching the filter (before pagination)"`
+	PairLimit     int                  `json:"pair_limit" doc:"Maximum pairs returned per page"`
+	PairOffset    int                  `json:"pair_offset" doc:"Offset into the filtered pair set"`
+	Pairs         []DZMetroPairLatency `json:"pairs" doc:"Metro pairs sorted by (metro1_code, metro2_code)"`
+}
+
+// DZMetroPairLatencyInput is the request for the metro-pair latency endpoint.
+// Multi-value filters accept repeated query params, e.g.
+// `?metro_code=NYC&metro_code=LAX`. Within a filter, values are OR'd; across
+// filters, AND'd. The metro filter matches either side of a pair; the
+// data_provider filter only narrows internet-side samples.
+type DZMetroPairLatencyInput struct {
+	MetroCode    []string `query:"metro_code,explode" doc:"Filter to metro pairs touching any of these metro codes (case-insensitive exact). Matches either side."`
+	DataProvider []string `query:"data_provider,explode" doc:"Filter internet-side samples by data provider (e.g. ripe-atlas, wheresitup). DZ-side is unaffected."`
+	Range        string   `query:"range" enum:"1h,3h,6h,12h,24h,3d,7d,14d,30d" default:"24h" doc:"Time range preset. Ignored if start_time and end_time are both set."`
+	StartTime    int64    `query:"start_time" minimum:"0" default:"0" doc:"Custom window start (unix seconds). If set together with end_time, overrides range."`
+	EndTime      int64    `query:"end_time" minimum:"0" default:"0" doc:"Custom window end (unix seconds)."`
+	Bucket       string   `query:"bucket" enum:"auto,10s,30s,1m,5m,10m,15m,30m,1h,4h,12h,1d" default:"auto" doc:"Bucket size. 'auto' picks granularity based on the window. Sub-5-minute buckets are capped to short windows."`
+	PairLimit    int      `query:"pair_limit" minimum:"1" maximum:"500" default:"100" doc:"Maximum pairs returned per page. Each pair includes the full bucket window."`
+	PairOffset   int      `query:"pair_offset" minimum:"0" default:"0" doc:"Offset into the filtered, sorted pair set."`
+}
+
+// DZMetroPairLatencyOutput wraps the response body for huma.
+type DZMetroPairLatencyOutput struct {
+	Body DZMetroPairLatencyResponse
+}
+
+func registerDZMetroPairsLatency(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-dz-metro-pairs-latency",
+		Method:      "GET",
+		Path:        "/dz/metro-pairs/latency",
+		Summary:     "List DZ vs public-internet latency time-series for metro pairs",
+		Description: "Returns per-bucket DZ and internet RTT/jitter percentiles and sample counts for each metro pair with samples in the window. Direction is normalized (one row per pair, least/greatest by metro code). Use the filter query params to narrow to specific metros or internet data providers — within a filter values are OR'd; across filters AND'd. The metro filter matches either side of the pair; data_provider only affects the internet side.",
+		Tags:        []string{"DZ/Metro Pairs"},
+	}, func(ctx context.Context, input *DZMetroPairLatencyInput) (*DZMetroPairLatencyOutput, error) {
+		opts := handlers.MetroPairLatencyOptions{
+			TimeRange: input.Range,
+			Bucket:    input.Bucket,
+			Filter: handlers.MetroPairLatencyFilter{
+				MetroCodes:    input.MetroCode,
+				DataProviders: input.DataProvider,
+			},
+		}
+
+		var windowDur time.Duration
+		if input.StartTime > 0 && input.EndTime > 0 {
+			st := time.Unix(input.StartTime, 0).UTC()
+			et := time.Unix(input.EndTime, 0).UTC()
+			if !et.After(st) {
+				return nil, huma.Error422UnprocessableEntity("end_time must be after start_time")
+			}
+			opts.StartTime = &st
+			opts.EndTime = &et
+			windowDur = et.Sub(st)
+		} else {
+			windowDur = rangePresetToDuration(input.Range)
+		}
+
+		if err := validateRawBucketWindow(input.Bucket, windowDur); err != nil {
+			return nil, huma.Error422UnprocessableEntity(err.Error())
+		}
+
+		result, err := api.FetchMetroPairLatency(ctx, opts)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch metro pair latency", err)
+		}
+
+		total := len(result.Pairs)
+		start := input.PairOffset
+		if start > total {
+			start = total
+		}
+		end := start + input.PairLimit
+		if end > total {
+			end = total
+		}
+		page := result.Pairs[start:end]
+
+		pairs := make([]DZMetroPairLatency, len(page))
+		for i, p := range page {
+			pairs[i] = toDZMetroPairLatency(p)
+		}
+
+		return &DZMetroPairLatencyOutput{Body: DZMetroPairLatencyResponse{
+			TimeRange:     result.TimeRange,
+			BucketSeconds: result.BucketSeconds,
+			BucketCount:   result.BucketCount,
+			TotalPairs:    total,
+			PairLimit:     input.PairLimit,
+			PairOffset:    input.PairOffset,
+			Pairs:         pairs,
+		}}, nil
+	})
+}
+
+func toDZMetroPairLatency(p *handlers.MetroPair) DZMetroPairLatency {
+	buckets := make([]DZMetroPairLatencyBucket, len(p.Buckets))
+	for i, b := range p.Buckets {
+		buckets[i] = DZMetroPairLatencyBucket{
+			TS: b.TS.Format(time.RFC3339),
+
+			DZSamples:     b.DZSamples,
+			DZAvgRttUs:    b.DZAvgRttUs,
+			DZMinRttUs:    b.DZMinRttUs,
+			DZP50RttUs:    b.DZP50RttUs,
+			DZP90RttUs:    b.DZP90RttUs,
+			DZP95RttUs:    b.DZP95RttUs,
+			DZP99RttUs:    b.DZP99RttUs,
+			DZMaxRttUs:    b.DZMaxRttUs,
+			DZAvgJitterUs: b.DZAvgJitterUs,
+			DZMinJitterUs: b.DZMinJitterUs,
+			DZP50JitterUs: b.DZP50JitterUs,
+			DZP90JitterUs: b.DZP90JitterUs,
+			DZP95JitterUs: b.DZP95JitterUs,
+			DZP99JitterUs: b.DZP99JitterUs,
+			DZMaxJitterUs: b.DZMaxJitterUs,
+			DZLossPct:     b.DZLossPct,
+
+			InternetSamples:     b.InternetSamples,
+			InternetAvgRttUs:    b.InternetAvgRttUs,
+			InternetMinRttUs:    b.InternetMinRttUs,
+			InternetP50RttUs:    b.InternetP50RttUs,
+			InternetP90RttUs:    b.InternetP90RttUs,
+			InternetP95RttUs:    b.InternetP95RttUs,
+			InternetP99RttUs:    b.InternetP99RttUs,
+			InternetMaxRttUs:    b.InternetMaxRttUs,
+			InternetAvgJitterUs: b.InternetAvgJitterUs,
+			InternetMinJitterUs: b.InternetMinJitterUs,
+			InternetP50JitterUs: b.InternetP50JitterUs,
+			InternetP90JitterUs: b.InternetP90JitterUs,
+			InternetP95JitterUs: b.InternetP95JitterUs,
+			InternetP99JitterUs: b.InternetP99JitterUs,
+			InternetMaxJitterUs: b.InternetMaxJitterUs,
+		}
+	}
+
+	return DZMetroPairLatency{
+		Metro1Code: p.Metro1Code,
+		Metro1Name: p.Metro1Name,
+		Metro2Code: p.Metro2Code,
+		Metro2Name: p.Metro2Name,
+		Buckets:    buckets,
+	}
+}

--- a/api/v1/dz_metro_pairs_latency.go
+++ b/api/v1/dz_metro_pairs_latency.go
@@ -50,14 +50,14 @@ type DZMetroPairLatencyBucket struct {
 }
 
 // DZMetroPairLatency is the per-pair entry in the listing response. Direction
-// is normalized so each pair appears once: metro1_code < metro2_code
-// lexicographically (least/greatest), matching the existing
-// dz_vs_internet_latency_comparison view.
+// is normalized so each pair appears once: metro_a_code < metro_b_code
+// lexicographically (least/greatest). A/B are labels, not directions — the
+// underlying samples are bidirectional.
 type DZMetroPairLatency struct {
-	Metro1Code string                     `json:"metro1_code" doc:"Lower-codepoint metro code in the normalized pair"`
-	Metro1Name string                     `json:"metro1_name" doc:"Display name for metro1"`
-	Metro2Code string                     `json:"metro2_code" doc:"Higher-codepoint metro code in the normalized pair"`
-	Metro2Name string                     `json:"metro2_name" doc:"Display name for metro2"`
+	MetroACode string                     `json:"metro_a_code" doc:"Lower-codepoint metro code in the normalized pair"`
+	MetroAName string                     `json:"metro_a_name" doc:"Display name for metro_a"`
+	MetroBCode string                     `json:"metro_b_code" doc:"Higher-codepoint metro code in the normalized pair"`
+	MetroBName string                     `json:"metro_b_name" doc:"Display name for metro_b"`
 	Buckets    []DZMetroPairLatencyBucket `json:"buckets" doc:"Time-ordered buckets (oldest first)"`
 }
 
@@ -99,7 +99,7 @@ func registerDZMetroPairsLatency(humaAPI huma.API, api *handlers.API) {
 		Method:      "GET",
 		Path:        "/dz/metro-pairs/latency",
 		Summary:     "List DZ vs public-internet latency time-series for metro pairs",
-		Description: "Returns per-bucket DZ and internet RTT/jitter percentiles and sample counts for each metro pair with samples in the window. Direction is normalized (one row per pair, least/greatest by metro code). Use the filter query params to narrow to specific metros or internet data providers — within a filter values are OR'd; across filters AND'd. The metro filter matches either side of the pair; data_provider only affects the internet side.",
+		Description: "Returns per-bucket DZ and internet RTT/jitter percentiles and sample counts for each metro pair with samples in the window. Direction is normalized (one row per pair, sorted lexicographically so metro_a_code < metro_b_code; A/B are labels, not directions). Use the filter query params to narrow to specific metros or internet data providers — within a filter values are OR'd; across filters AND'd. The metro filter matches either side of the pair; data_provider only affects the internet side.",
 		Tags:        []string{"DZ/Metro Pairs"},
 	}, func(ctx context.Context, input *DZMetroPairLatencyInput) (*DZMetroPairLatencyOutput, error) {
 		opts := handlers.MetroPairLatencyOptions{
@@ -204,10 +204,10 @@ func toDZMetroPairLatency(p *handlers.MetroPair) DZMetroPairLatency {
 	}
 
 	return DZMetroPairLatency{
-		Metro1Code: p.Metro1Code,
-		Metro1Name: p.Metro1Name,
-		Metro2Code: p.Metro2Code,
-		Metro2Name: p.Metro2Name,
+		MetroACode: p.MetroACode,
+		MetroAName: p.MetroAName,
+		MetroBCode: p.MetroBCode,
+		MetroBName: p.MetroBName,
 		Buckets:    buckets,
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/dz/metro-pairs/latency` returning per-bucket DZ and public-internet RTT percentiles, jitter percentiles, and sample counts for each normalized metro pair.
- Direction is normalized (one row per pair, `metro1 < metro2` via least/greatest) to match the existing `dz_vs_internet_latency_comparison` view.
- Filters: repeatable `metro_code` (matches either side of the pair) and `data_provider` (narrows internet-side samples only; DZ side is unaffected).
- Same `range`/`start_time`/`end_time`/`bucket` controls and sub-5-minute raw-window cap as the link-latency endpoint, plus paginated (`pair_limit`/`pair_offset`, max 500/page).
- DZ side re-aggregates from `link_rollup_5m` (≥5m bucket) or `fact_dz_device_link_latency` (sub-5m); internet side always queries `fact_dz_internet_metro_latency` raw since no rollup exists for it.

## Testing Verification

- [x] Contract test: response top-level keys, per-pair keys, per-bucket keys
- [x] Each filter exercised individually (`metro_code`, `data_provider`)
- [x] Multi-value within a filter (`?metro_code=LAX&metro_code=FRA`)
- [x] DZ-only pair (no internet samples) still appears with `internet_samples=0`
- [x] `data_provider` narrows internet samples but leaves DZ-only pairs intact
- [x] Empty-filter and zero-match cases
- [x] Pagination including offset past total
- [x] Raw-bucket window cap (accepts within-limit, rejects out-of-bounds with 422)
- [x] Inverted custom window (`end_time <= start_time`) rejected with 422
- [x] FULL OUTER JOIN keys preserved on unmatched-side rows — diagnostic surfaced a ClickHouse quirk where `ON d.x = i.x AND ...` silently drops join-key values from the unmatched side; `USING` is correct