### PR TITLE
fix(lake): read controller calls from controller db

### DIFF
--- a/api/handlers/device_controller_calls.go
+++ b/api/handlers/device_controller_calls.go
@@ -106,7 +106,7 @@ func (a *API) GetDeviceControllerCalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sourceDB := TelemetryDatabaseForEnv(EnvFromContext(ctx))
+	sourceDB := ControllerCallsDatabaseForEnv(EnvFromContext(ctx))
 	sourceAvailable, err := controllerCallsSourceAvailable(ctx, conn, sourceDB)
 	if err != nil {
 		logError("device controller calls: source check failed", "error", err, "pk", pk, "database", sourceDB)

--- a/api/handlers/device_controller_calls_test.go
+++ b/api/handlers/device_controller_calls_test.go
@@ -79,10 +79,10 @@ func TestGetDeviceControllerCalls_NotFound(t *testing.T) {
 }
 
 func TestGetDeviceControllerCalls_SourceUnavailableReturnsNoData(t *testing.T) {
-	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["testnet"] = api.Database
 	api.EnvDBs["testnet"] = api.DB
+	dropControllerCallsTable(t, api, "testnet")
 	insertControllerCallTestDevice(t, api, "dev-controller-nodata", "TEST-CONTROLLER-NODATA")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -106,21 +106,21 @@ func TestGetDeviceControllerCalls_SourceUnavailableReturnsNoData(t *testing.T) {
 	}
 }
 
-func TestGetDeviceControllerCalls_PrefersTelemetrySourceDB(t *testing.T) {
+func TestGetDeviceControllerCalls_ReadsControllerEnvSourceDB(t *testing.T) {
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["devnet"] = api.Database
 	api.EnvDBs["devnet"] = api.DB
-	insertControllerCallTestDevice(t, api, "dev-controller-telemetry-source", "DEV-CONTROLLER-TELEMETRY")
+	insertControllerCallTestDevice(t, api, "dev-controller-env-source", "DEV-CONTROLLER-ENV")
 	resetControllerCallsTable(t, api, "telemetry_devnet")
 	resetControllerCallsTable(t, api, "devnet")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
-	insertControllerCallEvents(t, api, "telemetry_devnet", "dev-controller-telemetry-source", start.Add(10*time.Minute), start.Add(20*time.Minute))
-	insertControllerCallEvents(t, api, "devnet", "dev-controller-telemetry-source", start.Add(50*time.Minute))
+	insertControllerCallEvents(t, api, "telemetry_devnet", "dev-controller-env-source", start.Add(10*time.Minute), start.Add(20*time.Minute))
+	insertControllerCallEvents(t, api, "devnet", "dev-controller-env-source", start.Add(50*time.Minute))
 
-	url := fmt.Sprintf("/api/dz/devices/dev-controller-telemetry-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
-	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-telemetry-source")
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-env-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-env-source")
 	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvDevnet))
 	rr := httptest.NewRecorder()
 	api.GetDeviceControllerCalls(rr, req)
@@ -129,25 +129,25 @@ func TestGetDeviceControllerCalls_PrefersTelemetrySourceDB(t *testing.T) {
 	var resp handlers.DeviceControllerCallsResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	assert.True(t, resp.SourceAvailable)
-	assert.Equal(t, uint64(2), resp.TotalCalls)
+	assert.Equal(t, uint64(1), resp.TotalCalls)
 	require.NotNil(t, resp.LastCallAt)
-	assert.Equal(t, start.Add(20*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
+	assert.Equal(t, start.Add(50*time.Minute).Format(time.RFC3339), *resp.LastCallAt)
 }
 
-func TestGetDeviceControllerCalls_DoesNotFallbackToEnvSourceDB(t *testing.T) {
+func TestGetDeviceControllerCalls_DoesNotReadTelemetrySourceDB(t *testing.T) {
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["testnet"] = api.Database
 	api.EnvDBs["testnet"] = api.DB
-	insertControllerCallTestDevice(t, api, "dev-controller-env-source", "TEST-CONTROLLER-ENV")
-	dropControllerCallsTable(t, api, "telemetry_testnet")
-	resetControllerCallsTable(t, api, "testnet")
+	insertControllerCallTestDevice(t, api, "dev-controller-telemetry-source", "TEST-CONTROLLER-TELEMETRY")
+	dropControllerCallsTable(t, api, "testnet")
+	resetControllerCallsTable(t, api, "telemetry_testnet")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
-	insertControllerCallEvents(t, api, "testnet", "dev-controller-env-source", start.Add(15*time.Minute))
+	insertControllerCallEvents(t, api, "telemetry_testnet", "dev-controller-telemetry-source", start.Add(15*time.Minute))
 
-	url := fmt.Sprintf("/api/dz/devices/dev-controller-env-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
-	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-env-source")
+	url := fmt.Sprintf("/api/dz/devices/dev-controller-telemetry-source/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
+	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-telemetry-source")
 	req = req.WithContext(handlers.ContextWithEnv(req.Context(), handlers.EnvTestnet))
 	rr := httptest.NewRecorder()
 	api.GetDeviceControllerCalls(rr, req)
@@ -170,7 +170,7 @@ func TestGetDeviceControllerCalls_StoppedUnlatchesAfterHistoryWindow(t *testing.
 	api.EnvDatabases["devnet"] = api.Database
 	api.EnvDBs["devnet"] = api.DB
 	insertControllerCallTestDevice(t, api, "dev-controller-unlatch", "DEV-CONTROLLER-UNLATCH")
-	resetControllerCallsTable(t, api, "telemetry_devnet")
+	resetControllerCallsTable(t, api, "devnet")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(74 * time.Hour)
@@ -179,7 +179,7 @@ func TestGetDeviceControllerCalls_StoppedUnlatchesAfterHistoryWindow(t *testing.
 		INSERT INTO %[1]s.controller_grpc_getconfig_success
 		SELECT toDateTime64('%[2]s', 3), 'dev-controller-unlatch'
 		FROM numbers(4001)
-	`, "`telemetry_devnet`", historyTS)))
+	`, "`devnet`", historyTS)))
 
 	url := fmt.Sprintf("/api/dz/devices/dev-controller-unlatch/controller-calls?start_time=%d&end_time=%d&bucket=30m", start.Unix(), end.Unix())
 	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-unlatch")
@@ -202,11 +202,11 @@ func TestGetDeviceControllerCalls_GapUsesLastCallBeforeBucketEnd(t *testing.T) {
 	api.EnvDatabases["devnet"] = api.Database
 	api.EnvDBs["devnet"] = api.DB
 	insertControllerCallTestDevice(t, api, "dev-controller-gap", "DEV-CONTROLLER-GAP")
-	resetControllerCallsTable(t, api, "telemetry_devnet")
+	resetControllerCallsTable(t, api, "devnet")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(time.Minute)
-	insertControllerCallEvents(t, api, "telemetry_devnet", "dev-controller-gap", start.Add(-10*time.Second), start.Add(45*time.Second))
+	insertControllerCallEvents(t, api, "devnet", "dev-controller-gap", start.Add(-10*time.Second), start.Add(45*time.Second))
 
 	url := fmt.Sprintf("/api/dz/devices/dev-controller-gap/controller-calls?start_time=%d&end_time=%d&bucket=30s", start.Unix(), end.Unix())
 	req := withDevicePK(httptest.NewRequest(http.MethodGet, url, nil), "dev-controller-gap")
@@ -225,12 +225,11 @@ func TestGetDeviceControllerCalls_GapUsesLastCallBeforeBucketEnd(t *testing.T) {
 }
 
 func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {
-	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	api.EnvDatabases["mainnet-beta"] = api.Database
 	api.EnvDBs["mainnet-beta"] = api.DB
 	insertControllerCallTestDevice(t, api, "dev-controller-recovered", "NYC-CONTROLLER-01")
-	createControllerCallsTable(t, api, "telemetry_mainnet_beta")
+	resetControllerCallsTable(t, api, "mainnet-beta")
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(2 * time.Hour)
@@ -238,7 +237,7 @@ func TestGetDeviceControllerCalls_ClassifiesStoppedAndRecovered(t *testing.T) {
 	recoveredTS := start.Add(70 * time.Minute).Format("2006-01-02 15:04:05")
 	callingTS := start.Add(100 * time.Minute).Format("2006-01-02 15:04:05")
 
-	quotedDB := "`telemetry_mainnet_beta`"
+	quotedDB := "`mainnet-beta`"
 	require.NoError(t, api.DB.Exec(t.Context(), fmt.Sprintf(`
 		INSERT INTO %[1]s.controller_grpc_getconfig_success
 		SELECT toDateTime64('%[2]s', 3), 'dev-controller-recovered'

--- a/api/handlers/env.go
+++ b/api/handlers/env.go
@@ -16,6 +16,12 @@ const (
 	EnvTestnet DZEnv = "testnet"
 )
 
+// ControllerCallsDatabaseForEnv returns the ClickHouse database used by the
+// controller service for GetConfig call history.
+func ControllerCallsDatabaseForEnv(env DZEnv) string {
+	return string(env)
+}
+
 // TelemetryDatabaseForEnv returns the ClickHouse database that mirrors the
 // dz/telemetry tables for the given environment (e.g. "mainnet-beta" →
 // "telemetry_mainnet_beta"). These databases are created by the admin

--- a/scripts/verify-controller-calls.sh
+++ b/scripts/verify-controller-calls.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify the Lake controller-calls endpoint against a running local API.
+#
+# This intentionally avoids /api/sql/query because that endpoint uses the
+# restricted public query ClickHouse user, which may not have grants on the
+# controller databases (devnet/testnet/mainnet-beta). Instead it discovers
+# valid device PKs through /api/dz/devices and then calls the real product
+# endpoint with X-DZ-Env.
+#
+# Usage:
+#   bash scripts/verify-controller-calls.sh
+#   bash scripts/verify-controller-calls.sh --env testnet
+#   bash scripts/verify-controller-calls.sh --pk <device_pubkey>
+#   bash scripts/verify-controller-calls.sh --range 7d --device-limit 100
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+DZ_ENV="${DZ_ENV:-devnet}"
+RANGE="${RANGE:-24h}"
+DEVICE_LIMIT="${DEVICE_LIMIT:-50}"
+PK="${PK:-}"
+REQUIRE_CALLS="${REQUIRE_CALLS:-false}"
+
+usage() {
+  cat <<EOF
+Usage: bash scripts/verify-controller-calls.sh [options]
+
+Options:
+  --base-url URL       Lake API base URL (default: ${BASE_URL})
+  --env ENV            DZ env: devnet, testnet, mainnet-beta (default: ${DZ_ENV})
+  --range RANGE        Endpoint range, e.g. 24h, 7d (default: ${RANGE})
+  --device-limit N     Number of /api/dz/devices rows to try (default: ${DEVICE_LIMIT})
+  --pk PUBKEY          Skip discovery and use this device pubkey
+  --require-calls      Fail unless selected response has total_calls > 0
+  -h, --help           Show this help
+
+Environment overrides: BASE_URL, DZ_ENV, RANGE, DEVICE_LIMIT, PK, REQUIRE_CALLS
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      BASE_URL="$2"
+      shift 2
+      ;;
+    --env)
+      DZ_ENV="$2"
+      shift 2
+      ;;
+    --range)
+      RANGE="$2"
+      shift 2
+      ;;
+    --device-limit)
+      DEVICE_LIMIT="$2"
+      shift 2
+      ;;
+    --pk)
+      PK="$2"
+      shift 2
+      ;;
+    --require-calls)
+      REQUIRE_CALLS="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+BASE_URL="${BASE_URL%/}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need jq
+
+if ! [[ "$DEVICE_LIMIT" =~ ^[0-9]+$ ]] || [[ "$DEVICE_LIMIT" -lt 1 ]]; then
+  echo "--device-limit must be a positive integer" >&2
+  exit 2
+fi
+
+case "$DZ_ENV" in
+  devnet)
+    CONTROLLER_DB="devnet"
+    ;;
+  testnet)
+    CONTROLLER_DB="testnet"
+    ;;
+  mainnet-beta)
+    CONTROLLER_DB="mainnet-beta"
+    ;;
+  *)
+    echo "Unsupported env: $DZ_ENV" >&2
+    echo "Expected one of: devnet, testnet, mainnet-beta" >&2
+    exit 2
+    ;;
+esac
+
+assert_json() {
+  local file="$1"
+  if ! jq -e . "$file" >/dev/null 2>&1; then
+    echo "Response was not JSON:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+get_with_env() {
+  local url="$1"
+  local out_file="$2"
+  curl -sS -o "$out_file" -w "%{http_code}" \
+    -H "X-DZ-Env: $DZ_ENV" \
+    "$url"
+}
+
+call_controller_calls() {
+  local pk="$1"
+  local out_file="$2"
+  local encoded_pk
+  encoded_pk=$(jq -rn --arg v "$pk" '$v|@uri')
+  get_with_env "$BASE_URL/api/dz/devices/$encoded_pk/controller-calls?range=$RANGE" "$out_file"
+}
+
+cleanup_files=()
+cleanup() {
+  if [[ ${#cleanup_files[@]} -gt 0 ]]; then
+    rm -f "${cleanup_files[@]}"
+  fi
+}
+trap cleanup EXIT
+
+mktemp_tracked() {
+  local tmp
+  tmp=$(mktemp)
+  cleanup_files+=("$tmp")
+  printf '%s' "$tmp"
+}
+
+echo "Lake API:       $BASE_URL"
+echo "Environment:    $DZ_ENV"
+echo "Controller DB:  $CONTROLLER_DB"
+echo "Endpoint range: $RANGE"
+
+response_file=$(mktemp_tracked)
+selected_pk=""
+selected_code=""
+selected_status=""
+selected_calls="0"
+
+if [[ -n "$PK" ]]; then
+  echo "Using provided PK: $PK"
+  http_code=$(call_controller_calls "$PK" "$response_file")
+  if [[ ! "$http_code" =~ ^2 ]]; then
+    echo "Controller-calls endpoint failed with HTTP $http_code:" >&2
+    cat "$response_file" >&2
+    echo >&2
+    exit 1
+  fi
+  assert_json "$response_file"
+  selected_pk="$PK"
+else
+  echo "Discovering devices from /api/dz/devices?limit=$DEVICE_LIMIT ..."
+  devices_file=$(mktemp_tracked)
+  http_code=$(get_with_env "$BASE_URL/api/dz/devices?limit=$DEVICE_LIMIT" "$devices_file")
+  if [[ ! "$http_code" =~ ^2 ]]; then
+    echo "Device discovery failed with HTTP $http_code:" >&2
+    cat "$devices_file" >&2
+    exit 1
+  fi
+  assert_json "$devices_file"
+
+  count=$(jq '.items | length' "$devices_file")
+  if [[ "$count" -eq 0 ]]; then
+    echo "No devices returned by /api/dz/devices for env $DZ_ENV" >&2
+    exit 1
+  fi
+
+  echo "Trying up to $count device(s); preferring one with total_calls > 0 ..."
+
+  candidate_file=$(mktemp_tracked)
+  while IFS=$'\t' read -r candidate_pk candidate_code candidate_status; do
+    [[ -z "$candidate_pk" ]] && continue
+
+    http_code=$(call_controller_calls "$candidate_pk" "$candidate_file")
+    if [[ ! "$http_code" =~ ^2 ]]; then
+      echo "  skip $candidate_code ($candidate_pk): HTTP $http_code"
+      continue
+    fi
+    if ! jq -e . "$candidate_file" >/dev/null 2>&1; then
+      echo "  skip $candidate_code ($candidate_pk): non-JSON response"
+      continue
+    fi
+
+    source_available=$(jq -r '.source_available' "$candidate_file")
+    total_calls=$(jq -r '.total_calls // 0' "$candidate_file")
+    last_status=$(jq -r '.last_status // ""' "$candidate_file")
+    echo "  $candidate_code ($candidate_pk): source_available=$source_available total_calls=$total_calls last_status=$last_status"
+
+    if [[ "$source_available" == "true" ]]; then
+      if [[ -z "$selected_pk" || "$total_calls" -gt 0 ]]; then
+        cp "$candidate_file" "$response_file"
+        selected_pk="$candidate_pk"
+        selected_code="$candidate_code"
+        selected_status="$candidate_status"
+        selected_calls="$total_calls"
+      fi
+      if [[ "$total_calls" -gt 0 ]]; then
+        break
+      fi
+    fi
+  done < <(jq -r '.items[] | [.pk, .code, .status] | @tsv' "$devices_file")
+
+  if [[ -z "$selected_pk" ]]; then
+    echo >&2
+    echo "FAIL: none of the discovered devices returned source_available=true." >&2
+    echo "If ${CONTROLLER_DB}.controller_grpc_getconfig_success exists, make sure:" >&2
+    echo "  1. the API was rebuilt/restarted after the ControllerCallsDatabaseForEnv change" >&2
+    echo "  2. the API ClickHouse user has SHOW TABLES and SELECT on ${CONTROLLER_DB}.controller_grpc_getconfig_success" >&2
+    exit 1
+  fi
+
+  echo "Selected PK:     $selected_pk"
+  [[ -n "$selected_code" ]] && echo "Device code:     $selected_code"
+  [[ -n "$selected_status" ]] && echo "Device status:   $selected_status"
+fi
+
+assert_json "$response_file"
+
+echo
+echo "Controller-calls response summary:"
+jq '{
+  device_pk,
+  device_code,
+  device_status,
+  source_available,
+  total_calls,
+  minutes_with_calls,
+  last_call_at,
+  current_gap_seconds,
+  last_status,
+  from,
+  to,
+  bucket_count
+}' "$response_file"
+
+source_available=$(jq -r '.source_available' "$response_file")
+total_calls=$(jq -r '.total_calls // 0' "$response_file")
+if [[ "$source_available" != "true" ]]; then
+  echo >&2
+  echo "FAIL: source_available is false." >&2
+  echo "If the table exists in ${CONTROLLER_DB}.controller_grpc_getconfig_success," >&2
+  echo "make sure the API was rebuilt/restarted with ControllerCallsDatabaseForEnv()." >&2
+  exit 1
+fi
+
+if [[ "$REQUIRE_CALLS" == "true" && "$total_calls" -le 0 ]]; then
+  echo >&2
+  echo "FAIL: source is available but total_calls is 0 for the selected device/range." >&2
+  echo "Try a larger device sample or wider range, for example:" >&2
+  echo "  bash scripts/verify-controller-calls.sh --env $DZ_ENV --range 7d --device-limit 200 --require-calls" >&2
+  exit 1
+fi
+
+echo
+if [[ "$total_calls" -gt 0 ]]; then
+  echo "OK: source_available=true and total_calls=$total_calls"
+else
+  echo "OK: source_available=true (selected device has total_calls=0 for range=$RANGE)"
+fi


### PR DESCRIPTION
# Summary

Fixes the controller-call status timeline by reading `controller_grpc_getconfig_success` from the controller-owned environment databases (`devnet`, `testnet`, `mainnet-beta`) instead of the telemetry databases.

The original #608 implementation looked under `telemetry_<env>`, but the deployed controller writes this table to the environment DBs. That made the API report `source_available=false` even though controller-call data existed.

## Changes

- Add `ControllerCallsDatabaseForEnv` for the controller-call source mapping.
- Update `/api/dz/devices/{pk}/controller-calls` to query:
  - `devnet.controller_grpc_getconfig_success`
  - `testnet.controller_grpc_getconfig_success`
  - `mainnet-beta.controller_grpc_getconfig_success`
- Keep the existing telemetry DB mapping unchanged for telemetry/gNMI data.
- Update handler tests to verify controller-call data comes from the controller
  env DBs and not `telemetry_<env>`.
- Add `scripts/verify-controller-calls.sh` to smoke-test the real product
  endpoint without relying on `/api/sql/query`.

## Verification

- Confirmed ClickHouse Cloud has the source table in `devnet`, `testnet`, and
  `mainnet-beta`, not in `telemetry_<env>`.
- Local smoke test against devnet returned real data:
  - `source_available=true`
  - `total_calls=13809`
  - `last_status=calling`
  - device: `chi-dn-dzd4`
- Passed:

```bash
go test ./api/handlers -run TestGetDeviceControllerCalls -count=1
make lint
git diff --check
```
