### PR TITLE
feat(api): add gNMI network state endpoint

### DIFF
--- a/api/handlers/network_state.go
+++ b/api/handlers/network_state.go
@@ -165,36 +165,56 @@ func (a *API) GetNetworkState(w http.ResponseWriter, r *http.Request) {
 }
 
 func queryNetworkFreshness(ctx context.Context, conn driver.Conn, tdb string) ([]TelemetryFreshness, error) {
-	freshness := make([]TelemetryFreshness, 0, len(networkStateFreshnessTables))
-	for _, table := range networkStateFreshnessTables {
-		query := fmt.Sprintf(`
+	parts := make([]string, 0, len(networkStateFreshnessTables))
+	for i, table := range networkStateFreshnessTables {
+		parts = append(parts, fmt.Sprintf(`
 			SELECT
+				%[1]d AS table_order,
+				'%[2]s' AS table_name,
 				count() AS rows,
 				uniqExact(device_pubkey) AS devices,
 				if(count() = 0, toDateTime64(0, 9), max(timestamp)) AS last_seen,
 				if(count() = 0, -1, dateDiff('second', max(timestamp), now())) AS seconds_stale
-			FROM %[1]s.%[2]s
-		`, tdb, quoteClickHouseIdent(table))
+			FROM %[3]s.%[4]s
+		`, i, table, tdb, quoteClickHouseIdent(table)))
+	}
 
