### PR TITLE
api/v1: filter metro-pair latency to DZ-covered pairs, add improvement fields

### DIFF
--- a/api/handlers/metro_pair_latency.go
+++ b/api/handlers/metro_pair_latency.go
@@ -69,6 +69,12 @@ type MetroPairLatencyBucket struct {
 	InternetP95JitterUs float64
 	InternetP99JitterUs float64
 	InternetMaxJitterUs float64
+
+	// Improvement vs internet, computed per-bucket from the avg values.
+	// Positive = DZ is faster; 0 when either side has no samples or the
+	// internet avg is zero (indeterminate).
+	AvgRttImprovementPct    float64
+	AvgJitterImprovementPct float64
 }
 
 // MetroPair is the per-pair entry in the listing. Direction is normalized:
@@ -165,6 +171,9 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 			inetP95J    *float64
 			inetP99J    *float64
 			inetMaxJ    *float64
+
+			rttImprovement    *float64
+			jitterImprovement *float64
 		)
 
 		if err := rows.Scan(
@@ -173,6 +182,7 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 			&dzAvgJ, &dzMinJ, &dzP50J, &dzP90J, &dzP95J, &dzP99J, &dzMaxJ, &dzLoss,
 			&inetSamples, &inetAvg, &inetMin, &inetP50, &inetP90, &inetP95, &inetP99, &inetMax,
 			&inetAvgJ, &inetMinJ, &inetP50J, &inetP90J, &inetP95J, &inetP99J, &inetMaxJ,
+			&rttImprovement, &jitterImprovement,
 		); err != nil {
 			return nil, fmt.Errorf("metro pair latency scan: %w", err)
 		}
@@ -230,6 +240,8 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 		applyFloat(&b.InternetP95JitterUs, inetP95J)
 		applyFloat(&b.InternetP99JitterUs, inetP99J)
 		applyFloat(&b.InternetMaxJitterUs, inetMaxJ)
