### PR TITLE
web: remove globe view tooltip from topology control bar

### DIFF
--- a/web/src/components/topology/TopologyControlBar.tsx
+++ b/web/src/components/topology/TopologyControlBar.tsx
@@ -308,7 +308,6 @@ export function TopologyControlBar({
             active={view === 'globe'}
             activeColor="blue"
             collapsed={collapsed}
-            tooltip="3D view of the DoubleZero network on a globe. Shows the same metros, devices, and links as the map view in a spherical projection."
           />
 
           {onZoomIn && (


### PR DESCRIPTION
## Summary

- Remove the interpretive tooltip from the Globe view button in the topology control bar. The button keeps its native collapsed-label title (just "Globe view") when the sidebar is collapsed, matching the other view nav items.

## Testing Verification

- Hovering the Globe view button no longer shows the descriptive tooltip; collapsed-state label tooltip still appears.