+	query := `
+		SELECT table_name, rows, devices, last_seen, seconds_stale
+		FROM (` + strings.Join(parts, ` UNION ALL `) + `)
+		ORDER BY table_order
+	`
+
+	start := time.Now()
+	resultRows, err := conn.Query(ctx, query)
+	metrics.RecordClickHouseQuery("network_state:freshness", time.Since(start), err)
+	if err != nil {
+		return nil, fmt.Errorf("freshness: %w", err)
+	}
+	defer resultRows.Close()
+
+	freshness := make([]TelemetryFreshness, 0, len(networkStateFreshnessTables))
+	for resultRows.Next() {
 		var (
-			rows         uint64
+			tableName    string
+			rowCount     uint64
 			devices      uint64
 			lastSeen     time.Time
 			secondsStale int64
 		)
-		start := time.Now()
-		err := conn.QueryRow(ctx, query).Scan(&rows, &devices, &lastSeen, &secondsStale)
-		metrics.RecordClickHouseQuery("network_state:freshness", time.Since(start), err)
-		if err != nil {
-			return nil, fmt.Errorf("freshness %s: %w", table, err)
+		if err := resultRows.Scan(&tableName, &rowCount, &devices, &lastSeen, &secondsStale); err != nil {
+			return nil, fmt.Errorf("freshness scan: %w", err)
 		}
 
-		item := TelemetryFreshness{Table: table, Rows: rows, Devices: devices}
-		if rows > 0 {
+		item := TelemetryFreshness{Table: tableName, Rows: rowCount, Devices: devices}
+		if rowCount > 0 {
 			item.LastSeen = lastSeen.UTC().Format(time.RFC3339)
 			item.SecondsStale = &secondsStale
 		}
 		freshness = append(freshness, item)
+	}
+	if err := resultRows.Err(); err != nil {
+		return nil, fmt.Errorf("freshness rows: %w", err)
 	}
 	return freshness, nil
 }

--- a/api/handlers/network_state.go
+++ b/api/handlers/network_state.go
@@ -1,0 +1,431 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+// NetworkStateResponse is the response for GET /api/dz/network-state.
+type NetworkStateResponse struct {
+	Env        string                  `json:"env"`
+	FetchedAt  string                  `json:"fetched_at"`
+	Freshness  []TelemetryFreshness    `json:"freshness"`
+	Interfaces NetworkInterfaceSummary `json:"interfaces"`
+	BGP        NetworkBGPSummary       `json:"bgp"`
+	ISIS       NetworkISISSummary      `json:"isis"`
+	Optics     NetworkOpticsSummary    `json:"optics"`
+	KnownGaps  []string                `json:"known_gaps"`
+}
+
+// TelemetryFreshness summarizes row volume and latest sample time for one
+// telemetry table.
+type TelemetryFreshness struct {
+	Table        string `json:"table"`
+	Rows         uint64 `json:"rows"`
+	Devices      uint64 `json:"devices"`
+	LastSeen     string `json:"last_seen,omitempty"`
+	SecondsStale *int64 `json:"seconds_stale,omitempty"`
+}
+
+// NetworkInterfaceSummary groups the latest interface snapshot by interface
+// family. Families are derived from interface name prefixes and intentionally
+// separate Switch* fabric interfaces from front-panel Ethernet ports.
+type NetworkInterfaceSummary struct {
+	Families []InterfaceFamilySummary `json:"families"`
+}
+
+// InterfaceFamilySummary is an aggregate over interface_state_latest.
+type InterfaceFamilySummary struct {
+	Family      string `json:"family"`
+	Interfaces  uint64 `json:"interfaces"`
+	Devices     uint64 `json:"devices"`
+	AdminUp     uint64 `json:"admin_up"`
+	AdminDown   uint64 `json:"admin_down"`
+	OperUp      uint64 `json:"oper_up"`
+	OperDown    uint64 `json:"oper_down"`
+	OperUnknown uint64 `json:"oper_unknown"`
+}
+
+// NetworkBGPSummary groups latest BGP neighbors by raw OpenConfig state.
+type NetworkBGPSummary struct {
+	States []BGPStateSummary `json:"states"`
+}
+
+// BGPStateSummary is an aggregate over bgp_neighbors_latest.
+type BGPStateSummary struct {
+	State             string `json:"state"`
+	Neighbors         uint64 `json:"neighbors"`
+	Devices           uint64 `json:"devices"`
+	InternalNeighbors uint64 `json:"internal_neighbors"`
+	ExternalNeighbors uint64 `json:"external_neighbors"`
+}
+
+// NetworkISISSummary groups latest ISIS adjacencies by raw OpenConfig state.
+type NetworkISISSummary struct {
+	States []ISISStateSummary `json:"states"`
+}
+
+// ISISStateSummary is an aggregate over isis_adjacencies_latest.
+type ISISStateSummary struct {
+	State       string `json:"state"`
+	Adjacencies uint64 `json:"adjacencies"`
+	Devices     uint64 `json:"devices"`
+	Systems     uint64 `json:"systems"`
+}
+
+// NetworkOpticsSummary summarizes the latest transceiver telemetry volume.
+type NetworkOpticsSummary struct {
+	Lanes                    uint64 `json:"lanes"`
+	Devices                  uint64 `json:"devices"`
+	Interfaces               uint64 `json:"interfaces"`
+	ThresholdRows            uint64 `json:"threshold_rows"`
+	DevicesWithThresholds    uint64 `json:"devices_with_thresholds"`
+	InterfacesWithThresholds uint64 `json:"interfaces_with_thresholds"`
+}
+
+var networkStateFreshnessTables = []string{
+	"interface_state",
+	"bgp_neighbors",
+	"isis_adjacencies",
+	"isis_global_state",
+	"isis_overload_bit",
+	"transceiver_state",
+	"transceiver_thresholds",
+}
+
+// GetNetworkState returns a read-only overview of the existing gNMI telemetry
+// for the selected DoubleZero environment. It reports raw observed telemetry
+// state only; callers should not treat these aggregates as incident status.
+func (a *API) GetNetworkState(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	env := EnvFromContext(ctx)
+	conn := a.envDB(ctx)
+	tdb := quoteClickHouseIdent(TelemetryDatabaseForEnv(env))
+
+	freshness, err := queryNetworkFreshness(ctx, conn, tdb)
+	if err != nil {
+		logError("network state freshness query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	families, err := queryNetworkInterfaceFamilies(ctx, conn, tdb)
+	if err != nil {
+		logError("network state interface summary query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	bgpStates, err := queryNetworkBGPStates(ctx, conn, tdb)
+	if err != nil {
+		logError("network state bgp summary query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	isisStates, err := queryNetworkISISStates(ctx, conn, tdb)
+	if err != nil {
+		logError("network state isis summary query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	optics, err := queryNetworkOptics(ctx, conn, tdb)
+	if err != nil {
+		logError("network state optics summary query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := NetworkStateResponse{
+		Env:        string(env),
+		FetchedAt:  time.Now().UTC().Format(time.RFC3339),
+		Freshness:  freshness,
+		Interfaces: NetworkInterfaceSummary{Families: families},
+		BGP:        NetworkBGPSummary{States: bgpStates},
+		ISIS:       NetworkISISSummary{States: isisStates},
+		Optics:     optics,
+		KnownGaps:  networkStateKnownGaps(env, freshness),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("network state: failed to encode response", "error", err)
+	}
+}
+
+func queryNetworkFreshness(ctx context.Context, conn driver.Conn, tdb string) ([]TelemetryFreshness, error) {
+	freshness := make([]TelemetryFreshness, 0, len(networkStateFreshnessTables))
+	for _, table := range networkStateFreshnessTables {
+		query := fmt.Sprintf(`
+			SELECT
+				count() AS rows,
+				uniqExact(device_pubkey) AS devices,
+				if(count() = 0, toDateTime64(0, 9), max(timestamp)) AS last_seen,
+				if(count() = 0, -1, dateDiff('second', max(timestamp), now())) AS seconds_stale
+			FROM %[1]s.%[2]s
+		`, tdb, quoteClickHouseIdent(table))
+
+		var (
+			rows         uint64
+			devices      uint64
+			lastSeen     time.Time
+			secondsStale int64
+		)
+		start := time.Now()
+		err := conn.QueryRow(ctx, query).Scan(&rows, &devices, &lastSeen, &secondsStale)
+		metrics.RecordClickHouseQuery("network_state:freshness", time.Since(start), err)
+		if err != nil {
+			return nil, fmt.Errorf("freshness %s: %w", table, err)
+		}
+
+		item := TelemetryFreshness{Table: table, Rows: rows, Devices: devices}
+		if rows > 0 {
+			item.LastSeen = lastSeen.UTC().Format(time.RFC3339)
+			item.SecondsStale = &secondsStale
+		}
+		freshness = append(freshness, item)
+	}
+	return freshness, nil
+}
+
+func queryNetworkInterfaceFamilies(ctx context.Context, conn driver.Conn, tdb string) ([]InterfaceFamilySummary, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			family,
+			count() AS interfaces,
+			uniqExact(device_pubkey) AS devices,
+			countIf(upper(admin_status) = 'UP') AS admin_up,
+			countIf(upper(admin_status) NOT IN ('', 'UP')) AS admin_down,
+			countIf(upper(oper_status) = 'UP') AS oper_up,
+			countIf(upper(oper_status) NOT IN ('', 'UP')) AS oper_down,
+			countIf(oper_status = '') AS oper_unknown
+		FROM (
+			SELECT
+				device_pubkey,
+				admin_status,
+				oper_status,
+				multiIf(
+					startsWith(lower(interface_name), 'switch'), 'switch',
+					startsWith(lower(interface_name), 'ethernet'), 'ethernet',
+					startsWith(lower(interface_name), 'port-channel') OR startsWith(lower(interface_name), 'portchannel'), 'port_channel',
+					startsWith(lower(interface_name), 'loopback'), 'loopback',
+					startsWith(lower(interface_name), 'vlan'), 'vlan',
+					startsWith(lower(interface_name), 'tunnel'), 'tunnel',
+					startsWith(lower(interface_name), 'management') OR startsWith(lower(interface_name), 'mgmt'), 'management',
+					interface_name = '', 'unknown',
+					'other'
+				) AS family
+			FROM %[1]s.interface_state_latest
+		)
+		GROUP BY family
+		ORDER BY interfaces DESC, family ASC
+	`, tdb)
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query)
+	metrics.RecordClickHouseQuery("network_state:interfaces", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	families := []InterfaceFamilySummary{}
+	for rows.Next() {
+		var item InterfaceFamilySummary
+		if err := rows.Scan(
+			&item.Family,
+			&item.Interfaces,
+			&item.Devices,
+			&item.AdminUp,
+			&item.AdminDown,
+			&item.OperUp,
+			&item.OperDown,
+			&item.OperUnknown,
+		); err != nil {
+			return nil, err
+		}
+		families = append(families, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return families, nil
+}
+
+func queryNetworkBGPStates(ctx context.Context, conn driver.Conn, tdb string) ([]BGPStateSummary, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			if(session_state = '', 'UNKNOWN', session_state) AS state,
+			count() AS neighbors,
+			uniqExact(device_pubkey) AS devices,
+			countIf(upper(peer_type) = 'INTERNAL') AS internal_neighbors,
+			countIf(upper(peer_type) = 'EXTERNAL') AS external_neighbors
+		FROM %[1]s.bgp_neighbors_latest
+		GROUP BY state
+		ORDER BY neighbors DESC, state ASC
+	`, tdb)
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query)
+	metrics.RecordClickHouseQuery("network_state:bgp", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	states := []BGPStateSummary{}
+	for rows.Next() {
+		var item BGPStateSummary
+		if err := rows.Scan(
+			&item.State,
+			&item.Neighbors,
+			&item.Devices,
+			&item.InternalNeighbors,
+			&item.ExternalNeighbors,
+		); err != nil {
+			return nil, err
+		}
+		states = append(states, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return states, nil
+}
+
+func queryNetworkISISStates(ctx context.Context, conn driver.Conn, tdb string) ([]ISISStateSummary, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			if(adjacency_state = '', 'UNKNOWN', adjacency_state) AS state,
+			count() AS adjacencies,
+			uniqExact(device_pubkey) AS devices,
+			uniqExact(system_id) AS systems
+		FROM %[1]s.isis_adjacencies_latest
+		GROUP BY state
+		ORDER BY adjacencies DESC, state ASC
+	`, tdb)
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query)
+	metrics.RecordClickHouseQuery("network_state:isis", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	states := []ISISStateSummary{}
+	for rows.Next() {
+		var item ISISStateSummary
+		if err := rows.Scan(&item.State, &item.Adjacencies, &item.Devices, &item.Systems); err != nil {
+			return nil, err
+		}
+		states = append(states, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return states, nil
+}
+
+func queryNetworkOptics(ctx context.Context, conn driver.Conn, tdb string) (NetworkOpticsSummary, error) {
+	query := fmt.Sprintf(`
+		WITH
+			state AS (
+				SELECT
+					count() AS lanes,
+					uniqExact(device_pubkey) AS devices,
+					uniqExact(device_pubkey, interface_name) AS interfaces
+				FROM %[1]s.transceiver_state_latest
+			),
+			thresholds AS (
+				SELECT
+					count() AS threshold_rows,
+					uniqExact(device_pubkey) AS devices_with_thresholds,
+					uniqExact(device_pubkey, interface_name) AS interfaces_with_thresholds
+				FROM %[1]s.transceiver_thresholds_latest
+			)
+		SELECT
+			state.lanes,
+			state.devices,
+			state.interfaces,
+			thresholds.threshold_rows,
+			thresholds.devices_with_thresholds,
+			thresholds.interfaces_with_thresholds
+		FROM state CROSS JOIN thresholds
+	`, tdb)
+
+	var summary NetworkOpticsSummary
+	start := time.Now()
+	err := conn.QueryRow(ctx, query).Scan(
+		&summary.Lanes,
+		&summary.Devices,
+		&summary.Interfaces,
+		&summary.ThresholdRows,
+		&summary.DevicesWithThresholds,
+		&summary.InterfacesWithThresholds,
+	)
+	metrics.RecordClickHouseQuery("network_state:optics", time.Since(start), err)
+	if err != nil {
+		return NetworkOpticsSummary{}, err
+	}
+	return summary, nil
+}
+
+func networkStateKnownGaps(env DZEnv, freshness []TelemetryFreshness) []string {
+	gaps := []string{
+		"raw_telemetry_states_not_incidents",
+		"system_state_stdout_only",
+	}
+
+	var totalRows uint64
+	var interfaceRows uint64
+	var overloadRows uint64
+	for _, item := range freshness {
+		totalRows += item.Rows
+		switch item.Table {
+		case "interface_state":
+			interfaceRows = item.Rows
+		case "isis_overload_bit":
+			overloadRows = item.Rows
+		}
+	}
+
+	if totalRows == 0 {
+		gaps = append(gaps, "telemetry_empty")
+	}
+	if env == EnvMainnet && interfaceRows == 0 {
+		gaps = append(gaps, "mainnet_beta_telemetry_pilot_not_flowing")
+	}
+	if overloadRows == 0 {
+		gaps = append(gaps, "isis_overload_bit_empty")
+	}
+	return gaps
+}
+
+func networkStateUserMessage(err error) string {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "unknown table") ||
+		strings.Contains(msg, "table not found") ||
+		strings.Contains(msg, "no such table") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "unknown column") ||
+		strings.Contains(msg, "no such column") {
+		return "Telemetry schema unavailable or outdated. Please verify telemetry remote tables are configured."
+	}
+	return dberror.UserMessage(err)
+}
+
+func quoteClickHouseIdent(name string) string {
+	return "`" + name + "`"
+}

--- a/api/handlers/network_state_test.go
+++ b/api/handlers/network_state_test.go
@@ -1,0 +1,337 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTelemetryNetworkStateTables(t *testing.T, api *handlers.API, env handlers.DZEnv) {
+	t.Helper()
+	ctx := t.Context()
+	db := handlers.TelemetryDatabaseForEnv(env)
+	qdb := "`" + db + "`"
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s", qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.interface_state (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			interface_name String,
+			admin_status String,
+			oper_status String
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.interface_state_latest AS %s.interface_state
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.bgp_neighbors (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			session_state String,
+			peer_type String
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, session_state, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.bgp_neighbors_latest AS %s.bgp_neighbors
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, session_state)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_adjacencies (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			adjacency_state String,
+			system_id String
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, adjacency_state, system_id, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_adjacencies_latest AS %s.isis_adjacencies
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, adjacency_state, system_id)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_global_state (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			network_instance String,
+			instance String,
+			net String,
+			level_capability String
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, network_instance, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_global_state_latest AS %s.isis_global_state
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, network_instance)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_overload_bit (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			network_instance String,
+			overload_bit Bool
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, network_instance, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.isis_overload_bit_latest AS %s.isis_overload_bit
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, network_instance)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.transceiver_state (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			interface_name String,
+			channel_index UInt16,
+			input_power Float64,
+			output_power Float64,
+			laser_bias_current Float64
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, channel_index, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.transceiver_state_latest AS %s.transceiver_state
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, channel_index)
+	`, qdb, qdb)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.transceiver_thresholds (
+			timestamp DateTime64(9),
+			device_pubkey String,
+			interface_name String,
+			severity String,
+			input_power_lower Float64,
+			input_power_upper Float64,
+			output_power_lower Float64,
+			output_power_upper Float64,
+			laser_bias_current_lower Float64,
+			laser_bias_current_upper Float64,
+			module_temperature_lower Float64,
+			module_temperature_upper Float64,
+			supply_voltage_lower Float64,
+			supply_voltage_upper Float64
+		) ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, severity, timestamp)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.transceiver_thresholds_latest AS %s.transceiver_thresholds
+		ENGINE = MergeTree
+		ORDER BY (device_pubkey, interface_name, severity)
+	`, qdb, qdb)))
+}
+
+func networkStateRequest(env handlers.DZEnv) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/network-state", nil)
+	return req.WithContext(handlers.ContextWithEnv(req.Context(), env))
+}
+
+func decodeNetworkStateResponse(t *testing.T, rr *httptest.ResponseRecorder) handlers.NetworkStateResponse {
+	t.Helper()
+	var resp handlers.NetworkStateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return resp
+}
+
+func TestGetNetworkState_EmptyTelemetryReturnsKnownGap(t *testing.T) {
+	for _, env := range []handlers.DZEnv{handlers.EnvMainnet, handlers.EnvDevnet, handlers.EnvTestnet} {
+		t.Run(string(env), func(t *testing.T) {
+			api := apitesting.NewTestAPI(t, testChDB)
+			api.EnvDatabases[string(env)] = api.Database
+			api.EnvDBs[string(env)] = api.DB
+			createTelemetryNetworkStateTables(t, api, env)
+
+			rr := httptest.NewRecorder()
+			api.GetNetworkState(rr, networkStateRequest(env))
+
+			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+			resp := decodeNetworkStateResponse(t, rr)
+
+			assert.Equal(t, string(env), resp.Env)
+			assert.Len(t, resp.Freshness, 7)
+			for _, item := range resp.Freshness {
+				assert.Zero(t, item.Rows)
+				assert.Zero(t, item.Devices)
+				assert.Empty(t, item.LastSeen)
+				assert.Nil(t, item.SecondsStale)
+			}
+			assert.NotNil(t, resp.Interfaces.Families)
+			assert.Empty(t, resp.Interfaces.Families)
+			assert.NotNil(t, resp.BGP.States)
+			assert.Empty(t, resp.BGP.States)
+			assert.NotNil(t, resp.ISIS.States)
+			assert.Empty(t, resp.ISIS.States)
+			assert.Contains(t, resp.KnownGaps, "telemetry_empty")
+			if env == handlers.EnvMainnet {
+				assert.Contains(t, resp.KnownGaps, "mainnet_beta_telemetry_pilot_not_flowing")
+			}
+		})
+	}
+}
+
+func TestGetNetworkState_MissingTelemetryTablesReturnsUsefulError(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+	require.NoError(t, api.DB.Exec(t.Context(), "DROP DATABASE IF EXISTS `telemetry_mainnet_beta`"))
+
+	rr := httptest.NewRecorder()
+	api.GetNetworkState(rr, networkStateRequest(handlers.EnvMainnet))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Telemetry schema unavailable or outdated")
+}
+
+func TestGetNetworkState_SummarizesTelemetry(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+	createTelemetryNetworkStateTables(t, api, handlers.EnvMainnet)
+	ctx := t.Context()
+	qdb := "`telemetry_mainnet_beta`"
+
+	interfaces := `
+		(timestamp, device_pubkey, interface_name, admin_status, oper_status) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Switch1/11/2', 'UP', 'UP'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Switch1/11/4', 'UP', 'DOWN'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-b', 'Ethernet1', 'UP', 'UP')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.interface_state %s", qdb, interfaces)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.interface_state_latest %s", qdb, interfaces)))
+
+	bgp := `
+		(timestamp, device_pubkey, session_state, peer_type) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'ESTABLISHED', 'INTERNAL'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'ACTIVE', 'EXTERNAL'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-b', 'ESTABLISHED', 'EXTERNAL')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.bgp_neighbors %s", qdb, bgp)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.bgp_neighbors_latest %s", qdb, bgp)))
+
+	isis := `
+		(timestamp, device_pubkey, adjacency_state, system_id) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'UP', '0000.0000.0001'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'DOWN', '0000.0000.0002'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-b', 'UP', '0000.0000.0003')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.isis_adjacencies %s", qdb, isis)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.isis_adjacencies_latest %s", qdb, isis)))
+
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.isis_global_state
+		(timestamp, device_pubkey, network_instance, instance, net, level_capability) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'default', 'default', '49.0001', 'LEVEL_2')
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.isis_global_state_latest
+		(timestamp, device_pubkey, network_instance, instance, net, level_capability) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'default', 'default', '49.0001', 'LEVEL_2')
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.isis_overload_bit
+		(timestamp, device_pubkey, network_instance, overload_bit) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'default', false)
+	`, qdb)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.isis_overload_bit_latest
+		(timestamp, device_pubkey, network_instance, overload_bit) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'default', false)
+	`, qdb)))
+
+	opticsState := `
+		(timestamp, device_pubkey, interface_name, channel_index) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Ethernet1', 0),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Ethernet1', 1),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-b', 'Ethernet2', 0)
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.transceiver_state %s", qdb, opticsState)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.transceiver_state_latest %s", qdb, opticsState)))
+
+	thresholds := `
+		(timestamp, device_pubkey, interface_name, severity) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Ethernet1', 'CRITICAL'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-a', 'Ethernet1', 'WARNING'),
+		(now64(9) - INTERVAL 2 SECOND, 'dev-b', 'Ethernet2', 'CRITICAL')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.transceiver_thresholds %s", qdb, thresholds)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO %s.transceiver_thresholds_latest %s", qdb, thresholds)))
+
+	rr := httptest.NewRecorder()
+	api.GetNetworkState(rr, networkStateRequest(handlers.EnvMainnet))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	resp := decodeNetworkStateResponse(t, rr)
+
+	families := map[string]handlers.InterfaceFamilySummary{}
+	for _, family := range resp.Interfaces.Families {
+		families[family.Family] = family
+	}
+	require.Contains(t, families, "switch")
+	assert.Equal(t, uint64(2), families["switch"].Interfaces)
+	assert.Equal(t, uint64(1), families["switch"].Devices)
+	assert.Equal(t, uint64(2), families["switch"].AdminUp)
+	assert.Equal(t, uint64(1), families["switch"].OperUp)
+	assert.Equal(t, uint64(1), families["switch"].OperDown)
+
+	bgpStates := map[string]handlers.BGPStateSummary{}
+	for _, state := range resp.BGP.States {
+		bgpStates[state.State] = state
+	}
+	require.Contains(t, bgpStates, "ESTABLISHED")
+	assert.Equal(t, uint64(2), bgpStates["ESTABLISHED"].Neighbors)
+	assert.Equal(t, uint64(2), bgpStates["ESTABLISHED"].Devices)
+	assert.Equal(t, uint64(1), bgpStates["ESTABLISHED"].InternalNeighbors)
+	assert.Equal(t, uint64(1), bgpStates["ESTABLISHED"].ExternalNeighbors)
+	require.Contains(t, bgpStates, "ACTIVE")
+	assert.Equal(t, uint64(1), bgpStates["ACTIVE"].Neighbors)
+
+	isisStates := map[string]handlers.ISISStateSummary{}
+	for _, state := range resp.ISIS.States {
+		isisStates[state.State] = state
+	}
+	require.Contains(t, isisStates, "UP")
+	assert.Equal(t, uint64(2), isisStates["UP"].Adjacencies)
+	assert.Equal(t, uint64(2), isisStates["UP"].Devices)
+	assert.Equal(t, uint64(2), isisStates["UP"].Systems)
+	require.Contains(t, isisStates, "DOWN")
+	assert.Equal(t, uint64(1), isisStates["DOWN"].Adjacencies)
+
+	assert.Equal(t, uint64(3), resp.Optics.Lanes)
+	assert.Equal(t, uint64(2), resp.Optics.Devices)
+	assert.Equal(t, uint64(2), resp.Optics.Interfaces)
+	assert.Equal(t, uint64(3), resp.Optics.ThresholdRows)
+	assert.Equal(t, uint64(2), resp.Optics.DevicesWithThresholds)
+	assert.Equal(t, uint64(2), resp.Optics.InterfacesWithThresholds)
+
+	freshness := map[string]handlers.TelemetryFreshness{}
+	for _, item := range resp.Freshness {
+		freshness[item.Table] = item
+	}
+	require.Contains(t, freshness, "interface_state")
+	assert.Equal(t, uint64(3), freshness["interface_state"].Rows)
+	assert.NotEmpty(t, freshness["interface_state"].LastSeen)
+	assert.NotNil(t, freshness["interface_state"].SecondsStale)
+	assert.NotContains(t, resp.KnownGaps, "telemetry_empty")
+}

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -730,7 +730,7 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Count query.
-	countQuery := `SELECT count(*) FROM fact_dz_shred_escrow_events AS e FINAL` + whereClause
+	countQuery := `SELECT count(*) FROM (SELECT * FROM fact_dz_shred_escrow_events FINAL) AS e` + whereClause
 	var total uint64
 	if err := a.envDB(ctx).QueryRow(ctx, countQuery, whereArgs...).Scan(&total); err != nil {
 		logError("shred escrow events count failed", "error", err)
@@ -745,7 +745,7 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 			e.event_ts, e.escrow_pk, e.client_seat_pk, e.tx_signature, e.slot,
 			e.event_type, e.amount_usdc, e.balance_after_usdc, e.epoch, e.status, e.signer,
 			COALESCE(s.client_ip, '') as client_ip
-		FROM fact_dz_shred_escrow_events AS e FINAL
+		FROM (SELECT * FROM fact_dz_shred_escrow_events FINAL) AS e
 		LEFT JOIN dim_dz_shred_client_seats_current s ON e.client_seat_pk = s.pk
 	` + whereClause + ` ` + orderBy + ` LIMIT ? OFFSET ?`
 	queryArgs := append(whereArgs, pagination.Limit, pagination.Offset)

--- a/api/handlers/shreds.go
+++ b/api/handlers/shreds.go
@@ -629,12 +629,12 @@ var escrowEventSortFields = map[string]string{
 }
 
 var escrowEventFilterFields = map[string]FilterFieldConfig{
-	"type":   {Column: "e.event_type", Type: FieldTypeText},
-	"escrow": {Column: "e.escrow_pk", Type: FieldTypeText},
-	"seat":   {Column: "e.client_seat_pk", Type: FieldTypeText},
-	"status": {Column: "e.status", Type: FieldTypeText},
-	"epoch":  {Column: "e.epoch", Type: FieldTypeNumeric},
-	"signer": {Column: "e.signer", Type: FieldTypeText},
+	"type":   {Column: "event_type", Type: FieldTypeText},
+	"escrow": {Column: "escrow_pk", Type: FieldTypeText},
+	"seat":   {Column: "client_seat_pk", Type: FieldTypeText},
+	"status": {Column: "status", Type: FieldTypeText},
+	"epoch":  {Column: "epoch", Type: FieldTypeNumeric},
+	"signer": {Column: "signer", Type: FieldTypeText},
 }
 
 // splitCSV splits a comma-separated string into trimmed non-empty values.
@@ -711,8 +711,10 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now()
 
-	// Build WHERE clause.
-	whereClause := ` WHERE e.event_ts >= ? AND e.event_ts <= ?`
+	// Build event-table WHERE clause. Keep these predicates inside the FINAL
+	// subquery; newer ClickHouse releases can fail if a FINAL subquery is filtered
+	// after a LEFT JOIN.
+	whereClause := ` WHERE event_ts >= ? AND event_ts <= ?`
 	whereArgs := []any{startTime, endTime}
 
 	filterClause, filterArgs := filters.BuildFilterClause(escrowEventFilterFields)
@@ -724,13 +726,13 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 	// Exclude internal/test signers unless include_internal=true.
 	if r.URL.Query().Get("include_internal") != "true" && len(escrowEventExcludedSigners) > 0 {
 		for _, signer := range escrowEventExcludedSigners {
-			whereClause += ` AND e.signer != ?`
+			whereClause += ` AND signer != ?`
 			whereArgs = append(whereArgs, signer)
 		}
 	}
 
 	// Count query.
-	countQuery := `SELECT count(*) FROM (SELECT * FROM fact_dz_shred_escrow_events FINAL) AS e` + whereClause
+	countQuery := `SELECT count(*) FROM fact_dz_shred_escrow_events FINAL` + whereClause
 	var total uint64
 	if err := a.envDB(ctx).QueryRow(ctx, countQuery, whereArgs...).Scan(&total); err != nil {
 		logError("shred escrow events count failed", "error", err)
@@ -745,9 +747,15 @@ func (a *API) GetShredEscrowEvents(w http.ResponseWriter, r *http.Request) {
 			e.event_ts, e.escrow_pk, e.client_seat_pk, e.tx_signature, e.slot,
 			e.event_type, e.amount_usdc, e.balance_after_usdc, e.epoch, e.status, e.signer,
 			COALESCE(s.client_ip, '') as client_ip
-		FROM (SELECT * FROM fact_dz_shred_escrow_events FINAL) AS e
+		FROM (
+			SELECT
+				event_ts, escrow_pk, client_seat_pk, tx_signature, slot,
+				event_type, amount_usdc, balance_after_usdc, epoch, status, signer
+			FROM fact_dz_shred_escrow_events FINAL
+		` + whereClause + `
+		) AS e
 		LEFT JOIN dim_dz_shred_client_seats_current s ON e.client_seat_pk = s.pk
-	` + whereClause + ` ` + orderBy + ` LIMIT ? OFFSET ?`
+	` + orderBy + ` LIMIT ? OFFSET ?`
 	queryArgs := append(whereArgs, pagination.Limit, pagination.Offset)
 
 	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)

--- a/api/main.go
+++ b/api/main.go
@@ -561,6 +561,7 @@ func main() {
 		r.Get("/api/dz/devices/{pk}/validator-stats", api.GetDeviceValidatorStats)
 		r.Get("/api/dz/devices/{pk}/optics", api.GetDeviceOptics)
 		r.Get("/api/dz/devices/{pk}/optics/history", api.GetDeviceOpticsHistory)
+		r.Get("/api/dz/network-state", api.GetNetworkState)
 		r.Get("/api/dz/links", api.GetLinks)
 		r.Get("/api/dz/links/{pk}", api.GetLink)
 		r.Get("/api/dz/links-health", api.GetLinkHealth)


### PR DESCRIPTION
# Summary

Adds a read-only `/api/dz/network-state` endpoint that summarizes existing gNMI telemetry for the selected DoubleZero environment.

## Changes

- Add env-aware network state API handler backed by telemetry ClickHouse tables.
- Summarize telemetry freshness across interface, BGP, ISIS, and transceiver tables.
- Aggregate latest interface state by interface family, including `Switch*` fabric interfaces.
- Aggregate latest BGP neighbors and ISIS adjacencies by raw OpenConfig state.
- Add optics volume summary from latest transceiver state and threshold telemetry.
- Include known-gap flags for empty telemetry, mainnet pilot gaps, and empty ISIS overload-bit data.
- Register `GET /api/dz/network-state` route.
- Add handler tests for empty telemetry, missing telemetry schema, and populated aggregate responses.

## Validation

- `go test ./api/handlers -run 'TestGetNetworkState|TestGetDeviceOptics' -count=1`
- `go test ./api/handlers -count=1`
- `make fmt`
- `make lint`