### PR TITLE
api/v1: add edge/shreds overview, devices, and client-seats endpoints

### DIFF
--- a/api/handlers/env.go
+++ b/api/handlers/env.go
@@ -84,11 +84,18 @@ func (a *API) RequireNeo4jMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// EnvMiddleware extracts the X-DZ-Env header and stores the environment in the
-// request context. Defaults to mainnet-beta if not provided or invalid.
+// EnvMiddleware extracts the request's target environment and stores it in
+// the context. The canonical channel is the `X-DZ-Env` header; when no valid
+// header is present we fall back to the `env` query parameter so URLs pasted
+// into a browser (or the Scalar API docs page) can target a non-default env
+// without needing custom header support. Defaults to mainnet-beta when
+// neither carries a recognized value.
 func EnvMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		env := DZEnv(r.Header.Get("X-DZ-Env"))
+		if !ValidEnvs[env] {
+			env = DZEnv(r.URL.Query().Get("env"))
+		}
 		if !ValidEnvs[env] {
 			env = EnvMainnet
 		}

--- a/api/handlers/env_test.go
+++ b/api/handlers/env_test.go
@@ -102,13 +102,24 @@ func TestEnvMiddleware(t *testing.T) {
 	tests := []struct {
 		name        string
 		headerValue string
+		queryEnv    string
 		expectedEnv handlers.DZEnv
 	}{
-		{"header present devnet", "devnet", handlers.EnvDevnet},
-		{"header present testnet", "testnet", handlers.EnvTestnet},
-		{"header present mainnet", "mainnet-beta", handlers.EnvMainnet},
-		{"header missing defaults to mainnet", "", handlers.EnvMainnet},
-		{"invalid header defaults to mainnet", "invalid-env", handlers.EnvMainnet},
+		{"header present devnet", "devnet", "", handlers.EnvDevnet},
+		{"header present testnet", "testnet", "", handlers.EnvTestnet},
+		{"header present mainnet", "mainnet-beta", "", handlers.EnvMainnet},
+		{"header missing defaults to mainnet", "", "", handlers.EnvMainnet},
+		{"invalid header defaults to mainnet", "invalid-env", "", handlers.EnvMainnet},
+
+		// Query-string fallback fires when the header is missing or invalid.
+		{"query fallback testnet, no header", "", "testnet", handlers.EnvTestnet},
+		{"query fallback devnet, no header", "", "devnet", handlers.EnvDevnet},
+		{"query fallback mainnet, no header", "", "mainnet-beta", handlers.EnvMainnet},
+		{"invalid header falls through to query", "invalid-env", "testnet", handlers.EnvTestnet},
+		{"invalid query defaults to mainnet", "", "invalid-env", handlers.EnvMainnet},
+
+		// Header wins when both are present.
+		{"header wins over conflicting query", "devnet", "testnet", handlers.EnvDevnet},
 	}
 
 	for _, tt := range tests {
@@ -122,7 +133,11 @@ func TestEnvMiddleware(t *testing.T) {
 			})
 
 			handler := handlers.EnvMiddleware(inner)
-			req := httptest.NewRequest("GET", "/test", nil)
+			url := "/test"
+			if tt.queryEnv != "" {
+				url += "?env=" + tt.queryEnv
+			}
+			req := httptest.NewRequest("GET", url, nil)
 			if tt.headerValue != "" {
 				req.Header.Set("X-DZ-Env", tt.headerValue)
 			}

--- a/api/handlers/shred_devices_fetch.go
+++ b/api/handlers/shred_devices_fetch.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+// FetchEdgeShredsDevices returns a paginated page of shred devices for the env
+// in ctx, sorted by device_code ASC so the v1 response is deterministic. This
+// is the narrowed v1 surface — no filter / sort knobs, just pagination —
+// intentionally decoupled from the broader internal GetShredDevices handler
+// which still exposes filter/sort for the lake UI.
+//
+// Returns the same ShredDeviceItem rows the legacy handler returns; the v1 op
+// is responsible for shaping them into the public response.
+func (a *API) FetchEdgeShredsDevices(ctx context.Context, limit, offset int) ([]ShredDeviceItem, uint64, error) {
+	start := time.Now()
+
+	baseQuery := `
+		SELECT
+			dh.device_key,
+			COALESCE(d.code, '') as device_code,
+			dh.metro_exchange_key,
+			COALESCE(m.code, '') as metro_code,
+			dh.is_enabled,
+			COALESCE(mh.current_usdc_price_dollars, 0) as base_price_dollars,
+			dh.current_usdc_metro_premium_dollars as premium_dollars,
+			toInt64(COALESCE(mh.current_usdc_price_dollars, 0)) + toInt64(dh.current_usdc_metro_premium_dollars) as total_price_dollars,
+			dh.active_granted_seats as granted_seats,
+			dh.active_total_available_seats as capacity,
+			toInt32(dh.active_total_available_seats) - toInt32(dh.active_granted_seats) as available_seats
+		FROM dim_dz_shred_device_histories_current dh
+		LEFT JOIN dz_devices_current d ON dh.device_key = d.pk
+		LEFT JOIN dz_metros_current m ON dh.metro_exchange_key = m.pk
+		LEFT JOIN dim_dz_shred_metro_histories_current mh ON mh.exchange_key = dh.metro_exchange_key
+	`
+
+	var total uint64
+	if err := a.envDB(ctx).QueryRow(ctx, `SELECT count(*) FROM dim_dz_shred_device_histories_current`).Scan(&total); err != nil {
+		metrics.RecordClickHouseQuery("edge_shreds_devices", time.Since(start), err)
+		return nil, 0, err
+	}
+
+	query := baseQuery + ` ORDER BY device_code ASC, dh.device_key ASC LIMIT ? OFFSET ?`
+	rows, err := a.envDB(ctx).Query(ctx, query, limit, offset)
+	metrics.RecordClickHouseQuery("edge_shreds_devices", time.Since(start), err)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var items []ShredDeviceItem
+	for rows.Next() {
+		var d ShredDeviceItem
+		if err := rows.Scan(
+			&d.DeviceKey, &d.DeviceCode,
+			&d.MetroExchangeKey, &d.MetroCode,
+			&d.IsEnabled,
+			&d.BasePriceDollars, &d.PremiumDollars, &d.TotalPriceDollars,
+			&d.GrantedSeats, &d.Capacity, &d.AvailableSeats,
+		); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -35,10 +35,11 @@ type ShredsOverview struct {
 	ValidatorClientRewardCount uint64 `json:"validator_client_reward_count"`
 }
 
-func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
+// FetchShredsOverview returns the program-state overview for the env in ctx.
+// Errors are swallowed: missing execution controller / count tables resolve to
+// zero values rather than propagating up, matching the legacy HTTP handler's
+// behavior so v1 and the internal handler stay in lockstep.
+func (a *API) FetchShredsOverview(ctx context.Context) ShredsOverview {
 	start := time.Now()
 
 	// Fetch execution controller singleton.
@@ -67,15 +68,13 @@ func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
 		&overview.SettledClientSeatsCount,
 		&overview.NextSeatFundingIndex,
 	)
-	duration := time.Since(start)
-	metrics.RecordClickHouseQuery("shreds", duration, err)
+	metrics.RecordClickHouseQuery("shreds", time.Since(start), err)
 
 	if err != nil {
 		// If no execution controller exists yet, return empty overview.
 		overview = ShredsOverview{}
 	}
 
-	// Fetch aggregate counts in parallel-ish (sequential but fast).
 	// Fetch current Solana epoch.
 	var solanaEpoch int64
 	if err := a.envDB(ctx).QueryRow(ctx, `SELECT max(epoch) FROM solana_vote_accounts_current`).Scan(&solanaEpoch); err != nil {
@@ -83,6 +82,7 @@ func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
 	}
 	overview.CurrentSolanaEpoch = uint64(solanaEpoch)
 
+	// Aggregate counts. Tables may not exist yet on a fresh env; treat as zero.
 	countQueries := []struct {
 		query string
 		dest  *uint64
@@ -96,10 +96,18 @@ func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
 
 	for _, cq := range countQueries {
 		if err := a.envDB(ctx).QueryRow(ctx, cq.query).Scan(cq.dest); err != nil {
-			// Tables may not exist yet; treat as zero.
 			*cq.dest = 0
 		}
 	}
+
+	return overview
+}
+
+func (a *API) GetShredsOverview(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	overview := a.FetchShredsOverview(ctx)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(overview); err != nil {

--- a/api/handlers/v1_shreds_client_seats_test.go
+++ b/api/handlers/v1_shreds_client_seats_test.go
@@ -1,0 +1,200 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1EdgeShredsClientSeatsContractFields is the authoritative JSON key set for
+// the /api/v1/edge/shreds/client-seats response. A mismatch means the public
+// contract has changed — bump the API version.
+var v1EdgeShredsClientSeatsContractFields = struct {
+	top  []string
+	seat []string
+}{
+	top: []string{"items", "total", "limit", "offset", "$schema"},
+	seat: []string{
+		"seat_pk",
+		"device_key",
+		"device_code",
+		"metro_pk",
+		"metro_code",
+		"tenure_epochs",
+		"funded_epoch",
+		"active_epoch",
+		"has_price_override",
+		"override_usdc_price_dollars",
+		"escrow_count",
+		"total_usdc_balance",
+		"price_per_epoch_dollars",
+		"funding_authority_key",
+		"user_pk",
+		"user_owner_pubkey",
+		"user_status",
+		"last_activity",
+	},
+}
+
+func TestV1EdgeShredsClientSeats_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var resp v1.EdgeShredsClientSeatsResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Empty(t, resp.Items)
+	assert.Equal(t, 0, resp.Total)
+}
+
+func TestV1EdgeShredsClientSeats_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1EdgeShredsClientSeatsContractFields.top, "response")
+
+	items, ok := raw["items"].([]any)
+	require.True(t, ok, "items must be a JSON array")
+	require.NotEmpty(t, items, "test data should produce client seats")
+	for i, it := range items {
+		obj, ok := it.(map[string]any)
+		require.True(t, ok, "items[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1EdgeShredsClientSeatsContractFields.seat, "items[i]")
+
+		// client_ip must NOT be exposed in the v1 contract — v1 is unauthed.
+		_, hasIP := obj["client_ip"]
+		assert.False(t, hasIP, "items[%d]: client_ip must not be exposed in v1", i)
+	}
+}
+
+func TestV1EdgeShredsClientSeats_WithData(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsClientSeatsResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	require.Len(t, resp.Items, 3)
+
+	// Inherits sort order from FetchShredSubscribers: active_epoch DESC, pk ASC.
+	// seat-1 (epoch 950), seat-2 (epoch 950), seat-3 (epoch 945).
+	assert.Equal(t, "seat-1", resp.Items[0].SeatPK)
+	assert.Equal(t, uint64(950), resp.Items[0].ActiveEpoch)
+	assert.Equal(t, uint64(948), resp.Items[0].FundedEpoch)
+	assert.Equal(t, uint32(1), resp.Items[0].EscrowCount)
+	assert.Equal(t, uint8(0), resp.Items[0].HasPriceOverride)
+	assert.Equal(t, "50.000000", resp.Items[0].TotalUSDCBalance)
+
+	// seat-2 has the price override.
+	seat2 := resp.Items[1]
+	assert.Equal(t, "seat-2", seat2.SeatPK)
+	assert.Equal(t, uint8(1), seat2.HasPriceOverride)
+	assert.Equal(t, uint16(25), seat2.OverrideUSDCPriceDollars)
+	assert.Equal(t, int64(25), seat2.PricePerEpochDollars)
+	assert.Equal(t, uint32(0), seat2.EscrowCount)
+}
+
+func TestV1EdgeShredsClientSeats_FilterByFunder(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats?funder=funder-1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsClientSeatsResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.Total, "funder-1 owns 2 seats")
+	require.Len(t, resp.Items, 2)
+	for _, s := range resp.Items {
+		assert.Equal(t, "funder-1", s.FundingAuthorityKey)
+	}
+	assert.ElementsMatch(t, []string{"seat-1", "seat-3"}, []string{resp.Items[0].SeatPK, resp.Items[1].SeatPK})
+}
+
+func TestV1EdgeShredsClientSeats_FilterByFunder_ExactMatchNotSubstring(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	// "funder" is a substring of "funder-1"/"funder-2" but must NOT match —
+	// the v1 funder filter is exact match. Guards against regressions where
+	// someone swaps to ILIKE / startsWith.
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats?funder=funder", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsClientSeatsResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Items)
+}
+
+func TestV1EdgeShredsClientSeats_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats?limit=2&offset=0", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsClientSeatsResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 2, resp.Limit)
+	assert.Equal(t, 0, resp.Offset)
+	require.Len(t, resp.Items, 2)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/client-seats?limit=2&offset=2", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 2, resp.Offset)
+	require.Len(t, resp.Items, 1)
+}

--- a/api/handlers/v1_shreds_devices_test.go
+++ b/api/handlers/v1_shreds_devices_test.go
@@ -1,0 +1,145 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1EdgeShredsDevicesContractFields is the authoritative JSON key set for the
+// /api/v1/edge/shreds/devices response. A mismatch means the public contract
+// has changed — bump the API version.
+var v1EdgeShredsDevicesContractFields = struct {
+	top    []string
+	device []string
+}{
+	top: []string{"items", "total", "limit", "offset", "$schema"},
+	device: []string{
+		"device_key",
+		"device_code",
+		"metro_exchange_key",
+		"metro_code",
+		"is_enabled",
+		"base_price_dollars",
+		"premium_dollars",
+		"total_price_dollars",
+		"granted_seats",
+		"capacity",
+		"available_seats",
+	},
+}
+
+func TestV1EdgeShredsDevices_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/devices", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var resp v1.EdgeShredsDevicesResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Empty(t, resp.Items)
+	assert.Equal(t, 0, resp.Total)
+}
+
+func TestV1EdgeShredsDevices_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/devices", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1EdgeShredsDevicesContractFields.top, "response")
+
+	items, ok := raw["items"].([]any)
+	require.True(t, ok, "items must be a JSON array")
+	require.NotEmpty(t, items, "test data should produce devices")
+	for i, it := range items {
+		obj, ok := it.(map[string]any)
+		require.True(t, ok, "items[%d] must be a JSON object", i)
+		assertJSONKeys(t, obj, v1EdgeShredsDevicesContractFields.device, "items[i]")
+	}
+}
+
+func TestV1EdgeShredsDevices_WithData(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/devices", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsDevicesResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Items, 1)
+
+	d := resp.Items[0]
+	assert.Equal(t, "dev-1", d.DeviceKey)
+	assert.Equal(t, "NYC-CORE-01", d.DeviceCode)
+	assert.Equal(t, "metro-nyc", d.MetroExchangeKey)
+	assert.Equal(t, "NYC", d.MetroCode)
+	assert.Equal(t, uint8(1), d.IsEnabled)
+	assert.Equal(t, uint16(10), d.BasePriceDollars)
+	assert.Equal(t, int16(-2), d.PremiumDollars)
+	// base (10) + premium (-2) = 8
+	assert.Equal(t, int64(8), d.TotalPriceDollars)
+	assert.Equal(t, uint16(2), d.GrantedSeats)
+	assert.Equal(t, uint16(10), d.Capacity)
+	// capacity (10) - granted (2) = 8
+	assert.Equal(t, int64(8), d.AvailableSeats)
+}
+
+func TestV1EdgeShredsDevices_Pagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/devices?limit=1&offset=0", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsDevicesResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Equal(t, 1, resp.Limit)
+	assert.Equal(t, 0, resp.Offset)
+	require.Len(t, resp.Items, 1)
+
+	// Offset past end returns empty page.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/devices?limit=1&offset=5", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Equal(t, 5, resp.Offset)
+	assert.Empty(t, resp.Items)
+}

