### PR TITLE
web: stop topology map zoom-out on click and stabilize link hover cursor

### DIFF
--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -2623,9 +2623,10 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
 
     const flyToLocation = (lng: number, lat: number, zoom = 3, usePanelOffset = false) => {
       if (mapRef.current) {
+        const currentZoom = mapRef.current.getZoom()
         mapRef.current.flyTo({
           center: [lng, lat],
-          zoom,
+          zoom: Math.max(currentZoom, zoom),
           duration: 1000,
           offset: usePanelOffset ? [getPanelOffsetX(), 0] : [0, 0],
         })
@@ -2800,6 +2801,13 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
         return
       }
 
+      // Cancel any pending hide timer so re-entering (e.g., when MapLibre fires
+      // a brief mouseleave between adjacent features) doesn't drop the hover state
+      if (linkHideTimerRef.current) {
+        clearTimeout(linkHideTimerRef.current)
+        linkHideTimerRef.current = null
+      }
+
       const props = e.features[0].properties
 
       // Pin tooltip position at hover start so it stays reachable as user moves toward it
@@ -2854,6 +2862,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
   }, [linkMap, buildLinkInfo, multicastTreesMode, dimOtherLinks, multicastTreeLinkPKs])
 
   const handleLinkMouseLeave = useCallback(() => {
+    if (linkHideTimerRef.current) clearTimeout(linkHideTimerRef.current)
     linkHideTimerRef.current = setTimeout(() => setHoveredLink(null), 400)
   }, [])
 


### PR DESCRIPTION
## Summary
- Clicking a device, link, metro, or validator on the topology map no longer zooms out — when you're already zoomed in past the target level the map only pans.
- Hovering a link now keeps the pointer cursor stable; previously the cursor would flicker back to default while still over the link.

The cursor flicker came from the 400 ms hide timer in `handleLinkMouseLeave` (kept so the tooltip stays reachable). MapLibre fires brief mouseleave/mouseenter pairs as the mouse moves across adjacent features along a link, and the stale timer would fire and clear `hoveredLink` while the user was still hovering. The fix cancels the pending timer on re-enter and defensively clears any prior timer before scheduling a new one.

The zoom-out came from `flyToLocation` hard-setting `zoom: 3` (or `4`) regardless of current zoom; now it uses `Math.max(currentZoom, targetZoom)` so flyTo never zooms out.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +10 | -1 |
| SDKs | 0 | 0 |
| Tests | 0 | 0 |

## Testing Verification
- Tested in localhost