### PR TITLE
web: add interpretive tooltips and section copy across data site

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -6,6 +6,7 @@
       "name": "web",
       "dependencies": {
         "@codemirror/lang-sql": "^6.10.0",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/react": "^10.36.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/wallet-adapter-base": "^0.9.23",
@@ -270,6 +271,14 @@
 
     "@fivebinaries/coin-selection": ["@fivebinaries/coin-selection@3.0.0", "", { "dependencies": { "@emurgo/cardano-serialization-lib-browser": "^13.2.0", "@emurgo/cardano-serialization-lib-nodejs": "13.2.0" } }, "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@fractalwagmi/popup-connection": ["@fractalwagmi/popup-connection@1.1.1", "", { "peerDependencies": { "react": "^17.0.2 || ^18", "react-dom": "^17.0.2 || ^18" } }, "sha512-hYL+45iYwNbwjvP2DxP3YzVsrAGtj/RV9LOgMpJyCxsfNoyyOoi2+YrnywKkiANingiG2kJ1nKsizbu1Bd4zZw=="],
 
     "@fractalwagmi/solana-wallet-adapter": ["@fractalwagmi/solana-wallet-adapter@0.1.1", "", { "dependencies": { "@fractalwagmi/popup-connection": "^1.0.18", "@solana/wallet-adapter-base": "^0.9.17", "bs58": "^5.0.0" } }, "sha512-oTZLEuD+zLKXyhZC5tDRMPKPj8iaxKLxXiCjqRfOo4xmSbS2izGRWLJbKMYYsJysn/OI3UJ3P6CWP8WUWi0dZg=="],
@@ -411,6 +420,48 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@1.24.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.60 <1.0" } }, "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@codemirror/lang-sql": "^6.10.0",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/react": "^10.36.0",
     "@solana/spl-token": "^0.4.14",
     "@solana/wallet-adapter-base": "^0.9.23",

--- a/web/src/components/contributors-page.tsx
+++ b/web/src/components/contributors-page.tsx
@@ -8,6 +8,7 @@ import { Pagination } from './pagination'
 import { InlineFilter } from './inline-filter'
 import { PageHeader } from './page-header'
 import { CopyableText } from './copyable-text'
+import { Tooltip } from './ui/tooltip'
 
 const PAGE_SIZE = 100
 
@@ -243,30 +244,36 @@ export function ContributorsPage() {
                       <SortIcon field="devices" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidea')} title="The originating or source side of a network link or transport path within the topology.">
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidea')}>
-                      Side A
-                      <SortIcon field="sidea" />
-                    </button>
-                  </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidez')} title="The destination or terminating side of a network link or transport path within the topology.">
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidez')}>
-                      Side Z
-                      <SortIcon field="sidez" />
-                    </button>
-                  </th>
+                  <Tooltip content="The originating or source side of a network link or transport path within the topology.">
+                    <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidea')}>
+                      <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidea')}>
+                        Side A
+                        <SortIcon field="sidea" />
+                      </button>
+                    </th>
+                  </Tooltip>
+                  <Tooltip content="The destination or terminating side of a network link or transport path within the topology.">
+                    <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidez')}>
+                      <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidez')}>
+                        Side Z
+                        <SortIcon field="sidez" />
+                      </button>
+                    </th>
+                  </Tooltip>
                   <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('links')}>
                     <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('links')}>
                       Links
                       <SortIcon field="links" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('users')} title="Active users over total available capacity.">
-                    <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('users')}>
-                      Users
-                      <SortIcon field="users" />
-                    </button>
-                  </th>
+                  <Tooltip content="Active users over total available capacity.">
+                    <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('users')}>
+                      <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('users')}>
+                        Users
+                        <SortIcon field="users" />
+                      </button>
+                    </th>
+                  </Tooltip>
                 </tr>
               </thead>
               <tbody>

--- a/web/src/components/contributors-page.tsx
+++ b/web/src/components/contributors-page.tsx
@@ -243,13 +243,13 @@ export function ContributorsPage() {
                       <SortIcon field="devices" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidea')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidea')} title="The originating or source side of a network link or transport path within the topology.">
                     <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidea')}>
                       Side A
                       <SortIcon field="sidea" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidez')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('sidez')} title="The destination or terminating side of a network link or transport path within the topology.">
                     <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('sidez')}>
                       Side Z
                       <SortIcon field="sidez" />
