### PR TITLE
feat(api): add controller-call status timeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_STORE
 .env
+.env.*
+!.env.example
+!*/.env.example
 .idea
 .private
 .vscode

--- a/api/handlers/device_controller_calls.go
+++ b/api/handlers/device_controller_calls.go
@@ -106,7 +106,8 @@ func (a *API) GetDeviceControllerCalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sourceDB, sourceAvailable, err := resolveControllerCallsSourceDB(ctx, conn, EnvFromContext(ctx))
+	sourceDB := TelemetryDatabaseForEnv(EnvFromContext(ctx))
+	sourceAvailable, err := controllerCallsSourceAvailable(ctx, conn, sourceDB)
 	if err != nil {
 		logError("device controller calls: source check failed", "error", err, "pk", pk, "database", sourceDB)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -217,20 +218,6 @@ func queryDeviceControllerCallMeta(ctx context.Context, conn driver.Conn, pk str
 	err := conn.QueryRow(ctx, query, pk).Scan(&meta.Code, &meta.Status)
 	metrics.RecordClickHouseQuery("device_controller_calls_device", time.Since(start), err)
 	return meta, err
-}
-
-func resolveControllerCallsSourceDB(ctx context.Context, conn driver.Conn, env DZEnv) (string, bool, error) {
-	candidates := []string{TelemetryDatabaseForEnv(env), string(env)}
-	for _, database := range candidates {
-		available, err := controllerCallsSourceAvailable(ctx, conn, database)
-		if err != nil {
-			return database, false, err
-		}
-		if available {
-			return database, true, nil
-		}
-	}
-	return candidates[0], false, nil
 }
 
 func controllerCallsSourceAvailable(ctx context.Context, conn driver.Conn, database string) (bool, error) {

--- a/api/handlers/device_controller_calls.go
+++ b/api/handlers/device_controller_calls.go
@@ -106,8 +106,7 @@ func (a *API) GetDeviceControllerCalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sourceDB := string(EnvFromContext(ctx))
-	sourceAvailable, err := controllerCallsSourceAvailable(ctx, conn, sourceDB)
+	sourceDB, sourceAvailable, err := resolveControllerCallsSourceDB(ctx, conn, EnvFromContext(ctx))
 	if err != nil {
 		logError("device controller calls: source check failed", "error", err, "pk", pk, "database", sourceDB)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -218,6 +217,20 @@ func queryDeviceControllerCallMeta(ctx context.Context, conn driver.Conn, pk str
 	err := conn.QueryRow(ctx, query, pk).Scan(&meta.Code, &meta.Status)
 	metrics.RecordClickHouseQuery("device_controller_calls_device", time.Since(start), err)
 	return meta, err
+}
+
+func resolveControllerCallsSourceDB(ctx context.Context, conn driver.Conn, env DZEnv) (string, bool, error) {
+	candidates := []string{TelemetryDatabaseForEnv(env), string(env)}
+	for _, database := range candidates {
+		available, err := controllerCallsSourceAvailable(ctx, conn, database)
+		if err != nil {
+			return database, false, err
+		}
+		if available {
+			return database, true, nil
+		}
+	}
+	return candidates[0], false, nil
 }
 
 func controllerCallsSourceAvailable(ctx context.Context, conn driver.Conn, database string) (bool, error) {
@@ -377,9 +390,11 @@ func buildDeviceControllerCallsResponse(
 			recentCalls := sumControllerCalls(prefixTimes, prefixCalls, bucketEnd.Add(-controllerCallAlertThreshold), bucketEnd)
 			if recentCalls > 0 {
 				status = ControllerCallStatusCalling
-			} else if stoppedOpen || sumControllerCalls(prefixTimes, prefixCalls, bucketEnd.Add(-controllerCallHistoryWindow), bucketEnd) > controllerCallPriorHistoryMinimum {
+			} else if sumControllerCalls(prefixTimes, prefixCalls, bucketEnd.Add(-controllerCallHistoryWindow), bucketEnd) > controllerCallPriorHistoryMinimum {
 				status = ControllerCallStatusStopped
 				stoppedOpen = true
+			} else {
+				stoppedOpen = false
 			}
 		}
 
@@ -449,11 +464,14 @@ func sumControllerCalls(times []time.Time, prefix []uint64, start, end time.Time
 
 func latestControllerCallAt(times, latestTimes []time.Time, before time.Time) *time.Time {
 	idx := sortSearchTimes(times, before) - 1
-	if idx < 0 || idx >= len(times) {
-		return nil
+	for idx >= 0 && idx < len(times) {
+		ts := latestTimes[idx]
+		if ts.Before(before) {
+			return &ts
+		}
+		idx--
 	}
-	ts := latestTimes[idx]
-	return &ts
+	return nil
 }
 
 func sortSearchTimes(times []time.Time, target time.Time) int {

--- a/api/handlers/device_controller_calls.go
+++ b/api/handlers/device_controller_calls.go
@@ -1,0 +1,482 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/go-chi/chi/v5"
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/malbeclabs/lake/api/metrics"
+)
+
+const (
+	ControllerCallStatusCalling     = "calling"
+	ControllerCallStatusStopped     = "stopped"
+	ControllerCallStatusRecovered   = "recovered"
+	ControllerCallStatusNoData      = "no_data"
+	ControllerCallStatusNotExpected = "not_expected"
+
+	controllerCallsTable              = "controller_grpc_getconfig_success"
+	controllerCallAlertThreshold      = 30 * time.Minute
+	controllerCallHistoryWindow       = 72 * time.Hour
+	controllerCallPriorHistoryMinimum = uint64(4000)
+)
+
+// DeviceControllerCallsResponse is the response for
+// GET /api/dz/devices/{pk}/controller-calls.
+type DeviceControllerCallsResponse struct {
+	DevicePK              string                        `json:"device_pk"`
+	DeviceCode            string                        `json:"device_code"`
+	DeviceStatus          string                        `json:"device_status"`
+	TimeRange             string                        `json:"time_range"`
+	BucketSeconds         int                           `json:"bucket_seconds"`
+	BucketCount           int                           `json:"bucket_count"`
+	From                  string                        `json:"from"`
+	To                    string                        `json:"to"`
+	SourceAvailable       bool                          `json:"source_available"`
+	LastCallAt            *string                       `json:"last_call_at,omitempty"`
+	CurrentGapSeconds     *int                          `json:"current_gap_seconds,omitempty"`
+	LastStatus            string                        `json:"last_status"`
+	TotalCalls            uint64                        `json:"total_calls"`
+	MinutesWithCalls      uint64                        `json:"minutes_with_calls"`
+	AlertThresholdMinutes int                           `json:"alert_threshold_minutes"`
+	HistoryWindowHours    int                           `json:"history_window_hours"`
+	PriorHistoryMinimum   uint64                        `json:"prior_history_minimum"`
+	Buckets               []DeviceControllerCallsBucket `json:"buckets"`
+}
+
+// DeviceControllerCallsBucket describes controller GetConfig calls for one bucket.
+type DeviceControllerCallsBucket struct {
+	TS               string `json:"ts"`
+	Calls            uint64 `json:"calls"`
+	MinutesWithCalls uint64 `json:"minutes_with_calls"`
+	Status           string `json:"status"`
+	GapSeconds       *int   `json:"gap_seconds,omitempty"`
+}
+
+type deviceControllerCallMeta struct {
+	Code   string
+	Status string
+}
+
+type controllerCallBucketAgg struct {
+	Calls            uint64
+	MinutesWithCalls uint64
+}
+
+type controllerCallMinuteAgg struct {
+	TS     time.Time
+	LastTS time.Time
+	Calls  uint64
+}
+
+// GetDeviceControllerCalls returns controller.GetConfig call history for one device.
+func (a *API) GetDeviceControllerCalls(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	pk := chi.URLParam(r, "pk")
+	if pk == "" {
+		http.Error(w, "missing device pk", http.StatusBadRequest)
+		return
+	}
+
+	params, err := resolveControllerCallParams(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	conn := a.envDB(ctx)
+	meta, err := queryDeviceControllerCallMeta(ctx, conn, pk)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		logError("device controller calls: device lookup failed", "error", err, "pk", pk)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	sourceDB := string(EnvFromContext(ctx))
+	sourceAvailable, err := controllerCallsSourceAvailable(ctx, conn, sourceDB)
+	if err != nil {
+		logError("device controller calls: source check failed", "error", err, "pk", pk, "database", sourceDB)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	bucketSecs := params.BucketSeconds
+	if bucketSecs <= 0 {
+		bucketSecs = 300
+	}
+
+	if !sourceAvailable {
+		resp := emptyDeviceControllerCallsResponse(pk, meta, params, bucketSecs, false)
+		writeJSON(w, resp)
+		return
+	}
+
+	bucketAggs, err := queryControllerCallBucketAggs(ctx, conn, sourceDB, pk, params, bucketSecs)
+	if err != nil {
+		if controllerCallSourceErr(err) {
+			resp := emptyDeviceControllerCallsResponse(pk, meta, params, bucketSecs, false)
+			writeJSON(w, resp)
+			return
+		}
+		logError("device controller calls: bucket query failed", "error", err, "pk", pk, "database", sourceDB)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	minuteAggs, err := queryControllerCallMinuteAggs(ctx, conn, sourceDB, pk, params)
+	if err != nil {
+		if controllerCallSourceErr(err) {
+			resp := emptyDeviceControllerCallsResponse(pk, meta, params, bucketSecs, false)
+			writeJSON(w, resp)
+			return
+		}
+		logError("device controller calls: minute query failed", "error", err, "pk", pk, "database", sourceDB)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := buildDeviceControllerCallsResponse(pk, meta, params, bucketSecs, true, bucketAggs, minuteAggs)
+	writeJSON(w, resp)
+}
+
+func resolveControllerCallParams(r *http.Request) (bucketParams, error) {
+	q := r.URL.Query()
+	timeRange := q.Get("range")
+	if timeRange == "" {
+		timeRange = "24h"
+	}
+
+	startTimeStr := q.Get("start_time")
+	endTimeStr := q.Get("end_time")
+	bucketStr := q.Get("bucket")
+
+	var params bucketParams
+	if startTimeStr != "" && endTimeStr != "" {
+		startUnix, err1 := strconv.ParseInt(startTimeStr, 10, 64)
+		endUnix, err2 := strconv.ParseInt(endTimeStr, 10, 64)
+		if err1 != nil || err2 != nil {
+			return params, fmt.Errorf("invalid start_time or end_time")
+		}
+		startTime := time.Unix(startUnix, 0).UTC()
+		endTime := time.Unix(endUnix, 0).UTC()
+		if !endTime.After(startTime) {
+			return params, fmt.Errorf("end_time must be after start_time")
+		}
+		params = parseBucketParamsCustom(startTime, endTime, 24)
+	} else {
+		now := time.Now().UTC()
+		duration := presetToDuration(timeRange)
+		startTime := now.Add(-duration)
+		params = parseBucketParamsCustom(startTime, now, 24)
+		params.TimeRange = timeRange
+	}
+
+	if bucketStr != "" && bucketStr != "auto" {
+		interval, ok := parseBucketString(bucketStr)
+		if !ok {
+			return params, fmt.Errorf("invalid bucket value")
+		}
+		secs := intervalToSeconds(interval)
+		var totalSecs int
+		if params.StartTime != nil && params.EndTime != nil {
+			totalSecs = int(params.EndTime.Sub(*params.StartTime).Seconds())
+		} else {
+			totalSecs = params.TotalMinutes * 60
+		}
+		count := (totalSecs + secs - 1) / secs
+		if count < 1 {
+			count = 1
+		}
+		params.BucketSeconds = secs
+		params.BucketMinutes = secs / 60
+		params.BucketInterval = interval
+		params.BucketCount = count
+		params.UseRaw = true
+	}
+
+	return params, nil
+}
+
+func queryDeviceControllerCallMeta(ctx context.Context, conn driver.Conn, pk string) (deviceControllerCallMeta, error) {
+	var meta deviceControllerCallMeta
+	query := `SELECT code, status FROM dz_devices_current WHERE pk = ?`
+	start := time.Now()
+	err := conn.QueryRow(ctx, query, pk).Scan(&meta.Code, &meta.Status)
+	metrics.RecordClickHouseQuery("device_controller_calls_device", time.Since(start), err)
+	return meta, err
+}
+
+func controllerCallsSourceAvailable(ctx context.Context, conn driver.Conn, database string) (bool, error) {
+	var count uint64
+	query := `
+		SELECT count()
+		FROM system.tables
+		WHERE database = ?
+		  AND name = ?
+	`
+	start := time.Now()
+	err := conn.QueryRow(ctx, query, database, controllerCallsTable).Scan(&count)
+	metrics.RecordClickHouseQuery("device_controller_calls_source", time.Since(start), err)
+	return count > 0, err
+}
+
+func queryControllerCallBucketAggs(ctx context.Context, conn driver.Conn, sourceDB, pk string, params bucketParams, bucketSecs int) (map[time.Time]controllerCallBucketAgg, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			toDateTime(toStartOfInterval(timestamp, INTERVAL %[2]d SECOND, 'UTC')) AS bucket_ts,
+			count() AS calls,
+			uniqExact(toStartOfMinute(timestamp)) AS minutes_with_calls
+		FROM %[1]s.%[3]s
+		WHERE timestamp >= ?
+		  AND timestamp < ?
+		  AND device_pubkey = ?
+		GROUP BY bucket_ts
+		ORDER BY bucket_ts
+		LIMIT 100000
+		SETTINGS max_execution_time = 30,
+		         max_rows_to_read = 1000000000,
+		         timeout_before_checking_execution_speed = 0
+	`, quoteClickHouseIdent(sourceDB), bucketSecs, quoteClickHouseIdent(controllerCallsTable))
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query, *params.StartTime, *params.EndTime, pk)
+	metrics.RecordClickHouseQuery("device_controller_calls_buckets", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[time.Time]controllerCallBucketAgg)
+	for rows.Next() {
+		var (
+			ts               time.Time
+			calls            uint64
+			minutesWithCalls uint64
+		)
+		if err := rows.Scan(&ts, &calls, &minutesWithCalls); err != nil {
+			return nil, err
+		}
+		out[ts.UTC()] = controllerCallBucketAgg{Calls: calls, MinutesWithCalls: minutesWithCalls}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func queryControllerCallMinuteAggs(ctx context.Context, conn driver.Conn, sourceDB, pk string, params bucketParams) ([]controllerCallMinuteAgg, error) {
+	historyStart := params.StartTime.Add(-controllerCallHistoryWindow)
+	query := fmt.Sprintf(`
+		SELECT
+			toDateTime(toStartOfMinute(timestamp)) AS minute_ts,
+			max(timestamp) AS last_ts,
+			count() AS calls
+		FROM %[1]s.%[2]s
+		WHERE timestamp >= ?
+		  AND timestamp < ?
+		  AND device_pubkey = ?
+		GROUP BY minute_ts
+		ORDER BY minute_ts
+		LIMIT 100000
+		SETTINGS max_execution_time = 30,
+		         max_rows_to_read = 1000000000,
+		         timeout_before_checking_execution_speed = 0
+	`, quoteClickHouseIdent(sourceDB), quoteClickHouseIdent(controllerCallsTable))
+
+	start := time.Now()
+	rows, err := conn.Query(ctx, query, historyStart, *params.EndTime, pk)
+	metrics.RecordClickHouseQuery("device_controller_calls_minutes", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []controllerCallMinuteAgg{}
+	for rows.Next() {
+		var (
+			ts     time.Time
+			lastTS time.Time
+			calls  uint64
+		)
+		if err := rows.Scan(&ts, &lastTS, &calls); err != nil {
+			return nil, err
+		}
+		out = append(out, controllerCallMinuteAgg{TS: ts.UTC(), LastTS: lastTS.UTC(), Calls: calls})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func buildDeviceControllerCallsResponse(
+	pk string,
+	meta deviceControllerCallMeta,
+	params bucketParams,
+	bucketSecs int,
+	sourceAvailable bool,
+	bucketAggs map[time.Time]controllerCallBucketAgg,
+	minuteAggs []controllerCallMinuteAgg,
+) DeviceControllerCallsResponse {
+	buckets := make([]DeviceControllerCallsBucket, 0, params.BucketCount)
+	bucketDuration := time.Duration(bucketSecs) * time.Second
+
+	prefixTimes := make([]time.Time, 0, len(minuteAggs))
+	latestTimes := make([]time.Time, 0, len(minuteAggs))
+	prefixCalls := make([]uint64, len(minuteAggs)+1)
+	var lastCallAt *time.Time
+	for i, minute := range minuteAggs {
+		prefixTimes = append(prefixTimes, minute.TS)
+		latestTimes = append(latestTimes, minute.LastTS)
+		prefixCalls[i+1] = prefixCalls[i] + minute.Calls
+		if minute.Calls > 0 {
+			lastTS := minute.LastTS
+			lastCallAt = &lastTS
+		}
+	}
+
+	var (
+		totalCalls       uint64
+		minutesWithCalls uint64
+		stoppedOpen      bool
+		lastStatus       = ControllerCallStatusNoData
+	)
+
+	for i := 0; i < params.BucketCount; i++ {
+		bucketStart := params.StartTime.Add(time.Duration(i) * bucketDuration).UTC()
+		bucketEnd := bucketStart.Add(bucketDuration)
+		agg := bucketAggs[bucketStart]
+		totalCalls += agg.Calls
+		minutesWithCalls += agg.MinutesWithCalls
+
+		status := ControllerCallStatusNoData
+		if !sourceAvailable {
+			status = ControllerCallStatusNoData
+		} else if agg.Calls > 0 {
+			if stoppedOpen {
+				status = ControllerCallStatusRecovered
+				stoppedOpen = false
+			} else {
+				status = ControllerCallStatusCalling
+			}
+		} else {
+			recentCalls := sumControllerCalls(prefixTimes, prefixCalls, bucketEnd.Add(-controllerCallAlertThreshold), bucketEnd)
+			if recentCalls > 0 {
+				status = ControllerCallStatusCalling
+			} else if stoppedOpen || sumControllerCalls(prefixTimes, prefixCalls, bucketEnd.Add(-controllerCallHistoryWindow), bucketEnd) > controllerCallPriorHistoryMinimum {
+				status = ControllerCallStatusStopped
+				stoppedOpen = true
+			}
+		}
+
+		var gapSeconds *int
+		if last := latestControllerCallAt(prefixTimes, latestTimes, bucketEnd); last != nil {
+			gap := int(bucketEnd.Sub(*last).Seconds())
+			if gap >= 0 {
+				gapSeconds = &gap
+			}
+		}
+
+		lastStatus = status
+		buckets = append(buckets, DeviceControllerCallsBucket{
+			TS:               bucketStart.Format(time.RFC3339),
+			Calls:            agg.Calls,
+			MinutesWithCalls: agg.MinutesWithCalls,
+			Status:           status,
+			GapSeconds:       gapSeconds,
+		})
+	}
+
+	var lastCallAtStr *string
+	var currentGapSeconds *int
+	if lastCallAt != nil {
+		formatted := lastCallAt.UTC().Format(time.RFC3339)
+		lastCallAtStr = &formatted
+		gap := int(params.EndTime.Sub(*lastCallAt).Seconds())
+		if gap >= 0 {
+			currentGapSeconds = &gap
+		}
+	}
+
+	return DeviceControllerCallsResponse{
+		DevicePK:              pk,
+		DeviceCode:            meta.Code,
+		DeviceStatus:          meta.Status,
+		TimeRange:             params.TimeRange,
+		BucketSeconds:         bucketSecs,
+		BucketCount:           params.BucketCount,
+		From:                  params.StartTime.UTC().Format(time.RFC3339),
+		To:                    params.EndTime.UTC().Format(time.RFC3339),
+		SourceAvailable:       sourceAvailable,
+		LastCallAt:            lastCallAtStr,
+		CurrentGapSeconds:     currentGapSeconds,
+		LastStatus:            lastStatus,
+		TotalCalls:            totalCalls,
+		MinutesWithCalls:      minutesWithCalls,
+		AlertThresholdMinutes: int(controllerCallAlertThreshold / time.Minute),
+		HistoryWindowHours:    int(controllerCallHistoryWindow / time.Hour),
+		PriorHistoryMinimum:   controllerCallPriorHistoryMinimum,
+		Buckets:               buckets,
+	}
+}
+
+func emptyDeviceControllerCallsResponse(pk string, meta deviceControllerCallMeta, params bucketParams, bucketSecs int, sourceAvailable bool) DeviceControllerCallsResponse {
+	return buildDeviceControllerCallsResponse(pk, meta, params, bucketSecs, sourceAvailable, map[time.Time]controllerCallBucketAgg{}, nil)
+}
+
+func sumControllerCalls(times []time.Time, prefix []uint64, start, end time.Time) uint64 {
+	if len(times) == 0 || !end.After(start) {
+		return 0
+	}
+	lo := sortSearchTimes(times, start)
+	hi := sortSearchTimes(times, end)
+	return prefix[hi] - prefix[lo]
+}
+
+func latestControllerCallAt(times, latestTimes []time.Time, before time.Time) *time.Time {
+	idx := sortSearchTimes(times, before) - 1
+	if idx < 0 || idx >= len(times) {
+		return nil
+	}
+	ts := latestTimes[idx]
+	return &ts
+}
+
+func sortSearchTimes(times []time.Time, target time.Time) int {
+	lo, hi := 0, len(times)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if times[mid].Before(target) {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+func controllerCallSourceErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "unknown table") ||
+		strings.Contains(errStr, "unknown database") ||
+		strings.Contains(errStr, "table not found") ||
+		strings.Contains(errStr, "access denied") ||
+		strings.Contains(errStr, "permission denied")
+}

--- a/api/handlers/device_controller_calls_test.go
+++ b/api/handlers/device_controller_calls_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,6 +39,30 @@ func createControllerCallsTable(t *testing.T, api *handlers.API, db string) {
 		PARTITION BY toYYYYMM(timestamp)
 		ORDER BY (timestamp, device_pubkey)
 	`, quotedDB)))
+}
+
+func dropControllerCallsTable(t *testing.T, api *handlers.API, db string) {
+	t.Helper()
+	ctx := t.Context()
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`.controller_grpc_getconfig_success", db)))
+	t.Cleanup(func() {
+		_ = api.DB.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS `%s`.controller_grpc_getconfig_success", db))
+	})
+}
+
+func resetControllerCallsTable(t *testing.T, api *handlers.API, db string) {
+	t.Helper()
+	dropControllerCallsTable(t, api, db)
+	createControllerCallsTable(t, api, db)
+}
+
+func insertControllerCallEvents(t *testing.T, api *handlers.API, db, pk string, times ...time.Time) {
+	t.Helper()
+	query := fmt.Sprintf("INSERT INTO `%s`.controller_grpc_getconfig_success (timestamp, device_pubkey) VALUES (?, ?)", db)
+	for _, ts := range times {
+		require.NoError(t, api.DB.Exec(t.Context(), query, ts.UTC(), pk))
+	}
 }
 
 func TestGetDeviceControllerCalls_NotFound(t *testing.T) {
@@ -79,6 +104,120 @@ func TestGetDeviceControllerCalls_SourceUnavailableReturnsNoData(t *testing.T) {
 		assert.Equal(t, handlers.ControllerCallStatusNoData, bucket.Status)
 		assert.Zero(t, bucket.Calls)
 	}
+}
+
+func TestGetDeviceControllerCalls_PrefersTelemetrySourceDB(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["devnet"] = api.Database
+	api.EnvDBs["devnet"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-telemetry-source", "DEV-CONTROLLER-TELEMETRY")
+	resetControllerCallsTable(t, api, "telemetry_devnet")
+	resetControllerCallsTable(t, api, "devnet")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	insertControllerCallEvents(t, api, "telemetry_devnet", "dev-controller-telemetry-source", start.Add(10*time.Minute), start.Add(20*time.Minute))
+	insertControllerCallEvents(t, api, "devnet", "dev-controller-telemetry-source", start.Add(50*time.Minute))
+
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-telemetry-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-telemetry-source")
+	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvDevnet))
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.SourceAvailable)
+	assert.Equal(t, uint64(2), resp.TotalCalls)
+	require.NotNil(t, resp.LastCallAt)
+	assert.Equal(t, start.Add(20*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
+}
+
+func TestGetDeviceControllerCalls_FallsBackToEnvSourceDB(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["testnet"] = api.Database
+	api.EnvDBs["testnet"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-env-source", "TEST-CONTROLLER-ENV")
+	dropControllerCallsTable(t, api, "telemetry_testnet")
+	resetControllerCallsTable(t, api, "testnet")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	insertControllerCallEvents(t, api, "testnet", "dev-controller-env-source", start.Add(15*time.Minute))
+
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-env-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-env-source")
+	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvTestnet))
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.SourceAvailable)
+	assert.Equal(t, uint64(1), resp.TotalCalls)
+	require.NotNil(t, resp.LastCallAt)
+	assert.Equal(t, start.Add(15*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
+}
+
+func TestGetDeviceControllerCalls_StoppedUnlatchesAfterHistoryWindow(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["devnet"] = api.Database
+	api.EnvDBs["devnet"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-unlatch", "DEV-CONTROLLER-UNLATCH")
+	resetControllerCallsTable(t, api, "telemetry_devnet")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(74 * time.Hour)
+	historyTS := start.Add(-time.Hour).Format("2006-01-02 15:04:05")
+	require.NoError(t, api.DB.Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO %[1]s.controller_grpc_getconfig_success
+		SELECT toDateTime64('%[2]s', 3), 'dev-controller-unlatch'
+		FROM numbers(4001)
+	`, "`telemetry_devnet`", historyTS)))
+
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-unlatch/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-unlatch")
+	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvDevnet))
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Buckets, 148)
+	assert.Equal(t, handlers.ControllerCallStatusStopped, resp.Buckets[0].Status)
+	assert.Equal(t, handlers.ControllerCallStatusStopped, resp.Buckets[141].Status)
+	assert.Equal(t, handlers.ControllerCallStatusNoData, resp.Buckets[142].Status)
+	assert.Equal(t, handlers.ControllerCallStatusNoData, resp.LastStatus)
+}
+
+func TestGetDeviceControllerCalls_GapUsesLastCallBeforeBucketEnd(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["devnet"] = api.Database
+	api.EnvDBs["devnet"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-gap", "DEV-CONTROLLER-GAP")
+	resetControllerCallsTable(t, api, "telemetry_devnet")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Minute)
+	insertControllerCallEvents(t, api, "telemetry_devnet", "dev-controller-gap", start.Add(-10*time.Second), start.Add(45*time.Second))
+
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-gap/controller-calls?start_time=%d&end_time=%d&bucket=30s", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-gap")
+	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvDevnet))
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Buckets, 2)
+	require.NotNil(t, resp.Buckets[0].GapSeconds)
+	assert.Equal(t, 40, *resp.Buckets[0].GapSeconds)
+	require.NotNil(t, resp.Buckets[1].GapSeconds)
+	assert.Equal(t, 15, *resp.Buckets[1].GapSeconds)
 }
 
 func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {

--- a/api/handlers/device_controller_calls_test.go
+++ b/api/handlers/device_controller_calls_test.go
@@ -1,0 +1,150 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func insertControllerCallTestDevice(t *testing.T, api *handlers.API, pk, code string) {
+	t.Helper()
+	err := api.DB.Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO dim_dz_devices_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, status, device_type, contributor_pk, metro_pk, public_ip, max_users)
+		VALUES
+		('%[1]s', now(), now(), generateUUIDv4(), 0, 1, '%[1]s', '%[2]s', 'activated', 'router', '', '', '10.0.0.1', 100)
+	`, pk, code))
+	require.NoError(t, err)
+}
+
+func createControllerCallsTable(t *testing.T, api *handlers.API, db string) {
+	t.Helper()
+	ctx := t.Context()
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)))
+	quotedDB := "`" + db + "`"
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.controller_grpc_getconfig_success (
+			timestamp DateTime64(3),
+			device_pubkey LowCardinality(String)
+		) ENGINE = MergeTree
+		PARTITION BY toYYYYMM(timestamp)
+		ORDER BY (timestamp, device_pubkey)
+	`, quotedDB)))
+}
+
+func TestGetDeviceControllerCalls_NotFound(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, "/api/dz/devices/missing/controller-calls", nil), "missing")
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetDeviceControllerCalls_SourceUnavailableReturnsNoData(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["testnet"] = api.Database
+	api.EnvDBs["testnet"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-nodata", "TEST-CONTROLLER-NODATA")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Hour)
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-nodata/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-nodata")
+	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvTestnet))
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.False(t, resp.SourceAvailable)
+	assert.Equal(t, handlers.ControllerCallStatusNoData, resp.LastStatus)
+	assert.Equal(t, 1800, resp.BucketSeconds)
+	require.Len(t, resp.Buckets, 4)
+	for _, bucket := range resp.Buckets {
+		assert.Equal(t, handlers.ControllerCallStatusNoData, bucket.Status)
+		assert.Zero(t, bucket.Calls)
+	}
+}
+
+func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-recovered", "NYC-CONTROLLER-01")
+	createControllerCallsTable(t, api, "mainnet-beta")
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Hour)
+	historyTS := start.Add(-60 * time.Minute).Format("2006-01-02 15:04:05")
+	recoveredTS := start.Add(70 * time.Minute).Format("2006-01-02 15:04:05")
+	callingTS := start.Add(100 * time.Minute).Format("2006-01-02 15:04:05")
+
+	quotedDB := "`mainnet-beta`"
+	require.NoError(t, api.DB.Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO %[1]s.controller_grpc_getconfig_success
+		SELECT toDateTime64('%[2]s', 3), 'dev-controller-recovered'
+		FROM numbers(4001)
+		UNION ALL SELECT toDateTime64('%[3]s', 3), 'dev-controller-recovered'
+		UNION ALL SELECT toDateTime64('%[4]s', 3), 'dev-controller-recovered'
+	`, quotedDB, historyTS, recoveredTS, callingTS)))
+
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-recovered/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-recovered")
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp handlers.DeviceControllerCallsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.SourceAvailable)
+	assert.Equal(t, "dev-controller-recovered", resp.DevicePK)
+	assert.Equal(t, "NYC-CONTROLLER-01", resp.DeviceCode)
+	assert.Equal(t, uint64(2), resp.TotalCalls)
+	assert.Equal(t, 30, resp.AlertThresholdMinutes)
+	assert.Equal(t, 72, resp.HistoryWindowHours)
+	require.Len(t, resp.Buckets, 4)
+
+	assert.Equal(t, handlers.ControllerCallStatusStopped, resp.Buckets[0].Status)
+	assert.Equal(t, handlers.ControllerCallStatusStopped, resp.Buckets[1].Status)
+	assert.Equal(t, handlers.ControllerCallStatusRecovered, resp.Buckets[2].Status)
+	assert.Equal(t, uint64(1), resp.Buckets[2].Calls)
+	assert.Equal(t, handlers.ControllerCallStatusCalling, resp.Buckets[3].Status)
+	assert.Equal(t, uint64(1), resp.Buckets[3].Calls)
+	assert.Equal(t, handlers.ControllerCallStatusCalling, resp.LastStatus)
+	require.NotNil(t, resp.LastCallAt)
+	assert.Equal(t, start.Add(100*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
+}
+
+func TestGetDeviceControllerCalls_InvalidRange(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	api.EnvDatabases["mainnet-beta"] = api.Database
+	api.EnvDBs["mainnet-beta"] = api.DB
+	insertControllerCallTestDevice(t, api, "dev-controller-invalid", "NYC-CONTROLLER-BAD")
+
+	start := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	end := start.Add(-time.Hour)
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-invalid/controller-calls?start_time=%d&end_time=%d", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-invalid")
+	rr := httptest.NewRecorder()
+	api.GetDeviceControllerCalls(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "end_time must be after start_time")
+}

--- a/api/handlers/device_controller_calls_test.go
+++ b/api/handlers/device_controller_calls_test.go
@@ -134,7 +134,7 @@ func TestGetDeviceControllerCalls_PrefersTelemetrySourceDB(t *testing.T) {
 	assert.Equal(t, start.Add(20*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
 }
 
-func TestGetDeviceControllerCalls_FallsBackToEnvSourceDB(t *testing.T) {
+func TestGetDeviceControllerCalls_DoesNotFallbackToEnvSourceDB(t *testing.T) {
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["testnet"] = api.Database
 	api.EnvDBs["testnet"] = api.DB
@@ -155,10 +155,14 @@ func TestGetDeviceControllerCalls_FallsBackToEnvSourceDB(t *testing.T) {
 
 	var resp handlers.DeviceControllerCallsResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	assert.True(t, resp.SourceAvailable)
-	assert.Equal(t, uint64(1), resp.TotalCalls)
-	require.NotNil(t, resp.LastCallAt)
-	assert.Equal(t, start.Add(15*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
+	assert.False(t, resp.SourceAvailable)
+	assert.Equal(t, uint64(0), resp.TotalCalls)
+	assert.Nil(t, resp.LastCallAt)
+	require.Len(t, resp.Buckets, 2)
+	for _, bucket := range resp.Buckets {
+		assert.Equal(t, handlers.ControllerCallStatusNoData, bucket.Status)
+		assert.Zero(t, bucket.Calls)
+	}
 }
 
 func TestGetDeviceControllerCalls_StoppedUnlatchesAfterHistoryWindow(t *testing.T) {
@@ -226,7 +230,7 @@ func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {
 	api.EnvDatabases["mainnet-beta"] = api.Database
 	api.EnvDBs["mainnet-beta"] = api.DB
 	insertControllerCallTestDevice(t, api, "dev-controller-recovered", "NYC-CONTROLLER-01")
-	createControllerCallsTable(t, api, "mainnet-beta")
+	createControllerCallsTable(t, api, "telemetry_mainnet_beta")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(2 * time.Hour)
@@ -234,7 +238,7 @@ func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {
 	recoveredTS := start.Add(70 * time.Minute).Format("2006-01-02 15:04:05")
 	callingTS := start.Add(100 * time.Minute).Format("2006-01-02 15:04:05")
 
-	quotedDB := "`mainnet-beta`"
+	quotedDB := "`telemetry_mainnet_beta`"
 	require.NoError(t, api.DB.Exec(t.Context(), fmt.Sprintf(`
 		INSERT INTO %[1]s.controller_grpc_getconfig_success
 		SELECT toDateTime64('%[2]s', 3), 'dev-controller-recovered'

--- a/api/main.go
+++ b/api/main.go
@@ -559,6 +559,7 @@ func main() {
 		r.Get("/api/dz/devices", api.GetDevices)
 		r.Get("/api/dz/devices/{pk}", api.GetDevice)
 		r.Get("/api/dz/devices/{pk}/validator-stats", api.GetDeviceValidatorStats)
+		r.Get("/api/dz/devices/{pk}/controller-calls", api.GetDeviceControllerCalls)
 		r.Get("/api/dz/devices/{pk}/optics", api.GetDeviceOptics)
 		r.Get("/api/dz/devices/{pk}/optics/history", api.GetDeviceOpticsHistory)
 		r.Get("/api/dz/network-state", api.GetNetworkState)

--- a/web/src/components/device-charts/DeviceControllerCallsChart.tsx
+++ b/web/src/components/device-charts/DeviceControllerCallsChart.tsx
@@ -1,0 +1,459 @@
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import type {
+  DeviceControllerCallsBucket,
+  DeviceControllerCallsResponse,
+  DeviceControllerCallStatus,
+} from '@/lib/api'
+
+interface DeviceControllerCallsChartProps {
+  data?: DeviceControllerCallsResponse
+  loading?: boolean
+  className?: string
+  compact?: boolean
+  onBarHover?: (range: { start: number; end: number } | null) => void
+  highlightedTime?: number | null
+}
+
+interface MergedCallBar {
+  ts: string
+  spanSeconds: number
+  calls: number
+  minutesWithCalls: number
+  status: DeviceControllerCallStatus
+  gapSeconds?: number
+}
+
+interface MetricTileProps {
+  label: string
+  value: string
+  title?: string
+  valueClassName?: string
+}
+
+const statusColors: Record<DeviceControllerCallStatus, string> = {
+  calling: 'bg-green-500',
+  stopped: 'bg-red-500',
+  recovered: 'bg-blue-500',
+  no_data: 'bg-muted/20 ring-1 ring-inset ring-border',
+  not_expected: 'bg-muted',
+}
+
+const statusTextColors: Record<DeviceControllerCallStatus, string> = {
+  calling: 'text-green-600 dark:text-green-400',
+  stopped: 'text-red-600 dark:text-red-400',
+  recovered: 'text-blue-600 dark:text-blue-400',
+  no_data: 'text-muted-foreground',
+  not_expected: 'text-muted-foreground',
+}
+
+const statusBadgeColors: Record<DeviceControllerCallStatus, string> = {
+  calling: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  stopped: 'bg-red-500/10 text-red-700 dark:text-red-400',
+  recovered: 'bg-blue-500/10 text-blue-700 dark:text-blue-400',
+  no_data: 'bg-muted text-muted-foreground',
+  not_expected: 'bg-muted text-muted-foreground',
+}
+
+const statusLabels: Record<DeviceControllerCallStatus, string> = {
+  calling: 'Calling',
+  stopped: 'Stopped',
+  recovered: 'Recovered',
+  no_data: 'No data',
+  not_expected: 'Not expected',
+}
+
+const statusPriority: Record<DeviceControllerCallStatus, number> = {
+  stopped: 4,
+  recovered: 3,
+  not_expected: 2,
+  no_data: 1,
+  calling: 0,
+}
+
+const BAR_WIDTH_PX = 8
+const MIN_BARS = 24
+const MAX_BARS = 192
+
+function useContainerBars() {
+  const [maxBars, setMaxBars] = useState(MAX_BARS)
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const containerRef = useCallback((node: HTMLDivElement | null) => setEl(node), [])
+
+  useLayoutEffect(() => {
+    if (!el) return
+    const measure = () => {
+      const width = el.getBoundingClientRect().width
+      const count = Math.floor(width / BAR_WIDTH_PX)
+      setMaxBars(Math.max(MIN_BARS, Math.min(MAX_BARS, count)))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [el])
+
+  return { containerRef, maxBars }
+}
+
+function worstStatus(a: DeviceControllerCallStatus, b: DeviceControllerCallStatus): DeviceControllerCallStatus {
+  return statusPriority[a] >= statusPriority[b] ? a : b
+}
+
+function aggregateBar(group: DeviceControllerCallsBucket[], bucketSeconds: number): MergedCallBar {
+  let status: DeviceControllerCallStatus = 'calling'
+  let calls = 0
+  let minutesWithCalls = 0
+  let gapSeconds: number | undefined
+  for (const bucket of group) {
+    status = worstStatus(status, bucket.status)
+    calls += bucket.calls
+    minutesWithCalls += bucket.minutes_with_calls
+    if (bucket.gap_seconds !== undefined) gapSeconds = bucket.gap_seconds
+  }
+  return {
+    ts: group[0].ts,
+    spanSeconds: group.length * bucketSeconds,
+    calls,
+    minutesWithCalls,
+    status,
+    gapSeconds,
+  }
+}
+
+function mergeBuckets(
+  buckets: DeviceControllerCallsBucket[],
+  bucketSeconds: number,
+  maxBars: number
+): MergedCallBar[] {
+  if (buckets.length <= maxBars) {
+    return buckets.map((bucket) => aggregateBar([bucket], bucketSeconds))
+  }
+
+  const groupSize = Math.ceil(buckets.length / maxBars)
+  const bars: MergedCallBar[] = []
+  for (let i = 0; i < buckets.length; i += groupSize) {
+    bars.push(aggregateBar(buckets.slice(i, i + groupSize), bucketSeconds))
+  }
+  return bars
+}
+
+function formatTimeRange(ts: string, spanSeconds: number): string {
+  const start = new Date(ts)
+  const end = new Date(start.getTime() + spanSeconds * 1000)
+  const timeOpts: Intl.DateTimeFormatOptions = {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(spanSeconds < 60 ? { second: '2-digit' } : {}),
+  }
+  const startTime = start.toLocaleTimeString([], timeOpts)
+  const endTime = end.toLocaleTimeString([], timeOpts)
+  const startDate = start.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  if (start.getDate() !== end.getDate()) {
+    const endDate = end.toLocaleDateString([], { month: 'short', day: 'numeric' })
+    return `${startDate} ${startTime} to ${endDate} ${endTime}`
+  }
+  return `${startDate} ${startTime} to ${endTime}`
+}
+
+function formatTimestamp(ts: string): string {
+  return new Date(ts).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const minutes = seconds / 60
+  if (minutes < 60) return `${Math.round(minutes)}m`
+  const hours = minutes / 60
+  if (hours < 48) return `${hours.toFixed(hours < 10 ? 1 : 0)}h`
+  return `${(hours / 24).toFixed(1)}d`
+}
+
+function formatCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(value)
+}
+
+function rangeLabels(data: DeviceControllerCallsResponse): { startLabel: string; endLabel: string } {
+  const rangeMap: Record<string, string> = {
+    '1h': '1h ago',
+    '3h': '3h ago',
+    '6h': '6h ago',
+    '12h': '12h ago',
+    '24h': '24h ago',
+    '3d': '3d ago',
+    '7d': '7d ago',
+    '14d': '14d ago',
+    '30d': '30d ago',
+  }
+  if (rangeMap[data.time_range]) return { startLabel: rangeMap[data.time_range], endLabel: 'Now' }
+  return { startLabel: formatTimestamp(data.from), endLabel: formatTimestamp(data.to) }
+}
+
+function selectedRangeMinutes(data: DeviceControllerCallsResponse): number {
+  const start = new Date(data.from).getTime()
+  const end = new Date(data.to).getTime()
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return 0
+  return Math.max(1, Math.ceil((end - start) / 60_000))
+}
+
+function formatMinuteCoverage(data: DeviceControllerCallsResponse): string {
+  if (!data.source_available) return 'No source'
+  const totalMinutes = selectedRangeMinutes(data)
+  if (totalMinutes === 0) return formatCount(data.minutes_with_calls)
+  const pct = Math.min(100, Math.round((data.minutes_with_calls / totalMinutes) * 100))
+  return `${formatCount(data.minutes_with_calls)} / ${formatCount(totalMinutes)} min (${pct}%)`
+}
+
+function statusSummary(data: DeviceControllerCallsResponse): string {
+  if (!data.source_available) {
+    return 'Controller history is not available for this environment.'
+  }
+  switch (data.last_status) {
+    case 'calling':
+      return 'Controller calls are arriving in the selected range.'
+    case 'stopped':
+      return `No controller calls for at least ${data.alert_threshold_minutes}m after steady prior history.`
+    case 'recovered':
+      return 'Controller calls resumed after a stopped period in this range.'
+    case 'not_expected':
+      return 'This device is not expected to call the controller.'
+    case 'no_data':
+    default:
+      return 'No controller calls were observed in the selected range.'
+  }
+}
+
+function barLabel(bar: MergedCallBar): string {
+  const parts = [
+    formatTimeRange(bar.ts, bar.spanSeconds),
+    statusLabels[bar.status],
+    `${formatCount(bar.calls)} calls`,
+  ]
+  if (bar.minutesWithCalls > 0) parts.push(`${formatCount(bar.minutesWithCalls)} min with calls`)
+  if (bar.gapSeconds !== undefined && bar.calls === 0) parts.push(`${formatDuration(bar.gapSeconds)} gap`)
+  return parts.join(', ')
+}
+
+function MetricTile({ label, value, title, valueClassName }: MetricTileProps) {
+  return (
+    <div className="min-w-0 border border-border/60 bg-muted/20 px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className={`truncate font-mono text-xs tabular-nums ${valueClassName ?? ''}`} title={title ?? value}>
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function LoadingSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={className} aria-busy="true" aria-label="Loading controller calls">
+      <div className="animate-pulse space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="h-3 w-32 bg-muted" />
+          <div className="h-5 w-16 bg-muted" />
+        </div>
+        <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-muted/50" />
+          ))}
+        </div>
+        <div className="flex gap-[2px]">
+          {Array.from({ length: 64 }).map((_, i) => (
+            <div key={i} className="h-7 flex-1 bg-muted/50" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function DeviceControllerCallsChart({
+  data,
+  loading,
+  className,
+  compact,
+  onBarHover,
+  highlightedTime,
+}: DeviceControllerCallsChartProps) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+  const { containerRef, maxBars } = useContainerBars()
+
+  const bars = useMemo(() => {
+    if (!data) return []
+    return mergeBuckets(data.buckets, data.bucket_seconds, maxBars)
+  }, [data, maxBars])
+
+  const highlightedBarIndex = useMemo(() => {
+    if (highlightedTime == null || bars.length === 0) return -1
+    let bestIdx = -1
+    let bestDist = Infinity
+    for (let i = 0; i < bars.length; i++) {
+      const start = new Date(bars[i].ts).getTime() / 1000
+      const end = start + bars[i].spanSeconds
+      if (highlightedTime >= start && highlightedTime < end) return i
+      const mid = start + bars[i].spanSeconds / 2
+      const dist = Math.abs(highlightedTime - mid)
+      if (dist < bestDist) {
+        bestDist = dist
+        bestIdx = i
+      }
+    }
+    return bestDist < (bars[0]?.spanSeconds ?? 0) ? bestIdx : -1
+  }, [highlightedTime, bars])
+
+  if (loading && !data) return <LoadingSkeleton className={className} />
+  if (!data) return null
+
+  const labels = rangeLabels(data)
+  const lastStatus = data.last_status ?? 'no_data'
+  const summary = statusSummary(data)
+  const gapAlertSeconds = data.alert_threshold_minutes * 60
+  const currentGapIsAlert = data.current_gap_seconds !== undefined && data.current_gap_seconds >= gapAlertSeconds
+  const lastCallValue = data.last_call_at
+    ? compact && data.current_gap_seconds !== undefined
+      ? `${formatDuration(data.current_gap_seconds)} ago`
+      : formatTimestamp(data.last_call_at)
+    : data.source_available
+      ? 'No calls observed'
+      : 'Source unavailable'
+  const lastCallTitle = data.last_call_at
+    ? `${formatTimestamp(data.last_call_at)}${data.current_gap_seconds !== undefined ? `, ${formatDuration(data.current_gap_seconds)} current gap` : ''}`
+    : lastCallValue
+  const currentGapValue = data.current_gap_seconds !== undefined
+    ? formatDuration(data.current_gap_seconds)
+    : data.source_available
+      ? 'Unknown'
+      : 'No source'
+  const callsLabel = data.time_range ? `Calls in ${data.time_range}` : 'Calls in range'
+  const barHeightClass = compact ? 'h-5' : 'h-7'
+
+  return (
+    <div ref={containerRef} className={className}>
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            <span>Controller calls</span>
+            <span className="bg-muted/60 px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-muted-foreground">
+              GetConfig
+            </span>
+            {!data.source_available && (
+              <span className="bg-muted/60 px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-muted-foreground">
+                source unavailable
+              </span>
+            )}
+          </div>
+          {!compact && (
+            <div className="mt-1 max-w-[72ch] text-xs text-muted-foreground">
+              {data.source_available
+                ? `Controller GetConfig successes from controller history. Stopped follows the ${data.alert_threshold_minutes}m no-call alert after ${data.history_window_hours}h of prior history.`
+                : 'Controller history is not available for this environment. No-data buckets are not outages.'}
+            </div>
+          )}
+        </div>
+        <span
+          className={`shrink-0 px-2 py-0.5 text-[11px] font-medium ${statusBadgeColors[lastStatus]}`}
+          title={summary}
+        >
+          {statusLabels[lastStatus]}
+        </span>
+      </div>
+
+      <div className={`mb-3 grid gap-2 ${compact ? 'grid-cols-2' : 'grid-cols-2 lg:grid-cols-4'}`}>
+        <MetricTile label="Last call" value={lastCallValue} title={lastCallTitle} />
+        {!compact && (
+          <MetricTile
+            label="Current gap"
+            value={currentGapValue}
+            valueClassName={currentGapIsAlert ? statusTextColors.stopped : data.current_gap_seconds !== undefined ? statusTextColors.calling : undefined}
+          />
+        )}
+        <MetricTile label={callsLabel} value={data.source_available ? formatCount(data.total_calls) : 'No source'} />
+        {!compact && (
+          <MetricTile
+            label="Minutes with calls"
+            value={formatMinuteCoverage(data)}
+            title={data.source_available ? `${data.minutes_with_calls} minutes with calls out of ${selectedRangeMinutes(data)} selected minutes` : 'Controller history source unavailable'}
+          />
+        )}
+      </div>
+
+      {bars.length === 0 ? (
+        <div className="border border-border/60 bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
+          No controller-call buckets were returned for this range.
+        </div>
+      ) : (
+        <div className="relative">
+          <div className="flex gap-[2px]" role="img" aria-label={`Controller calls timeline, ${statusLabels[lastStatus].toLowerCase()}`}>
+            {bars.map((bar, index) => {
+              const active = hoveredIndex === index
+              const start = new Date(bar.ts).getTime() / 1000
+              return (
+                <div
+                  key={`${bar.ts}-${index}`}
+                  className={`relative min-w-0 flex-1 ${highlightedBarIndex === index ? 'z-10 ring-1 ring-foreground/40' : ''}`}
+                  title={barLabel(bar)}
+                  onMouseEnter={() => {
+                    setHoveredIndex(index)
+                    onBarHover?.({ start, end: start + bar.spanSeconds })
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredIndex(null)
+                    onBarHover?.(null)
+                  }}
+                >
+                  <div className={`relative w-full cursor-pointer overflow-hidden transition-opacity hover:opacity-80 ${barHeightClass}`}>
+                    <div className={`absolute inset-0 ${statusColors[bar.status]}`} />
+                  </div>
+                  {active && (
+                    <div className="absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2">
+                      <div className="whitespace-nowrap border border-border bg-popover px-2.5 py-2 shadow-lg">
+                        <div className="mb-0.5 text-[11px] font-medium text-foreground/80">
+                          {formatTimeRange(bar.ts, bar.spanSeconds)}
+                        </div>
+                        <div className={`text-xs ${statusTextColors[bar.status]}`}>
+                          {statusLabels[bar.status]}
+                          <span className="text-muted-foreground"> · {formatCount(bar.calls)} calls</span>
+                          {bar.minutesWithCalls > 0 && (
+                            <span className="text-muted-foreground"> · {formatCount(bar.minutesWithCalls)} min</span>
+                          )}
+                          {bar.gapSeconds !== undefined && bar.calls === 0 && (
+                            <span className="text-muted-foreground"> · {formatDuration(bar.gapSeconds)} gap</span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="absolute left-1/2 top-full -mt-[1px] -translate-x-1/2">
+                        <div className="border-8 border-transparent border-t-border" />
+                        <div className="absolute left-1/2 top-0 -translate-x-1/2 border-[7px] border-transparent border-t-popover" />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          <div className="mt-1 flex justify-between text-[10px] text-muted-foreground">
+            <span>{labels.startLabel}</span>
+            <span>{labels.endLabel}</span>
+          </div>
+        </div>
+      )}
+
+      {!compact && (
+        <div className="mt-2 flex flex-wrap gap-1.5 text-[10px] font-medium">
+          {(['calling', 'stopped', 'recovered', 'no_data'] as DeviceControllerCallStatus[]).map((status) => (
+            <span key={status} className={`px-1.5 py-0.5 ${statusBadgeColors[status]}`}>
+              {statusLabels[status]}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/device-detail-page.tsx
+++ b/web/src/components/device-detail-page.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Loader2, RefreshCw, Server, AlertCircle, ArrowLeft } from 'lucide-react'
 import { CopyableText } from '@/components/copyable-text'
-import { fetchDevice, fetchDeviceMetrics, fetchDeviceValidatorStats } from '@/lib/api'
+import { fetchDevice, fetchDeviceControllerCalls, fetchDeviceMetrics, fetchDeviceValidatorStats } from '@/lib/api'
 import { DeviceInfoContent } from '@/components/shared/DeviceInfoContent'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
@@ -14,6 +14,7 @@ import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
 import { DeviceTrafficChart } from '@/components/device-charts/DeviceTrafficChart'
+import { DeviceControllerCallsChart } from '@/components/device-charts/DeviceControllerCallsChart'
 import { DeviceOpticsPanel } from '@/components/device-charts/DeviceOpticsPanel'
 import { TimeRangeSelector } from '@/components/topology/TimeRangeSelector'
 import type { TimeRange } from '@/components/topology/utils'
@@ -78,6 +79,16 @@ export function DeviceDetailPage() {
   } = useQuery({
     queryKey: ['deviceMetrics', pk, metricsParams],
     queryFn: () => fetchDeviceMetrics(pk!, metricsParams),
+    enabled: !!pk,
+  })
+
+  const {
+    data: controllerCalls,
+    isLoading: controllerCallsLoading,
+    isFetching: controllerCallsFetching,
+  } = useQuery({
+    queryKey: ['deviceControllerCalls', pk, metricsParams],
+    queryFn: () => fetchDeviceControllerCalls(pk!, metricsParams),
     enabled: !!pk,
   })
 
@@ -207,12 +218,15 @@ export function DeviceDetailPage() {
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pb-8 space-y-6">
         <div className="flex justify-end gap-2 items-center">
           <button
-            onClick={() => queryClient.invalidateQueries({ queryKey: ['deviceMetrics'] })}
-            disabled={metricsFetching}
+            onClick={() => {
+              queryClient.invalidateQueries({ queryKey: ['deviceMetrics'] })
+              queryClient.invalidateQueries({ queryKey: ['deviceControllerCalls'] })
+            }}
+            disabled={metricsFetching || controllerCallsFetching}
             className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
             title="Refresh"
           >
-            {metricsFetching ? (
+            {metricsFetching || controllerCallsFetching ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <RefreshCw className="h-4 w-4" />
@@ -260,6 +274,13 @@ export function DeviceDetailPage() {
         )}
         {metrics && (
           <div className="space-y-4">
+            <DeviceControllerCallsChart
+              data={controllerCalls}
+              loading={controllerCallsLoading || controllerCallsFetching}
+              className="rounded-lg border border-border p-4"
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
             <DeviceHealthTimeline
               data={metrics}
               onBarHover={setHoveredTimeRange}

--- a/web/src/components/shared/DeviceInfoContent.tsx
+++ b/web/src/components/shared/DeviceInfoContent.tsx
@@ -3,10 +3,11 @@ import { Info } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import type { DeviceInterface } from '@/lib/api'
-import { fetchDeviceMetrics } from '@/lib/api'
+import { fetchDeviceControllerCalls, fetchDeviceMetrics } from '@/lib/api'
 import { DeviceHealthTimeline } from '@/components/device-charts/DeviceHealthTimeline'
 import { DeviceTrafficChart } from '@/components/device-charts/DeviceTrafficChart'
 import { DeviceInterfaceIssuesChart } from '@/components/device-charts/DeviceInterfaceIssuesChart'
+import { DeviceControllerCallsChart } from '@/components/device-charts/DeviceControllerCallsChart'
 import { toDeviceMetricsParams } from '@/components/shared/metrics-params'
 import { TimeRangeSelector } from '@/components/topology/TimeRangeSelector'
 import type { TimeRange } from '@/components/topology/utils'
@@ -152,6 +153,12 @@ export function DeviceInfoContent({
   const { data: metrics, isFetching: metricsFetching } = useQuery({
     queryKey: ['deviceMetrics', device.pk, metricsParams],
     queryFn: () => fetchDeviceMetrics(device.pk, metricsParams),
+    enabled: !hideCharts,
+  })
+
+  const { data: controllerCalls, isFetching: controllerCallsFetching } = useQuery({
+    queryKey: ['deviceControllerCalls', device.pk, metricsParams],
+    queryFn: () => fetchDeviceControllerCalls(device.pk, metricsParams),
     enabled: !hideCharts,
   })
 
@@ -316,6 +323,14 @@ export function DeviceInfoContent({
         {/* Charts from unified metrics endpoint */}
         {!hideCharts && metrics && (
           <div className="space-y-4">
+            <DeviceControllerCallsChart
+              data={controllerCalls}
+              loading={controllerCallsFetching}
+              className={cardClass}
+              compact={compact}
+              onBarHover={setHoveredTimeRange}
+              highlightedTime={chartHoveredTime}
+            />
             {!hideStatusRow && (
               <DeviceHealthTimeline
                 data={metrics}
@@ -428,6 +443,13 @@ export function DeviceInfoContent({
 
       {!hideCharts && metrics && (
         <div className="space-y-4">
+          <DeviceControllerCallsChart
+            data={controllerCalls}
+            loading={controllerCallsFetching}
+            className={cardClass}
+            onBarHover={setHoveredTimeRange}
+            highlightedTime={chartHoveredTime}
+          />
           {!hideStatusRow && (
             <DeviceHealthTimeline
               data={metrics}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2957,6 +2957,58 @@ export async function fetchDeviceValidatorStats(pk: string): Promise<DeviceValid
   return res.json()
 }
 
+export type DeviceControllerCallStatus = 'calling' | 'stopped' | 'recovered' | 'no_data' | 'not_expected'
+
+export interface DeviceControllerCallsBucket {
+  ts: string
+  calls: number
+  minutes_with_calls: number
+  status: DeviceControllerCallStatus
+  gap_seconds?: number
+}
+
+export interface DeviceControllerCallsResponse {
+  device_pk: string
+  device_code: string
+  device_status: string
+  time_range: string
+  bucket_seconds: number
+  bucket_count: number
+  from: string
+  to: string
+  source_available: boolean
+  last_call_at?: string
+  current_gap_seconds?: number
+  last_status: DeviceControllerCallStatus
+  total_calls: number
+  minutes_with_calls: number
+  alert_threshold_minutes: number
+  history_window_hours: number
+  prior_history_minimum: number
+  buckets: DeviceControllerCallsBucket[]
+}
+
+export interface FetchDeviceControllerCallsParams {
+  range?: string
+  startTime?: number
+  endTime?: number
+  bucket?: string
+}
+
+export async function fetchDeviceControllerCalls(
+  pk: string,
+  params: FetchDeviceControllerCallsParams = {}
+): Promise<DeviceControllerCallsResponse> {
+  const qs = new URLSearchParams()
+  if (params.range) qs.set('range', params.range)
+  if (params.startTime) qs.set('start_time', params.startTime.toString())
+  if (params.endTime) qs.set('end_time', params.endTime.toString())
+  if (params.bucket) qs.set('bucket', params.bucket)
+  const res = await apiFetch(`/api/dz/devices/${encodeURIComponent(pk)}/controller-calls${qs.toString() ? '?' + qs.toString() : ''}`)
+  if (!res.ok) throw new Error('Failed to fetch device controller calls')
+  return res.json()
+}
+
 export type OpticsSeverity = 'ok' | 'warning' | 'critical' | 'unknown'
 
 export interface OpticsThresholds {


### PR DESCRIPTION
# Summary

Adds a controller GetConfig call timeline for devices so operators can correlate device pages and topology sidebars with “device stopped calling controller” alerts.

## Changes

- Adds `GET /api/dz/devices/{pk}/controller-calls`
- Classifies controller-call state as calling, stopped, recovered, or no data
- Handles missing/inaccessible controller-call source tables without breaking the UI
- Adds a Controller calls chart to the device detail page
- Adds the same chart to the topology device details sidebar
- Adds API types/fetcher and backend tests for not found, unavailable source, stopped/recovered classification, and invalid ranges

## Screenshots

### Devices page

<img width="1398" height="1123" alt="image" src="https://github.com/user-attachments/assets/d3056442-673d-4213-a056-3da39c48fd15" />

### Topology

<img width="1520" height="1069" alt="image" src="https://github.com/user-attachments/assets/dd362320-d386-4e32-b871-c87c7bb3f9d2" />