+		applyFloat(&b.AvgRttImprovementPct, rttImprovement)
+		applyFloat(&b.AvgJitterImprovementPct, jitterImprovement)
 		bucketsByPair[key][bucketTS.UTC()] = b
 	}
 	if err := rows.Err(); err != nil {
@@ -573,9 +585,18 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 			i.p90_jitter_us AS inet_p90_jitter_us,
 			i.p95_jitter_us AS inet_p95_jitter_us,
 			i.p99_jitter_us AS inet_p99_jitter_us,
-			i.max_jitter_us AS inet_max_jitter_us
+			i.max_jitter_us AS inet_max_jitter_us,
+			if(d.avg_rtt_us > 0 AND i.avg_rtt_us > 0,
+				(i.avg_rtt_us - d.avg_rtt_us) / i.avg_rtt_us * 100,
+				NULL) AS avg_rtt_improvement_pct,
+			if(d.avg_jitter_us > 0 AND i.avg_jitter_us > 0,
+				(i.avg_jitter_us - d.avg_jitter_us) / i.avg_jitter_us * 100,
+				NULL) AS avg_jitter_improvement_pct
 		FROM dz_data d
 		FULL OUTER JOIN inet_data i USING (metro_a, metro_b, bucket_ts)
+		WHERE (metro_a, metro_b) IN (
+			SELECT DISTINCT metro_a, metro_b FROM dz_data WHERE samples > 0
+		)
 		ORDER BY metro_a, metro_b, bucket_ts
 	`, dzCTE, inetCTE)
 

--- a/api/handlers/v1_dz_metro_pairs_latency_test.go
+++ b/api/handlers/v1_dz_metro_pairs_latency_test.go
@@ -47,6 +47,7 @@ var v1DZMetroPairLatencyContractFields = struct {
 		"internet_samples",
 		"internet_avg_rtt_us", "internet_min_rtt_us", "internet_p50_rtt_us", "internet_p90_rtt_us", "internet_p95_rtt_us", "internet_p99_rtt_us", "internet_max_rtt_us",
 		"internet_avg_jitter_us", "internet_min_jitter_us", "internet_p50_jitter_us", "internet_p90_jitter_us", "internet_p95_jitter_us", "internet_p99_jitter_us", "internet_max_jitter_us",
+		"avg_rtt_improvement_pct", "avg_jitter_improvement_pct",
 	},
 }
 
@@ -83,14 +84,19 @@ func seedDzVsInternetFixture(t *testing.T, api *handlers.API) time.Time {
 	seedLinkRollup(t, api, now.Add(-time.Hour), "link-nyc-lax", 50_000, 51_000, 0.5, 0.25, 3600, 3600, "activated", false, false)
 	seedLinkRollup(t, api, now.Add(-time.Hour), "link-nyc-fra", 70_000, 71_000, 0, 0, 3600, 3600, "activated", false, false)
 
-	// Internet samples for NYC↔LAX only (so NYC↔FRA is DZ-only). Seed at the
-	// same wall-clock time as the DZ rollup so both align into a single 10m
-	// bucket. Multiple providers so we can test data_provider filtering.
+	// Internet samples for NYC↔LAX. Seed at the same wall-clock time as the
+	// DZ rollup so both align into a single 10m bucket. Multiple providers so
+	// we can test data_provider filtering.
 	for i := int32(0); i < 4; i++ {
 		seedInternetMetroLatency(t, api, now.Add(-time.Hour), "metro-nyc", "metro-lax", "ripe-atlas", 80_000, 1_500, i)
 	}
 	for i := int32(0); i < 4; i++ {
 		seedInternetMetroLatency(t, api, now.Add(-time.Hour), "metro-nyc", "metro-lax", "wheresitup", 90_000, 2_000, i+10)
+	}
+	// Internet-only samples for LAX↔FRA — there is no DZ link between these
+	// metros, so this pair must NOT appear in the response (DZ-coverage filter).
+	for i := int32(0); i < 4; i++ {
+		seedInternetMetroLatency(t, api, now.Add(-time.Hour), "metro-lax", "metro-fra", "ripe-atlas", 120_000, 3_000, i+20)
 	}
 	return now
 }
@@ -170,6 +176,8 @@ func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
 	assert.InDelta(t, 50_500.0, withBoth.DZAvgRttUs, 1.0)
 	// Internet RTT is a mix of 80_000 and 90_000 with equal weight → 85_000 avg.
 	assert.InDelta(t, 85_000.0, withBoth.InternetAvgRttUs, 1.0)
+	// Improvement: (85_000 - 50_500) / 85_000 * 100 ≈ 40.59%.
+	assert.InDelta(t, 40.588, withBoth.AvgRttImprovementPct, 0.05)
 
 	// FRA-NYC is DZ-only: at least one bucket has DZ samples but no internet.
 	fraNyc := resp.Pairs[0]
@@ -182,6 +190,14 @@ func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
 	}
 	require.NotNil(t, dzOnly, "expected a DZ-populated bucket on FRA-NYC")
 	assert.Equal(t, uint64(0), dzOnly.InternetSamples)
+	// No internet samples in this bucket → improvement is 0 (indeterminate).
+	assert.Equal(t, 0.0, dzOnly.AvgRttImprovementPct)
+
+	// LAX-FRA has internet samples but no DZ link — must be excluded.
+	for _, p := range resp.Pairs {
+		assert.False(t, p.MetroACode == "FRA" && p.MetroBCode == "LAX",
+			"internet-only pair FRA-LAX must not appear in the response")
+	}
 }
 
 func TestV1DZMetroPairLatency_FilterByMetro(t *testing.T) {

--- a/api/v1/dz_metro_pairs_latency.go
+++ b/api/v1/dz_metro_pairs_latency.go
@@ -47,6 +47,12 @@ type DZMetroPairLatencyBucket struct {
 	InternetP95JitterUs float64 `json:"internet_p95_jitter_us" doc:"Internet p95 jitter, microseconds"`
 	InternetP99JitterUs float64 `json:"internet_p99_jitter_us" doc:"Internet p99 jitter, microseconds"`
 	InternetMaxJitterUs float64 `json:"internet_max_jitter_us" doc:"Internet max jitter, microseconds"`
+
+	// Computed per-bucket from the avg values. Positive = DZ is faster.
+	// 0 when either side has no samples in this bucket (check *_samples to
+	// disambiguate from a true 0% improvement).
+	AvgRttImprovementPct    float64 `json:"avg_rtt_improvement_pct" doc:"(internet_avg_rtt_us - dz_avg_rtt_us) / internet_avg_rtt_us * 100. 0 when either side is empty in this bucket."`
+	AvgJitterImprovementPct float64 `json:"avg_jitter_improvement_pct" doc:"(internet_avg_jitter_us - dz_avg_jitter_us) / internet_avg_jitter_us * 100. 0 when either side is empty in this bucket."`
 }
 
 // DZMetroPairLatency is the per-pair entry in the listing response. Direction
@@ -200,6 +206,9 @@ func toDZMetroPairLatency(p *handlers.MetroPair) DZMetroPairLatency {
 			InternetP95JitterUs: b.InternetP95JitterUs,
 			InternetP99JitterUs: b.InternetP99JitterUs,
 			InternetMaxJitterUs: b.InternetMaxJitterUs,
+
+			AvgRttImprovementPct:    b.AvgRttImprovementPct,
+			AvgJitterImprovementPct: b.AvgJitterImprovementPct,
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Filters `/api/v1/dz/metro-pairs/latency` to pairs that have DZ samples in the window. Internet-only metro pairs (no DZ link) used to surface with all-zero DZ values, making it look like DZ data was missing — they now drop out. Matches the `WHERE dz_sample_count > 0` filter on the existing `/api/topology/latency-comparison` view.
- Adds `avg_rtt_improvement_pct` and `avg_jitter_improvement_pct` per bucket, computed in SQL from the DZ vs internet avg values: `(internet_avg - dz_avg) / internet_avg * 100`. The `avg_` prefix makes the underlying aggregate explicit (vs p50/p95/etc).

## Testing Verification

- [x] `AllPairs` test asserts `avg_rtt_improvement_pct ≈ 40.59%` for NYC↔LAX (internet 85ms, DZ 50.5ms)
- [x] Internet-only pair (LAX↔FRA, seeded with internet samples but no DZ link) is excluded from the response
- [x] DZ-only pair (FRA↔NYC, no internet samples) still appears; improvement is 0 in buckets with no internet samples
- [x] Verified on staging: `ams-bom` and other internet-only pairs no longer appear; `ams-fra` shows populated DZ and improvement values