### PR TITLE
api/v1: prefix metro-pair improvement fields with dz_

### DIFF
--- a/api/handlers/metro_pair_latency.go
+++ b/api/handlers/metro_pair_latency.go
@@ -73,8 +73,8 @@ type MetroPairLatencyBucket struct {
 	// Improvement vs internet, computed per-bucket from the avg values.
 	// Positive = DZ is faster; 0 when either side has no samples or the
 	// internet avg is zero (indeterminate).
-	AvgRttImprovementPct    float64
-	AvgJitterImprovementPct float64
+	DZAvgRttImprovementPct    float64
+	DZAvgJitterImprovementPct float64
 }
 
 // MetroPair is the per-pair entry in the listing. Direction is normalized:
@@ -240,8 +240,8 @@ func (a *API) FetchMetroPairLatency(ctx context.Context, opts MetroPairLatencyOp
 		applyFloat(&b.InternetP95JitterUs, inetP95J)
 		applyFloat(&b.InternetP99JitterUs, inetP99J)
 		applyFloat(&b.InternetMaxJitterUs, inetMaxJ)
-		applyFloat(&b.AvgRttImprovementPct, rttImprovement)
-		applyFloat(&b.AvgJitterImprovementPct, jitterImprovement)
+		applyFloat(&b.DZAvgRttImprovementPct, rttImprovement)
+		applyFloat(&b.DZAvgJitterImprovementPct, jitterImprovement)
 		bucketsByPair[key][bucketTS.UTC()] = b
 	}
 	if err := rows.Err(); err != nil {
@@ -588,10 +588,10 @@ func queryMetroPairLatency(ctx context.Context, db driver.Conn, params bucketPar
 			i.max_jitter_us AS inet_max_jitter_us,
 			if(d.avg_rtt_us > 0 AND i.avg_rtt_us > 0,
 				(i.avg_rtt_us - d.avg_rtt_us) / i.avg_rtt_us * 100,
-				NULL) AS avg_rtt_improvement_pct,
+				NULL) AS dz_avg_rtt_improvement_pct,
 			if(d.avg_jitter_us > 0 AND i.avg_jitter_us > 0,
 				(i.avg_jitter_us - d.avg_jitter_us) / i.avg_jitter_us * 100,
-				NULL) AS avg_jitter_improvement_pct
+				NULL) AS dz_avg_jitter_improvement_pct
 		FROM dz_data d
 		FULL OUTER JOIN inet_data i USING (metro_a, metro_b, bucket_ts)
 		WHERE (metro_a, metro_b) IN (

--- a/api/handlers/v1_dz_metro_pairs_latency_test.go
+++ b/api/handlers/v1_dz_metro_pairs_latency_test.go
@@ -47,7 +47,7 @@ var v1DZMetroPairLatencyContractFields = struct {
 		"internet_samples",
 		"internet_avg_rtt_us", "internet_min_rtt_us", "internet_p50_rtt_us", "internet_p90_rtt_us", "internet_p95_rtt_us", "internet_p99_rtt_us", "internet_max_rtt_us",
 		"internet_avg_jitter_us", "internet_min_jitter_us", "internet_p50_jitter_us", "internet_p90_jitter_us", "internet_p95_jitter_us", "internet_p99_jitter_us", "internet_max_jitter_us",
-		"avg_rtt_improvement_pct", "avg_jitter_improvement_pct",
+		"dz_avg_rtt_improvement_pct", "dz_avg_jitter_improvement_pct",
 	},
 }
 
@@ -177,7 +177,7 @@ func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
 	// Internet RTT is a mix of 80_000 and 90_000 with equal weight → 85_000 avg.
 	assert.InDelta(t, 85_000.0, withBoth.InternetAvgRttUs, 1.0)
 	// Improvement: (85_000 - 50_500) / 85_000 * 100 ≈ 40.59%.
-	assert.InDelta(t, 40.588, withBoth.AvgRttImprovementPct, 0.05)
+	assert.InDelta(t, 40.588, withBoth.DZAvgRttImprovementPct, 0.05)
 
 	// FRA-NYC is DZ-only: at least one bucket has DZ samples but no internet.
 	fraNyc := resp.Pairs[0]
@@ -191,7 +191,7 @@ func TestV1DZMetroPairLatency_AllPairs(t *testing.T) {
 	require.NotNil(t, dzOnly, "expected a DZ-populated bucket on FRA-NYC")
 	assert.Equal(t, uint64(0), dzOnly.InternetSamples)
 	// No internet samples in this bucket → improvement is 0 (indeterminate).
-	assert.Equal(t, 0.0, dzOnly.AvgRttImprovementPct)
+	assert.Equal(t, 0.0, dzOnly.DZAvgRttImprovementPct)
 
 	// LAX-FRA has internet samples but no DZ link — must be excluded.
 	for _, p := range resp.Pairs {

--- a/api/v1/dz_metro_pairs_latency.go
+++ b/api/v1/dz_metro_pairs_latency.go
@@ -51,8 +51,8 @@ type DZMetroPairLatencyBucket struct {
 	// Computed per-bucket from the avg values. Positive = DZ is faster.
 	// 0 when either side has no samples in this bucket (check *_samples to
 	// disambiguate from a true 0% improvement).
-	AvgRttImprovementPct    float64 `json:"avg_rtt_improvement_pct" doc:"(internet_avg_rtt_us - dz_avg_rtt_us) / internet_avg_rtt_us * 100. 0 when either side is empty in this bucket."`
-	AvgJitterImprovementPct float64 `json:"avg_jitter_improvement_pct" doc:"(internet_avg_jitter_us - dz_avg_jitter_us) / internet_avg_jitter_us * 100. 0 when either side is empty in this bucket."`
+	DZAvgRttImprovementPct    float64 `json:"dz_avg_rtt_improvement_pct" doc:"(internet_avg_rtt_us - dz_avg_rtt_us) / internet_avg_rtt_us * 100. 0 when either side is empty in this bucket."`
+	DZAvgJitterImprovementPct float64 `json:"dz_avg_jitter_improvement_pct" doc:"(internet_avg_jitter_us - dz_avg_jitter_us) / internet_avg_jitter_us * 100. 0 when either side is empty in this bucket."`
 }
 
 // DZMetroPairLatency is the per-pair entry in the listing response. Direction
@@ -207,8 +207,8 @@ func toDZMetroPairLatency(p *handlers.MetroPair) DZMetroPairLatency {
 			InternetP99JitterUs: b.InternetP99JitterUs,
 			InternetMaxJitterUs: b.InternetMaxJitterUs,
 
-			AvgRttImprovementPct:    b.AvgRttImprovementPct,
-			AvgJitterImprovementPct: b.AvgJitterImprovementPct,
+			DZAvgRttImprovementPct:    b.DZAvgRttImprovementPct,
+			DZAvgJitterImprovementPct: b.DZAvgJitterImprovementPct,
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Renames `avg_rtt_improvement_pct` → `dz_avg_rtt_improvement_pct` and `avg_jitter_improvement_pct` → `dz_avg_jitter_improvement_pct` in the `/api/v1/dz/metro-pairs/latency` response.
- Makes DZ the explicit subject of the comparison; reads as "DZ's improvement over internet, based on the avg".

## Testing Verification

- [x] Contract test updated to reflect new field names
- [x] Improvement value assertion still passes (NYC↔LAX: ~40.59%)