@@ -261,7 +261,7 @@ export function ContributorsPage() {
                       <SortIcon field="links" />
                     </button>
                   </th>
-                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('users')}>
+                  <th className="px-4 py-3 font-medium text-right" aria-sort={sortAria('users')} title="Active users over total available capacity.">
                     <button className="inline-flex items-center gap-1 justify-end w-full" type="button" onClick={() => handleSort('users')}>
                       Users
                       <SortIcon field="users" />

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -12,6 +12,7 @@ import {
   type EdgeScoreboardLeader,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Tooltip } from '@/components/ui/tooltip'
 import { PageHeader } from './page-header'
 
 function useAnimatedNumber(target: number | undefined, duration = 500) {
@@ -2215,7 +2216,7 @@ export function EdgeScoreboardPage() {
                   [false, 'All Slots', 'Shred arrival rates across all observed slots.'] as const,
                   [true, 'DZ Edge Leaders', 'Scoped to slots where the scheduled leader is publishing shreds via DZ Edge.'] as const,
                 ]).map(([v, label, tooltip]) => (
-                  <div key={String(v)} className="relative group">
+                  <Tooltip key={String(v)} content={tooltip}>
                     <button
                       type="button"
                       onClick={() => setLeadersOnly(v)}
@@ -2228,10 +2229,7 @@ export function EdgeScoreboardPage() {
                     >
                       {label}
                     </button>
-                    <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-30 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
-                      {tooltip}
-                    </span>
-                  </div>
+                  </Tooltip>
                 ))}
               </div>
               <a
@@ -2344,7 +2342,10 @@ export function EdgeScoreboardPage() {
                       queue={liveTailStatus.queueLen} ({formatLag(liveTailStatus.queueLagMs)}) · server={formatLag(liveTailStatus.serverLagMs)} · slot={liveTailStatus.edge}
                     </span>
                   )}
-                  <div className="relative group">
+                  <Tooltip
+                    content={granular ? 'Showing DZ Edge, Jito, and Turbine separately — click to collapse to DZ vs Other' : 'Break out DZ Edge leaders and regional retransmits alongside Jito and Turbine'}
+                    align="end"
+                  >
                     <button
                       type="button"
                       onClick={() => setGranular(!granular)}