--- a/api/handlers/v1_shreds_overview_test.go
+++ b/api/handlers/v1_shreds_overview_test.go
@@ -1,0 +1,97 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	v1 "github.com/malbeclabs/lake/api/v1"
+)
+
+// v1EdgeShredsOverviewContractFields is the authoritative JSON key set for the
+// /api/v1/edge/shreds/overview response. A mismatch means the public contract
+// has changed — bump the API version.
+var v1EdgeShredsOverviewContractFields = []string{
+	"$schema",
+	"phase",
+	"current_subscription_epoch",
+	"current_solana_epoch",
+	"total_metros",
+	"total_enabled_devices",
+	"total_client_seats",
+	"settled_devices_count",
+	"settled_client_seats_count",
+	"next_seat_funding_index",
+	"client_seat_count",
+	"payment_escrow_count",
+	"metro_history_count",
+	"device_history_count",
+	"validator_client_reward_count",
+}
+
+func TestV1EdgeShredsOverview_Empty(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/overview", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var resp v1.EdgeShredsOverview
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "", resp.Phase)
+	assert.Equal(t, uint64(0), resp.CurrentSubscriptionEpoch)
+	assert.Equal(t, uint64(0), resp.CurrentSolanaEpoch)
+	assert.Equal(t, uint64(0), resp.ClientSeatCount)
+}
+
+func TestV1EdgeShredsOverview_Contract(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/overview", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assertJSONKeys(t, raw, v1EdgeShredsOverviewContractFields, "response")
+}
+
+func TestV1EdgeShredsOverview_WithData(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertShredsTestData(t, api)
+
+	r := newV1Router(t, api)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/edge/shreds/overview", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var resp v1.EdgeShredsOverview
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+
+	// Mirror values from insertShredsTestData.
+	assert.Equal(t, "open for requests", resp.Phase)
+	assert.Equal(t, uint64(950), resp.CurrentSubscriptionEpoch)
+	assert.Equal(t, uint64(950), resp.CurrentSolanaEpoch)
+	assert.Equal(t, uint64(3), resp.ClientSeatCount)
+	assert.Equal(t, uint64(1), resp.PaymentEscrowCount)
+	assert.Equal(t, uint64(1), resp.MetroHistoryCount)
+	assert.Equal(t, uint64(1), resp.DeviceHistoryCount)
+}

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -95,6 +95,9 @@ func Mount(r chi.Router, api *handlers.API) huma.API {
 			_, _ = w.Write([]byte(docsHTML))
 		})
 
