### PR TITLE
feat(lake): add network state page

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/malbeclabs/lake/indexer/pkg/neo4j"
+	"golang.org/x/sync/singleflight"
 )
 
 var errNoPgPool = errors.New("postgres not configured")
@@ -61,6 +63,10 @@ type API struct {
 
 	// OnSlackInstallationChange is called when a Slack installation changes.
 	OnSlackInstallationChange func(teamID string)
+
+	networkStateCacheMu sync.RWMutex
+	networkStateCache   map[DZEnv]networkStateCacheEntry
+	networkStateGroup   singleflight.Group
 }
 
 // envDB returns the ClickHouse connection for the environment in the context.

--- a/api/handlers/network_state.go
+++ b/api/handlers/network_state.go
@@ -101,53 +101,143 @@ var networkStateFreshnessTables = []string{
 	"transceiver_thresholds",
 }
 
+const (
+	networkStateCacheTTL       = 60 * time.Second
+	networkStateRequestTimeout = 20 * time.Second
+)
+
+type networkStateCacheEntry struct {
+	Response NetworkStateResponse
+	CachedAt time.Time
+	Stale    bool
+}
+
+type networkStateCacheResult struct {
+	Response    NetworkStateResponse
+	CacheStatus string
+}
+
 // GetNetworkState returns a read-only overview of the existing gNMI telemetry
 // for the selected DoubleZero environment. It reports raw observed telemetry
 // state only; callers should not treat these aggregates as incident status.
 func (a *API) GetNetworkState(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), networkStateRequestTimeout)
 	defer cancel()
 
 	env := EnvFromContext(ctx)
