### PR TITLE
indexer: ingest mroute state-collect snapshots into clickhouse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,6 +151,7 @@ require (
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260427160145-3afa6683f8b2 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/testcontainers/testcontainers-go/modules/minio v0.42.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44Xt
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0 h1:SwtkmOTGr0P2+XA2WuDYYNMv2rx7XdIZLZcqJGHB4yA=
 github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0/go.mod h1:J3Fm+fPJvXcuS2hu3hTEDJ0NEiEDhOqB1gocXre1FVc=
+github.com/testcontainers/testcontainers-go/modules/minio v0.42.0 h1:8yTWNv8ALG7JQHYvm1n9PegH0uJT7dRtWNHf6eQeTRs=
+github.com/testcontainers/testcontainers-go/modules/minio v0.42.0/go.mod h1:bcjonmVMA/aEzxFFIh/FRwSkeZ+fnxwvkGN/Z4EiW28=
 github.com/testcontainers/testcontainers-go/modules/neo4j v0.42.0 h1:F0AwRqPoxGVIHBG4sP/JOpRd47vM3wcxZABPtiQNnFk=
 github.com/testcontainers/testcontainers-go/modules/neo4j v0.42.0/go.mod h1:/hhq15EFU9OdNRXe7y3dQa/FrqFANyJxqBXDfwEGaVY=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 h1:GCbb1ndrF7OTDiIvxXyItaDab4qkzTFJ48LKFdM7EIo=

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -116,6 +116,12 @@ func run() error {
 	isisS3RegionFlag := flag.String("isis-s3-region", "us-east-1", "AWS region for IS-IS S3 bucket (or set ISIS_S3_REGION env var)")
 	isisRefreshIntervalFlag := flag.Duration("isis-refresh-interval", 30*time.Second, "Refresh interval for IS-IS sync (or set ISIS_REFRESH_INTERVAL env var)")
 
+	// Mroute (state-collect) configuration
+	mrouteEnabledFlag := flag.Bool("mroute-enabled", false, "Enable mroute state-collect sync from S3 (or set MROUTE_ENABLED env var)")
+	mrouteS3BucketFlag := flag.String("mroute-s3-bucket", "", "S3 bucket the state-ingest server writes to (or set MROUTE_S3_BUCKET env var)")
+	mrouteS3RegionFlag := flag.String("mroute-s3-region", "us-east-1", "AWS region for mroute S3 bucket (or set MROUTE_S3_REGION env var)")
+	mrouteS3KeyPrefixFlag := flag.String("mroute-s3-key-prefix", "", "Optional key prefix matching state-ingest BucketPathPrefix (or set MROUTE_S3_KEY_PREFIX env var)")
+
 	// validators.app configuration
 	validatorsAppAPIKeyFlag := flag.String("validatorsapp-api-key", "", "validators.app API key (or set VALIDATORSAPP_API_KEY env var)")
 	validatorsAppRefreshIntervalFlag := flag.Duration("validatorsapp-refresh-interval", 5*time.Minute, "validators.app refresh interval (or set VALIDATORSAPP_REFRESH_INTERVAL env var)")
@@ -192,6 +198,20 @@ func run() error {
 		if d, err := time.ParseDuration(envISISRefreshInterval); err == nil {
 			*isisRefreshIntervalFlag = d
 		}
+	}
+
+	// Override mroute flags with environment variables if set
+	if envMrouteEnabled := os.Getenv("MROUTE_ENABLED"); envMrouteEnabled != "" {
+		*mrouteEnabledFlag = envMrouteEnabled == "true"
+	}
+	if envMrouteBucket := os.Getenv("MROUTE_S3_BUCKET"); envMrouteBucket != "" {
+		*mrouteS3BucketFlag = envMrouteBucket
+	}
+	if envMrouteRegion := os.Getenv("MROUTE_S3_REGION"); envMrouteRegion != "" {
+		*mrouteS3RegionFlag = envMrouteRegion
+	}
+	if envMroutePrefix := os.Getenv("MROUTE_S3_KEY_PREFIX"); envMroutePrefix != "" {
+		*mrouteS3KeyPrefixFlag = envMroutePrefix
 	}
 
 	// Override validators.app flags with environment variables
@@ -566,6 +586,12 @@ func run() error {
 		ISISS3Region:        *isisS3RegionFlag,
 		ISISRefreshInterval: *isisRefreshIntervalFlag,
 
+		// Mroute (state-collect) configuration
+		MrouteEnabled:     *mrouteEnabledFlag,
+		MrouteS3Bucket:    *mrouteS3BucketFlag,
+		MrouteS3Region:    *mrouteS3RegionFlag,
+		MrouteS3KeyPrefix: *mrouteS3KeyPrefixFlag,
+
 		// validators.app configuration
 		ValidatorsAppClient:          validatorsAppClient,
 		ValidatorsAppRefreshInterval: *validatorsAppRefreshIntervalFlag,
@@ -632,6 +658,8 @@ func run() error {
 				GraphStore:     idx.GraphStore(),
 				ISISSource:     idx.ISISSource(),
 				ISISStore:      idx.ISISStore(),
+				MrouteSource:   idx.MrouteSource(),
+				MrouteStore:    idx.MrouteStore(),
 			})
 			if err != nil {
 				dzIngestErrCh <- err

--- a/indexer/db/clickhouse/migrations/20260518000001_dz_ip_mroute_entries.sql
+++ b/indexer/db/clickhouse/migrations/20260518000001_dz_ip_mroute_entries.sql
@@ -1,0 +1,125 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- dz_ip_mroute_entries
+-- Type-2 dimension capturing per-device PIM multicast forwarding state.
+-- Rows are scoped by (device_pubkey, vrf, mode, group_address, source_address);
+-- a new row lands only when one of the payload columns changes between
+-- snapshots, so steady-state OIL keeps the table compact.
+--
+-- Sourced from `show ip mroute | json` snapshots uploaded by
+-- doublezero-telemetry --state-collect-enable.
+CREATE TABLE IF NOT EXISTS dim_dz_ip_mroute_entries_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    vrf String,
+    mode String,
+    group_address String,
+    source_address String,
+    route_flags String,
+    register_in_oif_list UInt8,
+    rpf_interface String,
+    rpf_rib String,
+    rpf_prefix String,
+    rpf_preference Int64,
+    rpf_metric Int64,
+    rpf_neighbor String,
+    rpf_attached UInt8,
+    rpf_has_block UInt8,
+    oif_list String,
+    oif_count Int64,
+    creation_time DateTime64(3)
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_ip_mroute_entries_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    vrf String,
+    mode String,
+    group_address String,
+    source_address String,
+    route_flags String,
+    register_in_oif_list UInt8,
+    rpf_interface String,
+    rpf_rib String,
+    rpf_prefix String,
+    rpf_preference Int64,
+    rpf_metric Int64,
+    rpf_neighbor String,
+    rpf_attached UInt8,
+    rpf_has_block UInt8,
+    oif_list String,
+    oif_count Int64,
+    creation_time DateTime64(3)
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dz_ip_mroute_entries_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_ip_mroute_entries_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    device_pubkey,
+    vrf,
+    mode,
+    group_address,
+    source_address,
+    route_flags,
+    register_in_oif_list,
+    rpf_interface,
+    rpf_rib,
+    rpf_prefix,
+    rpf_preference,
+    rpf_metric,
+    rpf_neighbor,
+    rpf_attached,
+    rpf_has_block,
+    oif_list,
+    oif_count,
+    creation_time
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS dz_ip_mroute_entries_current;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_ip_mroute_entries_snapshot;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_dz_ip_mroute_entries_history;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/main_test.go
+++ b/indexer/pkg/dz/mroute/main_test.go
@@ -1,0 +1,28 @@
+package mroute
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+// sharedDB is a single ClickHouse testcontainer reused across every test in
+// this package. Per-test isolation is achieved by laketesting.NewClient
+// creating a fresh randomly-named database and running migrations into it.
+var sharedDB *clickhousetesting.DB
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("mroute: failed to start ClickHouse testcontainer", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -1,0 +1,49 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration_Applies is layer A: prove the migration SQL is valid for the
+// ClickHouse version lake uses and that every artifact the store/sync path
+// touches has materialized. Reused across the rest of this package's
+// integration tests via laketesting.NewClient (which runs RunMigrations).
+func TestMigration_Applies(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cases := []struct {
+		name string
+		kind string // "table" or "view"
+	}{
+		{"dim_dz_ip_mroute_entries_history", "table"},
+		{"stg_dim_dz_ip_mroute_entries_snapshot", "table"},
+		{"dz_ip_mroute_entries_current", "view"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rows, err := conn.Query(t.Context(), `
+				SELECT engine FROM system.tables
+				WHERE database = currentDatabase() AND name = ?
+			`, c.name)
+			require.NoError(t, err)
+			defer rows.Close()
+
+			require.True(t, rows.Next(), "%s did not materialize", c.name)
+			var got string
+			require.NoError(t, rows.Scan(&got))
+			if c.kind == "view" {
+				assert.Equal(t, "View", got, "%s should be a view, got engine %q", c.name, got)
+			} else {
+				assert.Equal(t, "MergeTree", got, "%s should be MergeTree, got engine %q", c.name, got)
+			}
+		})
+	}
+}

--- a/indexer/pkg/dz/mroute/parser.go
+++ b/indexer/pkg/dz/mroute/parser.go
@@ -1,0 +1,111 @@
+package mroute
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+)
+
+// rawDump matches the top-level shape of `show ip mroute | json` on Arista EOS.
+type rawDump struct {
+	VRFs map[string]rawVRF `json:"vrfs"`
+}
+
+type rawVRF struct {
+	SparseMode    rawModeGroups `json:"sparseMode"`
+	Bidirectional rawModeGroups `json:"bidirectional"`
+}
+
+type rawModeGroups struct {
+	Groups map[string]rawGroup `json:"groups"`
+}
+
+type rawGroup struct {
+	GroupSources map[string]rawSource `json:"groupSources"`
+}
+
+type rawSource struct {
+	SourceAddress     string   `json:"sourceAddress"`
+	CreationTime      float64  `json:"creationTime"`
+	RouteFlags        string   `json:"routeFlags"`
+	RegisterInOifList bool     `json:"registerInOifList"`
+	RpfInterface      string   `json:"rpfInterface"`
+	RPF               *rawRPF  `json:"rpf,omitempty"`
+	OifList           []string `json:"oifList"`
+}
+
+type rawRPF struct {
+	RpfRib              string `json:"rpfRib"`
+	RpfPrefix           string `json:"rpfPrefix"`
+	RpfPreference       uint32 `json:"rpfPreference"`
+	RpfMetric           uint32 `json:"rpfMetric"`
+	RpfNeighbor         string `json:"rpfNeighbor"`
+	RpfAttached         bool   `json:"rpfAttached"`
+	RpfEvpnTenantDomain bool   `json:"rpfEvpnTenantDomain"`
+	RpfMvpn             bool   `json:"rpfMvpn"`
+}
+
+// Parse converts a single device's `show ip mroute | json` dump into a flat
+// slice of Entry records. The DevicePubkey field is left zero — the caller
+// fills it from the snapshot key. Empty `groups` maps produce zero entries.
+func Parse(raw []byte) ([]Entry, error) {
+	var d rawDump
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("mroute: unmarshal: %w", err)
+	}
+
+	var out []Entry
+	for vrfName, vrf := range d.VRFs {
+		out = appendEntries(out, vrfName, ModeSparse, vrf.SparseMode)
+		out = appendEntries(out, vrfName, ModeBidirectional, vrf.Bidirectional)
+	}
+	return out, nil
+}
+
+func appendEntries(out []Entry, vrf string, mode Mode, mg rawModeGroups) []Entry {
+	for group, g := range mg.Groups {
+		for _, src := range g.GroupSources {
+			out = append(out, toEntry(vrf, mode, group, src))
+		}
+	}
+	return out
+}
+
+func toEntry(vrf string, mode Mode, group string, src rawSource) Entry {
+	e := Entry{
+		VRF:               vrf,
+		Mode:              mode,
+		GroupAddress:      group,
+		SourceAddress:     src.SourceAddress,
+		CreationTime:      fractionalToTime(src.CreationTime),
+		RouteFlags:        src.RouteFlags,
+		RegisterInOifList: src.RegisterInOifList,
+		RpfInterface:      src.RpfInterface,
+		OifList:           src.OifList,
+	}
+	if src.RPF != nil {
+		e.RPF = &RPF{
+			Rib:              src.RPF.RpfRib,
+			Prefix:           src.RPF.RpfPrefix,
+			Preference:       src.RPF.RpfPreference,
+			Metric:           src.RPF.RpfMetric,
+			Neighbor:         src.RPF.RpfNeighbor,
+			Attached:         src.RPF.RpfAttached,
+			EvpnTenantDomain: src.RPF.RpfEvpnTenantDomain,
+			Mvpn:             src.RPF.RpfMvpn,
+		}
+	}
+	return e
+}
+
+// fractionalToTime converts an Arista `creationTime` (seconds since epoch as a
+// float64, often with fractional precision) to a time.Time at nanosecond
+// resolution.
+func fractionalToTime(secs float64) time.Time {
+	if secs == 0 || math.IsNaN(secs) || math.IsInf(secs, 0) {
+		return time.Time{}
+	}
+	whole, frac := math.Modf(secs)
+	return time.Unix(int64(whole), int64(math.Round(frac*1e9))).UTC()
+}

--- a/indexer/pkg/dz/mroute/parser_test.go
+++ b/indexer/pkg/dz/mroute/parser_test.go
@@ -1,0 +1,204 @@
+package mroute
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Fixture excerpted from a mainnet-beta `show ip mroute | json` dump.
+// Covers the cases the parser must round-trip:
+//   - ME flag: rpfInterface=Null0, no rpf{} block, empty oifList
+//   - SMP flag: rpf block present, single OIF
+//   - SBNP flag: tunnel RPF interface, multi-element OIF list
+//   - E flag: encap-only, empty oifList
+//   - SP flag: prune state with rpf block
+//   - A single group with multiple sources (verifies map iteration)
+//   - Bidirectional groups map present but empty (verifies safe walk)
+const mrouteFixture = `{
+  "vrfs": {
+    "default": {
+      "bidirectional": { "groups": {} },
+      "sparseMode": {
+        "groups": {
+          "233.84.178.1": {
+            "groupSources": {
+              "148.51.120.0": {
+                "sourceAddress": "148.51.120.0",
+                "creationTime": 1777133184.0,
+                "routeFlags": "SMP",
+                "registerInOifList": false,
+                "rpfInterface": "Port-Channel1000.2020",
+                "rpf": {
+                  "rpfRib": "U",
+                  "rpfPrefix": "148.51.120.0/32",
+                  "rpfPreference": 200,
+                  "rpfMetric": 0,
+                  "rpfNeighbor": "172.16.0.207",
+                  "rpfAttached": false,
+                  "rpfEvpnTenantDomain": false,
+                  "rpfMvpn": false
+                },
+                "oifList": ["Port-Channel3000"]
+              },
+              "148.51.120.3": {
+                "sourceAddress": "148.51.120.3",
+                "creationTime": 1779234432.5,
+                "routeFlags": "ME",
+                "registerInOifList": false,
+                "rpfInterface": "Null0",
+                "oifList": []
+              },
+              "148.51.122.96": {
+                "sourceAddress": "148.51.122.96",
+                "creationTime": 1777570304.0,
+                "routeFlags": "SBNP",
+                "registerInOifList": false,
+                "rpfInterface": "Tunnel504",
+                "oifList": ["Port-Channel3000", "Port-Channel1000.2020"]
+              }
+            }
+          },
+          "233.84.178.6": {
+            "groupSources": {
+              "148.51.122.234": {
+                "sourceAddress": "148.51.122.234",
+                "creationTime": 1780067584.0,
+                "routeFlags": "E",
+                "registerInOifList": false,
+                "rpfInterface": "Null0",
+                "oifList": []
+              }
+            }
+          },
+          "233.84.178.10": {
+            "groupSources": {
+              "148.51.121.188": {
+                "sourceAddress": "148.51.121.188",
+                "creationTime": 1778752512.0,
+                "routeFlags": "SP",
+                "registerInOifList": false,
+                "rpfInterface": "Port-Channel3000",
+                "rpf": {
+                  "rpfRib": "U",
+                  "rpfPrefix": "148.51.121.188/32",
+                  "rpfPreference": 200,
+                  "rpfMetric": 0,
+                  "rpfNeighbor": "172.16.1.137",
+                  "rpfAttached": false,
+                  "rpfEvpnTenantDomain": false,
+                  "rpfMvpn": false
+                },
+                "oifList": ["Port-Channel1000.2020"]
+              },
+              "148.51.121.189": {
+                "sourceAddress": "148.51.121.189",
+                "creationTime": 1777961344.0,
+                "routeFlags": "SP",
+                "registerInOifList": false,
+                "rpfInterface": "Port-Channel1000.2020",
+                "rpf": {
+                  "rpfRib": "U",
+                  "rpfPrefix": "148.51.121.189/32",
+                  "rpfPreference": 200,
+                  "rpfMetric": 0,
+                  "rpfNeighbor": "172.16.0.207",
+                  "rpfAttached": false,
+                  "rpfEvpnTenantDomain": false,
+                  "rpfMvpn": false
+                },
+                "oifList": ["Port-Channel3000"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+func TestParse(t *testing.T) {
+	entries, err := Parse([]byte(mrouteFixture))
+	require.NoError(t, err)
+	require.Len(t, entries, 6)
+
+	byKey := indexByKey(entries)
+
+	t.Run("ME entry has no rpf, empty OIF", func(t *testing.T) {
+		e := byKey["default|sparse|233.84.178.1|148.51.120.3"]
+		require.NotNil(t, e)
+		assert.Equal(t, "ME", e.RouteFlags)
+		assert.Equal(t, "Null0", e.RpfInterface)
+		assert.Nil(t, e.RPF)
+		assert.Empty(t, e.OifList)
+		assert.False(t, e.CreationTime.IsZero(), "fractional creationTime should parse")
+	})
+
+	t.Run("SMP entry has rpf and single OIF", func(t *testing.T) {
+		e := byKey["default|sparse|233.84.178.1|148.51.120.0"]
+		require.NotNil(t, e)
+		assert.Equal(t, "SMP", e.RouteFlags)
+		require.NotNil(t, e.RPF)
+		assert.Equal(t, "172.16.0.207", e.RPF.Neighbor)
+		assert.Equal(t, uint32(200), e.RPF.Preference)
+		assert.Equal(t, []string{"Port-Channel3000"}, e.OifList)
+	})
+
+	t.Run("SBNP entry has tunnel RPF and multi-element OIF", func(t *testing.T) {
+		e := byKey["default|sparse|233.84.178.1|148.51.122.96"]
+		require.NotNil(t, e)
+		assert.Equal(t, "SBNP", e.RouteFlags)
+		assert.Equal(t, "Tunnel504", e.RpfInterface)
+		assert.Nil(t, e.RPF, "Arista does not emit rpf{} for tunnel SBNP")
+		assert.Equal(t, []string{"Port-Channel3000", "Port-Channel1000.2020"}, e.OifList)
+	})
+
+	t.Run("E entry has empty OIF and no rpf", func(t *testing.T) {
+		e := byKey["default|sparse|233.84.178.6|148.51.122.234"]
+		require.NotNil(t, e)
+		assert.Equal(t, "E", e.RouteFlags)
+		assert.Nil(t, e.RPF)
+		assert.Empty(t, e.OifList)
+	})
+
+	t.Run("multi-source group yields one entry per source", func(t *testing.T) {
+		var sources []string
+		for _, e := range entries {
+			if e.GroupAddress == "233.84.178.10" {
+				sources = append(sources, e.SourceAddress)
+			}
+		}
+		sort.Strings(sources)
+		assert.Equal(t, []string{"148.51.121.188", "148.51.121.189"}, sources)
+	})
+
+	t.Run("empty bidirectional groups produce no entries", func(t *testing.T) {
+		for _, e := range entries {
+			assert.NotEqual(t, ModeBidirectional, e.Mode)
+		}
+	})
+}
+
+func TestParse_Empty(t *testing.T) {
+	const empty = `{"vrfs":{"default":{"bidirectional":{"groups":{}},"sparseMode":{"groups":{}}}}}`
+	entries, err := Parse([]byte(empty))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestParse_InvalidJSON(t *testing.T) {
+	_, err := Parse([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func indexByKey(entries []Entry) map[string]*Entry {
+	m := make(map[string]*Entry, len(entries))
+	for i := range entries {
+		e := &entries[i]
+		k := string(e.VRF) + "|" + string(e.Mode) + "|" + e.GroupAddress + "|" + e.SourceAddress
+		m[k] = e
+	}
+	return m
+}

--- a/indexer/pkg/dz/mroute/schema.go
+++ b/indexer/pkg/dz/mroute/schema.go
@@ -1,0 +1,144 @@
+package mroute
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// Row is a flattened, ClickHouse-friendly representation of an mroute Entry
+// joined with the device pubkey and snapshot timestamp. One row per
+// (device, vrf, mode, group, source) per change observed.
+type Row struct {
+	DevicePubkey      string
+	VRF               string
+	Mode              string
+	GroupAddress      string
+	SourceAddress     string
+	RouteFlags        string
+	RegisterInOifList uint8
+	RpfInterface      string
+	RpfRib            string
+	RpfPrefix         string
+	RpfPreference     int64
+	RpfMetric         int64
+	RpfNeighbor       string
+	RpfAttached       uint8
+	RpfHasBlock       uint8
+	OifList           string // JSON array
+	OifCount          int64
+	CreationTime      time.Time
+}
+
+// EntryToRow flattens an Entry into a ClickHouse Row for the given device pubkey.
+func EntryToRow(devicePubkey string, e Entry) Row {
+	r := Row{
+		DevicePubkey:      devicePubkey,
+		VRF:               e.VRF,
+		Mode:              string(e.Mode),
+		GroupAddress:      e.GroupAddress,
+		SourceAddress:     e.SourceAddress,
+		RouteFlags:        e.RouteFlags,
+		RegisterInOifList: boolToU8(e.RegisterInOifList),
+		RpfInterface:      e.RpfInterface,
+		OifList:           oifListJSON(e.OifList),
+		OifCount:          int64(len(e.OifList)),
+		CreationTime:      e.CreationTime,
+	}
+	if e.RPF != nil {
+		r.RpfHasBlock = 1
+		r.RpfRib = e.RPF.Rib
+		r.RpfPrefix = e.RPF.Prefix
+		r.RpfPreference = int64(e.RPF.Preference)
+		r.RpfMetric = int64(e.RPF.Metric)
+		r.RpfNeighbor = e.RPF.Neighbor
+		r.RpfAttached = boolToU8(e.RPF.Attached)
+	}
+	return r
+}
+
+// EntrySchema defines the dimension schema for mroute entries.
+type EntrySchema struct{}
+
+func (s *EntrySchema) Name() string {
+	return "dz_ip_mroute_entries"
+}
+
+func (s *EntrySchema) PrimaryKeyColumns() []string {
+	return []string{
+		"device_pubkey:VARCHAR",
+		"vrf:VARCHAR",
+		"mode:VARCHAR",
+		"group_address:VARCHAR",
+		"source_address:VARCHAR",
+	}
+}
+
+func (s *EntrySchema) PayloadColumns() []string {
+	return []string{
+		"route_flags:VARCHAR",
+		"register_in_oif_list:BOOLEAN",
+		"rpf_interface:VARCHAR",
+		"rpf_rib:VARCHAR",
+		"rpf_prefix:VARCHAR",
+		"rpf_preference:BIGINT",
+		"rpf_metric:BIGINT",
+		"rpf_neighbor:VARCHAR",
+		"rpf_attached:BOOLEAN",
+		"rpf_has_block:BOOLEAN",
+		"oif_list:VARCHAR",
+		"oif_count:BIGINT",
+		"creation_time:DATETIME",
+	}
+}
+
+func (s *EntrySchema) ToRow(r Row) []any {
+	return []any{
+		r.DevicePubkey,
+		r.VRF,
+		r.Mode,
+		r.GroupAddress,
+		r.SourceAddress,
+		r.RouteFlags,
+		r.RegisterInOifList,
+		r.RpfInterface,
+		r.RpfRib,
+		r.RpfPrefix,
+		r.RpfPreference,
+		r.RpfMetric,
+		r.RpfNeighbor,
+		r.RpfAttached,
+		r.RpfHasBlock,
+		r.OifList,
+		r.OifCount,
+		r.CreationTime,
+	}
+}
+
+func (s *EntrySchema) GetPrimaryKey(r Row) string {
+	return r.DevicePubkey + "/" + r.VRF + "/" + r.Mode + "/" + r.GroupAddress + "/" + r.SourceAddress
+}
+
+var entrySchema = &EntrySchema{}
+
+// NewEntryDataset creates a new Type2 dimension dataset for mroute entries.
+func NewEntryDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, entrySchema)
+}
+
+func boolToU8(b bool) uint8 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func oifListJSON(oifs []string) string {
+	if len(oifs) == 0 {
+		return "[]"
+	}
+	b, _ := json.Marshal(oifs)
+	return string(b)
+}

--- a/indexer/pkg/dz/mroute/source.go
+++ b/indexer/pkg/dz/mroute/source.go
@@ -1,0 +1,15 @@
+package mroute
+
+import "context"
+
+// Source provides access to per-device mroute snapshot dumps written by
+// doublezero-telemetry's state-collect uploader to S3.
+type Source interface {
+	// FetchLatest returns the most recent snapshot for every device that has
+	// uploaded one within the source's lookback window. Devices with no
+	// recent snapshots are silently omitted.
+	FetchLatest(ctx context.Context) ([]*Dump, error)
+
+	// Close releases any resources held by the source.
+	Close() error
+}

--- a/indexer/pkg/dz/mroute/source_minio_test.go
+++ b/indexer/pkg/dz/mroute/source_minio_test.go
@@ -1,0 +1,154 @@
+package mroute
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+)
+
+// TestS3Source_FetchLatest_MinIO is layer C: round-trip the source against a
+// real S3-compatible backend. It mirrors the exact key layout the
+// telemetry state-ingest server writes
+// (telemetry/state-ingest/pkg/server/handler.go:302) and verifies:
+//
+//   - Device subprefixes under snapshots/ip-mroute/ are enumerated correctly.
+//   - For each device, the alphabetically-greatest key within the lookback
+//     window is selected.
+//   - The dump's DevicePubkey, FileName, and RawJSON match what we wrote.
+//   - SnapshotTS parses out of the `YYYYMMDDTHHMMSSZ.json` filename.
+func TestS3Source_FetchLatest_MinIO(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MinIO integration test in -short mode")
+	}
+
+	ctx := t.Context()
+
+	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = ctr.Terminate(termCtx)
+	})
+
+	endpoint, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	// Build a raw S3 client pointed at MinIO so we can pre-populate the bucket.
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
+	)
+	require.NoError(t, err)
+	rawS3 := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String("http://" + endpoint)
+		o.UsePathStyle = true
+	})
+
+	const bucket = "doublezero-mainnet-beta-state-collect"
+	_, err = rawS3.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+
+	// Use today's UTC date so the source's 3-day lookback finds everything.
+	now := time.Now().UTC()
+	earlier := now.Add(-30 * time.Minute)
+	yesterday := now.AddDate(0, 0, -1)
+
+	// devA has two snapshots today (later one should win) and one yesterday.
+	// devB has a single snapshot today.
+	type fixture struct {
+		pubkey string
+		ts     time.Time
+		body   string
+	}
+	const devAPK = "DzPkA111111111111111111111111111111111111111"
+	const devBPK = "DzPkB222222222222222222222222222222222222222"
+
+	devALatestBody := `{"vrfs":{"default":{"sparseMode":{"groups":{"233.84.178.1":{"groupSources":{"10.0.0.1":{"sourceAddress":"10.0.0.1","creationTime":1779000000.0,"routeFlags":"SMP","registerInOifList":false,"rpfInterface":"Port-Channel1000","oifList":["Port-Channel3000"]}}}}},"bidirectional":{"groups":{}}}}}`
+	fixtures := []fixture{
+		{devAPK, yesterday, `{"vrfs":{"default":{"sparseMode":{"groups":{}},"bidirectional":{"groups":{}}}}}`},
+		{devAPK, earlier, `{"vrfs":{"default":{"sparseMode":{"groups":{}},"bidirectional":{"groups":{}}}}}`},
+		{devAPK, now, devALatestBody},
+		{devBPK, earlier, `{"vrfs":{"default":{"sparseMode":{"groups":{"233.84.178.10":{"groupSources":{"10.0.0.5":{"sourceAddress":"10.0.0.5","creationTime":1779000000.0,"routeFlags":"ME","registerInOifList":false,"rpfInterface":"Null0","oifList":[]}}}}},"bidirectional":{"groups":{}}}}}`},
+	}
+
+	for _, f := range fixtures {
+		key := buildStateIngestKey(f.pubkey, f.ts)
+		_, err := rawS3.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   strings.NewReader(f.body),
+		})
+		require.NoError(t, err, "put %s", key)
+	}
+
+	// Construct the S3Source pointed at MinIO. The Source uses the default
+	// AWS credential chain; t.Setenv injects static creds so it picks them up.
+	t.Setenv("AWS_ACCESS_KEY_ID", ctr.Username)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", ctr.Password)
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	src, err := NewS3Source(ctx, S3SourceConfig{
+		Bucket:       bucket,
+		Region:       "us-east-1",
+		EndpointURL:  "http://" + endpoint,
+		LookbackDays: 3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	dumps, err := src.FetchLatest(ctx)
+	require.NoError(t, err)
+	require.Len(t, dumps, 2, "expected one latest dump per device")
+
+	byPK := map[string]*Dump{}
+	for _, d := range dumps {
+		byPK[d.DevicePubkey] = d
+	}
+
+	t.Run("devA: latest body across days", func(t *testing.T) {
+		d := byPK[devAPK]
+		require.NotNil(t, d)
+		assert.Equal(t, devALatestBody, string(d.RawJSON), "should return the latest snapshot, not yesterday's")
+		assert.Contains(t, d.FileName, "device="+devAPK)
+		assert.Contains(t, d.FileName, "date="+now.Format("2006-01-02"))
+		// SnapshotTS round-trips through the filename to second precision.
+		expected := now.Truncate(time.Second)
+		assert.WithinDuration(t, expected, d.SnapshotTS, time.Second)
+	})
+
+	t.Run("devB: single snapshot picked", func(t *testing.T) {
+		d := byPK[devBPK]
+		require.NotNil(t, d)
+		assert.Contains(t, d.FileName, "device="+devBPK)
+		// Confirm Parse can round-trip what FetchLatest returned.
+		entries, err := Parse(d.RawJSON)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "233.84.178.10", entries[0].GroupAddress)
+		assert.Equal(t, "10.0.0.5", entries[0].SourceAddress)
+		assert.Equal(t, "ME", entries[0].RouteFlags)
+	})
+}
+
+// buildStateIngestKey reproduces the key pattern from the telemetry
+// state-ingest server's buildSnapshotKey (handler.go:302) for the mroute
+// kind, with no BucketPathPrefix.
+func buildStateIngestKey(pubkey string, ts time.Time) string {
+	ts = ts.UTC()
+	return "snapshots/" + SnapshotKind +
+		"/device=" + pubkey +
+		"/date=" + ts.Format("2006-01-02") +
+		"/hour=" + ts.Format("15") +
+		"/" + ts.Format("20060102T150405Z") + ".json"
+}

--- a/indexer/pkg/dz/mroute/source_minio_test.go
+++ b/indexer/pkg/dz/mroute/source_minio_test.go
@@ -1,8 +1,9 @@
 package mroute
 
 import (
+	"bytes"
 	"context"
-	"strings"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+
+	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
 )
 
 // TestS3Source_FetchLatest_MinIO is layer C: round-trip the source against a
@@ -64,7 +67,9 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 	yesterday := now.AddDate(0, 0, -1)
 
 	// devA has two snapshots today (later one should win) and one yesterday.
-	// devB has a single snapshot today.
+	// devB has a single snapshot today. Body is the raw Arista JSON; the
+	// fixture wraps it in the StateSnapshot envelope before upload, matching
+	// what controlplane/telemetry/internal/state/collector.go writes.
 	type fixture struct {
 		pubkey string
 		ts     time.Time
@@ -83,10 +88,19 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 
 	for _, f := range fixtures {
 		key := buildStateIngestKey(f.pubkey, f.ts)
-		_, err := rawS3.PutObject(ctx, &s3.PutObjectInput{
+		body, err := json.Marshal(statecollect.Envelope{
+			Metadata: statecollect.Metadata{
+				Kind:      SnapshotKind,
+				Timestamp: f.ts.UTC().Format(time.RFC3339),
+				Device:    f.pubkey,
+			},
+			Data: json.RawMessage(f.body),
+		})
+		require.NoError(t, err)
+		_, err = rawS3.PutObject(ctx, &s3.PutObjectInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
-			Body:   strings.NewReader(f.body),
+			Body:   bytes.NewReader(body),
 		})
 		require.NoError(t, err, "put %s", key)
 	}

--- a/indexer/pkg/dz/mroute/source_mock.go
+++ b/indexer/pkg/dz/mroute/source_mock.go
@@ -1,0 +1,29 @@
+package mroute
+
+import "context"
+
+// MockSource is a Source implementation for testing.
+type MockSource struct {
+	Dumps    []*Dump
+	FetchErr error
+	Closed   bool
+}
+
+// NewMockSource creates a MockSource preloaded with the given dumps.
+func NewMockSource(dumps ...*Dump) *MockSource {
+	return &MockSource{Dumps: dumps}
+}
+
+// FetchLatest returns the configured dumps or error.
+func (m *MockSource) FetchLatest(ctx context.Context) ([]*Dump, error) {
+	if m.FetchErr != nil {
+		return nil, m.FetchErr
+	}
+	return m.Dumps, nil
+}
+
+// Close marks the source as closed.
+func (m *MockSource) Close() error {
+	m.Closed = true
+	return nil
+}

--- a/indexer/pkg/dz/mroute/source_s3.go
+++ b/indexer/pkg/dz/mroute/source_s3.go
@@ -1,0 +1,233 @@
+package mroute
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// SnapshotKind is the state-collect kind name for mroute dumps. It matches the
+// key used by the telemetry state-ingest server when it presigns the
+// device-side PUT.
+const SnapshotKind = "ip-mroute"
+
+// S3SourceConfig configures the state-collect mroute snapshot source.
+type S3SourceConfig struct {
+	Bucket      string // S3 bucket name written to by the state-ingest server
+	Region      string // AWS region
+	KeyPrefix   string // Optional path prefix matching the state-ingest server's BucketPathPrefix
+	EndpointURL string // Optional custom endpoint (for MinIO in tests)
+
+	// LookbackDays controls how many UTC days back to scan for snapshots when
+	// finding the latest per device. Three covers clock skew and the
+	// midnight-UTC boundary; tests can shorten this.
+	LookbackDays int
+}
+
+// S3Source implements Source against an S3 bucket populated by the telemetry
+// state-ingest server. Snapshot keys follow the pattern
+//
+//	<KeyPrefix>/snapshots/<SnapshotKind>/device=<pubkey>/date=YYYY-MM-DD/hour=HH/<ts>.json
+type S3Source struct {
+	client       *s3.Client
+	bucket       string
+	keyPrefix    string // already stripped of trailing slash; empty when no prefix
+	lookbackDays int
+}
+
+// NewS3Source constructs a state-collect S3 source using the default AWS
+// credential chain (env / IAM role / profile). The bucket is expected to be
+// the same one the telemetry state-ingest server writes to.
+func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("mroute: bucket is required")
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	if cfg.LookbackDays <= 0 {
+		cfg.LookbackDays = 3
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region))
+	if err != nil {
+		return nil, fmt.Errorf("mroute: load AWS config: %w", err)
+	}
+
+	clientOpts := []func(*s3.Options){
+		func(o *s3.Options) { o.UsePathStyle = true },
+	}
+	if cfg.EndpointURL != "" {
+		clientOpts = append(clientOpts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(cfg.EndpointURL)
+		})
+	}
+
+	return &S3Source{
+		client:       s3.NewFromConfig(awsCfg, clientOpts...),
+		bucket:       cfg.Bucket,
+		keyPrefix:    strings.TrimRight(cfg.KeyPrefix, "/"),
+		lookbackDays: cfg.LookbackDays,
+	}, nil
+}
+
+// snapshotsPrefix returns the key prefix that contains all device subprefixes
+// for this snapshot kind, with a trailing slash.
+func (s *S3Source) snapshotsPrefix() string {
+	if s.keyPrefix == "" {
+		return "snapshots/" + SnapshotKind + "/"
+	}
+	return s.keyPrefix + "/snapshots/" + SnapshotKind + "/"
+}
+
+// FetchLatest enumerates device subprefixes under the snapshots/ip-mroute/
+// path and returns the most recent dump per device within the lookback window.
+func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
+	devices, err := s.listDevicePubkeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	var dumps []*Dump
+	for _, pubkey := range devices {
+		key, snapTS, err := s.latestKeyForDevice(ctx, pubkey, now)
+		if err != nil {
+			return nil, err
+		}
+		if key == "" {
+			continue
+		}
+		body, err := s.getObject(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		dumps = append(dumps, &Dump{
+			FetchedAt:    time.Now().UTC(),
+			SnapshotTS:   snapTS,
+			DevicePubkey: pubkey,
+			RawJSON:      body,
+			FileName:     key,
+		})
+	}
+	return dumps, nil
+}
+
+// listDevicePubkeys uses delimiter listing to enumerate the device=<pubkey>
+// subprefixes under the snapshots/<kind>/ path. It does not page through
+// individual snapshot objects.
+func (s *S3Source) listDevicePubkeys(ctx context.Context) ([]string, error) {
+	prefix := s.snapshotsPrefix()
+	var pubkeys []string
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket:    aws.String(s.bucket),
+		Prefix:    aws.String(prefix),
+		Delimiter: aws.String("/"),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("mroute: list device prefixes: %w", err)
+		}
+		for _, cp := range page.CommonPrefixes {
+			if cp.Prefix == nil {
+				continue
+			}
+			// Extract pubkey from `<prefix>device=<pubkey>/`
+			rest := strings.TrimPrefix(*cp.Prefix, prefix)
+			rest = strings.TrimSuffix(rest, "/")
+			if pk := strings.TrimPrefix(rest, "device="); pk != rest && pk != "" {
+				pubkeys = append(pubkeys, pk)
+			}
+		}
+	}
+	return pubkeys, nil
+}
+
+// latestKeyForDevice scans the last LookbackDays date partitions for a single
+// device and returns the alphabetically-greatest key, with the snapshot
+// timestamp parsed from the filename. The filename format the state-ingest
+// server writes is `YYYYMMDDTHHMMSSZ.json`.
+func (s *S3Source) latestKeyForDevice(ctx context.Context, pubkey string, now time.Time) (string, time.Time, error) {
+	base := s.snapshotsPrefix() + "device=" + pubkey + "/"
+	var latestKey string
+	for daysBack := 0; daysBack < s.lookbackDays; daysBack++ {
+		date := now.AddDate(0, 0, -daysBack).Format("2006-01-02")
+		prefix := base + "date=" + date + "/"
+		key, err := s.latestKeyUnderPrefix(ctx, prefix)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		if key > latestKey {
+			latestKey = key
+		}
+	}
+	if latestKey == "" {
+		return "", time.Time{}, nil
+	}
+	return latestKey, snapshotTSFromKey(latestKey), nil
+}
+
+func (s *S3Source) latestKeyUnderPrefix(ctx context.Context, prefix string) (string, error) {
+	var latestKey string
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("mroute: list %s: %w", prefix, err)
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			if *obj.Key > latestKey {
+				latestKey = *obj.Key
+			}
+		}
+	}
+	return latestKey, nil
+}
+
+func (s *S3Source) getObject(ctx context.Context, key string) ([]byte, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mroute: get %s: %w", key, err)
+	}
+	defer out.Body.Close()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("mroute: read %s: %w", key, err)
+	}
+	return body, nil
+}
+
+// snapshotTSFromKey parses the `YYYYMMDDTHHMMSSZ.json` filename written by
+// the state-ingest server back into a time.Time. Returns zero on any parse
+// failure so callers can fall back to the dump's FetchedAt.
+func snapshotTSFromKey(key string) time.Time {
+	slash := strings.LastIndex(key, "/")
+	name := key[slash+1:]
+	name = strings.TrimSuffix(name, ".json")
+	t, err := time.Parse("20060102T150405Z", name)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}
+
+// Close releases resources. For S3Source, this is a no-op.
+func (s *S3Source) Close() error {
+	return nil
+}

--- a/indexer/pkg/dz/mroute/source_s3.go
+++ b/indexer/pkg/dz/mroute/source_s3.go
@@ -2,6 +2,7 @@ package mroute
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -10,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
 )
 
 // SnapshotKind is the state-collect kind name for mroute dumps. It matches the
@@ -87,7 +90,9 @@ func (s *S3Source) snapshotsPrefix() string {
 }
 
 // FetchLatest enumerates device subprefixes under the snapshots/ip-mroute/
-// path and returns the most recent dump per device within the lookback window.
+// path and returns the most recent dump per device within the lookback
+// window. Each S3 object is a statecollect.Envelope; this method unwraps
+// it so callers receive only the inner Arista JSON in Dump.RawJSON.
 func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 	devices, err := s.listDevicePubkeys(ctx)
 	if err != nil {
@@ -97,7 +102,7 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 	now := time.Now().UTC()
 	var dumps []*Dump
 	for _, pubkey := range devices {
-		key, snapTS, err := s.latestKeyForDevice(ctx, pubkey, now)
+		key, keyTS, err := s.latestKeyForDevice(ctx, pubkey, now)
 		if err != nil {
 			return nil, err
 		}
@@ -108,11 +113,34 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		var env statecollect.Envelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, fmt.Errorf("mroute: decode envelope %s: %w", key, err)
+		}
+		if env.Metadata.Kind != "" && env.Metadata.Kind != SnapshotKind {
+			return nil, fmt.Errorf("mroute: envelope kind mismatch in %s: got %q, want %q",
+				key, env.Metadata.Kind, SnapshotKind)
+		}
+
+		// Prefer the envelope's authoritative metadata; fall back to what
+		// we parsed out of the S3 key when the envelope is missing fields.
+		devicePK := pubkey
+		if env.Metadata.Device != "" {
+			devicePK = env.Metadata.Device
+		}
+		snapTS := keyTS
+		if env.Metadata.Timestamp != "" {
+			if parsed, err := time.Parse(time.RFC3339, env.Metadata.Timestamp); err == nil {
+				snapTS = parsed.UTC()
+			}
+		}
+
 		dumps = append(dumps, &Dump{
 			FetchedAt:    time.Now().UTC(),
 			SnapshotTS:   snapTS,
-			DevicePubkey: pubkey,
-			RawJSON:      body,
+			DevicePubkey: devicePK,
+			RawJSON:      env.Data,
 			FileName:     key,
 		})
 	}

--- a/indexer/pkg/dz/mroute/source_s3_test.go
+++ b/indexer/pkg/dz/mroute/source_s3_test.go
@@ -1,0 +1,72 @@
+package mroute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotsPrefix(t *testing.T) {
+	t.Run("no key prefix", func(t *testing.T) {
+		s := &S3Source{keyPrefix: ""}
+		assert.Equal(t, "snapshots/ip-mroute/", s.snapshotsPrefix())
+	})
+	t.Run("with key prefix", func(t *testing.T) {
+		s := &S3Source{keyPrefix: "env/testnet"}
+		assert.Equal(t, "env/testnet/snapshots/ip-mroute/", s.snapshotsPrefix())
+	})
+}
+
+func TestSnapshotTSFromKey(t *testing.T) {
+	t.Run("parses filename produced by state-ingest", func(t *testing.T) {
+		key := "snapshots/ip-mroute/device=DzPkAbCdEf/date=2026-05-18/hour=12/20260518T123456Z.json"
+		ts := snapshotTSFromKey(key)
+		require.False(t, ts.IsZero())
+		assert.Equal(t, time.Date(2026, 5, 18, 12, 34, 56, 0, time.UTC), ts)
+	})
+	t.Run("returns zero on malformed filename", func(t *testing.T) {
+		assert.True(t, snapshotTSFromKey("not-a-key").IsZero())
+		assert.True(t, snapshotTSFromKey("snapshots/ip-mroute/device=x/date=2026-05-18/hour=12/garbage.json").IsZero())
+	})
+}
+
+func TestMockSource(t *testing.T) {
+	t.Run("returns configured dumps", func(t *testing.T) {
+		want := []*Dump{
+			{DevicePubkey: "pk1", FileName: "k1.json"},
+			{DevicePubkey: "pk2", FileName: "k2.json"},
+		}
+		ms := NewMockSource(want...)
+		got, err := ms.FetchLatest(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns configured error", func(t *testing.T) {
+		ms := &MockSource{FetchErr: errors.New("boom")}
+		dumps, err := ms.FetchLatest(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, dumps)
+	})
+
+	t.Run("close marks closed", func(t *testing.T) {
+		ms := NewMockSource()
+		assert.False(t, ms.Closed)
+		require.NoError(t, ms.Close())
+		assert.True(t, ms.Closed)
+	})
+}
+
+func TestS3SourceClose(t *testing.T) {
+	s := &S3Source{}
+	assert.NoError(t, s.Close())
+}
+
+func TestSourceInterface(t *testing.T) {
+	var _ Source = (*MockSource)(nil)
+	var _ Source = (*S3Source)(nil)
+}

--- a/indexer/pkg/dz/mroute/store.go
+++ b/indexer/pkg/dz/mroute/store.go
@@ -1,0 +1,68 @@
+package mroute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// StoreConfig holds configuration for the mroute ClickHouse store.
+type StoreConfig struct {
+	Logger     *slog.Logger
+	ClickHouse clickhouse.Client
+}
+
+func (cfg *StoreConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	return nil
+}
+
+// Store manages mroute dimension data in ClickHouse.
+type Store struct {
+	log *slog.Logger
+	cfg StoreConfig
+}
+
+// NewStore creates a new mroute ClickHouse store.
+func NewStore(cfg StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Store{log: cfg.Logger, cfg: cfg}, nil
+}
+
+// ReplaceEntries replaces all mroute entries in ClickHouse. With
+// MissingMeansDeleted=true, any (device, vrf, mode, group, source) tuple not
+// present in the current batch is marked deleted in the type2 dimension.
+func (s *Store) ReplaceEntries(ctx context.Context, rows []Row) error {
+	s.log.Debug("mroute/store: replacing entries", "count", len(rows))
+
+	d, err := NewEntryDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("mroute: build dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("mroute: get clickhouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(rows), func(i int) ([]any, error) {
+		return entrySchema.ToRow(rows[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("mroute: write entries: %w", err)
+	}
+	return nil
+}

--- a/indexer/pkg/dz/mroute/store_test.go
+++ b/indexer/pkg/dz/mroute/store_test.go
@@ -108,6 +108,58 @@ func TestStore_SCD2_RoundTrip(t *testing.T) {
 	})
 }
 
+// TestStore_Sync_FailsFastOnParseError locks in the fail-fast contract:
+// when any dump in a batch is unparseable, Sync must return an error and
+// write nothing — including not tombstoning prior state for the
+// well-formed devices in the same batch.
+func TestStore_Sync_FailsFastOnParseError(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	store, err := NewStore(StoreConfig{
+		Logger:     laketesting.NewLogger(),
+		ClickHouse: info.Client,
+	})
+	require.NoError(t, err)
+
+	const devicePK = "DzPkFailFast111111111111111111111111111111111"
+
+	// Seed one row so we can check it survives the failed sync.
+	seedRow := EntryToRow(devicePK, Entry{
+		VRF:           "default",
+		Mode:          ModeSparse,
+		GroupAddress:  "233.84.178.1",
+		SourceAddress: "10.0.0.99",
+		RouteFlags:    "SMP",
+		RpfInterface:  "Port-Channel1000",
+		OifList:       []string{"Port-Channel3000"},
+		CreationTime:  time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, store.ReplaceEntries(t.Context(), []Row{seedRow}))
+	require.Len(t, queryCurrent(t, info.Client, devicePK), 1, "seed should be visible")
+
+	// Now run a Sync with one good dump + one corrupt dump. Whether
+	// the good dump's device exists in seed state or not, Sync must
+	// refuse to write.
+	goodDump := &Dump{
+		DevicePubkey: devicePK,
+		FileName:     "good.json",
+		RawJSON:      []byte(`{"vrfs":{"default":{"sparseMode":{"groups":{}},"bidirectional":{"groups":{}}}}}`),
+	}
+	corruptDump := &Dump{
+		DevicePubkey: "DzPkBad22222222222222222222222222222222222222",
+		FileName:     "corrupt.json",
+		RawJSON:      []byte(`{"vrfs": "not-an-object"`), // truncated + wrong shape
+	}
+
+	err = store.Sync(t.Context(), []*Dump{goodDump, corruptDump})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to write")
+
+	// The seed must still be visible — the failed sync didn't tombstone it.
+	got := queryCurrent(t, info.Client, devicePK)
+	require.Len(t, got, 1, "seeded row must survive a sync that failed before write")
+	assert.Equal(t, "10.0.0.99", got[0].SourceAddress)
+}
+
 type currentRow struct {
 	DevicePubkey  string
 	GroupAddress  string

--- a/indexer/pkg/dz/mroute/store_test.go
+++ b/indexer/pkg/dz/mroute/store_test.go
@@ -1,0 +1,174 @@
+package mroute
+
+import (
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStore_SCD2_RoundTrip is layer B: prove ReplaceEntries -> the
+// underlying DimensionType2Dataset.WriteBatch path round-trips correctly for
+// the column types and 5-column PK shape declared in EntrySchema.
+//
+// Three batches exercise the SCD2 contract:
+//
+//   - batch1 inserts three (S,G) entries; _current view returns all three.
+//   - batch2 omits one entry (tombstone), changes one (new attrs), keeps one
+//     identical; _current returns the surviving two with the updated payload
+//     visible on the changed row.
+//   - batch3 re-runs batch2 unchanged; _current is identical and the active
+//     history row count does not grow.
+//
+// This is the test that catches a column-type mismatch, a bad attrs_hash
+// expression, or MissingMeansDeleted semantics that differ from what the
+// store assumes.
+func TestStore_SCD2_RoundTrip(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	store, err := NewStore(StoreConfig{
+		Logger:     laketesting.NewLogger(),
+		ClickHouse: info.Client,
+	})
+	require.NoError(t, err)
+
+	const devicePK = "DzPkAbCdEfGhJkLmNoPqRsTuVwXyZ1234567890aaaaa"
+
+	mk := func(group, source, flags string, rpfIface string, oifs []string, rpf *RPF) Row {
+		e := Entry{
+			VRF:           "default",
+			Mode:          ModeSparse,
+			GroupAddress:  group,
+			SourceAddress: source,
+			RouteFlags:    flags,
+			RpfInterface:  rpfIface,
+			OifList:       oifs,
+			RPF:           rpf,
+			CreationTime:  time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		}
+		return EntryToRow(devicePK, e)
+	}
+
+	rpfOK := &RPF{Rib: "U", Prefix: "10.0.0.1/32", Preference: 200, Metric: 0, Neighbor: "172.16.0.1"}
+
+	batch1 := []Row{
+		mk("233.84.178.1", "10.0.0.1", "SMP", "Port-Channel1000", []string{"Port-Channel3000"}, rpfOK),
+		mk("233.84.178.1", "10.0.0.2", "ME", "Null0", nil, nil),
+		mk("233.84.178.10", "10.0.0.3", "SBNP", "Tunnel504", []string{"Port-Channel3000", "Port-Channel1000"}, nil),
+	}
+
+	t.Run("batch1: initial insert visible in _current", func(t *testing.T) {
+		require.NoError(t, store.ReplaceEntries(t.Context(), batch1))
+
+		got := queryCurrent(t, info.Client, devicePK)
+		require.Len(t, got, 3)
+		assertHasEntry(t, got, "233.84.178.1", "10.0.0.1", "SMP", `["Port-Channel3000"]`, 1)
+		assertHasEntry(t, got, "233.84.178.1", "10.0.0.2", "ME", `[]`, 0)
+		assertHasEntry(t, got, "233.84.178.10", "10.0.0.3", "SBNP", `["Port-Channel3000","Port-Channel1000"]`, 2)
+	})
+
+	// batch2: drop "10.0.0.2", change OIF for "10.0.0.1", keep "10.0.0.3".
+	batch2 := []Row{
+		mk("233.84.178.1", "10.0.0.1", "SMP", "Port-Channel1000", []string{"Port-Channel3000", "Port-Channel2000"}, rpfOK),
+		mk("233.84.178.10", "10.0.0.3", "SBNP", "Tunnel504", []string{"Port-Channel3000", "Port-Channel1000"}, nil),
+	}
+
+	t.Run("batch2: missing row tombstoned, changed row updates", func(t *testing.T) {
+		require.NoError(t, store.ReplaceEntries(t.Context(), batch2))
+
+		got := queryCurrent(t, info.Client, devicePK)
+		require.Len(t, got, 2, "10.0.0.2 should be tombstoned out of _current")
+		for _, row := range got {
+			assert.NotEqual(t, "10.0.0.2", row.SourceAddress, "tombstoned entry should not appear in _current")
+		}
+		assertHasEntry(t, got, "233.84.178.1", "10.0.0.1", "SMP", `["Port-Channel3000","Port-Channel2000"]`, 2)
+		assertHasEntry(t, got, "233.84.178.10", "10.0.0.3", "SBNP", `["Port-Channel3000","Port-Channel1000"]`, 2)
+	})
+
+	t.Run("batch3: identical re-run does not grow active history", func(t *testing.T) {
+		before := historyActiveCount(t, info.Client, devicePK)
+		require.NoError(t, store.ReplaceEntries(t.Context(), batch2))
+		after := historyActiveCount(t, info.Client, devicePK)
+		assert.Equal(t, before, after,
+			"identical batch should produce no new active history rows (attrs_hash unchanged)")
+
+		got := queryCurrent(t, info.Client, devicePK)
+		require.Len(t, got, 2)
+		assertHasEntry(t, got, "233.84.178.1", "10.0.0.1", "SMP", `["Port-Channel3000","Port-Channel2000"]`, 2)
+		assertHasEntry(t, got, "233.84.178.10", "10.0.0.3", "SBNP", `["Port-Channel3000","Port-Channel1000"]`, 2)
+	})
+
+	t.Run("empty batch tombstones all remaining entries", func(t *testing.T) {
+		require.NoError(t, store.ReplaceEntries(t.Context(), nil))
+
+		got := queryCurrent(t, info.Client, devicePK)
+		assert.Empty(t, got, "empty batch with MissingMeansDeleted=true should tombstone all remaining entries")
+	})
+}
+
+type currentRow struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RouteFlags    string
+	OifList       string
+	OifCount      int64
+}
+
+func queryCurrent(t *testing.T, client clickhouse.Client, devicePK string) []currentRow {
+	t.Helper()
+	conn, err := client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rows, err := conn.Query(t.Context(), `
+		SELECT device_pubkey, group_address, source_address, route_flags, oif_list, oif_count
+		FROM dz_ip_mroute_entries_current
+		WHERE device_pubkey = ?
+		ORDER BY group_address, source_address
+	`, devicePK)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []currentRow
+	for rows.Next() {
+		var r currentRow
+		require.NoError(t, rows.Scan(&r.DevicePubkey, &r.GroupAddress, &r.SourceAddress, &r.RouteFlags, &r.OifList, &r.OifCount))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func historyActiveCount(t *testing.T, client clickhouse.Client, devicePK string) uint64 {
+	t.Helper()
+	conn, err := client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rows, err := conn.Query(t.Context(), `
+		SELECT count() FROM dim_dz_ip_mroute_entries_history
+		WHERE device_pubkey = ? AND is_deleted = 0
+	`, devicePK)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var n uint64
+	require.NoError(t, rows.Scan(&n))
+	return n
+}
+
+func assertHasEntry(t *testing.T, got []currentRow, group, source, flags, oifListJSON string, oifCount int64) {
+	t.Helper()
+	for _, r := range got {
+		if r.GroupAddress == group && r.SourceAddress == source {
+			assert.Equal(t, flags, r.RouteFlags, "%s,%s: route_flags", group, source)
+			assert.Equal(t, oifListJSON, r.OifList, "%s,%s: oif_list", group, source)
+			assert.Equal(t, oifCount, r.OifCount, "%s,%s: oif_count", group, source)
+			return
+		}
+	}
+	t.Errorf("no entry for (%s, %s) in: %+v", group, source, got)
+}

--- a/indexer/pkg/dz/mroute/sync.go
+++ b/indexer/pkg/dz/mroute/sync.go
@@ -1,0 +1,40 @@
+package mroute
+
+import (
+	"context"
+	"fmt"
+)
+
+// Sync parses per-device dumps into mroute Rows and replaces them in
+// ClickHouse. Devices that fail to parse are skipped after logging — a single
+// bad dump should not prevent the rest of the fleet from being written.
+func (s *Store) Sync(ctx context.Context, dumps []*Dump) error {
+	var rows []Row
+	for _, d := range dumps {
+		if d == nil {
+			continue
+		}
+		entries, err := Parse(d.RawJSON)
+		if err != nil {
+			s.log.Warn("mroute/sync: failed to parse dump, skipping device",
+				"device_pubkey", d.DevicePubkey,
+				"file", d.FileName,
+				"err", err,
+			)
+			continue
+		}
+		for _, e := range entries {
+			rows = append(rows, EntryToRow(d.DevicePubkey, e))
+		}
+	}
+
+	if err := s.ReplaceEntries(ctx, rows); err != nil {
+		return fmt.Errorf("mroute: sync replace: %w", err)
+	}
+
+	s.log.Info("mroute: synced to ClickHouse",
+		"dumps", len(dumps),
+		"entries", len(rows),
+	)
+	return nil
+}

--- a/indexer/pkg/dz/mroute/sync.go
+++ b/indexer/pkg/dz/mroute/sync.go
@@ -2,30 +2,40 @@ package mroute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
 // Sync parses per-device dumps into mroute Rows and replaces them in
-// ClickHouse. Devices that fail to parse are skipped after logging — a single
-// bad dump should not prevent the rest of the fleet from being written.
+// ClickHouse.
+//
+// On any parse failure, Sync returns the error and writes nothing.
+// ReplaceEntries uses MissingMeansDeleted=true at the dataset layer, so
+// silently dropping a device from the batch would tombstone that device's
+// previously-current rows — not a recoverable "skip, try again next
+// snapshot" semantic. Refusing to write preserves all prior state until
+// the underlying parse issue is investigated.
 func (s *Store) Sync(ctx context.Context, dumps []*Dump) error {
-	var rows []Row
+	rows := make([]Row, 0)
+	var parseErrs []error
 	for _, d := range dumps {
 		if d == nil {
 			continue
 		}
 		entries, err := Parse(d.RawJSON)
 		if err != nil {
-			s.log.Warn("mroute/sync: failed to parse dump, skipping device",
-				"device_pubkey", d.DevicePubkey,
-				"file", d.FileName,
-				"err", err,
-			)
+			parseErrs = append(parseErrs, fmt.Errorf("%s (%s): %w", d.DevicePubkey, d.FileName, err))
 			continue
 		}
 		for _, e := range entries {
 			rows = append(rows, EntryToRow(d.DevicePubkey, e))
 		}
+	}
+	if len(parseErrs) > 0 {
+		// Don't write — destructive for the affected devices under
+		// MissingMeansDeleted=true semantics.
+		return fmt.Errorf("mroute: %d/%d dumps failed to parse, refusing to write: %w",
+			len(parseErrs), len(dumps), errors.Join(parseErrs...))
 	}
 
 	if err := s.ReplaceEntries(ctx, rows); err != nil {

--- a/indexer/pkg/dz/mroute/types.go
+++ b/indexer/pkg/dz/mroute/types.go
@@ -1,0 +1,53 @@
+package mroute
+
+import "time"
+
+// Mode is the PIM operating mode for a multicast group.
+type Mode string
+
+const (
+	ModeSparse        Mode = "sparse"
+	ModeBidirectional Mode = "bidirectional"
+)
+
+// Dump represents a single device's raw mroute snapshot.
+type Dump struct {
+	FetchedAt    time.Time
+	SnapshotTS   time.Time
+	DevicePubkey string
+	RawJSON      []byte
+	FileName     string
+}
+
+// Entry is one parsed (vrf, mode, group, source) row from `show ip mroute | json`.
+type Entry struct {
+	DevicePubkey      string
+	VRF               string
+	Mode              Mode
+	GroupAddress      string
+	SourceAddress     string
+	CreationTime      time.Time
+	RouteFlags        string
+	RegisterInOifList bool
+	RpfInterface      string
+
+	// Optional RPF detail block. Present only when the device has installed an
+	// active RPF towards the source (RpfInterface != "Null0").
+	RPF *RPF
+
+	// OifList may be empty for ME/E entries.
+	OifList []string
+}
+
+// RPF holds the reverse-path-forwarding detail Arista emits when an mroute
+// has an installed RPF interface.
+type RPF struct {
+	Rib              string
+	Prefix           string
+	Preference       uint32
+	Metric           uint32
+	Neighbor         string
+	Attached         bool
+	EvpnTenantDomain bool
+	Mvpn             bool
+}

--- a/indexer/pkg/dz/statecollect/envelope.go
+++ b/indexer/pkg/dz/statecollect/envelope.go
@@ -1,0 +1,33 @@
+// Package statecollect describes the on-disk format used by the
+// doublezero-telemetry state collector. Per-kind packages (e.g. mroute,
+// msdp) parse the inner Data payload after the envelope has been
+// unwrapped.
+package statecollect
+
+import "encoding/json"
+
+// Envelope is the JSON shape every state-collect snapshot uploads to S3.
+// It mirrors controlplane/telemetry/internal/state/snapshot.go in the
+// doublezero repo; any change to that producer must be matched here.
+//
+// Wire format:
+//
+//	{
+//	  "metadata": {
+//	    "kind":      "ip-mroute",
+//	    "timestamp": "2026-05-29T15:34:56Z",
+//	    "device":    "<solana pubkey>"
+//	  },
+//	  "data": { ... raw Arista eAPI JSON ... }
+//	}
+type Envelope struct {
+	Metadata Metadata        `json:"metadata"`
+	Data     json.RawMessage `json:"data"`
+}
+
+// Metadata is the envelope's identifying fields.
+type Metadata struct {
+	Kind      string `json:"kind"`      // matches state-ingest kind name, e.g. "ip-mroute"
+	Timestamp string `json:"timestamp"` // RFC3339 UTC, capture time on the device
+	Device    string `json:"device"`    // device pubkey (base58)
+}

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -10,6 +10,7 @@ import (
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -41,6 +42,8 @@ type Activities struct {
 	GraphStore     *dzgraph.Store     // nil when Neo4j is not configured
 	ISISSource     isis.Source        // nil when ISIS is not enabled
 	ISISStore      *isis.Store        // nil when ISIS is not enabled
+	MrouteSource   mroute.Source      // nil when mroute ingest is not enabled
+	MrouteStore    *mroute.Store      // nil when mroute ingest is not enabled
 
 	// failures tracks consecutive-failure counts per activity name.
 	// map[string]*atomic.Int32; populated lazily.
@@ -208,6 +211,25 @@ func (a *Activities) RefreshShredEscrowEvents(ctx context.Context) error {
 			return result, fmt.Errorf("escrow events refresh: %w", err)
 		}
 		return result, nil
+	})
+}
+
+// SyncIPMroute fetches per-device `show ip mroute` snapshots from S3 (uploaded
+// by doublezero-telemetry --state-collect-enable) and replaces the
+// dz_ip_mroute_entries dimension in ClickHouse. No-op if mroute ingest is not
+// configured.
+func (a *Activities) SyncIPMroute(ctx context.Context) error {
+	if a.MrouteSource == nil || a.MrouteStore == nil {
+		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncIPMroute", a.Network)
+		return nil
+	}
+	return a.refresh(ctx, "SyncIPMroute", func() (ingestionlog.RefreshResult, error) {
+		var result ingestionlog.RefreshResult
+		dumps, err := a.MrouteSource.FetchLatest(ctx)
+		if err != nil {
+			return result, fmt.Errorf("mroute fetch: %w", err)
+		}
+		return result, a.MrouteStore.Sync(ctx, dumps)
 	})
 }
 

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -18,6 +18,7 @@ import (
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -45,6 +46,8 @@ type Config struct {
 	GraphStore     *dzgraph.Store     // optional
 	ISISSource     isis.Source        // optional
 	ISISStore      *isis.Store        // optional
+	MrouteSource   mroute.Source      // optional
+	MrouteStore    *mroute.Store      // optional
 }
 
 // TaskQueue returns the Temporal task queue name for the given network.
@@ -90,6 +93,8 @@ func Start(ctx context.Context, cfg Config) error {
 		GraphStore:     cfg.GraphStore,
 		ISISSource:     cfg.ISISSource,
 		ISISStore:      cfg.ISISStore,
+		MrouteSource:   cfg.MrouteSource,
+		MrouteStore:    cfg.MrouteStore,
 	}
 
 	w := worker.New(tc, tq, worker.Options{})

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -60,6 +60,7 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		shredsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShreds)
 		escrowEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShredEscrowEvents)
 		isisSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncISIS)
+		mrouteSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncIPMroute)
 		graphSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncGraph)
 
 		// Telemetry usage runs less frequently (~5 minutes).
@@ -97,6 +98,12 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 				return ctx.Err()
 			}
 			logger.Error("isis sync failed", "error", err)
+		}
+		if err := mrouteSyncFuture.Get(ctx, nil); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			logger.Error("mroute sync failed", "error", err)
 		}
 		if err := graphSyncFuture.Get(ctx, nil); err != nil {
 			if ctx.Err() != nil {

--- a/indexer/pkg/indexer/config.go
+++ b/indexer/pkg/indexer/config.go
@@ -76,6 +76,16 @@ type Config struct {
 	ISISS3EndpointURL   string        // Custom S3 endpoint URL (for testing)
 	ISISRefreshInterval time.Duration // Refresh interval for IS-IS sync (default: 30s)
 
+	// Mroute (state-collect) configuration (optional).
+	// When enabled, periodically pulls `show ip mroute | json` snapshots that
+	// doublezero-telemetry uploads to S3 and writes the parsed entries to
+	// ClickHouse as a type-2 dimension.
+	MrouteEnabled       bool
+	MrouteS3Bucket      string // S3 bucket the state-ingest server writes to
+	MrouteS3Region      string // AWS region (default: us-east-1)
+	MrouteS3KeyPrefix   string // Optional matching state-ingest BucketPathPrefix
+	MrouteS3EndpointURL string // Custom S3 endpoint URL (for testing)
+
 	// validators.app configuration (optional, mainnet-beta only).
 	ValidatorsAppClient          validatorsapp.Client
 	ValidatorsAppRefreshInterval time.Duration

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -10,6 +10,7 @@ import (
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -36,6 +37,8 @@ type Indexer struct {
 	geoip         *mcpgeoip.View
 	isisSource    isis.Source
 	isisStore     *isis.Store
+	mrouteSource  mroute.Source
+	mrouteStore   *mroute.Store
 	validatorsApp *validatorsapp.View
 }
 
@@ -247,6 +250,32 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 			"region", cfg.ISISS3Region)
 	}
 
+	// Initialize mroute source and store if enabled
+	var mrouteSource mroute.Source
+	var mrouteStore *mroute.Store
+	if cfg.MrouteEnabled {
+		mrouteSource, err = mroute.NewS3Source(ctx, mroute.S3SourceConfig{
+			Bucket:      cfg.MrouteS3Bucket,
+			Region:      cfg.MrouteS3Region,
+			KeyPrefix:   cfg.MrouteS3KeyPrefix,
+			EndpointURL: cfg.MrouteS3EndpointURL,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mroute S3 source: %w", err)
+		}
+		mrouteStore, err = mroute.NewStore(mroute.StoreConfig{
+			Logger:     cfg.Logger,
+			ClickHouse: cfg.ClickHouse,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mroute store: %w", err)
+		}
+		cfg.Logger.Info("mroute state-collect source initialized",
+			"bucket", cfg.MrouteS3Bucket,
+			"region", cfg.MrouteS3Region,
+			"key_prefix", cfg.MrouteS3KeyPrefix)
+	}
+
 	// Initialize validators.app view (optional)
 	var validatorsAppView *validatorsapp.View
 	if cfg.ValidatorsAppClient != nil {
@@ -277,6 +306,8 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 		geoip:         geoipView,
 		isisSource:    isisSource,
 		isisStore:     isisStore,
+		mrouteSource:  mrouteSource,
+		mrouteStore:   mrouteStore,
 		validatorsApp: validatorsAppView,
 	}
 
@@ -302,6 +333,12 @@ func (i *Indexer) Close() error {
 		if err := i.isisSource.Close(); err != nil {
 			i.log.Warn("failed to close ISIS source", "error", err)
 			errs = append(errs, fmt.Errorf("failed to close ISIS source: %w", err))
+		}
+	}
+	if i.mrouteSource != nil {
+		if err := i.mrouteSource.Close(); err != nil {
+			i.log.Warn("failed to close mroute source", "error", err)
+			errs = append(errs, fmt.Errorf("failed to close mroute source: %w", err))
 		}
 	}
 	if len(errs) > 0 {
@@ -350,6 +387,16 @@ func (i *Indexer) ISISSource() isis.Source {
 // ISISStore returns the ISIS ClickHouse store, or nil if not configured.
 func (i *Indexer) ISISStore() *isis.Store {
 	return i.isisStore
+}
+
+// MrouteSource returns the state-collect mroute data source, or nil if not configured.
+func (i *Indexer) MrouteSource() mroute.Source {
+	return i.mrouteSource
+}
+
+// MrouteStore returns the mroute ClickHouse store, or nil if not configured.
+func (i *Indexer) MrouteStore() *mroute.Store {
+	return i.mrouteStore
 }
 
 // Geolocation returns the geolocation view, or nil if not configured.


### PR DESCRIPTION
## Summary

- Add `lake/indexer/pkg/dz/mroute` package that parses `show ip mroute | json` snapshots written by `doublezero-telemetry --state-collect-enable` and writes them to ClickHouse as a type-2 dimension (`dim_dz_ip_mroute_entries_history` + `dz_ip_mroute_entries_current` view).
- Wire a new `SyncIPMroute` activity into the `dzingest` Temporal workflow so per-device PIM forwarding state — flags, RPF interface/neighbor, OIF list, creation time — flows into ClickHouse alongside ISIS without a separate worker.
- Mroute ingest is gated by `--mroute-enabled` / `MROUTE_ENABLED` (off by default); when enabled, the source enumerates `snapshots/ip-mroute/device=<pubkey>/` prefixes and pulls the latest snapshot per device over the previous 3 days.

## Why

This is the lake half of malbeclabs/infra#1416. doublezero/PR #3801 (already open) adds the corresponding `ip-mroute` and `ip-mroute-count` default state-collect kinds on the device side. Together they put live OIL state in ClickHouse for the multicast demo dashboard (#1428) and for any future per-(S,G) debugging.

The type-2 storage model means a steady-state cluster produces zero writes between snapshots — only OIL/RPF/flag changes per (device, vrf, mode, group, source) tuple turn into rows — so the table stays cheap to query and supports "state at time T" via the existing `GetAsOfRows` API.

## Testing Verification

- `go test ./indexer/pkg/dz/mroute/...` — parser exercises the prod-derived fixture (ME/SMP/SBNP/E/SP flag variants, missing `rpf{}` block on `Null0`, multi-element OIF, multi-source group, empty `bidirectional.groups`); source_s3 unit tests cover `snapshotsPrefix` with and without `BucketPathPrefix`, snapshot-timestamp parsing from the state-ingest filename format, and the Source interface assertions.
- `go vet ./indexer/...` clean.
- Manually walked the lake-side S3 key format against the state-ingest server (`telemetry/state-ingest/pkg/server/handler.go:302`) so the source pulls from `snapshots/ip-mroute/device=<pk>/date=YYYY-MM-DD/hour=HH/YYYYMMDDTHHMMSSZ.json` — the path the device-side PR writes.

## Notes

Closes malbeclabs/infra#1416 (paired with doublezero PR #3801, which lands the device-side state-collect kinds).

PR is ~700 lines of new non-test Go + 125 lines of migration SQL + ~120 lines of wiring, which is above the 500-line guideline; the package mirrors the ISIS one-to-one (types/parser/schema/source/store/sync split + S3 source + migration), so I kept it as a single review rather than splitting since each file is small and the shape only makes sense as a whole. Happy to split the migration out separately if the reviewer prefers.