+		registerEdgeShredsOverview(humaAPI, api)
+		registerEdgeShredsDevices(humaAPI, api)
+		registerEdgeShredsClientSeats(humaAPI, api)
 		registerEdgeShredsPublishers(humaAPI, api)
 		registerEdgeShredsSubscribers(humaAPI, api)
 		registerValidatorsMetadata(humaAPI, api)

--- a/api/v1/shreds_client_seats.go
+++ b/api/v1/shreds_client_seats.go
@@ -1,0 +1,106 @@
+package v1
+
+import (
+	"context"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// EdgeShredsClientSeat is the public, stable shape of a single shred client
+// seat. This is the same row source as /edge/shreds/subscribers but exposes a
+// few extra fields (funded_epoch, escrow_count, has_price_override,
+// override_usdc_price_dollars) that wallet UIs need to display the active
+// state and remaining-balance estimate. client_ip is intentionally omitted:
+// v1 is unauthed and the internal handler redacts it for non-internal callers.
+type EdgeShredsClientSeat struct {
+	SeatPK                   string `json:"seat_pk" doc:"Client seat pubkey"`
+	DeviceKey                string `json:"device_key" doc:"DoubleZero edge device pubkey"`
+	DeviceCode               string `json:"device_code" doc:"DoubleZero edge device code"`
+	MetroPK                  string `json:"metro_pk" doc:"DoubleZero metro pubkey"`
+	MetroCode                string `json:"metro_code" doc:"DoubleZero metro code"`
+	TenureEpochs             uint16 `json:"tenure_epochs" doc:"Number of epochs this seat has been active"`
+	FundedEpoch              uint64 `json:"funded_epoch" doc:"Epoch the seat was most recently funded for"`
+	ActiveEpoch              uint64 `json:"active_epoch" doc:"Epoch the seat became active"`
+	HasPriceOverride         uint8  `json:"has_price_override" doc:"1 if the seat has an explicit per-seat price override, 0 otherwise"`
+	OverrideUSDCPriceDollars uint16 `json:"override_usdc_price_dollars" doc:"Per-seat price override (whole USDC dollars); 0 unless has_price_override = 1"`
+	EscrowCount              uint32 `json:"escrow_count" doc:"Number of payment escrows currently attached to the seat"`
+	TotalUSDCBalance         string `json:"total_usdc_balance" doc:"Sum of USDC balances across all escrows attached to this seat, as a decimal USDC string (6 fractional digits)" example:"50.000000"`
+	PricePerEpochDollars     int64  `json:"price_per_epoch_dollars" doc:"Effective per-epoch price (override or metro + device premium)"`
+	FundingAuthorityKey      string `json:"funding_authority_key" doc:"Funder pubkey (on-chain authority that funded this seat)"`
+	UserPK                   string `json:"user_pk" doc:"Linked DoubleZero user pubkey, if any"`
+	UserOwnerPubkey          string `json:"user_owner_pubkey" doc:"Solana wallet that owns the linked DZ user"`
+	UserStatus               string `json:"user_status" doc:"Linked DZ user status (e.g. activated)"`
+	LastActivity             string `json:"last_activity" doc:"RFC3339 timestamp of the last escrow event for this seat, if any" example:"2026-04-23T12:34:56Z"`
+}
+
+// EdgeShredsClientSeatsResponse is the paginated response body.
+type EdgeShredsClientSeatsResponse struct {
+	Items  []EdgeShredsClientSeat `json:"items"`
+	Total  int                    `json:"total" doc:"Total matching client seats (ignores limit/offset)"`
+	Limit  int                    `json:"limit"`
+	Offset int                    `json:"offset"`
+}
+
+// EdgeShredsClientSeatsInput is the request for the client-seats endpoint.
+type EdgeShredsClientSeatsInput struct {
+	Funder string `query:"funder" doc:"Filter by funder pubkey (funding_authority_key, exact match)" example:""`
+	Limit  int    `query:"limit" minimum:"1" maximum:"1000" default:"100" doc:"Maximum items to return"`
+	Offset int    `query:"offset" minimum:"0" default:"0" doc:"Offset into the result set"`
+}
+
+// EdgeShredsClientSeatsOutput wraps the response body for huma.
+type EdgeShredsClientSeatsOutput struct {
+	Body EdgeShredsClientSeatsResponse
+}
+
+func registerEdgeShredsClientSeats(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-edge-shreds-client-seats",
+		Method:      "GET",
+		Path:        "/edge/shreds/client-seats",
+		Summary:     "List shred client seats",
+		Description: "Returns a paginated list of shred client seats. Same row source as /edge/shreds/subscribers, but exposes funded_epoch, escrow_count, and per-seat price-override fields useful for wallet UIs displaying balance and active state. Optionally filter by funder pubkey. client_ip is not exposed.",
+		Tags:        []string{"Edge/Shreds"},
+	}, func(ctx context.Context, input *EdgeShredsClientSeatsInput) (*EdgeShredsClientSeatsOutput, error) {
+		rows, total, err := api.FetchShredSubscribers(ctx, input.Funder, input.Limit, input.Offset)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch shred client seats", err)
+		}
+
+		items := make([]EdgeShredsClientSeat, len(rows))
+		for i, r := range rows {
+			items[i] = EdgeShredsClientSeat{
+				SeatPK:                   r.PK,
+				DeviceKey:                r.DeviceKey,
+				DeviceCode:               r.DeviceCode,
+				MetroPK:                  r.MetroPK,
+				MetroCode:                r.MetroCode,
+				TenureEpochs:             r.TenureEpochs,
+				FundedEpoch:              r.FundedEpoch,
+				ActiveEpoch:              r.ActiveEpoch,
+				HasPriceOverride:         r.HasPriceOverride,
+				OverrideUSDCPriceDollars: r.OverrideUSDCPriceDollars,
+				EscrowCount:              r.EscrowCount,
+				TotalUSDCBalance:         formatUSDC(r.TotalUSDCBalance),
+				PricePerEpochDollars:     r.PricePerEpochDollars,
+				FundingAuthorityKey:      r.FundingAuthorityKey,
+				UserPK:                   r.UserPK,
+				UserOwnerPubkey:          r.UserOwnerPubkey,
+				UserStatus:               r.UserStatus,
+			}
+			if r.LastActivity != nil && !r.LastActivity.IsZero() {
+				items[i].LastActivity = r.LastActivity.UTC().Format(time.RFC3339)
+			}
+		}
+
+		return &EdgeShredsClientSeatsOutput{Body: EdgeShredsClientSeatsResponse{
+			Items:  items,
+			Total:  int(total),
+			Limit:  input.Limit,
+			Offset: input.Offset,
+		}}, nil
+	})
+}