@@ -2357,10 +2358,7 @@ export function EdgeScoreboardPage() {
                     >
                       <Layers size={15} />
                     </button>
-                    <span className="pointer-events-none absolute top-full right-0 mt-2 z-30 w-48 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
-                      {granular ? 'Showing DZ Edge, Jito, and Turbine separately — click to collapse to DZ vs Other' : 'Break out DZ Edge leaders and regional retransmits alongside Jito and Turbine'}
-                    </span>
-                  </div>
+                  </Tooltip>
                   <button
                     onClick={() => toggleLiveRef.current?.()}
                     className={cn(

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -2213,7 +2213,7 @@ export function EdgeScoreboardPage() {
               <div className="flex flex-wrap items-center gap-1.5 text-xs">
                 {([
                   [false, 'All Slots', 'Shred arrival rates across all observed slots.'] as const,
-                  [true, 'DZ Edge Leaders', 'Scoped to slots where the scheduled leader was publishing shreds via DZ Edge.'] as const,
+                  [true, 'DZ Edge Leaders', 'Scoped to slots where the scheduled leader is publishing shreds via DZ Edge.'] as const,
                 ]).map(([v, label, tooltip]) => (
                   <div key={String(v)} className="relative group">
                     <button

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -874,6 +874,9 @@ export function IncidentsPage() {
             </div>
           }
         />
+        <p className="text-sm text-muted-foreground -mt-4 mb-6 max-w-4xl">
+          This dashboard tracks network outages, degradations, and fluctuations across the network.
+        </p>
         {showCreateIncident && (
           <CreateIncidentModal
             onClose={() => setShowCreateIncident(false)}
@@ -1144,27 +1147,28 @@ export function IncidentsPage() {
             >
               {(
                 [
-                  ...(scope === 'links' ? [{ key: 'packet_loss', label: 'Packet Loss' }] : []),
-                  { key: 'errors', label: 'Errors' },
-                  { key: 'fcs', label: 'FCS Errors' },
-                  { key: 'discards', label: 'Discards' },
-                  { key: 'carrier', label: 'Carrier' },
-                  { key: 'no_data', label: 'No Data' },
-                  ...(scope === 'links' ? [{ key: 'isis_down', label: 'ISIS Down' }] : []),
+                  ...(scope === 'links' ? [{ key: 'packet_loss', label: 'Packet Loss', tooltip: 'Packets that failed to arrive at their destination.' }] : []),
+                  { key: 'errors', label: 'Errors', tooltip: 'Packets or frames that were received or transmitted incorrectly.' },
+                  { key: 'fcs', label: 'FCS Errors', tooltip: 'Frames that failed the Frame Check Sequence (FCS) integrity check.' },
+                  { key: 'discards', label: 'Discards', tooltip: 'Packets intentionally dropped by a device.' },
+                  { key: 'carrier', label: 'Carrier', tooltip: 'Transitions on the physical link status between network devices.' },
+                  { key: 'no_data', label: 'No Data', tooltip: 'No telemetry was received from the device or interface during the window.' },
+                  ...(scope === 'links' ? [{ key: 'isis_down', label: 'IS-IS Down', tooltip: 'IS-IS routing session between devices is unavailable.' }] : []),
                   ...(scope === 'devices'
                     ? [
-                        { key: 'isis_overload', label: 'ISIS Overload' },
-                        { key: 'isis_unreachable', label: 'ISIS Unreachable' },
+                        { key: 'isis_overload', label: 'IS-IS Overload', tooltip: 'Device is signaling IS-IS overload, so traffic is being steered away from it.' },
+                        { key: 'isis_unreachable', label: 'IS-IS Unreachable', tooltip: 'Device is not reachable via IS-IS from its expected neighbors.' },
                       ]
                     : []),
-                ] as { key: string; label: string }[]
-              ).map(({ key, label }) => {
+                ] as { key: string; label: string; tooltip: string }[]
+              ).map(({ key, label, tooltip }) => {
                 const count = filteredByType.byType[key] || 0
                 const isSelected = selectedTypes.has(key)
                 return (
                   <button
                     key={key}
                     onClick={() => toggleType(key)}
+                    title={tooltip}
                     className={`text-center p-3 rounded-lg border transition-colors ${
                       isSelected
                         ? 'border-primary bg-primary/5 ring-1 ring-primary'

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -1150,9 +1150,9 @@ export function IncidentsPage() {
                 [
                   ...(scope === 'links' ? [{ key: 'packet_loss', label: 'Packet Loss', tooltip: 'Packets that failed to arrive at their destination.' }] : []),
                   { key: 'errors', label: 'Errors', tooltip: 'Packets or frames that were received or transmitted incorrectly.' },
-                  { key: 'fcs', label: 'FCS Errors', tooltip: 'Frames that failed the Frame Check Sequence (FCS) integrity check.' },
+                  { key: 'fcs', label: 'FCS Errors', tooltip: 'Frame Check Sequence (FCS) integrity check.' },
                   { key: 'discards', label: 'Discards', tooltip: 'Packets intentionally dropped by a device.' },
-                  { key: 'carrier', label: 'Carrier', tooltip: 'Transitions on the physical link status between network devices.' },
+                  { key: 'carrier', label: 'Carrier', tooltip: 'The physical link status between network devices.' },
                   { key: 'no_data', label: 'No Data', tooltip: 'No telemetry was received from the device or interface during the window.' },
                   ...(scope === 'links' ? [{ key: 'isis_down', label: 'IS-IS Down', tooltip: 'IS-IS routing session between devices is unavailable.' }] : []),
                   ...(scope === 'devices'

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/api'
 import { StatusFilters, useStatusFilters } from '@/components/status-search-bar'
 import { PageHeader } from '@/components/page-header'
+import { Tooltip } from '@/components/ui/tooltip'
 import { useActiveOpsTickets } from '@/hooks/use-ops-tickets'
 import { useIsOpsUser } from '@/hooks/use-is-ops-user'
 import { opsTicketUrl, type OpsTicket } from '@/lib/ops-api'
@@ -1165,19 +1166,19 @@ export function IncidentsPage() {
                 const count = filteredByType.byType[key] || 0
                 const isSelected = selectedTypes.has(key)
                 return (
-                  <button
-                    key={key}
-                    onClick={() => toggleType(key)}
-                    title={tooltip}
-                    className={`text-center p-3 rounded-lg border transition-colors ${
-                      isSelected
-                        ? 'border-primary bg-primary/5 ring-1 ring-primary'
-                        : 'border-border hover:border-muted-foreground/30'
-                    }`}
-                  >
-                    <div className="text-2xl font-medium tabular-nums tracking-tight">{count}</div>
-                    <div className="text-xs text-muted-foreground">{label}</div>
-                  </button>
+                  <Tooltip key={key} content={tooltip}>
+                    <button
+                      onClick={() => toggleType(key)}
+                      className={`text-center p-3 rounded-lg border transition-colors ${
+                        isSelected
+                          ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                          : 'border-border hover:border-muted-foreground/30'
+                      }`}
+                    >
+                      <div className="text-2xl font-medium tabular-nums tracking-tight">{count}</div>
+                      <div className="text-xs text-muted-foreground">{label}</div>
+                    </button>
+                  </Tooltip>
                 )
               })}
             </div>

--- a/web/src/components/topology/TopologyControlBar.tsx
+++ b/web/src/components/topology/TopologyControlBar.tsx
@@ -34,6 +34,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useTopology, type TopologyMode } from './TopologyContext'
 import { useEnv } from '@/contexts/EnvContext'
 import { fetchTopologies } from '@/lib/api'
+import { Tooltip } from '@/components/ui/tooltip'
 
 interface TopologyControlBarProps {
   // Zoom controls (view-specific)
@@ -81,7 +82,7 @@ function NavItem({ icon, label, shortcut, onClick, active = false, disabled = fa
     yellow: 'text-yellow-500',
   }
 
-  return (
+  const button = (
     <button
       onClick={onClick}
       disabled={disabled}
@@ -90,7 +91,7 @@ function NavItem({ icon, label, shortcut, onClick, active = false, disabled = fa
           ? colorClasses[activeColor]
           : 'hover:bg-[var(--muted)] text-muted-foreground hover:text-foreground'
       } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
-      title={tooltip ?? (collapsed ? `${label}${shortcut ? ` (${shortcut})` : ''}` : undefined)}
+      title={tooltip ? undefined : collapsed ? `${label}${shortcut ? ` (${shortcut})` : ''}` : undefined}
     >
       <span className={`flex-shrink-0 ${active ? activeTextClasses[activeColor] : ''}`}>
         {icon}
@@ -106,6 +107,14 @@ function NavItem({ icon, label, shortcut, onClick, active = false, disabled = fa
         </>
       )}
     </button>
+  )
+
+  if (!tooltip) return button
+
+  return (
+    <Tooltip content={tooltip} side="right">
+      {button}
+    </Tooltip>
   )
 }
 

--- a/web/src/components/topology/TopologyControlBar.tsx
+++ b/web/src/components/topology/TopologyControlBar.tsx
@@ -57,9 +57,10 @@ interface NavItemProps {
   disabled?: boolean
   activeColor?: 'amber' | 'red' | 'green' | 'purple' | 'blue' | 'cyan' | 'yellow'
   collapsed?: boolean
+  tooltip?: string
 }
 
-function NavItem({ icon, label, shortcut, onClick, active = false, disabled = false, activeColor = 'blue', collapsed = false }: NavItemProps) {
+function NavItem({ icon, label, shortcut, onClick, active = false, disabled = false, activeColor = 'blue', collapsed = false, tooltip }: NavItemProps) {
   const colorClasses: Record<string, string> = {
     amber: 'bg-amber-500/20 text-amber-500',
     red: 'bg-red-500/20 text-red-500',
@@ -89,7 +90,7 @@ function NavItem({ icon, label, shortcut, onClick, active = false, disabled = fa
           ? colorClasses[activeColor]
           : 'hover:bg-[var(--muted)] text-muted-foreground hover:text-foreground'
       } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
-      title={collapsed ? `${label}${shortcut ? ` (${shortcut})` : ''}` : undefined}
+      title={tooltip ?? (collapsed ? `${label}${shortcut ? ` (${shortcut})` : ''}` : undefined)}
     >
       <span className={`flex-shrink-0 ${active ? activeTextClasses[activeColor] : ''}`}>
         {icon}
@@ -298,6 +299,7 @@ export function TopologyControlBar({
             active={view === 'globe'}
             activeColor="blue"
             collapsed={collapsed}
+            tooltip="3D view of the DoubleZero network on a globe. Shows the same metros, devices, and links as the map view in a spherical projection."
           />
 
           {onZoomIn && (
@@ -538,7 +540,7 @@ export function TopologyControlBar({
           {hasNeo4j && (
             <NavItem
               icon={<GitCompare className="h-3.5 w-3.5" />}
-              label="ISIS"
+              label="IS-IS"
               onClick={() => handleToggleOverlay('isisHealth')}
               active={overlays.isisHealth}
               activeColor="green"
@@ -554,6 +556,7 @@ export function TopologyControlBar({
             active={overlays.trafficFlow}
             activeColor="cyan"
             collapsed={collapsed}
+            tooltip="Color and size links by current utilization (traffic over capacity). Highlights links approaching saturation."
           />
 
           {hasTopologies && (

--- a/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
@@ -1,5 +1,6 @@
 import { Monitor, X } from 'lucide-react'
 import { useTopology } from '../TopologyContext'
+import { Tooltip } from '@/components/ui/tooltip'
 
 // Device type colors (must match topology-graph.tsx and topology-map.tsx)
 // Avoid green/red (status colors) and blue/purple (link colors)
@@ -47,24 +48,22 @@ export function DeviceTypeOverlayPanel({ isDark, deviceCounts }: DeviceTypeOverl
           const colors = DEVICE_TYPE_COLORS[type] || DEVICE_TYPE_COLORS.default
           const count = deviceCounts?.[type] ?? 0
           return (
-            <div
-              key={type}
-              className="flex items-center justify-between"
-              title={DEVICE_TYPE_TOOLTIPS[type]}
-            >
-              <div className="flex items-center gap-2">
-                <div
-                  className="w-4 h-4 rounded-full"
-                  style={{
-                    backgroundColor: isDark ? colors.dark : colors.light,
-                  }}
-                />
-                <span className="capitalize">{type}</span>
+            <Tooltip key={type} content={DEVICE_TYPE_TOOLTIPS[type]} side="left">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="w-4 h-4 rounded-full"
+                    style={{
+                      backgroundColor: isDark ? colors.dark : colors.light,
+                    }}
+                  />
+                  <span className="capitalize">{type}</span>
+                </div>
+                {deviceCounts && (
+                  <span className="text-muted-foreground">{count}</span>
+                )}
               </div>
-              {deviceCounts && (
-                <span className="text-muted-foreground">{count}</span>
-              )}
-            </div>
+            </Tooltip>
           )
         })}
       </div>

--- a/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
@@ -14,9 +14,9 @@ const DEVICE_TYPE_COLORS: Record<string, { light: string; dark: string }> = {
 const DEVICE_TYPES = ['hybrid', 'transit', 'edge']
 
 const DEVICE_TYPE_TOOLTIPS: Record<string, string> = {
-  hybrid: 'Device that handles both inter-metro transit and edge connections (validators, users) on the same router.',
-  transit: 'Device that only forwards traffic between metros. It does not terminate validator or user connections directly.',
-  edge: 'Device at the network edge where validators and users connect into DoubleZero.',
+  hybrid: 'A DZD that combines both edge and transit functionality, providing both user connectivity and backbone routing.',
+  transit: 'A DZD that provides backbone connectivity within the DoubleZero network. Transit devices move traffic between DZDs but do not terminate user connections directly.',
+  edge: 'A DZD that provides user connectivity to the DoubleZero network. Edge devices leverage CYOA interfaces to terminate users (validators, RPC operators) and connect them to the network.',
 }
 
 interface DeviceTypeOverlayPanelProps {

--- a/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
+++ b/web/src/components/topology/overlays/DeviceTypeOverlayPanel.tsx
@@ -12,6 +12,12 @@ const DEVICE_TYPE_COLORS: Record<string, { light: string; dark: string }> = {
 
 const DEVICE_TYPES = ['hybrid', 'transit', 'edge']
 
+const DEVICE_TYPE_TOOLTIPS: Record<string, string> = {
+  hybrid: 'Device that handles both inter-metro transit and edge connections (validators, users) on the same router.',
+  transit: 'Device that only forwards traffic between metros. It does not terminate validator or user connections directly.',
+  edge: 'Device at the network edge where validators and users connect into DoubleZero.',
+}
+
 interface DeviceTypeOverlayPanelProps {
   isDark: boolean
   deviceCounts?: Record<string, number>
@@ -41,7 +47,11 @@ export function DeviceTypeOverlayPanel({ isDark, deviceCounts }: DeviceTypeOverl
           const colors = DEVICE_TYPE_COLORS[type] || DEVICE_TYPE_COLORS.default
           const count = deviceCounts?.[type] ?? 0
           return (
-            <div key={type} className="flex items-center justify-between">
+            <div
+              key={type}
+              className="flex items-center justify-between"
+              title={DEVICE_TYPE_TOOLTIPS[type]}
+            >
               <div className="flex items-center gap-2">
                 <div
                   className="w-4 h-4 rounded-full"

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+const TooltipRoot = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, children, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      data-tooltip-content=""
+      className={cn(
+        "z-50 max-w-xs rounded-lg border border-border bg-popover px-3 py-2 text-xs leading-relaxed text-popover-foreground shadow-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <TooltipPrimitive.Arrow className="fill-popover" width={11} height={5} />
+    </TooltipPrimitive.Content>
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+interface TooltipProps
+  extends Pick<
+    React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+    "side" | "align" | "sideOffset"
+  > {
+  /** Tooltip text/content. When empty the trigger renders as-is with no tooltip. */
+  content: React.ReactNode
+  /** Single element that triggers the tooltip; rendered via `asChild`. */
+  children: React.ReactElement
+  /** Override hover open delay (ms). Defaults to the provider value. */
+  delayDuration?: number
+  /** Extra classes for the tooltip content panel. */
+  className?: string
+}
+
+/**
+ * Convenience wrapper around the Radix tooltip primitives. Renders its child as
+ * the trigger (via `asChild`), so it preserves DOM/table semantics, and portals
+ * the content out of `overflow:hidden` containers.
+ */
+export function Tooltip({
+  content,
+  children,
+  delayDuration,
+  className,
+  side,
+  align,
+  sideOffset,
+}: TooltipProps) {
+  if (content === null || content === undefined || content === "") return children
+  return (
+    <TooltipRoot delayDuration={delayDuration}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} align={align} sideOffset={sideOffset} className={className}>
+        {content}
+      </TooltipContent>
+    </TooltipRoot>
+  )
+}
+
+export { TooltipProvider, TooltipRoot, TooltipTrigger, TooltipContent }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -431,3 +431,21 @@ table {
 .animate-scoreboard-edge-load {
   animation: scoreboardEdgeLoad 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
+
+/* Radix tooltip fade-in (no animate plugin in use) */
+@keyframes tooltipIn {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+[data-tooltip-content][data-state='delayed-open'],
+[data-tooltip-content][data-state='instant-open'] {
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+  animation: tooltipIn 120ms ease-out;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from '@/hooks/use-theme'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { fetchConfig } from '@/lib/api'
 
 // Handle chunk loading failures (stale tabs after deploys) by reloading the page
@@ -76,11 +77,13 @@ async function init() {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <ThemeProvider>
-        <BrowserRouter>
-          <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
-            <App />
-          </Sentry.ErrorBoundary>
-        </BrowserRouter>
+        <TooltipProvider delayDuration={200} skipDelayDuration={300}>
+          <BrowserRouter>
+            <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
+              <App />
+            </Sentry.ErrorBoundary>
+          </BrowserRouter>
+        </TooltipProvider>
       </ThemeProvider>
     </StrictMode>,
   )

--- a/web/src/pages/traffic-dashboard-page.tsx
+++ b/web/src/pages/traffic-dashboard-page.tsx
@@ -37,7 +37,7 @@ function DashboardContent() {
         <div className="[&>div]:mb-0">
           <PageHeader icon={BarChart3} title="Traffic Overview" actions={<DashboardFilters />} />
         </div>
-        <p className="text-sm text-muted-foreground mt-3 max-w-4xl">
+        <p className="text-sm text-muted-foreground mt-3">
           This dashboard compares total traffic measured via throughput, packets, or overall utilization across different network groupings, such as contributors, metros, device types, or transport categories.
         </p>
         <div className="flex items-center mt-3">

--- a/web/src/pages/traffic-dashboard-page.tsx
+++ b/web/src/pages/traffic-dashboard-page.tsx
@@ -37,6 +37,9 @@ function DashboardContent() {
         <div className="[&>div]:mb-0">
           <PageHeader icon={BarChart3} title="Traffic Overview" actions={<DashboardFilters />} />
         </div>
+        <p className="text-sm text-muted-foreground mt-3 max-w-4xl">
+          This dashboard compares total traffic measured via throughput, packets, or overall utilization across different network groupings, such as contributors, metros, device types, or transport categories.
+        </p>
         <div className="flex items-center mt-3">
           <div className="flex items-center gap-3 ml-auto">
             <DashboardFilterBadges />

--- a/web/src/pages/traffic-page.tsx
+++ b/web/src/pages/traffic-page.tsx
@@ -840,7 +840,12 @@ function TrafficPageContent() {
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Sticky header */}
       <div className="flex-none bg-background border-b border-border px-4 sm:px-8 pt-6 pb-4 z-10">
-        <PageHeader icon={Network} title="Interfaces" />
+        <div className="[&>div]:mb-0">
+          <PageHeader icon={Network} title="Interfaces" />
+        </div>
+        <p className="text-sm text-muted-foreground mt-3 max-w-4xl">
+          This dashboard provides visibility into how much traffic is entering and leaving interfaces, overall link utilization, interface health, and whether physical or logical network connections are experiencing congestion, errors, or instability.
+        </p>
         <div className="flex items-center gap-3 mt-3 w-full flex-wrap justify-between">
           <DashboardFilters excludeMetrics={['utilization']} />
           <DashboardFilterBadges />

--- a/web/src/pages/traffic-page.tsx
+++ b/web/src/pages/traffic-page.tsx
@@ -843,7 +843,7 @@ function TrafficPageContent() {
         <div className="[&>div]:mb-0">
           <PageHeader icon={Network} title="Interfaces" />
         </div>
-        <p className="text-sm text-muted-foreground mt-3 max-w-4xl">
+        <p className="text-sm text-muted-foreground mt-3">
           This dashboard provides visibility into how much traffic is entering and leaving interfaces, overall link utilization, interface health, and whether physical or logical network connections are experiencing congestion, errors, or instability.
         </p>
         <div className="flex items-center gap-3 mt-3 w-full flex-wrap justify-between">


### PR DESCRIPTION
## Summary

- Adds short operational tooltips and contextual section copy across the data site so infra/networking engineers can interpret what each metric measures and why it matters
- Covers Topology, Traffic Overview, Traffic Interfaces, Shreds Scoreboard, Incidents, and Contributors
- Renames user-visible "ISIS" to "IS-IS" on the Incidents type cards and the Topology IS-IS overlay button (other places still say "ISIS" — left out of scope)

### What changed by page

- **Topology** (`/topology/map`): tooltips on Globe view, Traffic overlay, and the Hybrid/Transit/Edge legend in the device-type panel
- **Traffic Overview** (`/traffic/overview`): description block under the page header
- **Traffic Interfaces** (`/traffic/interfaces`): description block under the page header
- **Shreds Scoreboard** (`/dz/shreds/scoreboard`): DZ Edge Leaders tooltip changed from past tense to present tense ("…is publishing shreds…")
- **Incidents** (`/incidents/links`): subheading copy plus tooltips on every type card (Packet Loss, Errors, FCS Errors, Discards, Carrier, No Data, IS-IS Down/Overload/Unreachable)
- **Contributors** (`/dz/contributors`): tooltips on Side A, Side Z, Users column headers

The topology copy (Globe view, Traffic, Hybrid/Transit/Edge) was drafted in this PR since the source notes left those tooltips blank — easy to revise.

## Testing Verification

- [ ] Hover Globe view, Traffic, and the Hybrid/Transit/Edge legend entries on `/topology/map` and confirm tooltip copy
- [ ] Confirm description block renders under headers on `/traffic/overview` and `/traffic/interfaces`
- [ ] Hover DZ Edge Leaders on `/dz/shreds/scoreboard` and confirm the tooltip uses present tense
- [ ] Hover each type card on `/incidents/links` (Links and Devices scopes) and confirm tooltips
- [ ] Confirm "IS-IS Down", "IS-IS Overload", "IS-IS Unreachable" labels render correctly on the Incidents type cards
- [ ] Hover Side A / Side Z / Users column headers on `/dz/contributors` and confirm tooltips