### PR TITLE
api: add device optics panel and history endpoints

### DIFF
--- a/api/handlers/device_optics.go
+++ b/api/handlers/device_optics.go
@@ -1,0 +1,473 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+// Severity values returned in optics responses. Ordered worst-first so the
+// "overall" severity is easy to compute by taking the max rank.
+const (
+	OpticsSeverityUnknown  = "unknown"
+	OpticsSeverityOK       = "ok"
+	OpticsSeverityWarning  = "warning"
+	OpticsSeverityCritical = "critical"
+)
+
+// DeviceOpticsResponse is the response for GET /api/devices/{pk}/optics.
+type DeviceOpticsResponse struct {
+	DevicePK   string        `json:"device_pk"`
+	DeviceCode string        `json:"device_code"`
+	Lanes      []OpticsLane  `json:"lanes"`
+	Summary    OpticsSummary `json:"summary"`
+	FetchedAt  string        `json:"fetched_at"`
+}
+
+// OpticsLane is one (interface, channel) sample with thresholds + severities.
+type OpticsLane struct {
+	InterfaceName    string            `json:"interface_name"`
+	ChannelIndex     uint16            `json:"channel_index"`
+	Timestamp        string            `json:"timestamp"`
+	InputPower       float64           `json:"input_power"`
+	OutputPower      float64           `json:"output_power"`
+	LaserBiasCurrent float64           `json:"laser_bias_current"`
+	InputSeverity    string            `json:"input_severity"`
+	OutputSeverity   string            `json:"output_severity"`
+	BiasSeverity     string            `json:"bias_severity"`
+	OverallSeverity  string            `json:"overall_severity"`
+	Thresholds       *OpticsThresholds `json:"thresholds,omitempty"`
+}
+
+// OpticsThresholds carries the warning and critical bounds for a lane.
+// Pointers are used so JSON omits missing values rather than reporting 0.
+type OpticsThresholds struct {
+	InputWarningLower  *float64 `json:"input_warning_lower,omitempty"`
+	InputWarningUpper  *float64 `json:"input_warning_upper,omitempty"`
+	InputCriticalLower *float64 `json:"input_critical_lower,omitempty"`
+	InputCriticalUpper *float64 `json:"input_critical_upper,omitempty"`
+
+	OutputWarningLower  *float64 `json:"output_warning_lower,omitempty"`
+	OutputWarningUpper  *float64 `json:"output_warning_upper,omitempty"`
+	OutputCriticalLower *float64 `json:"output_critical_lower,omitempty"`
+	OutputCriticalUpper *float64 `json:"output_critical_upper,omitempty"`
+
+	BiasWarningLower  *float64 `json:"bias_warning_lower,omitempty"`
+	BiasWarningUpper  *float64 `json:"bias_warning_upper,omitempty"`
+	BiasCriticalLower *float64 `json:"bias_critical_lower,omitempty"`
+	BiasCriticalUpper *float64 `json:"bias_critical_upper,omitempty"`
+}
+
+// OpticsSummary holds lane counts by overall severity.
+type OpticsSummary struct {
+	OK       int `json:"ok"`
+	Warning  int `json:"warning"`
+	Critical int `json:"critical"`
+	Unknown  int `json:"unknown"`
+	Total    int `json:"total"`
+}
+
+// GetDeviceOptics returns per-lane transceiver state joined to thresholds,
+// with computed severity per metric. Reads from the telemetry_<env> database
+// populated by the admin setup-remote-tables command.
+func (a *API) GetDeviceOptics(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	pk := chi.URLParam(r, "pk")
+	if pk == "" {
+		http.Error(w, "missing device pk", http.StatusBadRequest)
+		return
+	}
+
+	conn := a.envDB(ctx)
+	tdb := TelemetryDatabaseForEnv(EnvFromContext(ctx))
+
+	// Resolve device code (also confirms the device exists in the current env).
+	var deviceCode string
+	deviceQ := `SELECT code FROM dz_devices_current WHERE pk = ?`
+	if err := conn.QueryRow(ctx, deviceQ, pk).Scan(&deviceCode); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		logError("device optics: device lookup failed", "error", err, "pk", pk)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	query := fmt.Sprintf(`
+		WITH thresholds AS (
+			SELECT
+				device_pubkey,
+				interface_name,
+				minIf(input_power_lower,        severity = 'CRITICAL') AS in_crit_lo,
+				maxIf(input_power_upper,        severity = 'CRITICAL') AS in_crit_hi,
+				minIf(input_power_lower,        severity = 'WARNING')  AS in_warn_lo,
+				maxIf(input_power_upper,        severity = 'WARNING')  AS in_warn_hi,
+				minIf(output_power_lower,       severity = 'CRITICAL') AS out_crit_lo,
+				maxIf(output_power_upper,       severity = 'CRITICAL') AS out_crit_hi,
+				minIf(output_power_lower,       severity = 'WARNING')  AS out_warn_lo,
+				maxIf(output_power_upper,       severity = 'WARNING')  AS out_warn_hi,
+				minIf(laser_bias_current_lower, severity = 'CRITICAL') AS bias_crit_lo,
+				maxIf(laser_bias_current_upper, severity = 'CRITICAL') AS bias_crit_hi,
+				minIf(laser_bias_current_lower, severity = 'WARNING')  AS bias_warn_lo,
+				maxIf(laser_bias_current_upper, severity = 'WARNING')  AS bias_warn_hi,
+				countIf(severity = 'CRITICAL') AS n_crit,
+				countIf(severity = 'WARNING')  AS n_warn
+			FROM %[1]s.transceiver_thresholds_latest
+			WHERE device_pubkey = ?
+			GROUP BY device_pubkey, interface_name
+		)
+		SELECT
+			s.interface_name,
+			s.channel_index,
+			s.timestamp,
+			s.input_power,
+			s.output_power,
+			s.laser_bias_current,
+			t.in_crit_lo,  t.in_crit_hi,  t.in_warn_lo,  t.in_warn_hi,
+			t.out_crit_lo, t.out_crit_hi, t.out_warn_lo, t.out_warn_hi,
+			t.bias_crit_lo, t.bias_crit_hi, t.bias_warn_lo, t.bias_warn_hi,
+			t.n_crit, t.n_warn
+		FROM %[1]s.transceiver_state_latest s
+		LEFT JOIN thresholds t
+			ON s.device_pubkey = t.device_pubkey AND s.interface_name = t.interface_name
+		WHERE s.device_pubkey = ?
+		ORDER BY s.interface_name, s.channel_index
+	`, "`"+tdb+"`")
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query, pk, pk)
+	duration := time.Since(start)
+	metrics.RecordClickHouseQuery("device_optics", duration, err)
+	if err != nil {
+		logError("device optics query failed", "error", err, "pk", pk)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	var (
+		lanes   = []OpticsLane{}
+		summary OpticsSummary
+	)
+	for rows.Next() {
+		var (
+			ifname                                         string
+			ch                                             uint16
+			ts                                             time.Time
+			inP, outP, bias                                float64
+			inCritLo, inCritHi, inWarnLo, inWarnHi         float64
+			outCritLo, outCritHi, outWarnLo, outWarnHi     float64
+			biasCritLo, biasCritHi, biasWarnLo, biasWarnHi float64
+			nCrit, nWarn                                   uint64
+		)
+		if err := rows.Scan(
+			&ifname, &ch, &ts, &inP, &outP, &bias,
+			&inCritLo, &inCritHi, &inWarnLo, &inWarnHi,
+			&outCritLo, &outCritHi, &outWarnLo, &outWarnHi,
+			&biasCritLo, &biasCritHi, &biasWarnLo, &biasWarnHi,
+			&nCrit, &nWarn,
+		); err != nil {
+			logError("device optics row scan failed", "error", err, "pk", pk)
+			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+			return
+		}
+
+		hasCrit := nCrit > 0
+		hasWarn := nWarn > 0
+		lane := OpticsLane{
+			InterfaceName:    ifname,
+			ChannelIndex:     ch,
+			Timestamp:        ts.UTC().Format(time.RFC3339),
+			InputPower:       inP,
+			OutputPower:      outP,
+			LaserBiasCurrent: bias,
+			InputSeverity:    classifyOpticsValue(inP, inCritLo, inCritHi, hasCrit, inWarnLo, inWarnHi, hasWarn),
+			OutputSeverity:   classifyOpticsValue(outP, outCritLo, outCritHi, hasCrit, outWarnLo, outWarnHi, hasWarn),
+			BiasSeverity:     classifyOpticsValue(bias, biasCritLo, biasCritHi, hasCrit, biasWarnLo, biasWarnHi, hasWarn),
+		}
+		lane.OverallSeverity = worstSeverity(lane.InputSeverity, lane.OutputSeverity, lane.BiasSeverity)
+
+		if hasCrit || hasWarn {
+			lane.Thresholds = &OpticsThresholds{
+				InputCriticalLower:  optFloat(inCritLo, hasCrit),
+				InputCriticalUpper:  optFloat(inCritHi, hasCrit),
+				InputWarningLower:   optFloat(inWarnLo, hasWarn),
+				InputWarningUpper:   optFloat(inWarnHi, hasWarn),
+				OutputCriticalLower: optFloat(outCritLo, hasCrit),
+				OutputCriticalUpper: optFloat(outCritHi, hasCrit),
+				OutputWarningLower:  optFloat(outWarnLo, hasWarn),
+				OutputWarningUpper:  optFloat(outWarnHi, hasWarn),
+				BiasCriticalLower:   optFloat(biasCritLo, hasCrit),
+				BiasCriticalUpper:   optFloat(biasCritHi, hasCrit),
+				BiasWarningLower:    optFloat(biasWarnLo, hasWarn),
+				BiasWarningUpper:    optFloat(biasWarnHi, hasWarn),
+			}
+		}
+
+		switch lane.OverallSeverity {
+		case OpticsSeverityCritical:
+			summary.Critical++
+		case OpticsSeverityWarning:
+			summary.Warning++
+		case OpticsSeverityOK:
+			summary.OK++
+		default:
+			summary.Unknown++
+		}
+		summary.Total++
+		lanes = append(lanes, lane)
+	}
+	if err := rows.Err(); err != nil {
+		logError("device optics rows iteration failed", "error", err, "pk", pk)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := DeviceOpticsResponse{
+		DevicePK:   pk,
+		DeviceCode: deviceCode,
+		Lanes:      lanes,
+		Summary:    summary,
+		FetchedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("device optics: failed to encode response", "error", err)
+	}
+}
+
+// classifyOpticsValue returns the severity for a measurement against critical
+// and warning thresholds. Missing thresholds (sentinel 0/0 from the source)
+// produce "unknown" so the UI can omit a verdict rather than show false OK.
+func classifyOpticsValue(v, critLo, critHi float64, hasCrit bool, warnLo, warnHi float64, hasWarn bool) string {
+	critSet := hasCrit && !(critLo == 0 && critHi == 0)
+	warnSet := hasWarn && !(warnLo == 0 && warnHi == 0)
+	if !critSet && !warnSet {
+		return OpticsSeverityUnknown
+	}
+	if critSet && (v < critLo || v > critHi) {
+		return OpticsSeverityCritical
+	}
+	if warnSet && (v < warnLo || v > warnHi) {
+		return OpticsSeverityWarning
+	}
+	return OpticsSeverityOK
+}
+
+func worstSeverity(svs ...string) string {
+	rank := func(s string) int {
+		switch s {
+		case OpticsSeverityCritical:
+			return 3
+		case OpticsSeverityWarning:
+			return 2
+		case OpticsSeverityOK:
+			return 1
+		default:
+			return 0
+		}
+	}
+	best := OpticsSeverityUnknown
+	bestR := 0
+	for _, s := range svs {
+		if r := rank(s); r > bestR {
+			best = s
+			bestR = r
+		}
+	}
+	return best
+}
+
+func optFloat(v float64, present bool) *float64 {
+	if !present {
+		return nil
+	}
+	return &v
+}
+
+// DeviceOpticsHistoryResponse is the response for
+// GET /api/devices/{pk}/optics/history.
+type DeviceOpticsHistoryResponse struct {
+	DevicePK      string                     `json:"device_pk"`
+	InterfaceName string                     `json:"interface_name"`
+	ChannelIndex  *uint16                    `json:"channel_index,omitempty"`
+	BucketSeconds int                        `json:"bucket_seconds"`
+	From          string                     `json:"from"`
+	To            string                     `json:"to"`
+	Buckets       []DeviceOpticsHistoryPoint `json:"buckets"`
+}
+
+// DeviceOpticsHistoryPoint is one bucketed sample. Avg/min/max are returned
+// so the UI can render a band as well as a center line.
+type DeviceOpticsHistoryPoint struct {
+	TS                  string  `json:"ts"`
+	ChannelIndex        uint16  `json:"channel_index"`
+	AvgInputPower       float64 `json:"avg_input_power"`
+	MinInputPower       float64 `json:"min_input_power"`
+	MaxInputPower       float64 `json:"max_input_power"`
+	AvgOutputPower      float64 `json:"avg_output_power"`
+	MinOutputPower      float64 `json:"min_output_power"`
+	MaxOutputPower      float64 `json:"max_output_power"`
+	AvgLaserBiasCurrent float64 `json:"avg_laser_bias_current"`
+}
+
+// GetDeviceOpticsHistory returns bucketed transceiver_state samples for a
+// specific (device, interface[, channel]).
+func (a *API) GetDeviceOpticsHistory(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	pk := chi.URLParam(r, "pk")
+	if pk == "" {
+		http.Error(w, "missing device pk", http.StatusBadRequest)
+		return
+	}
+	q := r.URL.Query()
+	ifname := q.Get("interface")
+	if ifname == "" {
+		http.Error(w, "interface query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	// Optional channel filter.
+	var channelPtr *uint16
+	if chStr := q.Get("channel"); chStr != "" {
+		v, err := strconv.ParseUint(chStr, 10, 16)
+		if err != nil {
+			http.Error(w, "invalid channel", http.StatusBadRequest)
+			return
+		}
+		ch := uint16(v)
+		channelPtr = &ch
+	}
+
+	// Window. Default 24h, max 30d.
+	hours := 24
+	if hStr := q.Get("hours"); hStr != "" {
+		v, err := strconv.Atoi(hStr)
+		if err != nil || v < 1 {
+			http.Error(w, "invalid hours", http.StatusBadRequest)
+			return
+		}
+		hours = v
+	}
+	if hours > 30*24 {
+		hours = 30 * 24
+	}
+
+	// Bucket size scales with the window so we keep ~300-720 points.
+	var bucketSec int
+	switch {
+	case hours <= 6:
+		bucketSec = 60
+	case hours <= 24:
+		bucketSec = 300
+	case hours <= 7*24:
+		bucketSec = 900
+	default:
+		bucketSec = 3600
+	}
+
+	conn := a.envDB(ctx)
+	tdb := TelemetryDatabaseForEnv(EnvFromContext(ctx))
+
+	channelClause := ""
+	args := []any{pk, ifname}
+	if channelPtr != nil {
+		channelClause = " AND channel_index = ?"
+		args = append(args, *channelPtr)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			toDateTime(toStartOfInterval(timestamp, INTERVAL %[2]d SECOND)) AS bucket_ts,
+			channel_index,
+			avg(input_power)        AS avg_in,
+			min(input_power)        AS min_in,
+			max(input_power)        AS max_in,
+			avg(output_power)       AS avg_out,
+			min(output_power)       AS min_out,
+			max(output_power)       AS max_out,
+			avg(laser_bias_current) AS avg_bias
+		FROM %[1]s.transceiver_state
+		WHERE timestamp >= now() - INTERVAL %[3]d HOUR
+		  AND device_pubkey = ?
+		  AND interface_name = ?%[4]s
+		GROUP BY bucket_ts, channel_index
+		ORDER BY bucket_ts, channel_index
+	`, "`"+tdb+"`", bucketSec, hours, channelClause)
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query, args...)
+	duration := time.Since(start)
+	metrics.RecordClickHouseQuery("device_optics_history", duration, err)
+	if err != nil {
+		logError("device optics history query failed", "error", err, "pk", pk, "interface", ifname)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	buckets := []DeviceOpticsHistoryPoint{}
+	for rows.Next() {
+		var (
+			ts     time.Time
+			ch     uint16
+			avgIn  float64
+			minIn  float64
+			maxIn  float64
+			avgOut float64
+			minOut float64
+			maxOut float64
+			avgBs  float64
+		)
+		if err := rows.Scan(&ts, &ch, &avgIn, &minIn, &maxIn, &avgOut, &minOut, &maxOut, &avgBs); err != nil {
+			logError("device optics history row scan failed", "error", err, "pk", pk)
+			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+			return
+		}
+		buckets = append(buckets, DeviceOpticsHistoryPoint{
+			TS:                  ts.UTC().Format(time.RFC3339),
+			ChannelIndex:        ch,
+			AvgInputPower:       avgIn,
+			MinInputPower:       minIn,
+			MaxInputPower:       maxIn,
+			AvgOutputPower:      avgOut,
+			MinOutputPower:      minOut,
+			MaxOutputPower:      maxOut,
+			AvgLaserBiasCurrent: avgBs,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		logError("device optics history rows iteration failed", "error", err, "pk", pk)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	now := time.Now().UTC()
+	resp := DeviceOpticsHistoryResponse{
+		DevicePK:      pk,
+		InterfaceName: ifname,
+		ChannelIndex:  channelPtr,
+		BucketSeconds: bucketSec,
+		From:          now.Add(-time.Duration(hours) * time.Hour).Format(time.RFC3339),
+		To:            now.Format(time.RFC3339),
+		Buckets:       buckets,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("device optics history: failed to encode response", "error", err)
+	}
+}

--- a/api/handlers/device_optics.go
+++ b/api/handlers/device_optics.go
@@ -353,38 +353,56 @@ func (a *API) GetDeviceOpticsHistory(w http.ResponseWriter, r *http.Request) {
 		channelPtr = &ch
 	}
 
-	// Window. Default 24h, max 30d.
-	hours := 24
-	if hStr := q.Get("hours"); hStr != "" {
-		v, err := strconv.Atoi(hStr)
-		if err != nil || v < 1 {
-			http.Error(w, "invalid hours", http.StatusBadRequest)
+	// Time range / custom window, matching the device-metrics endpoint shape.
+	timeRange := q.Get("range")
+	if timeRange == "" {
+		timeRange = "24h"
+	}
+	startTimeStr := q.Get("start_time")
+	endTimeStr := q.Get("end_time")
+	bucketStr := q.Get("bucket")
+
+	var params bucketParams
+	if startTimeStr != "" && endTimeStr != "" {
+		startUnix, err1 := strconv.ParseInt(startTimeStr, 10, 64)
+		endUnix, err2 := strconv.ParseInt(endTimeStr, 10, 64)
+		if err1 != nil || err2 != nil {
+			http.Error(w, "invalid start_time or end_time", http.StatusBadRequest)
 			return
 		}
-		hours = v
-	}
-	if hours > 30*24 {
-		hours = 30 * 24
+		startT := time.Unix(startUnix, 0).UTC()
+		endT := time.Unix(endUnix, 0).UTC()
+		params = parseBucketParamsCustom(startT, endT, 24)
+	} else {
+		now := time.Now().UTC()
+		duration := presetToDuration(timeRange)
+		startT := now.Add(-duration)
+		params = parseBucketParamsCustom(startT, now, 24)
+		params.TimeRange = timeRange
 	}
 
-	// Bucket size scales with the window so we keep ~300-720 points.
-	var bucketSec int
-	switch {
-	case hours <= 6:
-		bucketSec = 60
-	case hours <= 24:
+	if bucketStr != "" && bucketStr != "auto" {
+		interval, ok := parseBucketString(bucketStr)
+		if !ok {
+			http.Error(w, "invalid bucket value", http.StatusBadRequest)
+			return
+		}
+		secs := intervalToSeconds(interval)
+		params.BucketSeconds = secs
+		params.BucketMinutes = secs / 60
+		params.BucketInterval = interval
+	}
+
+	bucketSec := params.BucketSeconds
+	if bucketSec <= 0 {
 		bucketSec = 300
-	case hours <= 7*24:
-		bucketSec = 900
-	default:
-		bucketSec = 3600
 	}
 
 	conn := a.envDB(ctx)
 	tdb := TelemetryDatabaseForEnv(EnvFromContext(ctx))
 
 	channelClause := ""
-	args := []any{pk, ifname}
+	args := []any{*params.StartTime, *params.EndTime, pk, ifname}
 	if channelPtr != nil {
 		channelClause = " AND channel_index = ?"
 		args = append(args, *channelPtr)
@@ -402,12 +420,13 @@ func (a *API) GetDeviceOpticsHistory(w http.ResponseWriter, r *http.Request) {
 			max(output_power)       AS max_out,
 			avg(laser_bias_current) AS avg_bias
 		FROM %[1]s.transceiver_state
-		WHERE timestamp >= now() - INTERVAL %[3]d HOUR
+		WHERE timestamp >= ?
+		  AND timestamp < ?
 		  AND device_pubkey = ?
-		  AND interface_name = ?%[4]s
+		  AND interface_name = ?%[3]s
 		GROUP BY bucket_ts, channel_index
 		ORDER BY bucket_ts, channel_index
-	`, "`"+tdb+"`", bucketSec, hours, channelClause)
+	`, "`"+tdb+"`", bucketSec, channelClause)
 
 	start := time.Now()
 	rows, err := conn.Query(ctx, query, args...)
@@ -456,14 +475,13 @@ func (a *API) GetDeviceOpticsHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now().UTC()
 	resp := DeviceOpticsHistoryResponse{
 		DevicePK:      pk,
 		InterfaceName: ifname,
 		ChannelIndex:  channelPtr,
 		BucketSeconds: bucketSec,
-		From:          now.Add(-time.Duration(hours) * time.Hour).Format(time.RFC3339),
-		To:            now.Format(time.RFC3339),
+		From:          params.StartTime.UTC().Format(time.RFC3339),
+		To:            params.EndTime.UTC().Format(time.RFC3339),
 		Buckets:       buckets,
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/api/handlers/device_optics_test.go
+++ b/api/handlers/device_optics_test.go
@@ -208,7 +208,7 @@ func TestGetDeviceOpticsHistory_BucketsSamples(t *testing.T) {
 	`, "`telemetry_mainnet_beta`"))
 	require.NoError(t, err)
 
-	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/dev-optics/optics/history?interface=Ethernet1&hours=6", nil), "dev-optics")
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/dev-optics/optics/history?interface=Ethernet1&range=6h", nil), "dev-optics")
 	rr := httptest.NewRecorder()
 	api.GetDeviceOpticsHistory(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())

--- a/api/handlers/device_optics_test.go
+++ b/api/handlers/device_optics_test.go
@@ -1,0 +1,238 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTelemetryOpticsTables creates the telemetry_mainnet_beta database +
+// the two tables the optics handlers read, matching production schema closely
+// enough for the handler queries to resolve.
+func createTelemetryOpticsTables(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	const db = "telemetry_mainnet_beta"
+
+	err := api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db))
+	require.NoError(t, err)
+
+	err = api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.transceiver_state (
+			timestamp        DateTime64(9),
+			device_pubkey    LowCardinality(String),
+			interface_name   String,
+			channel_index    UInt16,
+			input_power      Float64,
+			output_power     Float64,
+			laser_bias_current Float64
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, channel_index, timestamp)
+	`, db))
+	require.NoError(t, err)
+
+	// _latest is a regular table in tests; we insert the same rows we want
+	// classified as "current".
+	err = api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.transceiver_state_latest (
+			timestamp        DateTime64(9),
+			device_pubkey    LowCardinality(String),
+			interface_name   String,
+			channel_index    UInt16,
+			input_power      Float64,
+			output_power     Float64,
+			laser_bias_current Float64
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, channel_index)
+	`, db))
+	require.NoError(t, err)
+
+	err = api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.transceiver_thresholds_latest (
+			timestamp                  DateTime64(9),
+			device_pubkey              LowCardinality(String),
+			interface_name             String,
+			severity                   LowCardinality(String),
+			input_power_lower          Float64,
+			input_power_upper          Float64,
+			output_power_lower         Float64,
+			output_power_upper         Float64,
+			laser_bias_current_lower   Float64,
+			laser_bias_current_upper   Float64,
+			module_temperature_lower   Float64,
+			module_temperature_upper   Float64,
+			supply_voltage_lower       Float64,
+			supply_voltage_upper       Float64
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, severity)
+	`, db))
+	require.NoError(t, err)
+}
+
+func insertOpticsTestDevice(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	err := api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, status, device_type, contributor_pk, metro_pk, public_ip, max_users)
+		VALUES
+		('dev-optics', now(), now(), generateUUIDv4(), 0, 1, 'dev-optics', 'NYC-OPTICS-01', 'activated', 'router', '', '', '10.0.0.1', 100)
+	`)
+	require.NoError(t, err)
+}
+
+// withDevicePK returns a request with the pk URL param set on the chi route
+// context, matching how the router would invoke the handler.
+func withDevicePK(req *http.Request, pk string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("pk", pk)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestGetDeviceOptics_NotFound(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/missing/optics", nil), "missing")
+	rr := httptest.NewRecorder()
+	api.GetDeviceOptics(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetDeviceOptics_ClassifiesLanes(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	insertOpticsTestDevice(t, api)
+	createTelemetryOpticsTables(t, api)
+
+	ctx := t.Context()
+
+	// State: 3 lanes
+	//  - Eth1/ch0 healthy (in=-5, out=-2, bias=30)
+	//  - Eth2/ch0 input below CRITICAL (in=-25, out=-2, bias=30)
+	//  - Eth3/ch0 has no thresholds (severity = unknown)
+	err := api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.transceiver_state_latest
+		(timestamp, device_pubkey, interface_name, channel_index, input_power, output_power, laser_bias_current)
+		VALUES
+		(now(), 'dev-optics', 'Ethernet1', 0, -5,  -2, 30),
+		(now(), 'dev-optics', 'Ethernet2', 0, -25, -2, 30),
+		(now(), 'dev-optics', 'Ethernet3', 0, -5,  -2, 30)
+	`, "`telemetry_mainnet_beta`"))
+	require.NoError(t, err)
+
+	// Thresholds for Eth1 and Eth2 only.
+	err = api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.transceiver_thresholds_latest
+		(timestamp, device_pubkey, interface_name, severity,
+		 input_power_lower, input_power_upper,
+		 output_power_lower, output_power_upper,
+		 laser_bias_current_lower, laser_bias_current_upper,
+		 module_temperature_lower, module_temperature_upper,
+		 supply_voltage_lower, supply_voltage_upper)
+		VALUES
+		(now(), 'dev-optics', 'Ethernet1', 'CRITICAL', -20, 3, -12, 3, 1, 100, 0, 0, 0, 0),
+		(now(), 'dev-optics', 'Ethernet1', 'WARNING',  -14, 0, -8,  0, 2, 90,  0, 0, 0, 0),
+		(now(), 'dev-optics', 'Ethernet2', 'CRITICAL', -20, 3, -12, 3, 1, 100, 0, 0, 0, 0),
+		(now(), 'dev-optics', 'Ethernet2', 'WARNING',  -14, 0, -8,  0, 2, 90,  0, 0, 0, 0)
+	`, "`telemetry_mainnet_beta`"))
+	require.NoError(t, err)
+
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/dev-optics/optics", nil), "dev-optics")
+	rr := httptest.NewRecorder()
+	api.GetDeviceOptics(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceOpticsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	assert.Equal(t, "dev-optics", resp.DevicePK)
+	assert.Equal(t, "NYC-OPTICS-01", resp.DeviceCode)
+	require.Len(t, resp.Lanes, 3)
+
+	// Lanes come back ordered by interface name.
+	assert.Equal(t, "Ethernet1", resp.Lanes[0].InterfaceName)
+	assert.Equal(t, handlers.OpticsSeverityOK, resp.Lanes[0].OverallSeverity)
+
+	assert.Equal(t, "Ethernet2", resp.Lanes[1].InterfaceName)
+	assert.Equal(t, handlers.OpticsSeverityCritical, resp.Lanes[1].InputSeverity)
+	assert.Equal(t, handlers.OpticsSeverityCritical, resp.Lanes[1].OverallSeverity)
+
+	assert.Equal(t, "Ethernet3", resp.Lanes[2].InterfaceName)
+	assert.Equal(t, handlers.OpticsSeverityUnknown, resp.Lanes[2].OverallSeverity)
+	assert.Nil(t, resp.Lanes[2].Thresholds)
+
+	assert.Equal(t, 1, resp.Summary.OK)
+	assert.Equal(t, 1, resp.Summary.Critical)
+	assert.Equal(t, 1, resp.Summary.Unknown)
+	assert.Equal(t, 0, resp.Summary.Warning)
+	assert.Equal(t, 3, resp.Summary.Total)
+}
+
+func TestGetDeviceOpticsHistory_BucketsSamples(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	insertOpticsTestDevice(t, api)
+	createTelemetryOpticsTables(t, api)
+
+	ctx := t.Context()
+	// 5 samples in the last hour for the same lane.
+	err := api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.transceiver_state
+		(timestamp, device_pubkey, interface_name, channel_index, input_power, output_power, laser_bias_current)
+		VALUES
+		(now() - INTERVAL 50 MINUTE, 'dev-optics', 'Ethernet1', 0, -5.0, -2.0, 30),
+		(now() - INTERVAL 40 MINUTE, 'dev-optics', 'Ethernet1', 0, -5.5, -2.1, 30),
+		(now() - INTERVAL 30 MINUTE, 'dev-optics', 'Ethernet1', 0, -6.0, -2.2, 30),
+		(now() - INTERVAL 20 MINUTE, 'dev-optics', 'Ethernet1', 0, -5.8, -2.1, 30),
+		(now() - INTERVAL 10 MINUTE, 'dev-optics', 'Ethernet1', 0, -5.2, -2.0, 30),
+		(now() - INTERVAL 5  MINUTE, 'dev-optics', 'Ethernet2', 0, -8.0, -3.0, 25)
+	`, "`telemetry_mainnet_beta`"))
+	require.NoError(t, err)
+
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/dev-optics/optics/history?interface=Ethernet1&hours=6", nil), "dev-optics")
+	rr := httptest.NewRecorder()
+	api.GetDeviceOpticsHistory(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceOpticsHistoryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Ethernet1", resp.InterfaceName)
+	assert.Equal(t, 60, resp.BucketSeconds)
+	assert.NotEmpty(t, resp.Buckets)
+	for _, b := range resp.Buckets {
+		assert.LessOrEqual(t, b.MinInputPower, b.AvgInputPower)
+		assert.LessOrEqual(t, b.AvgInputPower, b.MaxInputPower)
+	}
+}
+
+func TestGetDeviceOpticsHistory_RequiresInterface(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/dev-optics/optics/history", nil), "dev-optics")
+	rr := httptest.NewRecorder()
+	api.GetDeviceOpticsHistory(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/api/handlers/env.go
+++ b/api/handlers/env.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // DZEnv represents a DoubleZero network environment.
@@ -14,6 +15,14 @@ const (
 	EnvDevnet  DZEnv = "devnet"
 	EnvTestnet DZEnv = "testnet"
 )
+
+// TelemetryDatabaseForEnv returns the ClickHouse database that mirrors the
+// dz/telemetry tables for the given environment (e.g. "mainnet-beta" →
+// "telemetry_mainnet_beta"). These databases are created by the admin
+// `setup-remote-tables` command and proxy the remote telemetry cluster.
+func TelemetryDatabaseForEnv(env DZEnv) string {
+	return "telemetry_" + strings.ReplaceAll(string(env), "-", "_")
+}
 
 // ValidEnvs contains all recognized environment values.
 var ValidEnvs = map[DZEnv]bool{

--- a/api/main.go
+++ b/api/main.go
@@ -559,6 +559,8 @@ func main() {
 		r.Get("/api/dz/devices", api.GetDevices)
 		r.Get("/api/dz/devices/{pk}", api.GetDevice)
 		r.Get("/api/dz/devices/{pk}/validator-stats", api.GetDeviceValidatorStats)
+		r.Get("/api/dz/devices/{pk}/optics", api.GetDeviceOptics)
+		r.Get("/api/dz/devices/{pk}/optics/history", api.GetDeviceOpticsHistory)
 		r.Get("/api/dz/links", api.GetLinks)
 		r.Get("/api/dz/links/{pk}", api.GetLink)
 		r.Get("/api/dz/links-health", api.GetLinkHealth)

--- a/web/src/components/device-charts/DeviceOpticsChart.tsx
+++ b/web/src/components/device-charts/DeviceOpticsChart.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import uPlot from 'uplot'
+import { Loader2 } from 'lucide-react'
+import { useTheme } from '@/hooks/use-theme'
+import { useUPlotChart } from '@/hooks/use-uplot-chart'
+import { fetchDeviceOpticsHistory } from '@/lib/api'
+
+interface DeviceOpticsChartProps {
+  devicePk: string
+  interfaceName: string
+  channelIndex: number
+  hours?: number
+  className?: string
+}
+
+export function DeviceOpticsChart({
+  devicePk,
+  interfaceName,
+  channelIndex,
+  hours = 24,
+  className,
+}: DeviceOpticsChartProps) {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
+  const chartRef = useRef<HTMLDivElement>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['deviceOpticsHistory', devicePk, interfaceName, channelIndex, hours],
+    queryFn: () => fetchDeviceOpticsHistory(devicePk, { interface: interfaceName, channel: channelIndex, hours }),
+  })
+
+  const inputColor = isDark ? '#60a5fa' : '#2563eb'
+  const outputColor = isDark ? '#34d399' : '#059669'
+
+  const { uPlotData, uPlotSeries } = useMemo(() => {
+    const buckets = data?.buckets ?? []
+    if (buckets.length === 0) {
+      return { uPlotData: [[]] as uPlot.AlignedData, uPlotSeries: [] as uPlot.Series[] }
+    }
+    const ts = buckets.map(b => new Date(b.ts).getTime() / 1000)
+    const inP = buckets.map(b => b.avg_input_power)
+    const outP = buckets.map(b => b.avg_output_power)
+    return {
+      uPlotData: [ts, inP, outP] as uPlot.AlignedData,
+      uPlotSeries: [
+        {},
+        { label: 'input', stroke: inputColor, width: 1.5, points: { show: false } },
+        { label: 'output', stroke: outputColor, width: 1.5, points: { show: false } },
+      ] as uPlot.Series[],
+    }
+  }, [data, inputColor, outputColor])
+
+  const axes = useMemo((): uPlot.Axis[] => [
+    {},
+    { values: (_u: uPlot, vals: number[]) => vals.map(v => `${v.toFixed(1)}`) },
+  ], [])
+
+  const scales = useMemo((): uPlot.Scales => ({
+    x: { time: true },
+    y: { auto: true },
+  }), [])
+
+  useUPlotChart({
+    containerRef: chartRef,
+    data: uPlotData,
+    series: uPlotSeries,
+    height: 144,
+    axes,
+    scales,
+  })
+
+  const hasData = uPlotData[0].length > 0
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between text-xs text-muted-foreground uppercase tracking-wider mb-1">
+        <span>
+          Optical Power — {interfaceName} / channel {channelIndex}
+        </span>
+        {isLoading && <Loader2 className="h-3 w-3 animate-spin" />}
+      </div>
+      {hasData ? (
+        <>
+          <div ref={chartRef} className="h-36" />
+          <div className="mt-2 flex items-center gap-4 text-[11px] text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full" style={{ background: inputColor }} />
+              Input (dBm)
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full" style={{ background: outputColor }} />
+              Output (dBm)
+            </span>
+          </div>
+        </>
+      ) : (
+        <div className="text-xs text-muted-foreground/60 py-6 text-center">
+          {isLoading ? 'Loading…' : 'No samples in the selected window'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/device-charts/DeviceOpticsChart.tsx
+++ b/web/src/components/device-charts/DeviceOpticsChart.tsx
@@ -1,42 +1,70 @@
-import { useMemo, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useQuery, keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import uPlot from 'uplot'
-import { Loader2 } from 'lucide-react'
+import { Loader2, RefreshCw } from 'lucide-react'
 import { useTheme } from '@/hooks/use-theme'
 import { useUPlotChart } from '@/hooks/use-uplot-chart'
 import { fetchDeviceOpticsHistory } from '@/lib/api'
+import type { TimeRange } from '@/components/topology/utils'
+import { formatHoveredTime } from '@/components/topology/utils'
+import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 
 interface DeviceOpticsChartProps {
   devicePk: string
   interfaceName: string
   channelIndex: number
-  hours?: number
+  timeRange: TimeRange
   className?: string
+}
+
+function formatDbm(v: number | null | undefined): string {
+  return v == null ? '—' : `${v.toFixed(2)} dBm`
 }
 
 export function DeviceOpticsChart({
   devicePk,
   interfaceName,
   channelIndex,
-  hours = 24,
+  timeRange,
   className,
 }: DeviceOpticsChartProps) {
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
   const chartRef = useRef<HTMLDivElement>(null)
+  const queryClient = useQueryClient()
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['deviceOpticsHistory', devicePk, interfaceName, channelIndex, hours],
-    queryFn: () => fetchDeviceOpticsHistory(devicePk, { interface: interfaceName, channel: channelIndex, hours }),
+  const fetchParams = useMemo(() => {
+    const { range, startTime, endTime } = toDeviceMetricsParams(timeRange)
+    return {
+      interface: interfaceName,
+      channel: channelIndex,
+      range,
+      startTime,
+      endTime,
+    }
+  }, [timeRange, interfaceName, channelIndex])
+
+  const queryKey = ['deviceOpticsHistory', devicePk, fetchParams] as const
+
+  const { data, isFetching } = useQuery({
+    queryKey,
+    queryFn: () => fetchDeviceOpticsHistory(devicePk, fetchParams),
+    placeholderData: keepPreviousData,
   })
 
   const inputColor = isDark ? '#60a5fa' : '#2563eb'
   const outputColor = isDark ? '#34d399' : '#059669'
 
-  const { uPlotData, uPlotSeries } = useMemo(() => {
+  const { uPlotData, uPlotSeries, inputValues, outputValues } = useMemo(() => {
     const buckets = data?.buckets ?? []
     if (buckets.length === 0) {
-      return { uPlotData: [[]] as uPlot.AlignedData, uPlotSeries: [] as uPlot.Series[] }
+      return {
+        uPlotData: [[]] as uPlot.AlignedData,
+        uPlotSeries: [] as uPlot.Series[],
+        inputValues: [] as (number | null)[],
+        outputValues: [] as (number | null)[],
+      }
     }
     const ts = buckets.map(b => new Date(b.ts).getTime() / 1000)
     const inP = buckets.map(b => b.avg_input_power)
@@ -48,18 +76,31 @@ export function DeviceOpticsChart({
         { label: 'input', stroke: inputColor, width: 1.5, points: { show: false } },
         { label: 'output', stroke: outputColor, width: 1.5, points: { show: false } },
       ] as uPlot.Series[],
+      inputValues: inP as (number | null)[],
+      outputValues: outP as (number | null)[],
     }
   }, [data, inputColor, outputColor])
 
   const axes = useMemo((): uPlot.Axis[] => [
     {},
-    { values: (_u: uPlot, vals: number[]) => vals.map(v => `${v.toFixed(1)}`) },
+    { values: (_u: uPlot, vals: number[]) => vals.map(v => v.toFixed(1)) },
   ], [])
 
-  const scales = useMemo((): uPlot.Scales => ({
-    x: { time: true },
-    y: { auto: true },
-  }), [])
+  const scales = useMemo((): uPlot.Scales => {
+    const fromMs = data?.from ? new Date(data.from).getTime() : undefined
+    const toMs = data?.to ? new Date(data.to).getTime() : undefined
+    if (fromMs != null && toMs != null) {
+      return {
+        x: { time: true, range: () => [fromMs / 1000, toMs / 1000] },
+        y: { auto: true },
+      }
+    }
+    return { x: { time: true }, y: { auto: true } }
+  }, [data?.from, data?.to])
+
+  const handleCursorIdx = useCallback((idx: number | null) => {
+    setHoveredIdx(idx)
+  }, [])
 
   useUPlotChart({
     containerRef: chartRef,
@@ -68,36 +109,102 @@ export function DeviceOpticsChart({
     height: 144,
     axes,
     scales,
+    onCursorIdx: handleCursorIdx,
   })
 
   const hasData = uPlotData[0].length > 0
+  const bucketSeconds = data?.bucket_seconds ?? 0
+
+  const timestamps = uPlotData[0] as ArrayLike<number>
+  const hoveredTime = useMemo(
+    () => formatHoveredTime(timestamps, hoveredIdx, bucketSeconds > 0 && bucketSeconds < 60),
+    [timestamps, hoveredIdx, bucketSeconds],
+  )
+
+  const displayIdx =
+    hoveredIdx != null && hoveredIdx < inputValues.length ? hoveredIdx : inputValues.length - 1
+  const currentInput = displayIdx >= 0 ? inputValues[displayIdx] : null
+  const currentOutput = displayIdx >= 0 ? outputValues[displayIdx] : null
+
+  const { maxInput, maxOutput } = useMemo(() => {
+    let mi: number | null = null
+    let mo: number | null = null
+    for (const v of inputValues) if (v != null && (mi == null || v > mi)) mi = v
+    for (const v of outputValues) if (v != null && (mo == null || v > mo)) mo = v
+    return { maxInput: mi, maxOutput: mo }
+  }, [inputValues, outputValues])
 
   return (
-    <div className={className}>
-      <div className="flex items-center justify-between text-xs text-muted-foreground uppercase tracking-wider mb-1">
+    <div className={`${className ?? ''} group/chart`}>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-1">
         <span>
           Optical Power — {interfaceName} / channel {channelIndex}
         </span>
-        {isLoading && <Loader2 className="h-3 w-3 animate-spin" />}
+        {isFetching ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <button
+            type="button"
+            onClick={() => queryClient.invalidateQueries({ queryKey })}
+            className="opacity-0 group-hover/chart:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+            title="Refresh"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
+        )}
       </div>
+      <div className="h-0.5 w-full overflow-hidden rounded-full mb-1">
+        {isFetching && (
+          <div className="h-full w-1/3 bg-muted-foreground/40 animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full" />
+        )}
+      </div>
+      <div ref={chartRef} className="h-36" />
       {hasData ? (
-        <>
-          <div ref={chartRef} className="h-36" />
-          <div className="mt-2 flex items-center gap-4 text-[11px] text-muted-foreground">
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full" style={{ background: inputColor }} />
-              Input (dBm)
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full" style={{ background: outputColor }} />
-              Output (dBm)
+        <div className="flex flex-col text-xs px-2 pt-2 pb-1">
+          <div className="flex items-center px-1 mb-1">
+            <span className="text-xs text-muted-foreground flex-1 min-w-0">Series</span>
+            <span className="text-xs text-muted-foreground w-24 text-right whitespace-nowrap">Max</span>
+            <span className="text-xs text-muted-foreground w-32 text-right whitespace-nowrap">
+              {hoveredTime ?? 'Value'}
             </span>
           </div>
-        </>
-      ) : (
-        <div className="text-xs text-muted-foreground/60 py-6 text-center">
-          {isLoading ? 'Loading…' : 'No samples in the selected window'}
+          <div className="flex items-center px-1 py-0.5">
+            <div className="flex items-center gap-1.5 min-w-0 flex-1">
+              <span
+                className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: inputColor }}
+              />
+              <span className="font-mono text-foreground truncate">Input</span>
+            </div>
+            <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-24 text-right">
+              {formatDbm(maxInput)}
+            </span>
+            <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-32 text-right">
+              {formatDbm(currentInput)}
+            </span>
+          </div>
+          <div className="flex items-center px-1 py-0.5">
+            <div className="flex items-center gap-1.5 min-w-0 flex-1">
+              <span
+                className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: outputColor }}
+              />
+              <span className="font-mono text-foreground truncate">Output</span>
+            </div>
+            <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-24 text-right">
+              {formatDbm(maxOutput)}
+            </span>
+            <span className="text-muted-foreground font-mono tabular-nums whitespace-nowrap w-32 text-right">
+              {formatDbm(currentOutput)}
+            </span>
+          </div>
         </div>
+      ) : (
+        !isFetching && (
+          <div className="text-xs text-muted-foreground/60 py-2 text-center">
+            No samples in the selected time range
+          </div>
+        )
       )}
     </div>
   )

--- a/web/src/components/device-charts/DeviceOpticsPanel.tsx
+++ b/web/src/components/device-charts/DeviceOpticsPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Loader2, AlertCircle, ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { fetchDeviceOptics, type OpticsLane, type OpticsSeverity } from '@/lib/api'
 import { DeviceOpticsChart } from './DeviceOpticsChart'
 
@@ -38,46 +38,13 @@ function laneKey(lane: OpticsLane): string {
 export function DeviceOpticsPanel({ devicePk, className }: DeviceOpticsPanelProps) {
   const [expanded, setExpanded] = useState<string | null>(null)
 
-  const { data, isLoading, error } = useQuery({
+  const { data } = useQuery({
     queryKey: ['deviceOptics', devicePk],
     queryFn: () => fetchDeviceOptics(devicePk),
   })
 
-  if (isLoading) {
-    return (
-      <div className={className}>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
-          <span>Optics</span>
-          <Loader2 className="h-3 w-3 animate-spin" />
-        </div>
-        <div className="animate-pulse bg-muted rounded h-20 w-full" />
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className={className}>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
-          <span>Optics</span>
-        </div>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <AlertCircle className="h-3.5 w-3.5" />
-          Failed to load optics
-        </div>
-      </div>
-    )
-  }
-
   if (!data || !data.lanes || data.lanes.length === 0) {
-    return (
-      <div className={className}>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
-          <span>Optics</span>
-        </div>
-        <div className="text-xs text-muted-foreground/60">No transceiver telemetry for this device</div>
-      </div>
-    )
+    return null
   }
 
   const { lanes, summary } = data

--- a/web/src/components/device-charts/DeviceOpticsPanel.tsx
+++ b/web/src/components/device-charts/DeviceOpticsPanel.tsx
@@ -2,10 +2,12 @@ import { Fragment, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { fetchDeviceOptics, type OpticsLane, type OpticsSeverity } from '@/lib/api'
+import type { TimeRange } from '@/components/topology/utils'
 import { DeviceOpticsChart } from './DeviceOpticsChart'
 
 interface DeviceOpticsPanelProps {
   devicePk: string
+  timeRange: TimeRange
   className?: string
 }
 
@@ -35,7 +37,7 @@ function laneKey(lane: OpticsLane): string {
   return `${lane.interface_name}:${lane.channel_index}`
 }
 
-export function DeviceOpticsPanel({ devicePk, className }: DeviceOpticsPanelProps) {
+export function DeviceOpticsPanel({ devicePk, timeRange, className }: DeviceOpticsPanelProps) {
   const [expanded, setExpanded] = useState<string | null>(null)
 
   const { data } = useQuery({
@@ -137,6 +139,7 @@ export function DeviceOpticsPanel({ devicePk, className }: DeviceOpticsPanelProp
                           devicePk={devicePk}
                           interfaceName={lane.interface_name}
                           channelIndex={lane.channel_index}
+                          timeRange={timeRange}
                         />
                         {lane.thresholds && (
                           <div className="mt-3 grid grid-cols-3 gap-3 text-[11px] text-muted-foreground">

--- a/web/src/components/device-charts/DeviceOpticsPanel.tsx
+++ b/web/src/components/device-charts/DeviceOpticsPanel.tsx
@@ -1,0 +1,237 @@
+import { Fragment, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, AlertCircle, ChevronDown, ChevronRight } from 'lucide-react'
+import { fetchDeviceOptics, type OpticsLane, type OpticsSeverity } from '@/lib/api'
+import { DeviceOpticsChart } from './DeviceOpticsChart'
+
+interface DeviceOpticsPanelProps {
+  devicePk: string
+  className?: string
+}
+
+const severityBadge: Record<OpticsSeverity, string> = {
+  ok: 'bg-green-500/10 text-green-600 dark:text-green-400',
+  warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  critical: 'bg-red-500/10 text-red-600 dark:text-red-400',
+  unknown: 'bg-muted/60 text-muted-foreground',
+}
+
+const severityDot: Record<OpticsSeverity, string> = {
+  ok: 'bg-green-500',
+  warning: 'bg-amber-500',
+  critical: 'bg-red-500',
+  unknown: 'bg-muted-foreground/40',
+}
+
+function formatDbm(v: number): string {
+  return `${v.toFixed(2)} dBm`
+}
+
+function formatMa(v: number): string {
+  return `${v.toFixed(2)} mA`
+}
+
+function laneKey(lane: OpticsLane): string {
+  return `${lane.interface_name}:${lane.channel_index}`
+}
+
+export function DeviceOpticsPanel({ devicePk, className }: DeviceOpticsPanelProps) {
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['deviceOptics', devicePk],
+    queryFn: () => fetchDeviceOptics(devicePk),
+  })
+
+  if (isLoading) {
+    return (
+      <div className={className}>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
+          <span>Optics</span>
+          <Loader2 className="h-3 w-3 animate-spin" />
+        </div>
+        <div className="animate-pulse bg-muted rounded h-20 w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={className}>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
+          <span>Optics</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <AlertCircle className="h-3.5 w-3.5" />
+          Failed to load optics
+        </div>
+      </div>
+    )
+  }
+
+  if (!data || !data.lanes || data.lanes.length === 0) {
+    return (
+      <div className={className}>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider mb-2">
+          <span>Optics</span>
+        </div>
+        <div className="text-xs text-muted-foreground/60">No transceiver telemetry for this device</div>
+      </div>
+    )
+  }
+
+  const { lanes, summary } = data
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider">
+          <span>Optics</span>
+          <span className="text-muted-foreground/60 normal-case tracking-normal">
+            {summary.total} {summary.total === 1 ? 'lane' : 'lanes'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-[11px]">
+          {summary.critical > 0 && (
+            <span className={`px-2 py-0.5 rounded-full ${severityBadge.critical}`}>
+              {summary.critical} critical
+            </span>
+          )}
+          {summary.warning > 0 && (
+            <span className={`px-2 py-0.5 rounded-full ${severityBadge.warning}`}>
+              {summary.warning} warning
+            </span>
+          )}
+          {summary.ok > 0 && (
+            <span className={`px-2 py-0.5 rounded-full ${severityBadge.ok}`}>
+              {summary.ok} ok
+            </span>
+          )}
+          {summary.unknown > 0 && (
+            <span className={`px-2 py-0.5 rounded-full ${severityBadge.unknown}`}>
+              {summary.unknown} unknown
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-xs text-muted-foreground uppercase tracking-wider">
+            <tr>
+              <th className="text-left font-normal px-3 py-2 w-6"></th>
+              <th className="text-left font-normal px-3 py-2">Interface</th>
+              <th className="text-left font-normal px-3 py-2">Ch</th>
+              <th className="text-right font-normal px-3 py-2">Input</th>
+              <th className="text-right font-normal px-3 py-2">Output</th>
+              <th className="text-right font-normal px-3 py-2">Bias</th>
+              <th className="text-left font-normal px-3 py-2">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lanes.map(lane => {
+              const key = laneKey(lane)
+              const isOpen = expanded === key
+              return (
+                <Fragment key={key}>
+                  <tr
+                    className="border-t border-border cursor-pointer hover:bg-muted/30"
+                    onClick={() => setExpanded(isOpen ? null : key)}
+                  >
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {isOpen ? (
+                        <ChevronDown className="h-3.5 w-3.5" />
+                      ) : (
+                        <ChevronRight className="h-3.5 w-3.5" />
+                      )}
+                    </td>
+                    <td className="px-3 py-2 font-mono">{lane.interface_name}</td>
+                    <td className="px-3 py-2 font-mono text-muted-foreground">{lane.channel_index}</td>
+                    <td className={`px-3 py-2 text-right font-mono ${lane.input_severity === 'critical' ? 'text-red-600 dark:text-red-400' : lane.input_severity === 'warning' ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+                      {formatDbm(lane.input_power)}
+                    </td>
+                    <td className={`px-3 py-2 text-right font-mono ${lane.output_severity === 'critical' ? 'text-red-600 dark:text-red-400' : lane.output_severity === 'warning' ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+                      {formatDbm(lane.output_power)}
+                    </td>
+                    <td className={`px-3 py-2 text-right font-mono ${lane.bias_severity === 'critical' ? 'text-red-600 dark:text-red-400' : lane.bias_severity === 'warning' ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+                      {formatMa(lane.laser_bias_current)}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className={`inline-block h-2 w-2 rounded-full ${severityDot[lane.overall_severity]}`} />
+                        <span className="capitalize text-xs">{lane.overall_severity}</span>
+                      </span>
+                    </td>
+                  </tr>
+                  {isOpen && (
+                    <tr className="border-border bg-muted/10">
+                      <td colSpan={7} className="px-3 py-3">
+                        <DeviceOpticsChart
+                          devicePk={devicePk}
+                          interfaceName={lane.interface_name}
+                          channelIndex={lane.channel_index}
+                        />
+                        {lane.thresholds && (
+                          <div className="mt-3 grid grid-cols-3 gap-3 text-[11px] text-muted-foreground">
+                            <ThresholdSummary
+                              label="Input"
+                              unit="dBm"
+                              warnLo={lane.thresholds.input_warning_lower}
+                              warnHi={lane.thresholds.input_warning_upper}
+                              critLo={lane.thresholds.input_critical_lower}
+                              critHi={lane.thresholds.input_critical_upper}
+                            />
+                            <ThresholdSummary
+                              label="Output"
+                              unit="dBm"
+                              warnLo={lane.thresholds.output_warning_lower}
+                              warnHi={lane.thresholds.output_warning_upper}
+                              critLo={lane.thresholds.output_critical_lower}
+                              critHi={lane.thresholds.output_critical_upper}
+                            />
+                            <ThresholdSummary
+                              label="Bias"
+                              unit="mA"
+                              warnLo={lane.thresholds.bias_warning_lower}
+                              warnHi={lane.thresholds.bias_warning_upper}
+                              critLo={lane.thresholds.bias_critical_lower}
+                              critHi={lane.thresholds.bias_critical_upper}
+                            />
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+interface ThresholdSummaryProps {
+  label: string
+  unit: string
+  warnLo?: number
+  warnHi?: number
+  critLo?: number
+  critHi?: number
+}
+
+function ThresholdSummary({ label, unit, warnLo, warnHi, critLo, critHi }: ThresholdSummaryProps) {
+  const fmt = (v: number | undefined) => (v == null ? '—' : v.toFixed(2))
+  return (
+    <div>
+      <div className="font-medium text-foreground/80 mb-0.5">{label}</div>
+      <div>
+        Warn: {fmt(warnLo)} to {fmt(warnHi)} {unit}
+      </div>
+      <div>
+        Crit: {fmt(critLo)} to {fmt(critHi)} {unit}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -14,6 +14,7 @@ import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
 import { DeviceTrafficChart } from '@/components/device-charts/DeviceTrafficChart'
+import { DeviceOpticsPanel } from '@/components/device-charts/DeviceOpticsPanel'
 import { TimeRangeSelector } from '@/components/topology/TimeRangeSelector'
 import type { TimeRange } from '@/components/topology/utils'
 import { useActiveOpsTickets, useOpsTicketHistory } from '@/hooks/use-ops-tickets'
@@ -308,6 +309,7 @@ export function DeviceDetailPage() {
               showIncidents={showIncidents}
               showMaintenance={showMaintenance}
             />
+            <DeviceOpticsPanel devicePk={device.pk} className="rounded-lg border border-border p-4" />
           </div>
         )}
       </div>

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -309,7 +309,11 @@ export function DeviceDetailPage() {
               showIncidents={showIncidents}
               showMaintenance={showMaintenance}
             />
-            <DeviceOpticsPanel devicePk={device.pk} className="rounded-lg border border-border p-4" />
+            <DeviceOpticsPanel
+              devicePk={device.pk}
+              timeRange={timeRange}
+              className="rounded-lg border border-border p-4"
+            />
           </div>
         )}
       </div>

--- a/web/src/hooks/use-ops-tickets.ts
+++ b/web/src/hooks/use-ops-tickets.ts
@@ -1,5 +1,6 @@
 // web/src/hooks/use-ops-tickets.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '@/contexts/AuthContext'
 import {
   fetchActiveOpsTickets,
   fetchOpsTicketHistory,
@@ -13,12 +14,14 @@ import {
 const STALE_TIME = 5 * 60 * 1000 // 5 minutes
 
 // Fetch all active tickets once; filter client-side per entity.
-// Returns undefined data (empty state) for unauthenticated users — no error shown.
+// Skipped entirely for unauthenticated users so the 401 never fires.
 export function useActiveOpsTickets() {
+  const { user } = useAuth()
   return useQuery({
     queryKey: ['ops-tickets', 'active'],
     queryFn: fetchActiveOpsTickets,
     staleTime: STALE_TIME,
+    enabled: !!user,
     retry: false,
     throwOnError: false,
   })
@@ -40,12 +43,16 @@ export function useTicketsForEntity(entityPk: string): OpsTicket[] {
 }
 
 // Fetch 5 most recent closed tickets for a specific entity (detail page only).
+// Skipped for unauthenticated users so the 401 never fires.
 export function useOpsTicketHistory(entityPk: string, ticketType?: OpsTicketType, entityType?: 'link' | 'device') {
+  const { user } = useAuth()
   return useQuery({
     queryKey: ['ops-tickets', 'history', entityPk, ticketType, entityType],
     queryFn: () => fetchOpsTicketHistory(entityPk, ticketType, entityType),
     staleTime: STALE_TIME,
-    enabled: !!entityPk,
+    enabled: !!entityPk && !!user,
+    retry: false,
+    throwOnError: false,
   })
 }
 
@@ -61,11 +68,14 @@ export function useCreateOpsTicket() {
 }
 
 // Fetch the list of valid assignees. Cached for 5 minutes.
+// Skipped for unauthenticated users so the 401 never fires.
 export function useOpsAssignees() {
+  const { user } = useAuth()
   return useQuery({
     queryKey: ['ops-assignees'],
     queryFn: fetchOpsAssignees,
     staleTime: STALE_TIME,
+    enabled: !!user,
     retry: false,
     throwOnError: false,
   })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2957,6 +2957,99 @@ export async function fetchDeviceValidatorStats(pk: string): Promise<DeviceValid
   return res.json()
 }
 
+export type OpticsSeverity = 'ok' | 'warning' | 'critical' | 'unknown'
+
+export interface OpticsThresholds {
+  input_warning_lower?: number
+  input_warning_upper?: number
+  input_critical_lower?: number
+  input_critical_upper?: number
+  output_warning_lower?: number
+  output_warning_upper?: number
+  output_critical_lower?: number
+  output_critical_upper?: number
+  bias_warning_lower?: number
+  bias_warning_upper?: number
+  bias_critical_lower?: number
+  bias_critical_upper?: number
+}
+
+export interface OpticsLane {
+  interface_name: string
+  channel_index: number
+  timestamp: string
+  input_power: number
+  output_power: number
+  laser_bias_current: number
+  input_severity: OpticsSeverity
+  output_severity: OpticsSeverity
+  bias_severity: OpticsSeverity
+  overall_severity: OpticsSeverity
+  thresholds?: OpticsThresholds
+}
+
+export interface OpticsSummary {
+  ok: number
+  warning: number
+  critical: number
+  unknown: number
+  total: number
+}
+
+export interface DeviceOpticsResponse {
+  device_pk: string
+  device_code: string
+  lanes: OpticsLane[]
+  summary: OpticsSummary
+  fetched_at: string
+}
+
+export async function fetchDeviceOptics(pk: string): Promise<DeviceOpticsResponse> {
+  const res = await fetchWithRetry(`/api/dz/devices/${encodeURIComponent(pk)}/optics`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch device optics')
+  }
+  return res.json()
+}
+
+export interface DeviceOpticsHistoryPoint {
+  ts: string
+  channel_index: number
+  avg_input_power: number
+  min_input_power: number
+  max_input_power: number
+  avg_output_power: number
+  min_output_power: number
+  max_output_power: number
+  avg_laser_bias_current: number
+}
+
+export interface DeviceOpticsHistoryResponse {
+  device_pk: string
+  interface_name: string
+  channel_index?: number
+  bucket_seconds: number
+  from: string
+  to: string
+  buckets: DeviceOpticsHistoryPoint[]
+}
+
+export async function fetchDeviceOpticsHistory(
+  pk: string,
+  params: { interface: string; channel?: number; hours?: number }
+): Promise<DeviceOpticsHistoryResponse> {
+  const search = new URLSearchParams({ interface: params.interface })
+  if (params.channel !== undefined) search.set('channel', String(params.channel))
+  if (params.hours !== undefined) search.set('hours', String(params.hours))
+  const res = await fetchWithRetry(
+    `/api/dz/devices/${encodeURIComponent(pk)}/optics/history?${search.toString()}`
+  )
+  if (!res.ok) {
+    throw new Error('Failed to fetch device optics history')
+  }
+  return res.json()
+}
+
 export interface Link {
   pk: string
   code: string

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3034,13 +3034,25 @@ export interface DeviceOpticsHistoryResponse {
   buckets: DeviceOpticsHistoryPoint[]
 }
 
+export interface FetchDeviceOpticsHistoryParams {
+  interface: string
+  channel?: number
+  range?: string
+  startTime?: number
+  endTime?: number
+  bucket?: string
+}
+
 export async function fetchDeviceOpticsHistory(
   pk: string,
-  params: { interface: string; channel?: number; hours?: number }
+  params: FetchDeviceOpticsHistoryParams
 ): Promise<DeviceOpticsHistoryResponse> {
   const search = new URLSearchParams({ interface: params.interface })
   if (params.channel !== undefined) search.set('channel', String(params.channel))
-  if (params.hours !== undefined) search.set('hours', String(params.hours))
+  if (params.range) search.set('range', params.range)
+  if (params.startTime !== undefined) search.set('start_time', String(params.startTime))
+  if (params.endTime !== undefined) search.set('end_time', String(params.endTime))
+  if (params.bucket) search.set('bucket', params.bucket)
   const res = await fetchWithRetry(
     `/api/dz/devices/${encodeURIComponent(pk)}/optics/history?${search.toString()}`
   )


### PR DESCRIPTION
## Summary

- Surface per-lane transceiver state on the device detail page so operators can spot degrading optics before they cause a hard link failure. Reads from the new `telemetry_<env>` mirrors added in #597.
- `GET /api/dz/devices/{pk}/optics` joins `transceiver_state_latest` against `transceiver_thresholds_latest` and classifies each lane's input power, output power, and laser bias current as `ok` / `warning` / `critical` / `unknown`. Missing or 0/0 sentinel thresholds (a real data-hygiene case on testnet) yield `unknown` rather than a false OK.
- `GET /api/dz/devices/{pk}/optics/history` returns bucketed avg/min/max input + output power for a given `(interface, channel)` over a 1h–30d window; bucket size scales with the requested window.
- New `DeviceOpticsPanel` on the device detail page shows summary chips (`X critical / Y warning / Z ok / W unknown`) and a per-lane table with traffic-light coloring. Clicking a row expands a uPlot `DeviceOpticsChart` of input/output power and shows the threshold bounds inline.
- Bundled fix: ops-tickets queries (`useActiveOpsTickets`, `useOpsTicketHistory`, `useOpsAssignees`) are now gated on `useAuth().user`, so unauthenticated dev sessions no longer hit 401s — the history query in particular was missing `throwOnError: false` and was tearing down the detail page.

## Testing Verification

- `go test ./api/handlers/ -run TestGetDeviceOptics` — covers severity classification (ok / warning / critical / missing-thresholds), the not-found path, and history bucketing.
- `golangci-lint run ./api/handlers/` — clean.
- Local API + Playwright dev session against `telemetry_testnet`:
  - `lon-dz001` (`Cpt3doj17dCF6bEhvc7VeAuZbXLD88a1EboTyE8uj6ZL`) returns 14 lanes with 1 critical (`Ethernet5/0` at -26.78 dBm input, below the -20 dBm CRITICAL bound), 1 unknown (`Ethernet41/0` with 0/0 sentinel thresholds), 12 ok.
  - History endpoint returns 220 buckets at 60s resolution for a 4h window.