--- a/api/v1/shreds_devices.go
+++ b/api/v1/shreds_devices.go
@@ -1,0 +1,87 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// EdgeShredsDevice is the public, stable shape of a single shred-eligible
+// device. Fields mirror the internal ShredDeviceItem 1:1 — they're already
+// derived from on-chain state and safe to expose.
+type EdgeShredsDevice struct {
+	DeviceKey         string `json:"device_key" doc:"DoubleZero edge device pubkey"`
+	DeviceCode        string `json:"device_code" doc:"Human-readable device code (e.g. NYC-CORE-01)"`
+	MetroExchangeKey  string `json:"metro_exchange_key" doc:"Metro exchange pubkey the device is registered under"`
+	MetroCode         string `json:"metro_code" doc:"Metro code (e.g. NYC, LAX)"`
+	IsEnabled         uint8  `json:"is_enabled" doc:"1 if the device is currently enabled for shreds, 0 otherwise"`
+	BasePriceDollars  uint16 `json:"base_price_dollars" doc:"Metro base USDC price per epoch (whole dollars; 6-decimal scaling applied client-side)"`
+	PremiumDollars    int16  `json:"premium_dollars" doc:"Device-specific USDC premium over the metro base (signed)"`
+	TotalPriceDollars int64  `json:"total_price_dollars" doc:"Effective per-epoch USDC price for a seat on this device (base + premium, clamped to >= 0 on chain)"`
+	GrantedSeats      uint16 `json:"granted_seats" doc:"Seats currently granted on this device"`
+	Capacity          uint16 `json:"capacity" doc:"Total seat capacity available on this device"`
+	AvailableSeats    int64  `json:"available_seats" doc:"Capacity minus granted seats (signed for safety; negative would indicate overgranted state)"`
+}
+
+// EdgeShredsDevicesResponse is the paginated response body.
+type EdgeShredsDevicesResponse struct {
+	Items  []EdgeShredsDevice `json:"items"`
+	Total  int                `json:"total" doc:"Total devices in the env (ignores limit/offset)"`
+	Limit  int                `json:"limit"`
+	Offset int                `json:"offset"`
+}
+
+// EdgeShredsDevicesInput is the request for the devices endpoint. The v1
+// surface intentionally exposes only pagination; the internal
+// /api/dz/shreds/devices endpoint still has filter/sort knobs for the lake UI.
+type EdgeShredsDevicesInput struct {
+	Limit  int `query:"limit" minimum:"1" maximum:"1000" default:"500" doc:"Maximum items to return"`
+	Offset int `query:"offset" minimum:"0" default:"0" doc:"Offset into the result set"`
+}
+
+// EdgeShredsDevicesOutput wraps the response body for huma.
+type EdgeShredsDevicesOutput struct {
+	Body EdgeShredsDevicesResponse
+}
+
+func registerEdgeShredsDevices(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-edge-shreds-devices",
+		Method:      "GET",
+		Path:        "/edge/shreds/devices",
+		Summary:     "List shred-eligible edge devices",
+		Description: "Returns a paginated list of edge devices known to the shred subscription program, with per-device pricing and seat availability. Sorted by device_code ascending for deterministic ordering.",
+		Tags:        []string{"Edge/Shreds"},
+	}, func(ctx context.Context, input *EdgeShredsDevicesInput) (*EdgeShredsDevicesOutput, error) {
+		rows, total, err := api.FetchEdgeShredsDevices(ctx, input.Limit, input.Offset)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch shreds devices", err)
+		}
+
+		items := make([]EdgeShredsDevice, len(rows))
+		for i, r := range rows {
+			items[i] = EdgeShredsDevice{
+				DeviceKey:         r.DeviceKey,
+				DeviceCode:        r.DeviceCode,
+				MetroExchangeKey:  r.MetroExchangeKey,
+				MetroCode:         r.MetroCode,
+				IsEnabled:         r.IsEnabled,
+				BasePriceDollars:  r.BasePriceDollars,
+				PremiumDollars:    r.PremiumDollars,
+				TotalPriceDollars: r.TotalPriceDollars,
+				GrantedSeats:      r.GrantedSeats,
+				Capacity:          r.Capacity,
+				AvailableSeats:    r.AvailableSeats,
+			}
+		}
+
+		return &EdgeShredsDevicesOutput{Body: EdgeShredsDevicesResponse{
+			Items:  items,
+			Total:  int(total),
+			Limit:  input.Limit,
+			Offset: input.Offset,
+		}}, nil
+	})
+}