+	resp, cacheStatus, err := a.cachedNetworkState(ctx, env)
+	if err != nil {
+		logError("network state query failed", "error", err, "env", env)
+		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Cache", cacheStatus)
+	w.Header().Add("Vary", "X-DZ-Env")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("network state: failed to encode response", "error", err)
+	}
+}
+
+func (a *API) cachedNetworkState(ctx context.Context, env DZEnv) (NetworkStateResponse, string, error) {
+	if entry, ok := a.freshNetworkStateCacheEntry(env, time.Now()); ok {
+		return entry.Response, entry.cacheStatus(), nil
+	}
+
+	value, err, _ := a.networkStateGroup.Do(string(env), func() (any, error) {
+		if entry, ok := a.freshNetworkStateCacheEntry(env, time.Now()); ok {
+			return networkStateCacheResult{Response: entry.Response, CacheStatus: entry.cacheStatus()}, nil
+		}
+
+		resp, err := a.FetchNetworkStateData(ctx, env)
+		if err != nil {
+			if entry, ok := a.networkStateCacheEntry(env); ok {
+				logError("network state refresh failed, serving stale cache", "error", err, "env", env)
+				a.storeNetworkStateCacheEntry(env, entry.Response, true)
+				return networkStateCacheResult{Response: entry.Response, CacheStatus: "STALE"}, nil
+			}
+			return nil, err
+		}
+
+		a.storeNetworkStateCacheEntry(env, resp, false)
+		return networkStateCacheResult{Response: resp, CacheStatus: "MISS"}, nil
+	})
+	if err != nil {
+		return NetworkStateResponse{}, "", err
+	}
+
+	result, ok := value.(networkStateCacheResult)
+	if !ok {
+		return NetworkStateResponse{}, "", fmt.Errorf("network state cache returned unexpected type %T", value)
+	}
+	return result.Response, result.CacheStatus, nil
+}
+
+func (a *API) freshNetworkStateCacheEntry(env DZEnv, now time.Time) (networkStateCacheEntry, bool) {
+	entry, ok := a.networkStateCacheEntry(env)
+	if !ok || now.Sub(entry.CachedAt) >= networkStateCacheTTL {
+		return networkStateCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (a *API) networkStateCacheEntry(env DZEnv) (networkStateCacheEntry, bool) {
+	a.networkStateCacheMu.RLock()
+	defer a.networkStateCacheMu.RUnlock()
+	entry, ok := a.networkStateCache[env]
+	return entry, ok
+}
+
+func (entry networkStateCacheEntry) cacheStatus() string {
+	if entry.Stale {
+		return "STALE"
+	}
+	return "HIT"
+}
+
+func (a *API) storeNetworkStateCacheEntry(env DZEnv, resp NetworkStateResponse, stale bool) {
+	a.networkStateCacheMu.Lock()
+	defer a.networkStateCacheMu.Unlock()
+	if a.networkStateCache == nil {
+		a.networkStateCache = make(map[DZEnv]networkStateCacheEntry)
+	}
+	a.networkStateCache[env] = networkStateCacheEntry{Response: resp, CachedAt: time.Now(), Stale: stale}
+}
+
+// FetchNetworkStateData queries ClickHouse for the current network-state
+// overview without consulting the request cache.
+func (a *API) FetchNetworkStateData(ctx context.Context, env DZEnv) (NetworkStateResponse, error) {
+	ctx = ContextWithEnv(ctx, env)
 	conn := a.envDB(ctx)
 	tdb := quoteClickHouseIdent(TelemetryDatabaseForEnv(env))
 
 	freshness, err := queryNetworkFreshness(ctx, conn, tdb)
 	if err != nil {
-		logError("network state freshness query failed", "error", err, "env", env)
-		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
-		return
+		return NetworkStateResponse{}, fmt.Errorf("freshness query failed: %w", err)
 	}
 
 	families, err := queryNetworkInterfaceFamilies(ctx, conn, tdb)
 	if err != nil {
-		logError("network state interface summary query failed", "error", err, "env", env)
-		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
-		return
+		return NetworkStateResponse{}, fmt.Errorf("interface summary query failed: %w", err)
 	}
 
 	bgpStates, err := queryNetworkBGPStates(ctx, conn, tdb)
 	if err != nil {
-		logError("network state bgp summary query failed", "error", err, "env", env)
-		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
-		return
+		return NetworkStateResponse{}, fmt.Errorf("bgp summary query failed: %w", err)
 	}
 
 	isisStates, err := queryNetworkISISStates(ctx, conn, tdb)
 	if err != nil {
-		logError("network state isis summary query failed", "error", err, "env", env)
-		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
-		return
+		return NetworkStateResponse{}, fmt.Errorf("isis summary query failed: %w", err)
 	}
 
 	optics, err := queryNetworkOptics(ctx, conn, tdb)
 	if err != nil {
-		logError("network state optics summary query failed", "error", err, "env", env)
-		http.Error(w, networkStateUserMessage(err), http.StatusInternalServerError)
-		return
+		return NetworkStateResponse{}, fmt.Errorf("optics summary query failed: %w", err)
 	}
 
-	resp := NetworkStateResponse{
+	return NetworkStateResponse{
 		Env:        string(env),
 		FetchedAt:  time.Now().UTC().Format(time.RFC3339),
 		Freshness:  freshness,
@@ -156,12 +246,7 @@ func (a *API) GetNetworkState(w http.ResponseWriter, r *http.Request) {
 		ISIS:       NetworkISISSummary{States: isisStates},
 		Optics:     optics,
 		KnownGaps:  networkStateKnownGaps(env, freshness),
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		logError("network state: failed to encode response", "error", err)
-	}
+	}, nil
 }
 
 func queryNetworkFreshness(ctx context.Context, conn driver.Conn, tdb string) ([]TelemetryFreshness, error) {

--- a/api/handlers/network_state_test.go
+++ b/api/handlers/network_state_test.go
@@ -205,6 +205,61 @@ func TestGetNetworkState_MissingTelemetryTablesReturnsUsefulError(t *testing.T) 
 	assert.Contains(t, rr.Body.String(), "Telemetry schema unavailable or outdated")
 }
 
+func TestGetNetworkState_CachesPerEnv(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+	api.EnvDatabases["devnet"] = api.Database
+	api.EnvDBs["devnet"] = api.DB
+	createTelemetryNetworkStateTables(t, api, handlers.EnvMainnet)
+	createTelemetryNetworkStateTables(t, api, handlers.EnvDevnet)
+	ctx := t.Context()
+
+	mainnetRows := `
+		(timestamp, device_pubkey, interface_name, admin_status, oper_status) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'mainnet-dev-a', 'Ethernet1', 'UP', 'UP')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_mainnet_beta`.interface_state %s", mainnetRows)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_mainnet_beta`.interface_state_latest %s", mainnetRows)))
+
+	devnetRows := `
+		(timestamp, device_pubkey, interface_name, admin_status, oper_status) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'devnet-dev-a', 'Ethernet1', 'UP', 'UP'),
+		(now64(9) - INTERVAL 2 SECOND, 'devnet-dev-b', 'Switch1/11/2', 'UP', 'DOWN')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_devnet`.interface_state %s", devnetRows)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_devnet`.interface_state_latest %s", devnetRows)))
+
+	mainnetRR := httptest.NewRecorder()
+	api.GetNetworkState(mainnetRR, networkStateRequest(handlers.EnvMainnet))
+	require.Equal(t, http.StatusOK, mainnetRR.Code, mainnetRR.Body.String())
+	assert.Equal(t, "MISS", mainnetRR.Header().Get("X-Cache"))
+	mainnetResp := decodeNetworkStateResponse(t, mainnetRR)
+	assert.Equal(t, uint64(1), mainnetResp.Freshness[0].Rows)
+
+	devnetRR := httptest.NewRecorder()
+	api.GetNetworkState(devnetRR, networkStateRequest(handlers.EnvDevnet))
+	require.Equal(t, http.StatusOK, devnetRR.Code, devnetRR.Body.String())
+	assert.Equal(t, "MISS", devnetRR.Header().Get("X-Cache"))
+	devnetResp := decodeNetworkStateResponse(t, devnetRR)
+	assert.Equal(t, uint64(2), devnetResp.Freshness[0].Rows)
+
+	moreMainnetRows := `
+		(timestamp, device_pubkey, interface_name, admin_status, oper_status) VALUES
+		(now64(9) - INTERVAL 2 SECOND, 'mainnet-dev-b', 'Switch1/11/2', 'UP', 'UP')
+	`
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_mainnet_beta`.interface_state %s", moreMainnetRows)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("INSERT INTO `telemetry_mainnet_beta`.interface_state_latest %s", moreMainnetRows)))
+
+	cachedRR := httptest.NewRecorder()
+	api.GetNetworkState(cachedRR, networkStateRequest(handlers.EnvMainnet))
+	require.Equal(t, http.StatusOK, cachedRR.Code, cachedRR.Body.String())
+	assert.Equal(t, "HIT", cachedRR.Header().Get("X-Cache"))
+	cachedResp := decodeNetworkStateResponse(t, cachedRR)
+	assert.Equal(t, uint64(1), cachedResp.Freshness[0].Rows)
+	assert.Equal(t, mainnetResp.FetchedAt, cachedResp.FetchedAt)
+}
+
 func TestGetNetworkState_SummarizesTelemetry(t *testing.T) {
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["mainnet-beta"] = api.Database

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,6 +51,7 @@ import { ValidatorsPage } from '@/components/validators-page'
 import { GossipNodesPage } from '@/components/gossip-nodes-page'
 import { DeviceDetailPage } from '@/components/device-detail-page'
 import { LinkDetailPage } from '@/components/link-detail-page'
+import { NetworkStatePage } from '@/components/network-state-page'
 import { TopologiesPage } from '@/components/topologies-page'
 import { TopologyDetailPage } from '@/components/topology-detail-page'
 import { MetroDetailPage } from '@/components/metro-detail-page'
@@ -698,6 +699,7 @@ function AppContent() {
             <Route path="/dz/links/topologies" element={<TopologiesPage />} />
             <Route path="/dz/links/topologies/:name" element={<TopologyDetailPage />} />
             <Route path="/dz/links/:pk" element={<LinkDetailPage />} />
+            <Route path="/dz/network-state" element={<NetworkStatePage />} />
             <Route path="/dz/metros" element={<MetrosPage />} />
             <Route path="/dz/metros/:pk" element={<MetroDetailPage />} />
             <Route path="/dz/facilities" element={<FacilitiesPage />} />

--- a/web/src/components/network-state-page.tsx
+++ b/web/src/components/network-state-page.tsx
@@ -1,0 +1,463 @@
+import { useMemo, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  Activity,
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  RefreshCw,
+  WifiOff,
+} from 'lucide-react'
+
+import { PageHeader } from './page-header'
+import { Button } from '@/components/ui/button'
+import { useEnv } from '@/contexts/EnvContext'
+import {
+  fetchNetworkState,
+  type BGPStateSummary,
+  type InterfaceFamilySummary,
+  type ISISStateSummary,
+  type NetworkStateResponse,
+  type TelemetryFreshness,
+} from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+function formatCount(value: number | undefined): string {
+  return new Intl.NumberFormat().format(value ?? 0)
+}
+
+function formatCompact(value: number | undefined): string {
+  const n = value ?? 0
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return formatCount(n)
+}
+
+function formatSeconds(seconds: number | undefined): string {
+  if (seconds === undefined || seconds < 0) return 'No rows'
+  if (seconds < 60) return `${seconds}s stale`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m stale`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h stale`
+  return `${Math.floor(seconds / 86400)}d stale`
+}
+
+function formatTimeAgo(isoString: string | undefined): string {
+  if (!isoString) return 'No samples'
+  const date = new Date(isoString)
+  const diffSecs = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+  if (diffSecs < 60) return `${diffSecs}s ago`
+  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m ago`
+  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}h ago`
+  return `${Math.floor(diffSecs / 86400)}d ago`
+}
+
+function tableLabel(table: string): string {
+  return table.replaceAll('_', ' ')
+}
+
+function gapLabel(gap: string): string {
+  const labels: Record<string, string> = {
+    raw_telemetry_states_not_incidents: 'Raw telemetry states, not incident status',
+    system_state_stdout_only: 'System state is still stdout-only',
+    telemetry_empty: 'No telemetry rows in this environment',
+    mainnet_beta_telemetry_pilot_not_flowing: 'Mainnet-beta gNMI pilot is not flowing yet',
+    isis_overload_bit_empty: 'ISIS overload-bit telemetry is empty',
+  }
+  return labels[gap] ?? gap.replaceAll('_', ' ')
+}
+
+function stateBadgeClass(state: string): string {
+  const normalized = state.toUpperCase()
+  if (normalized === 'UP' || normalized === 'ESTABLISHED') {
+    return 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20'
+  }
+  if (normalized === 'ACTIVE' || normalized === 'CONNECT' || normalized === 'UNKNOWN') {
+    return 'bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20'
+  }
+  if (normalized === 'DOWN' || normalized === 'IDLE') {
+    return 'bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20'
+  }
+  return 'bg-muted text-muted-foreground border-border'
+}
+
+function OverviewMetric({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div className="px-4 py-3 sm:px-5 sm:py-4">
+      <div className="text-xs text-muted-foreground uppercase tracking-wide">{label}</div>
+      <div className="mt-1 text-2xl font-medium tabular-nums">{value}</div>
+      {detail && <div className="mt-1 text-xs text-muted-foreground">{detail}</div>}
+    </div>
+  )
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-border">
+        <h2 className="text-sm font-medium">{title}</h2>
+        {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function EmptyRows({ message }: { message: string }) {
+  return (
+    <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+      {message}
+    </div>
+  )
+}
+
+function FreshnessTable({ rows }: { rows: TelemetryFreshness[] }) {
+  return (
+    <Section title="Telemetry freshness" description="Raw table volume and latest sample time from normalized gNMI tables.">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground border-b border-border">
+              <th className="px-4 py-3 font-medium">Table</th>
+              <th className="px-4 py-3 font-medium text-right">Rows</th>
+              <th className="px-4 py-3 font-medium text-right">Devices</th>
+              <th className="px-4 py-3 font-medium">Last seen</th>
+              <th className="px-4 py-3 font-medium">Age</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(row => (
+              <tr key={row.table} className="border-b border-border/60 last:border-0">
+                <td className="px-4 py-3 font-mono text-xs">{tableLabel(row.table)}</td>
+                <td className="px-4 py-3 text-right tabular-nums">{formatCount(row.rows)}</td>
+                <td className="px-4 py-3 text-right tabular-nums">{formatCount(row.devices)}</td>
+                <td className="px-4 py-3 text-muted-foreground whitespace-nowrap">{formatTimeAgo(row.last_seen)}</td>
+                <td className="px-4 py-3 text-muted-foreground whitespace-nowrap">{formatSeconds(row.seconds_stale)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  )
+}
+
+function InterfaceTable({ families }: { families: InterfaceFamilySummary[] }) {
+  return (
+    <Section title="Interfaces" description="Latest interface snapshots grouped by family.">
+      {families.length === 0 ? (
+        <EmptyRows message="No latest interface telemetry found." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">Family</th>
+                <th className="px-4 py-3 font-medium text-right">Interfaces</th>
+                <th className="px-4 py-3 font-medium text-right">Devices</th>
+                <th className="px-4 py-3 font-medium text-right">Admin up</th>
+                <th className="px-4 py-3 font-medium text-right">Oper up</th>
+                <th className="px-4 py-3 font-medium text-right">Oper down</th>
+              </tr>
+            </thead>
+            <tbody>
+              {families.map(family => (
+                <tr key={family.family} className="border-b border-border/60 last:border-0">
+                  <td className="px-4 py-3 capitalize">{family.family.replaceAll('_', ' ')}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(family.interfaces)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(family.devices)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(family.admin_up)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(family.oper_up)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">{formatCount(family.oper_down)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+function BGPTable({ states }: { states: BGPStateSummary[] }) {
+  return (
+    <Section title="BGP neighbors" description="Latest raw OpenConfig session states.">
+      {states.length === 0 ? (
+        <EmptyRows message="No latest BGP neighbor telemetry found." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">State</th>
+                <th className="px-4 py-3 font-medium text-right">Neighbors</th>
+                <th className="px-4 py-3 font-medium text-right">Devices</th>
+                <th className="px-4 py-3 font-medium text-right">Internal</th>
+                <th className="px-4 py-3 font-medium text-right">External</th>
+              </tr>
+            </thead>
+            <tbody>
+              {states.map(state => (
+                <tr key={state.state} className="border-b border-border/60 last:border-0">
+                  <td className="px-4 py-3">
+                    <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium', stateBadgeClass(state.state))}>
+                      {state.state}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.neighbors)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.devices)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.internal_neighbors)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.external_neighbors)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+function ISISTable({ states }: { states: ISISStateSummary[] }) {
+  return (
+    <Section title="ISIS adjacencies" description="Latest raw adjacency states by device and system ID.">
+      {states.length === 0 ? (
+        <EmptyRows message="No latest ISIS adjacency telemetry found." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">State</th>
+                <th className="px-4 py-3 font-medium text-right">Adjacencies</th>
+                <th className="px-4 py-3 font-medium text-right">Devices</th>
+                <th className="px-4 py-3 font-medium text-right">Systems</th>
+              </tr>
+            </thead>
+            <tbody>
+              {states.map(state => (
+                <tr key={state.state} className="border-b border-border/60 last:border-0">
+                  <td className="px-4 py-3">
+                    <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium', stateBadgeClass(state.state))}>
+                      {state.state}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.adjacencies)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.devices)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{formatCount(state.systems)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+function OpticsPanel({ data }: { data: NetworkStateResponse['optics'] }) {
+  const items = [
+    ['Lanes', data.lanes],
+    ['Devices', data.devices],
+    ['Interfaces', data.interfaces],
+    ['Threshold rows', data.threshold_rows],
+    ['Devices with thresholds', data.devices_with_thresholds],
+    ['Interfaces with thresholds', data.interfaces_with_thresholds],
+  ] as const
+
+  return (
+    <Section title="Optics" description="Latest transceiver lane and threshold volume.">
+      <div className="grid grid-cols-2 gap-px bg-border">
+        {items.map(([label, value]) => (
+          <div key={label} className="bg-card px-4 py-3">
+            <div className="text-xs text-muted-foreground">{label}</div>
+            <div className="mt-1 text-lg font-medium tabular-nums">{formatCount(value)}</div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+function KnownGaps({ env, gaps }: { env: string; gaps: string[] }) {
+  const mainnetPilot = gaps.includes('mainnet_beta_telemetry_pilot_not_flowing')
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-full bg-muted p-1.5 text-muted-foreground">
+          {mainnetPilot ? <WifiOff className="h-4 w-4" /> : <AlertCircle className="h-4 w-4" />}
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-sm font-medium">Known gaps</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {mainnetPilot
+              ? `No gNMI telemetry is flowing for ${env} yet. The endpoint is healthy, but the pilot is not currently producing rows.`
+              : 'These are expected product and collection gaps. They are not incident status.'}
+          </p>
+          {gaps.length > 0 && (
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {gaps.map(gap => (
+                <li key={gap} className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
+                  {gapLabel(gap)}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function NetworkStateSkeleton() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-[1600px] mx-auto px-4 sm:px-8 py-8">
+        <div className="h-9 w-56 animate-pulse rounded bg-muted mb-6" />
+        <div className="h-28 animate-pulse rounded-lg bg-muted mb-6" />
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          <div className="h-80 animate-pulse rounded-lg bg-muted" />
+          <div className="h-80 animate-pulse rounded-lg bg-muted" />
+          <div className="h-64 animate-pulse rounded-lg bg-muted" />
+          <div className="h-64 animate-pulse rounded-lg bg-muted" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function NetworkStatePage() {
+  const { env } = useEnv()
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: ['network-state', env],
+    queryFn: fetchNetworkState,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+
+  const summary = useMemo(() => {
+    const freshness = data?.freshness ?? []
+    const families = data?.interfaces.families ?? []
+    const bgpStates = data?.bgp.states ?? []
+    const isisStates = data?.isis.states ?? []
+    return {
+      totalRows: freshness.reduce((sum, row) => sum + row.rows, 0),
+      telemetryDevices: Math.max(0, ...freshness.map(row => row.devices)),
+      interfaces: families.reduce((sum, row) => sum + row.interfaces, 0),
+      bgpNeighbors: bgpStates.reduce((sum, row) => sum + row.neighbors, 0),
+      isisAdjacencies: isisStates.reduce((sum, row) => sum + row.adjacencies, 0),
+      opticsLanes: data?.optics.lanes ?? 0,
+      latestSeen: freshness
+        .filter(row => row.last_seen)
+        .sort((a, b) => new Date(b.last_seen!).getTime() - new Date(a.last_seen!).getTime())[0]?.last_seen,
+    }
+  }, [data])
+
+  if (isLoading) return <NetworkStateSkeleton />
+
+  if (error || !data) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <div className="text-lg font-medium mb-2">Unable to load network state</div>
+          <div className="text-sm text-muted-foreground mb-4">
+            {error instanceof Error ? error.message : 'Unknown error'}
+          </div>
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Try again
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const telemetryEmpty = data.known_gaps.includes('telemetry_empty')
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-[1600px] mx-auto px-4 sm:px-8 py-8">
+        <PageHeader
+          icon={Activity}
+          title="Network State"
+          subtitle={
+            <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+              <span>{data.env}</span>
+              <span aria-hidden="true">·</span>
+              <Clock3 className="h-3.5 w-3.5" />
+              <span>fetched {formatTimeAgo(data.fetched_at)}</span>
+            </span>
+          }
+          actions={
+            <>
+              {data.cache_status && (
+                <span className="inline-flex items-center rounded-full border border-border bg-card px-2.5 py-1 text-xs text-muted-foreground">
+                  Cache {data.cache_status.toLowerCase()}
+                </span>
+              )}
+              <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+                <RefreshCw className={cn('h-3.5 w-3.5 mr-2', isFetching && 'animate-spin')} />
+                Refresh
+              </Button>
+            </>
+          }
+        />
+
+        {telemetryEmpty && (
+          <div className="mb-6 rounded-lg border border-border bg-card p-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-muted p-1.5 text-muted-foreground">
+                <WifiOff className="h-4 w-4" />
+              </div>
+              <div>
+                <div className="text-sm font-medium">No telemetry rows yet</div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  The telemetry schema is reachable for {data.env}, but no normalized gNMI rows are present.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="mb-6 rounded-lg border border-border bg-card overflow-hidden">
+          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 divide-x divide-y md:divide-y-0 divide-border">
+            <OverviewMetric label="Telemetry devices" value={formatCount(summary.telemetryDevices)} detail={`${formatCompact(summary.totalRows)} rows`} />
+            <OverviewMetric label="Interfaces" value={formatCount(summary.interfaces)} detail={`${formatCount(data.interfaces.families.length)} families`} />
+            <OverviewMetric label="BGP neighbors" value={formatCount(summary.bgpNeighbors)} detail={`${formatCount(data.bgp.states.length)} states`} />
+            <OverviewMetric label="ISIS adjacencies" value={formatCount(summary.isisAdjacencies)} detail={`${formatCount(data.isis.states.length)} states`} />
+            <OverviewMetric label="Optics lanes" value={formatCount(summary.opticsLanes)} detail={`${formatCount(data.optics.interfaces)} interfaces`} />
+            <OverviewMetric label="Latest sample" value={formatTimeAgo(summary.latestSeen)} detail="Across telemetry tables" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          <div className="xl:col-span-2">
+            <FreshnessTable rows={data.freshness} />
+          </div>
+          <InterfaceTable families={data.interfaces.families} />
+          <div className="space-y-6">
+            <BGPTable states={data.bgp.states} />
+            <ISISTable states={data.isis.states} />
+          </div>
+          <OpticsPanel data={data.optics} />
+          <KnownGaps env={data.env} gaps={data.known_gaps} />
+        </div>
+
+        <div className="mt-6 flex items-center gap-2 text-xs text-muted-foreground">
+          <CheckCircle2 className="h-3.5 w-3.5" />
+          <span>Raw gNMI observations only. Health and incident decisions live on the Status pages.</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -94,6 +94,7 @@ const { resolvedTheme, setTheme } = useTheme()
   // Entity routes
   const isDevicesRoute = location.pathname.startsWith('/dz/devices')
   const isLinksRoute = location.pathname.startsWith('/dz/links')
+  const isNetworkStateRoute = location.pathname === '/dz/network-state'
   const isMetrosRoute = location.pathname.startsWith('/dz/metros')
   const isFacilitiesRoute = location.pathname.startsWith('/dz/facilities')
   const isContributorsRoute = location.pathname.startsWith('/dz/contributors')
@@ -564,6 +565,10 @@ const { resolvedTheme, setTheme } = useTheme()
                 Topologies
               </Link>
             )}
+            <Link to="/dz/network-state" className={navItemClass(isNetworkStateRoute)}>
+              <Activity className="h-4 w-4" />
+              Network State
+            </Link>
             <Link to="/dz/metros" className={navItemClass(isMetrosRoute)}>
               <MapPin className="h-4 w-4" />
               Metros

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1356,6 +1356,71 @@ export async function fetchStatus(): Promise<StatusResponse> {
   return res.json()
 }
 
+export interface TelemetryFreshness {
+  table: string
+  rows: number
+  devices: number
+  last_seen?: string
+  seconds_stale?: number
+}
+
+export interface InterfaceFamilySummary {
+  family: string
+  interfaces: number
+  devices: number
+  admin_up: number
+  admin_down: number
+  oper_up: number
+  oper_down: number
+  oper_unknown: number
+}
+
+export interface BGPStateSummary {
+  state: string
+  neighbors: number
+  devices: number
+  internal_neighbors: number
+  external_neighbors: number
+}
+
+export interface ISISStateSummary {
+  state: string
+  adjacencies: number
+  devices: number
+  systems: number
+}
+
+export interface NetworkOpticsSummary {
+  lanes: number
+  devices: number
+  interfaces: number
+  threshold_rows: number
+  devices_with_thresholds: number
+  interfaces_with_thresholds: number
+}
+
+export interface NetworkStateResponse {
+  env: string
+  fetched_at: string
+  freshness: TelemetryFreshness[]
+  interfaces: { families: InterfaceFamilySummary[] }
+  bgp: { states: BGPStateSummary[] }
+  isis: { states: ISISStateSummary[] }
+  optics: NetworkOpticsSummary
+  known_gaps: string[]
+  cache_status?: string
+}
+
+export async function fetchNetworkState(): Promise<NetworkStateResponse> {
+  const res = await fetchWithRetry('/api/dz/network-state')
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || 'Failed to fetch network state')
+  }
+  const data = await res.json()
+  return { ...data, cache_status: res.headers.get('X-Cache') || undefined }
+}
+
 // Link history types for status timeline
 export interface LinkHourStatus {
   hour: string


### PR DESCRIPTION
# Summary

Adds a read-only DoubleZero Network State page backed by the existing gNMI telemetry summary endpoint, with API-side caching to make the page usable against large telemetry tables.

## Changes

- Add per-environment in-memory caching for `GET /api/dz/network-state`
- Add singleflight refresh behavior to avoid duplicate expensive ClickHouse queries
- Serve stale cached network-state data when refreshes fail
- Return `X-Cache: MISS | HIT | STALE` and vary responses by `X-DZ-Env`
- Add typed frontend API client support via `fetchNetworkState()`
- Add `/dz/network-state` route and sidebar navigation entry
- Add Network State UI for telemetry freshness, interfaces, BGP, ISIS, optics, and known gaps
- Add tests covering empty telemetry, missing tables, summaries, and per-env cache behavior

## Validation

- `go test ./api/...`
- `go test -race ./api/handlers -run 'TestGetNetworkState' -count=1`
- `golangci-lint run -c ./.golangci.yaml ./api/...`
- `cd web && bun run build`
- `cd web && bun run test:run`
- `cd web && bun run lint`
- `git diff --check`

## Screenshots

### Devnet

<img width="1829" height="1320" alt="image" src="https://github.com/user-attachments/assets/3e117e8f-ead2-4efe-a221-ce797664d3aa" />

### Testnet

<img width="1828" height="1324" alt="image" src="https://github.com/user-attachments/assets/129be81f-df3e-4d0d-b469-834d41a8ebca" />