--- a/api/v1/shreds_overview.go
+++ b/api/v1/shreds_overview.go
@@ -1,0 +1,67 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/malbeclabs/lake/api/handlers"
+)
+
+// EdgeShredsOverview is the public, stable shape of the shred subscription
+// program's overall state. Fields are a 1:1 projection of the internal
+// ShredsOverview struct; we keep them stable across releases.
+type EdgeShredsOverview struct {
+	Phase                      string `json:"phase" doc:"Current execution phase (e.g. 'open for requests', 'closed for requests', 'updating prices', 'settlement', 'settled')"`
+	CurrentSubscriptionEpoch   uint64 `json:"current_subscription_epoch" doc:"DZ shred subscription epoch the program is currently in"`
+	CurrentSolanaEpoch         uint64 `json:"current_solana_epoch" doc:"Latest observed Solana epoch (max from vote accounts); useful for determining seat active/inactive state"`
+	TotalMetros                uint16 `json:"total_metros" doc:"Initialized metro count tracked by the execution controller"`
+	TotalEnabledDevices        uint16 `json:"total_enabled_devices" doc:"Devices that are currently enabled for shreds"`
+	TotalClientSeats           uint32 `json:"total_client_seats" doc:"Total client seats known to the execution controller"`
+	SettledDevicesCount        uint16 `json:"settled_devices_count" doc:"Devices that have completed settlement in the current epoch"`
+	SettledClientSeatsCount    uint16 `json:"settled_client_seats_count" doc:"Client seats that have completed settlement in the current epoch"`
+	NextSeatFundingIndex       uint64 `json:"next_seat_funding_index" doc:"Monotonic funding index the program will assign to the next funded seat"`
+	ClientSeatCount            uint64 `json:"client_seat_count" doc:"Live row count of client seats currently tracked"`
+	PaymentEscrowCount         uint64 `json:"payment_escrow_count" doc:"Live row count of payment escrows currently tracked"`
+	MetroHistoryCount          uint64 `json:"metro_history_count" doc:"Live row count of metro history entries currently tracked"`
+	DeviceHistoryCount         uint64 `json:"device_history_count" doc:"Live row count of device history entries currently tracked"`
+	ValidatorClientRewardCount uint64 `json:"validator_client_reward_count" doc:"Live row count of validator client reward entries currently tracked"`
+}
+
+// EdgeShredsOverviewInput is empty (no inputs), but huma requires a non-nil
+// pointer type so we declare a struct here for symmetry with the rest of v1.
+type EdgeShredsOverviewInput struct{}
+
+// EdgeShredsOverviewOutput wraps the response body for huma.
+type EdgeShredsOverviewOutput struct {
+	Body EdgeShredsOverview
+}
+
+func registerEdgeShredsOverview(humaAPI huma.API, api *handlers.API) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "get-edge-shreds-overview",
+		Method:      "GET",
+		Path:        "/edge/shreds/overview",
+		Summary:     "Get shred subscription program overview",
+		Description: "Returns the current state of the DoubleZero shred subscription program — execution phase, current subscription/Solana epochs, and aggregate row counts. Use this to determine whether the program is open for requests, what epoch consumers are currently funding, and to size dashboards.",
+		Tags:        []string{"Edge/Shreds"},
+	}, func(ctx context.Context, _ *EdgeShredsOverviewInput) (*EdgeShredsOverviewOutput, error) {
+		o := api.FetchShredsOverview(ctx)
+		return &EdgeShredsOverviewOutput{Body: EdgeShredsOverview{
+			Phase:                      o.Phase,
+			CurrentSubscriptionEpoch:   o.CurrentSubscriptionEpoch,
+			CurrentSolanaEpoch:         o.CurrentSolanaEpoch,
+			TotalMetros:                o.TotalMetros,
+			TotalEnabledDevices:        o.TotalEnabledDevices,
+			TotalClientSeats:           o.TotalClientSeats,
+			SettledDevicesCount:        o.SettledDevicesCount,
+			SettledClientSeatsCount:    o.SettledClientSeatsCount,
+			NextSeatFundingIndex:       o.NextSeatFundingIndex,
+			ClientSeatCount:            o.ClientSeatCount,
+			PaymentEscrowCount:         o.PaymentEscrowCount,
+			MetroHistoryCount:          o.MetroHistoryCount,
+			DeviceHistoryCount:         o.DeviceHistoryCount,
+			ValidatorClientRewardCount: o.ValidatorClientRewardCount,
+		}}, nil
+	})
+}


### PR DESCRIPTION
## Summary

- Adds three v1 huma operations under `/api/v1/edge/shreds/*`:
  - `GET /edge/shreds/overview` — execution-controller state, current subscription/Solana epochs, and aggregate row counts. Used by wallet UIs (e.g. doublezero.xyz shreds subscribe) to show the current epoch and program phase.
  - `GET /edge/shreds/devices` — paginated list of shred-eligible devices with per-device pricing and seat availability. Used by the buy flow to populate the city/device picker.
  - `GET /edge/shreds/client-seats` — paginated list of client seats with optional funder filter. Same row source as `/edge/shreds/subscribers` but exposes `funded_epoch`, `escrow_count`, and per-seat price-override fields useful for wallet UIs showing balance + active state. `client_ip` stays redacted in the v1 contract.
- Refactor: extracts `FetchShredsOverview` from `GetShredsOverview` so the v1 op and the legacy `/api/dz/shreds/overview` handler share the same SQL.
- Adds `FetchEdgeShredsDevices` (paginated, no filter/sort) for the new devices op. The legacy `/api/dz/shreds/devices` keeps its filter/sort surface for the lake UI.
- `/edge/shreds/client-seats` reuses the existing `FetchShredSubscribers`, no new SQL needed.
- Env switching is inherited from `EnvMiddleware` (`X-DZ-Env: mainnet-beta|testnet|devnet`), so all three endpoints honor the env header out of the box.

## Why

The doublezero.xyz shreds-subscribe page (PR doublezerofoundation/doublezero.xyz-new#641) currently reads from the internal `/api/dz/shreds/{overview,devices,client-seats}` endpoints. Moving the wallet UI to the stable v1 surface unblocks the testnet end-to-end test path: v1 inherits `EnvMiddleware`, so as soon as the frontend starts sending `X-DZ-Env: testnet` it sees real testnet shred data instead of the mainnet payload that ships today.

## Testing Verification

- [x] Contract tests (top-level + per-item key sets) for all three new endpoints
- [x] WithData tests verify field values against the shared `insertShredsTestData` fixture
- [x] Pagination tests for devices and client-seats
- [x] Funder filter on client-seats including an exact-match guard against substring regression
- [x] `client_ip` redaction asserted in the client-seats contract test
- [x] Existing legacy `TestGetShreds*` tests still pass after the overview refactor