### PR TITLE
indexer: ingest msdp state-collect snapshots into clickhouse

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -726,6 +726,7 @@ func run() error {
 		dzLedgerRPCURL string
 		noInflux       bool
 		mrouteS3Bucket string // empty = mroute ingest disabled for this env
+		msdpS3Bucket   string // empty = MSDP ingest disabled for this env
 	}
 	secondaryEnvs := map[string]secondaryEnvConfig{
 		"devnet":  {database: "lake_devnet"},
@@ -761,9 +762,10 @@ func run() error {
 		cfg.noInflux = true
 		secondaryEnvs["testnet"] = cfg
 	}
-	// Mroute ingest is per-env; the bucket the state-ingest server writes to
-	// differs between devnet/testnet/mainnet. Setting the env-specific bucket
-	// enables mroute ingest for that secondary network.
+	// Mroute / MSDP ingest are per-env; setting the env-specific bucket
+	// enables the relevant ingest for that secondary network. Region and
+	// key-prefix reuse the global --{mroute,msdp}-s3-{region,key-prefix}
+	// flags.
 	if b := os.Getenv("MROUTE_S3_BUCKET_DEVNET"); b != "" {
 		cfg := secondaryEnvs["devnet"]
 		cfg.mrouteS3Bucket = b
@@ -772,6 +774,16 @@ func run() error {
 	if b := os.Getenv("MROUTE_S3_BUCKET_TESTNET"); b != "" {
 		cfg := secondaryEnvs["testnet"]
 		cfg.mrouteS3Bucket = b
+		secondaryEnvs["testnet"] = cfg
+	}
+	if b := os.Getenv("MSDP_S3_BUCKET_DEVNET"); b != "" {
+		cfg := secondaryEnvs["devnet"]
+		cfg.msdpS3Bucket = b
+		secondaryEnvs["devnet"] = cfg
+	}
+	if b := os.Getenv("MSDP_S3_BUCKET_TESTNET"); b != "" {
+		cfg := secondaryEnvs["testnet"]
+		cfg.msdpS3Bucket = b
 		secondaryEnvs["testnet"] = cfg
 	}
 	if *noDevnetFlag {
@@ -810,6 +822,9 @@ func run() error {
 				mrouteS3Bucket:             envCfg.mrouteS3Bucket,
 				mrouteS3Region:             *mrouteS3RegionFlag,
 				mrouteS3KeyPrefix:          *mrouteS3KeyPrefixFlag,
+				msdpS3Bucket:               envCfg.msdpS3Bucket,
+				msdpS3Region:               *msdpS3RegionFlag,
+				msdpS3KeyPrefix:            *msdpS3KeyPrefixFlag,
 				influxURL:                  secondaryInfluxURL,
 				influxToken:                secondaryInfluxToken,
 				influxOrg:                  influxOrg,
@@ -892,6 +907,12 @@ type secondaryNetworkConfig struct {
 	mrouteS3Bucket    string
 	mrouteS3Region    string
 	mrouteS3KeyPrefix string
+
+	// MSDP (state-collect) configuration (optional, per-env).
+	// msdpS3Bucket="" means MSDP ingest is disabled for this network.
+	msdpS3Bucket    string
+	msdpS3Region    string
+	msdpS3KeyPrefix string
 
 	// InfluxDB configuration (optional).
 	influxURL                  string
@@ -1014,6 +1035,13 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		MrouteS3Bucket:    cfg.mrouteS3Bucket,
 		MrouteS3Region:    cfg.mrouteS3Region,
 		MrouteS3KeyPrefix: cfg.mrouteS3KeyPrefix,
+
+		// MSDP (state-collect) configuration. Enabled iff a per-env
+		// bucket was provided via MSDP_S3_BUCKET_<ENV>.
+		MSDPEnabled:     cfg.msdpS3Bucket != "",
+		MSDPS3Bucket:    cfg.msdpS3Bucket,
+		MSDPS3Region:    cfg.msdpS3Region,
+		MSDPS3KeyPrefix: cfg.msdpS3KeyPrefix,
 	}
 	if shredsClient != nil {
 		secondaryIdxCfg.ShredsRPC = shredsClient

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -686,6 +686,8 @@ func run() error {
 				ISISStore:      idx.ISISStore(),
 				MrouteSource:   idx.MrouteSource(),
 				MrouteStore:    idx.MrouteStore(),
+				MSDPSource:     idx.MSDPSource(),
+				MSDPStore:      idx.MSDPStore(),
 			})
 			if err != nil {
 				dzIngestErrCh <- err
@@ -1085,6 +1087,8 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		ISISStore:      idx.ISISStore(),
 		MrouteSource:   idx.MrouteSource(),
 		MrouteStore:    idx.MrouteStore(),
+		MSDPSource:     idx.MSDPSource(),
+		MSDPStore:      idx.MSDPStore(),
 	})
 
 	select {

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -122,6 +122,12 @@ func run() error {
 	mrouteS3RegionFlag := flag.String("mroute-s3-region", "us-east-1", "AWS region for mroute S3 bucket (or set MROUTE_S3_REGION env var)")
 	mrouteS3KeyPrefixFlag := flag.String("mroute-s3-key-prefix", "", "Optional key prefix matching state-ingest BucketPathPrefix (or set MROUTE_S3_KEY_PREFIX env var)")
 
+	// MSDP (state-collect) configuration
+	msdpEnabledFlag := flag.Bool("msdp-enabled", false, "Enable MSDP state-collect sync from S3 (or set MSDP_ENABLED env var)")
+	msdpS3BucketFlag := flag.String("msdp-s3-bucket", "", "S3 bucket the state-ingest server writes to (or set MSDP_S3_BUCKET env var)")
+	msdpS3RegionFlag := flag.String("msdp-s3-region", "us-east-1", "AWS region for MSDP S3 bucket (or set MSDP_S3_REGION env var)")
+	msdpS3KeyPrefixFlag := flag.String("msdp-s3-key-prefix", "", "Optional key prefix matching state-ingest BucketPathPrefix (or set MSDP_S3_KEY_PREFIX env var)")
+
 	// validators.app configuration
 	validatorsAppAPIKeyFlag := flag.String("validatorsapp-api-key", "", "validators.app API key (or set VALIDATORSAPP_API_KEY env var)")
 	validatorsAppRefreshIntervalFlag := flag.Duration("validatorsapp-refresh-interval", 5*time.Minute, "validators.app refresh interval (or set VALIDATORSAPP_REFRESH_INTERVAL env var)")
@@ -212,6 +218,20 @@ func run() error {
 	}
 	if envMroutePrefix := os.Getenv("MROUTE_S3_KEY_PREFIX"); envMroutePrefix != "" {
 		*mrouteS3KeyPrefixFlag = envMroutePrefix
+	}
+
+	// Override MSDP flags with environment variables if set
+	if envMSDPEnabled := os.Getenv("MSDP_ENABLED"); envMSDPEnabled != "" {
+		*msdpEnabledFlag = envMSDPEnabled == "true"
+	}
+	if envMSDPBucket := os.Getenv("MSDP_S3_BUCKET"); envMSDPBucket != "" {
+		*msdpS3BucketFlag = envMSDPBucket
+	}
+	if envMSDPRegion := os.Getenv("MSDP_S3_REGION"); envMSDPRegion != "" {
+		*msdpS3RegionFlag = envMSDPRegion
+	}
+	if envMSDPPrefix := os.Getenv("MSDP_S3_KEY_PREFIX"); envMSDPPrefix != "" {
+		*msdpS3KeyPrefixFlag = envMSDPPrefix
 	}
 
 	// Override validators.app flags with environment variables
@@ -591,6 +611,12 @@ func run() error {
 		MrouteS3Bucket:    *mrouteS3BucketFlag,
 		MrouteS3Region:    *mrouteS3RegionFlag,
 		MrouteS3KeyPrefix: *mrouteS3KeyPrefixFlag,
+
+		// MSDP (state-collect) configuration
+		MSDPEnabled:     *msdpEnabledFlag,
+		MSDPS3Bucket:    *msdpS3BucketFlag,
+		MSDPS3Region:    *msdpS3RegionFlag,
+		MSDPS3KeyPrefix: *msdpS3KeyPrefixFlag,
 
 		// validators.app configuration
 		ValidatorsAppClient:          validatorsAppClient,

--- a/indexer/db/clickhouse/migrations/20260601000001_dz_ip_msdp_tables.sql
+++ b/indexer/db/clickhouse/migrations/20260601000001_dz_ip_msdp_tables.sql
@@ -1,0 +1,249 @@
+-- +goose Up
+
+-- ============================================================================
+-- MSDP state from doublezero-telemetry --state-collect-enable.
+-- Three independent dimensions, one per `show ip msdp ...` command kind:
+--   - dz_ip_msdp_peers           ← `show ip msdp summary`
+--   - dz_ip_msdp_pim_sa_cache    ← `show ip msdp pim sa-cache`
+--   - dz_ip_msdp_sa_cache        ← `show ip msdp sa-cache rejected`
+--                                  (single command returns both accepted
+--                                  and rejected SAs; status column
+--                                  distinguishes them.)
+-- ============================================================================
+
+-- ------------------------------------------------------------------------
+-- dz_ip_msdp_peers  ← `show ip msdp summary`
+-- ------------------------------------------------------------------------
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dim_dz_ip_msdp_peers_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    peer_address String,
+    state String,
+    session_start_time DateTime64(3),
+    sa_count Int64,
+    reset_count Int64
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_ip_msdp_peers_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    peer_address String,
+    state String,
+    session_start_time DateTime64(3),
+    sa_count Int64,
+    reset_count Int64
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dz_ip_msdp_peers_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_ip_msdp_peers_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    device_pubkey,
+    peer_address,
+    state,
+    session_start_time,
+    sa_count,
+    reset_count
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- ------------------------------------------------------------------------
+-- dz_ip_msdp_pim_sa_cache  ← `show ip msdp pim sa-cache`
+-- ------------------------------------------------------------------------
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dim_dz_ip_msdp_pim_sa_cache_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    group_address String,
+    source_address String,
+    rp_address String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_ip_msdp_pim_sa_cache_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    group_address String,
+    source_address String,
+    rp_address String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dz_ip_msdp_pim_sa_cache_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_ip_msdp_pim_sa_cache_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    device_pubkey,
+    group_address,
+    source_address,
+    rp_address
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- ------------------------------------------------------------------------
+-- dz_ip_msdp_sa_cache  ← `show ip msdp sa-cache rejected`
+-- Combined accepted + rejected SAs distinguished by the `status` column.
+-- ------------------------------------------------------------------------
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dim_dz_ip_msdp_sa_cache_history
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    group_address String,
+    source_address String,
+    remote_address String,
+    status String,
+    rp_address String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_ip_msdp_sa_cache_snapshot
+(
+    entity_id String,
+    snapshot_ts DateTime64(3),
+    ingested_at DateTime64(3),
+    op_id UUID,
+    is_deleted UInt8 DEFAULT 0,
+    attrs_hash UInt64,
+    device_pubkey String,
+    group_address String,
+    source_address String,
+    remote_address String,
+    status String,
+    rp_address String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dz_ip_msdp_sa_cache_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_ip_msdp_sa_cache_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    device_pubkey,
+    group_address,
+    source_address,
+    remote_address,
+    status,
+    rp_address
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS dz_ip_msdp_sa_cache_current;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_ip_msdp_sa_cache_snapshot;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_dz_ip_msdp_sa_cache_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS dz_ip_msdp_pim_sa_cache_current;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_ip_msdp_pim_sa_cache_snapshot;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_dz_ip_msdp_pim_sa_cache_history;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS dz_ip_msdp_peers_current;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS stg_dim_dz_ip_msdp_peers_snapshot;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dim_dz_ip_msdp_peers_history;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/msdp/main_test.go
+++ b/indexer/pkg/dz/msdp/main_test.go
@@ -1,0 +1,28 @@
+package msdp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+// sharedDB is a single ClickHouse testcontainer reused across every test
+// in this package. Per-test isolation is achieved by laketesting.NewClient
+// creating a fresh randomly-named database and running migrations into it.
+var sharedDB *clickhousetesting.DB
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("msdp: failed to start ClickHouse testcontainer", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}

--- a/indexer/pkg/dz/msdp/migration_test.go
+++ b/indexer/pkg/dz/msdp/migration_test.go
@@ -1,0 +1,57 @@
+package msdp
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration_Applies proves the MSDP migration SQL is valid for the
+// ClickHouse version lake uses and that every artifact the store/sync
+// path touches has materialized.
+func TestMigration_Applies(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cases := []struct {
+		name string
+		kind string // "table" or "view"
+	}{
+		// Peers
+		{"dim_dz_ip_msdp_peers_history", "table"},
+		{"stg_dim_dz_ip_msdp_peers_snapshot", "table"},
+		{"dz_ip_msdp_peers_current", "view"},
+		// PIM SA cache
+		{"dim_dz_ip_msdp_pim_sa_cache_history", "table"},
+		{"stg_dim_dz_ip_msdp_pim_sa_cache_snapshot", "table"},
+		{"dz_ip_msdp_pim_sa_cache_current", "view"},
+		// SA cache (accepted + rejected combined)
+		{"dim_dz_ip_msdp_sa_cache_history", "table"},
+		{"stg_dim_dz_ip_msdp_sa_cache_snapshot", "table"},
+		{"dz_ip_msdp_sa_cache_current", "view"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rows, err := conn.Query(t.Context(), `
+				SELECT engine FROM system.tables
+				WHERE database = currentDatabase() AND name = ?
+			`, c.name)
+			require.NoError(t, err)
+			defer rows.Close()
+
+			require.True(t, rows.Next(), "%s did not materialize", c.name)
+			var got string
+			require.NoError(t, rows.Scan(&got))
+			if c.kind == "view" {
+				assert.Equal(t, "View", got, "%s should be a view, got engine %q", c.name, got)
+			} else {
+				assert.Equal(t, "MergeTree", got, "%s should be MergeTree, got engine %q", c.name, got)
+			}
+		})
+	}
+}

--- a/indexer/pkg/dz/msdp/parser.go
+++ b/indexer/pkg/dz/msdp/parser.go
@@ -1,0 +1,115 @@
+package msdp
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+)
+
+// ParseSummary parses `show ip msdp summary | json`. DevicePubkey on the
+// returned Peers is left zero — the caller (Sync) fills it from the
+// Dump's DevicePubkey.
+func ParseSummary(raw []byte) ([]Peer, error) {
+	var d struct {
+		PeerList []struct {
+			PeerIPAddress    string  `json:"peerIpAddress"`
+			State            string  `json:"state"`
+			SessionStartTime float64 `json:"sessionStartTime"`
+			SACount          int64   `json:"saCount"`
+			ResetCount       int64   `json:"resetCount"`
+		} `json:"peerList"`
+	}
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("msdp: parse summary: %w", err)
+	}
+	out := make([]Peer, 0, len(d.PeerList))
+	for _, p := range d.PeerList {
+		out = append(out, Peer{
+			PeerIPAddress:    p.PeerIPAddress,
+			State:            p.State,
+			SessionStartTime: fractionalToTime(p.SessionStartTime),
+			SACount:          p.SACount,
+			ResetCount:       p.ResetCount,
+		})
+	}
+	return out, nil
+}
+
+// ParsePimSACache parses `show ip msdp pim sa-cache | json`. Returns the
+// local PIM SA cache being advertised over MSDP.
+func ParsePimSACache(raw []byte) ([]PimSACacheEntry, error) {
+	var d struct {
+		SACache []struct {
+			SourceGroupPair struct {
+				SourceAddress string `json:"sourceAddress"`
+				GroupAddress  string `json:"groupAddress"`
+			} `json:"sourceGroupPair"`
+			RPAddress string `json:"rpAddress"`
+		} `json:"saCache"`
+	}
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("msdp: parse pim sa-cache: %w", err)
+	}
+	out := make([]PimSACacheEntry, 0, len(d.SACache))
+	for _, e := range d.SACache {
+		out = append(out, PimSACacheEntry{
+			SourceAddress: e.SourceGroupPair.SourceAddress,
+			GroupAddress:  e.SourceGroupPair.GroupAddress,
+			RPAddress:     e.RPAddress,
+		})
+	}
+	return out, nil
+}
+
+// ParseSACacheRejected parses `show ip msdp sa-cache rejected | json`.
+// Returns one slice combining both the `acceptedSaMsg` (Status="accepted")
+// and `rejectedSaMsg` (Status="rejected") arrays from the response.
+func ParseSACacheRejected(raw []byte) ([]SACacheEntry, error) {
+	type saMsg struct {
+		SourceGroupPair struct {
+			SourceAddress string `json:"sourceAddress"`
+			GroupAddress  string `json:"groupAddress"`
+		} `json:"sourceGroupPair"`
+		RPAddress     string `json:"rpAddress"`
+		RemoteAddress string `json:"remoteAddress"`
+	}
+	var d struct {
+		AcceptedSaMsg []saMsg `json:"acceptedSaMsg"`
+		RejectedSaMsg []saMsg `json:"rejectedSaMsg"`
+	}
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("msdp: parse sa-cache rejected: %w", err)
+	}
+	out := make([]SACacheEntry, 0, len(d.AcceptedSaMsg)+len(d.RejectedSaMsg))
+	for _, e := range d.AcceptedSaMsg {
+		out = append(out, SACacheEntry{
+			SourceAddress: e.SourceGroupPair.SourceAddress,
+			GroupAddress:  e.SourceGroupPair.GroupAddress,
+			RemoteAddress: e.RemoteAddress,
+			RPAddress:     e.RPAddress,
+			Status:        SACacheStatusAccepted,
+		})
+	}
+	for _, e := range d.RejectedSaMsg {
+		out = append(out, SACacheEntry{
+			SourceAddress: e.SourceGroupPair.SourceAddress,
+			GroupAddress:  e.SourceGroupPair.GroupAddress,
+			RemoteAddress: e.RemoteAddress,
+			RPAddress:     e.RPAddress,
+			Status:        SACacheStatusRejected,
+		})
+	}
+	return out, nil
+}
+
+// fractionalToTime converts a `sessionStartTime` value (seconds since
+// epoch as a float64) to time.Time at nanosecond resolution. Returns
+// the zero time when the value is missing or non-finite.
+func fractionalToTime(secs float64) time.Time {
+	if secs == 0 || math.IsNaN(secs) || math.IsInf(secs, 0) {
+		return time.Time{}
+	}
+	whole, frac := math.Modf(secs)
+	return time.Unix(int64(whole), int64(math.Round(frac*1e9))).UTC()
+}

--- a/indexer/pkg/dz/msdp/parser_test.go
+++ b/indexer/pkg/dz/msdp/parser_test.go
@@ -1,0 +1,179 @@
+package msdp
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Fixture excerpted from a mainnet-beta `show ip msdp summary | json`
+// dump. Includes one "connecting" peer with no sessionStartTime — the
+// real case the parser must handle without producing garbage.
+const summaryFixture = `{
+  "peerList": [
+    {
+      "peerIpAddress": "172.16.0.244",
+      "state": "established",
+      "sessionStartTime": 1779369727.1818933,
+      "saCount": 6,
+      "resetCount": 7
+    },
+    {
+      "peerIpAddress": "172.16.1.176",
+      "state": "connecting",
+      "saCount": 0,
+      "resetCount": 0
+    },
+    {
+      "peerIpAddress": "172.16.0.81",
+      "state": "established",
+      "sessionStartTime": 1758515130.1377997,
+      "saCount": 3,
+      "resetCount": 1
+    }
+  ]
+}`
+
+const pimSACacheFixture = `{
+  "saCache": [
+    {
+      "sourceGroupPair": {
+        "sourceAddress": "148.51.120.84",
+        "groupAddress": "233.84.178.1"
+      },
+      "rpAddress": "10.0.0.0"
+    },
+    {
+      "sourceGroupPair": {
+        "sourceAddress": "148.51.121.150",
+        "groupAddress": "233.84.178.1"
+      },
+      "rpAddress": "10.0.0.0"
+    }
+  ]
+}`
+
+const saCacheRejectedFixture = `{
+  "acceptedSaMsg": [
+    {
+      "sourceGroupPair": {
+        "sourceAddress": "148.51.120.16",
+        "groupAddress": "233.84.178.1"
+      },
+      "rpAddress": "10.0.0.0",
+      "remoteAddress": "172.16.1.6"
+    },
+    {
+      "sourceGroupPair": {
+        "sourceAddress": "148.51.122.86",
+        "groupAddress": "233.84.178.1"
+      },
+      "rpAddress": "10.0.0.0",
+      "remoteAddress": "172.16.0.244"
+    }
+  ],
+  "rejectedSaMsg": [
+    {
+      "sourceGroupPair": {
+        "sourceAddress": "10.99.99.99",
+        "groupAddress": "239.0.0.1"
+      },
+      "rpAddress": "10.0.0.0",
+      "remoteAddress": "172.16.0.244"
+    }
+  ]
+}`
+
+func TestParseSummary(t *testing.T) {
+	peers, err := ParseSummary([]byte(summaryFixture))
+	require.NoError(t, err)
+	require.Len(t, peers, 3)
+
+	byPeer := map[string]Peer{}
+	for _, p := range peers {
+		byPeer[p.PeerIPAddress] = p
+	}
+
+	t.Run("established peer has sessionStartTime", func(t *testing.T) {
+		p, ok := byPeer["172.16.0.244"]
+		require.True(t, ok)
+		assert.Equal(t, "established", p.State)
+		assert.False(t, p.SessionStartTime.IsZero())
+		assert.Equal(t, int64(6), p.SACount)
+		assert.Equal(t, int64(7), p.ResetCount)
+	})
+
+	t.Run("connecting peer has zero sessionStartTime", func(t *testing.T) {
+		p, ok := byPeer["172.16.1.176"]
+		require.True(t, ok)
+		assert.Equal(t, "connecting", p.State)
+		assert.True(t, p.SessionStartTime.IsZero(), "missing sessionStartTime must parse as zero, not garbage")
+		assert.Equal(t, int64(0), p.SACount)
+	})
+}
+
+func TestParsePimSACache(t *testing.T) {
+	entries, err := ParsePimSACache([]byte(pimSACacheFixture))
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	var sources []string
+	for _, e := range entries {
+		sources = append(sources, e.SourceAddress)
+		assert.Equal(t, "233.84.178.1", e.GroupAddress)
+		assert.Equal(t, "10.0.0.0", e.RPAddress)
+	}
+	sort.Strings(sources)
+	assert.Equal(t, []string{"148.51.120.84", "148.51.121.150"}, sources)
+}
+
+func TestParseSACacheRejected(t *testing.T) {
+	entries, err := ParseSACacheRejected([]byte(saCacheRejectedFixture))
+	require.NoError(t, err)
+	require.Len(t, entries, 3, "should combine acceptedSaMsg + rejectedSaMsg into one slice")
+
+	var accepted, rejected int
+	for _, e := range entries {
+		switch e.Status {
+		case SACacheStatusAccepted:
+			accepted++
+		case SACacheStatusRejected:
+			rejected++
+			assert.Equal(t, "10.99.99.99", e.SourceAddress)
+			assert.Equal(t, "239.0.0.1", e.GroupAddress)
+		default:
+			t.Errorf("unexpected status %q", e.Status)
+		}
+	}
+	assert.Equal(t, 2, accepted)
+	assert.Equal(t, 1, rejected)
+}
+
+func TestParse_Empty(t *testing.T) {
+	t.Run("summary empty peerList", func(t *testing.T) {
+		peers, err := ParseSummary([]byte(`{"peerList":[]}`))
+		require.NoError(t, err)
+		assert.Empty(t, peers)
+	})
+	t.Run("pim sa-cache empty", func(t *testing.T) {
+		entries, err := ParsePimSACache([]byte(`{"saCache":[]}`))
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+	t.Run("sa-cache rejected both empty", func(t *testing.T) {
+		entries, err := ParseSACacheRejected([]byte(`{"acceptedSaMsg":[],"rejectedSaMsg":[]}`))
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+}
+
+func TestParse_InvalidJSON(t *testing.T) {
+	_, err := ParseSummary([]byte("not json"))
+	assert.Error(t, err)
+	_, err = ParsePimSACache([]byte("not json"))
+	assert.Error(t, err)
+	_, err = ParseSACacheRejected([]byte("not json"))
+	assert.Error(t, err)
+}

--- a/indexer/pkg/dz/msdp/schema.go
+++ b/indexer/pkg/dz/msdp/schema.go
@@ -1,0 +1,209 @@
+package msdp
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// ------------------------------------------------------------------
+// Peer (`show ip msdp summary`) — one row per MSDP peer
+// ------------------------------------------------------------------
+
+// PeerRow is the ClickHouse-shaped representation of a Peer.
+type PeerRow struct {
+	DevicePubkey     string
+	PeerIPAddress    string
+	State            string
+	SessionStartTime time.Time
+	SACount          int64
+	ResetCount       int64
+}
+
+// PeerToRow flattens a Peer into a PeerRow for the given device.
+func PeerToRow(devicePubkey string, p Peer) PeerRow {
+	return PeerRow{
+		DevicePubkey:     devicePubkey,
+		PeerIPAddress:    p.PeerIPAddress,
+		State:            p.State,
+		SessionStartTime: p.SessionStartTime,
+		SACount:          p.SACount,
+		ResetCount:       p.ResetCount,
+	}
+}
+
+// PeerSchema defines the dimension schema for MSDP peers.
+type PeerSchema struct{}
+
+func (s *PeerSchema) Name() string { return "dz_ip_msdp_peers" }
+
+func (s *PeerSchema) PrimaryKeyColumns() []string {
+	return []string{
+		"device_pubkey:VARCHAR",
+		"peer_address:VARCHAR",
+	}
+}
+
+func (s *PeerSchema) PayloadColumns() []string {
+	return []string{
+		"state:VARCHAR",
+		"session_start_time:DATETIME",
+		"sa_count:BIGINT",
+		"reset_count:BIGINT",
+	}
+}
+
+func (s *PeerSchema) ToRow(r PeerRow) []any {
+	return []any{
+		r.DevicePubkey,
+		r.PeerIPAddress,
+		r.State,
+		r.SessionStartTime,
+		r.SACount,
+		r.ResetCount,
+	}
+}
+
+func (s *PeerSchema) GetPrimaryKey(r PeerRow) string {
+	return r.DevicePubkey + "/" + r.PeerIPAddress
+}
+
+var peerSchema = &PeerSchema{}
+
+// NewPeerDataset creates a Type-2 dimension dataset for MSDP peers.
+func NewPeerDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, peerSchema)
+}
+
+// ------------------------------------------------------------------
+// PimSACacheEntry (`show ip msdp pim sa-cache`)
+// ------------------------------------------------------------------
+
+// PimSACacheRow is the ClickHouse-shaped representation of a PimSACacheEntry.
+type PimSACacheRow struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RPAddress     string
+}
+
+// PimSACacheToRow flattens a PimSACacheEntry into a PimSACacheRow.
+func PimSACacheToRow(devicePubkey string, e PimSACacheEntry) PimSACacheRow {
+	return PimSACacheRow{
+		DevicePubkey:  devicePubkey,
+		GroupAddress:  e.GroupAddress,
+		SourceAddress: e.SourceAddress,
+		RPAddress:     e.RPAddress,
+	}
+}
+
+// PimSACacheSchema defines the dimension schema for the local PIM SA cache.
+type PimSACacheSchema struct{}
+
+func (s *PimSACacheSchema) Name() string { return "dz_ip_msdp_pim_sa_cache" }
+
+func (s *PimSACacheSchema) PrimaryKeyColumns() []string {
+	return []string{
+		"device_pubkey:VARCHAR",
+		"group_address:VARCHAR",
+		"source_address:VARCHAR",
+	}
+}
+
+func (s *PimSACacheSchema) PayloadColumns() []string {
+	return []string{
+		"rp_address:VARCHAR",
+	}
+}
+
+func (s *PimSACacheSchema) ToRow(r PimSACacheRow) []any {
+	return []any{
+		r.DevicePubkey,
+		r.GroupAddress,
+		r.SourceAddress,
+		r.RPAddress,
+	}
+}
+
+func (s *PimSACacheSchema) GetPrimaryKey(r PimSACacheRow) string {
+	return r.DevicePubkey + "/" + r.GroupAddress + "/" + r.SourceAddress
+}
+
+var pimSACacheSchema = &PimSACacheSchema{}
+
+// NewPimSACacheDataset creates a Type-2 dimension dataset for the local
+// PIM SA cache entries.
+func NewPimSACacheDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, pimSACacheSchema)
+}
+
+// ------------------------------------------------------------------
+// SACacheEntry (`show ip msdp sa-cache rejected`) — combined accepted +
+// rejected SAs, distinguished by the status column in the PK.
+// ------------------------------------------------------------------
+
+// SACacheRow is the ClickHouse-shaped representation of a SACacheEntry.
+type SACacheRow struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RemoteAddress string
+	Status        string // 'accepted' | 'rejected'
+	RPAddress     string
+}
+
+// SACacheToRow flattens a SACacheEntry into a SACacheRow.
+func SACacheToRow(devicePubkey string, e SACacheEntry) SACacheRow {
+	return SACacheRow{
+		DevicePubkey:  devicePubkey,
+		GroupAddress:  e.GroupAddress,
+		SourceAddress: e.SourceAddress,
+		RemoteAddress: e.RemoteAddress,
+		Status:        string(e.Status),
+		RPAddress:     e.RPAddress,
+	}
+}
+
+// SACacheSchema defines the dimension schema for MSDP SA-cache entries.
+type SACacheSchema struct{}
+
+func (s *SACacheSchema) Name() string { return "dz_ip_msdp_sa_cache" }
+
+func (s *SACacheSchema) PrimaryKeyColumns() []string {
+	return []string{
+		"device_pubkey:VARCHAR",
+		"group_address:VARCHAR",
+		"source_address:VARCHAR",
+		"remote_address:VARCHAR",
+		"status:VARCHAR",
+	}
+}
+
+func (s *SACacheSchema) PayloadColumns() []string {
+	return []string{
+		"rp_address:VARCHAR",
+	}
+}
+
+func (s *SACacheSchema) ToRow(r SACacheRow) []any {
+	return []any{
+		r.DevicePubkey,
+		r.GroupAddress,
+		r.SourceAddress,
+		r.RemoteAddress,
+		r.Status,
+		r.RPAddress,
+	}
+}
+
+func (s *SACacheSchema) GetPrimaryKey(r SACacheRow) string {
+	return r.DevicePubkey + "/" + r.GroupAddress + "/" + r.SourceAddress + "/" + r.RemoteAddress + "/" + r.Status
+}
+
+var saCacheSchema = &SACacheSchema{}
+
+// NewSACacheDataset creates a Type-2 dimension dataset for MSDP SA-cache entries.
+func NewSACacheDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
+	return dataset.NewDimensionType2Dataset(log, saCacheSchema)
+}

--- a/indexer/pkg/dz/msdp/source.go
+++ b/indexer/pkg/dz/msdp/source.go
@@ -1,0 +1,19 @@
+package msdp
+
+import "context"
+
+// Source provides access to per-device MSDP snapshot dumps written by
+// doublezero-telemetry's state-collect uploader. One Source handles all
+// three MSDP kinds (summary, pim sa-cache, sa-cache rejected) and
+// returns them keyed by kind.
+type Source interface {
+	// FetchLatest returns the most recent snapshot per (kind, device)
+	// within the source's lookback window. The outer map key is the
+	// snapshot kind; the inner slice has one entry per device that
+	// uploaded that kind. Devices with no recent snapshot for a given
+	// kind are silently omitted from that kind's slice.
+	FetchLatest(ctx context.Context) (map[string][]*Dump, error)
+
+	// Close releases any resources held by the source.
+	Close() error
+}

--- a/indexer/pkg/dz/msdp/source_minio_test.go
+++ b/indexer/pkg/dz/msdp/source_minio_test.go
@@ -1,0 +1,166 @@
+package msdp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+
+	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+)
+
+// TestS3Source_FetchLatest_MinIO is layer C for MSDP: round-trip the
+// source against a real S3-compatible backend with envelope-wrapped
+// objects matching what doublezero-telemetry writes. Exercises all
+// three MSDP kinds in a single device, plus a second device
+// contributing only the summary kind, to verify per-kind device
+// enumeration is independent.
+func TestS3Source_FetchLatest_MinIO(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MinIO integration test in -short mode")
+	}
+
+	ctx := t.Context()
+
+	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = ctr.Terminate(termCtx)
+	})
+
+	endpoint, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
+	)
+	require.NoError(t, err)
+	rawS3 := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String("http://" + endpoint)
+		o.UsePathStyle = true
+	})
+
+	const bucket = "doublezero-mainnet-beta-state-collect"
+	_, err = rawS3.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	const devAPK = "DzPkA111111111111111111111111111111111111111"
+	const devBPK = "DzPkB222222222222222222222222222222222222222"
+
+	devASummary := `{"peerList":[{"peerIpAddress":"172.16.0.1","state":"established","sessionStartTime":1779369727.0,"saCount":5,"resetCount":2}]}`
+	devAPim := `{"saCache":[{"sourceGroupPair":{"sourceAddress":"148.51.120.1","groupAddress":"233.84.178.1"},"rpAddress":"10.0.0.0"}]}`
+	devASA := `{"acceptedSaMsg":[{"sourceGroupPair":{"sourceAddress":"148.51.120.16","groupAddress":"233.84.178.1"},"rpAddress":"10.0.0.0","remoteAddress":"172.16.1.6"}],"rejectedSaMsg":[]}`
+	devBSummary := `{"peerList":[{"peerIpAddress":"172.16.0.2","state":"connecting","saCount":0,"resetCount":0}]}`
+
+	uploads := []struct {
+		pubkey string
+		kind   string
+		body   string
+	}{
+		{devAPK, SnapshotKindSummary, devASummary},
+		{devAPK, SnapshotKindPimSACache, devAPim},
+		{devAPK, SnapshotKindSACacheRejected, devASA},
+		{devBPK, SnapshotKindSummary, devBSummary},
+	}
+
+	for _, u := range uploads {
+		key := buildStateIngestKey(u.kind, u.pubkey, now)
+		body, err := json.Marshal(statecollect.Envelope{
+			Metadata: statecollect.Metadata{
+				Kind:      u.kind,
+				Timestamp: now.UTC().Format(time.RFC3339),
+				Device:    u.pubkey,
+			},
+			Data: json.RawMessage(u.body),
+		})
+		require.NoError(t, err)
+		_, err = rawS3.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader(body),
+		})
+		require.NoError(t, err, "put %s", key)
+	}
+
+	t.Setenv("AWS_ACCESS_KEY_ID", ctr.Username)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", ctr.Password)
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	src, err := NewS3Source(ctx, S3SourceConfig{
+		Bucket:       bucket,
+		Region:       "us-east-1",
+		EndpointURL:  "http://" + endpoint,
+		LookbackDays: 3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	dumpsByKind, err := src.FetchLatest(ctx)
+	require.NoError(t, err)
+
+	t.Run("summary kind has both devices", func(t *testing.T) {
+		require.Len(t, dumpsByKind[SnapshotKindSummary], 2)
+	})
+
+	t.Run("pim and sa-cache only have devA", func(t *testing.T) {
+		require.Len(t, dumpsByKind[SnapshotKindPimSACache], 1)
+		require.Len(t, dumpsByKind[SnapshotKindSACacheRejected], 1)
+		assert.Equal(t, devAPK, dumpsByKind[SnapshotKindPimSACache][0].DevicePubkey)
+		assert.Equal(t, devAPK, dumpsByKind[SnapshotKindSACacheRejected][0].DevicePubkey)
+	})
+
+	t.Run("envelope is unwrapped — Parse* consume Dump.RawJSON directly", func(t *testing.T) {
+		// Summary
+		var devASumDump *Dump
+		for _, d := range dumpsByKind[SnapshotKindSummary] {
+			if d.DevicePubkey == devAPK {
+				devASumDump = d
+				break
+			}
+		}
+		require.NotNil(t, devASumDump)
+		peers, err := ParseSummary(devASumDump.RawJSON)
+		require.NoError(t, err)
+		require.Len(t, peers, 1)
+		assert.Equal(t, "172.16.0.1", peers[0].PeerIPAddress)
+		assert.Equal(t, int64(5), peers[0].SACount)
+
+		// PIM SA cache
+		entries, err := ParsePimSACache(dumpsByKind[SnapshotKindPimSACache][0].RawJSON)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "148.51.120.1", entries[0].SourceAddress)
+
+		// SA-cache rejected (single accepted, zero rejected)
+		sa, err := ParseSACacheRejected(dumpsByKind[SnapshotKindSACacheRejected][0].RawJSON)
+		require.NoError(t, err)
+		require.Len(t, sa, 1)
+		assert.Equal(t, SACacheStatusAccepted, sa[0].Status)
+	})
+}
+
+// buildStateIngestKey reproduces the key pattern from the telemetry
+// state-ingest server's buildSnapshotKey for a given kind, with no
+// BucketPathPrefix.
+func buildStateIngestKey(kind, pubkey string, ts time.Time) string {
+	ts = ts.UTC()
+	return "snapshots/" + kind +
+		"/device=" + pubkey +
+		"/date=" + ts.Format("2006-01-02") +
+		"/hour=" + ts.Format("15") +
+		"/" + ts.Format("20060102T150405Z") + ".json"
+}

--- a/indexer/pkg/dz/msdp/source_mock.go
+++ b/indexer/pkg/dz/msdp/source_mock.go
@@ -1,0 +1,27 @@
+package msdp
+
+import "context"
+
+// MockSource is a Source implementation for testing.
+type MockSource struct {
+	Dumps    map[string][]*Dump
+	FetchErr error
+	Closed   bool
+}
+
+// NewMockSource preloads dumps grouped by kind.
+func NewMockSource(dumps map[string][]*Dump) *MockSource {
+	return &MockSource{Dumps: dumps}
+}
+
+func (m *MockSource) FetchLatest(ctx context.Context) (map[string][]*Dump, error) {
+	if m.FetchErr != nil {
+		return nil, m.FetchErr
+	}
+	return m.Dumps, nil
+}
+
+func (m *MockSource) Close() error {
+	m.Closed = true
+	return nil
+}

--- a/indexer/pkg/dz/msdp/source_s3.go
+++ b/indexer/pkg/dz/msdp/source_s3.go
@@ -1,0 +1,260 @@
+package msdp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+)
+
+// snapshotKinds lists the state-collect kinds this package consumes.
+// `ip-msdp-sa-cache` is intentionally absent — the `*-rejected` variant
+// returns the same accepted SAs plus rejected ones, so this is the
+// single source of truth (see doublezero PR dropping the redundant
+// command from defaults).
+var snapshotKinds = []string{
+	SnapshotKindSummary,
+	SnapshotKindPimSACache,
+	SnapshotKindSACacheRejected,
+}
+
+// S3SourceConfig configures the state-collect MSDP snapshot source.
+type S3SourceConfig struct {
+	Bucket       string
+	Region       string
+	KeyPrefix    string
+	EndpointURL  string
+	LookbackDays int
+}
+
+// S3Source implements Source against an S3 bucket populated by the
+// telemetry state-ingest server. The same bucket holds snapshots for
+// every state-collect kind under their own subprefix; this Source walks
+// each MSDP kind in turn.
+type S3Source struct {
+	client       *s3.Client
+	bucket       string
+	keyPrefix    string
+	lookbackDays int
+}
+
+// NewS3Source constructs a state-collect S3 source using the default
+// AWS credential chain.
+func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("msdp: bucket is required")
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	if cfg.LookbackDays <= 0 {
+		cfg.LookbackDays = 3
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region))
+	if err != nil {
+		return nil, fmt.Errorf("msdp: load AWS config: %w", err)
+	}
+
+	clientOpts := []func(*s3.Options){
+		func(o *s3.Options) { o.UsePathStyle = true },
+	}
+	if cfg.EndpointURL != "" {
+		clientOpts = append(clientOpts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(cfg.EndpointURL)
+		})
+	}
+
+	return &S3Source{
+		client:       s3.NewFromConfig(awsCfg, clientOpts...),
+		bucket:       cfg.Bucket,
+		keyPrefix:    strings.TrimRight(cfg.KeyPrefix, "/"),
+		lookbackDays: cfg.LookbackDays,
+	}, nil
+}
+
+// snapshotsPrefix returns the key prefix that contains all device
+// subprefixes for the given kind, with a trailing slash.
+func (s *S3Source) snapshotsPrefix(kind string) string {
+	if s.keyPrefix == "" {
+		return "snapshots/" + kind + "/"
+	}
+	return s.keyPrefix + "/snapshots/" + kind + "/"
+}
+
+// FetchLatest walks each MSDP kind's subprefix, returns the most recent
+// envelope-wrapped dump per device for each kind. The returned
+// Dump.RawJSON is the inner Arista JSON (envelope already unwrapped).
+func (s *S3Source) FetchLatest(ctx context.Context) (map[string][]*Dump, error) {
+	now := time.Now().UTC()
+	out := make(map[string][]*Dump, len(snapshotKinds))
+	for _, kind := range snapshotKinds {
+		dumps, err := s.fetchLatestForKind(ctx, kind, now)
+		if err != nil {
+			return nil, err
+		}
+		out[kind] = dumps
+	}
+	return out, nil
+}
+
+func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time.Time) ([]*Dump, error) {
+	devices, err := s.listDevicePubkeys(ctx, kind)
+	if err != nil {
+		return nil, err
+	}
+	var dumps []*Dump
+	for _, pubkey := range devices {
+		key, keyTS, err := s.latestKeyForDevice(ctx, kind, pubkey, now)
+		if err != nil {
+			return nil, err
+		}
+		if key == "" {
+			continue
+		}
+		body, err := s.getObject(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+
+		var env statecollect.Envelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			return nil, fmt.Errorf("msdp: decode envelope %s: %w", key, err)
+		}
+		if env.Metadata.Kind != "" && env.Metadata.Kind != kind {
+			return nil, fmt.Errorf("msdp: envelope kind mismatch in %s: got %q, want %q",
+				key, env.Metadata.Kind, kind)
+		}
+
+		devicePK := pubkey
+		if env.Metadata.Device != "" {
+			devicePK = env.Metadata.Device
+		}
+		snapTS := keyTS
+		if env.Metadata.Timestamp != "" {
+			if parsed, err := time.Parse(time.RFC3339, env.Metadata.Timestamp); err == nil {
+				snapTS = parsed.UTC()
+			}
+		}
+
+		dumps = append(dumps, &Dump{
+			Kind:         kind,
+			FetchedAt:    time.Now().UTC(),
+			SnapshotTS:   snapTS,
+			DevicePubkey: devicePK,
+			RawJSON:      env.Data,
+			FileName:     key,
+		})
+	}
+	return dumps, nil
+}
+
+func (s *S3Source) listDevicePubkeys(ctx context.Context, kind string) ([]string, error) {
+	prefix := s.snapshotsPrefix(kind)
+	var pubkeys []string
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket:    aws.String(s.bucket),
+		Prefix:    aws.String(prefix),
+		Delimiter: aws.String("/"),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("msdp: list device prefixes (%s): %w", kind, err)
+		}
+		for _, cp := range page.CommonPrefixes {
+			if cp.Prefix == nil {
+				continue
+			}
+			rest := strings.TrimPrefix(*cp.Prefix, prefix)
+			rest = strings.TrimSuffix(rest, "/")
+			if pk := strings.TrimPrefix(rest, "device="); pk != rest && pk != "" {
+				pubkeys = append(pubkeys, pk)
+			}
+		}
+	}
+	return pubkeys, nil
+}
+
+func (s *S3Source) latestKeyForDevice(ctx context.Context, kind, pubkey string, now time.Time) (string, time.Time, error) {
+	base := s.snapshotsPrefix(kind) + "device=" + pubkey + "/"
+	var latestKey string
+	for daysBack := 0; daysBack < s.lookbackDays; daysBack++ {
+		date := now.AddDate(0, 0, -daysBack).Format("2006-01-02")
+		prefix := base + "date=" + date + "/"
+		key, err := s.latestKeyUnderPrefix(ctx, prefix)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		if key > latestKey {
+			latestKey = key
+		}
+	}
+	if latestKey == "" {
+		return "", time.Time{}, nil
+	}
+	return latestKey, snapshotTSFromKey(latestKey), nil
+}
+
+func (s *S3Source) latestKeyUnderPrefix(ctx context.Context, prefix string) (string, error) {
+	var latestKey string
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("msdp: list %s: %w", prefix, err)
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			if *obj.Key > latestKey {
+				latestKey = *obj.Key
+			}
+		}
+	}
+	return latestKey, nil
+}
+
+func (s *S3Source) getObject(ctx context.Context, key string) ([]byte, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("msdp: get %s: %w", key, err)
+	}
+	defer out.Body.Close()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("msdp: read %s: %w", key, err)
+	}
+	return body, nil
+}
+
+// snapshotTSFromKey parses the `YYYYMMDDTHHMMSSZ.json` filename written
+// by the state-ingest server back into a time.Time.
+func snapshotTSFromKey(key string) time.Time {
+	slash := strings.LastIndex(key, "/")
+	name := key[slash+1:]
+	name = strings.TrimSuffix(name, ".json")
+	t, err := time.Parse("20060102T150405Z", name)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}
+
+// Close releases resources. For S3Source, this is a no-op.
+func (s *S3Source) Close() error { return nil }

--- a/indexer/pkg/dz/msdp/store.go
+++ b/indexer/pkg/dz/msdp/store.go
@@ -1,0 +1,112 @@
+package msdp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// StoreConfig holds configuration for the MSDP ClickHouse store.
+type StoreConfig struct {
+	Logger     *slog.Logger
+	ClickHouse clickhouse.Client
+}
+
+func (cfg *StoreConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	return nil
+}
+
+// Store manages MSDP dimension data in ClickHouse across three tables.
+type Store struct {
+	log *slog.Logger
+	cfg StoreConfig
+}
+
+// NewStore creates a new MSDP ClickHouse store.
+func NewStore(cfg StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Store{log: cfg.Logger, cfg: cfg}, nil
+}
+
+// ReplacePeers replaces dim_dz_ip_msdp_peers in ClickHouse. With
+// MissingMeansDeleted=true any (device, peer_address) tuple not in the
+// batch is tombstoned.
+func (s *Store) ReplacePeers(ctx context.Context, rows []PeerRow) error {
+	s.log.Debug("msdp/store: replacing peers", "count", len(rows))
+	d, err := NewPeerDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("msdp: build peer dataset: %w", err)
+	}
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("msdp: get clickhouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(rows), func(i int) ([]any, error) {
+		return peerSchema.ToRow(rows[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("msdp: write peers: %w", err)
+	}
+	return nil
+}
+
+// ReplacePimSACache replaces dim_dz_ip_msdp_pim_sa_cache in ClickHouse.
+func (s *Store) ReplacePimSACache(ctx context.Context, rows []PimSACacheRow) error {
+	s.log.Debug("msdp/store: replacing pim sa-cache", "count", len(rows))
+	d, err := NewPimSACacheDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("msdp: build pim sa-cache dataset: %w", err)
+	}
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("msdp: get clickhouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(rows), func(i int) ([]any, error) {
+		return pimSACacheSchema.ToRow(rows[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("msdp: write pim sa-cache: %w", err)
+	}
+	return nil
+}
+
+// ReplaceSACache replaces dim_dz_ip_msdp_sa_cache in ClickHouse.
+func (s *Store) ReplaceSACache(ctx context.Context, rows []SACacheRow) error {
+	s.log.Debug("msdp/store: replacing sa-cache", "count", len(rows))
+	d, err := NewSACacheDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("msdp: build sa-cache dataset: %w", err)
+	}
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("msdp: get clickhouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := d.WriteBatch(ctx, conn, len(rows), func(i int) ([]any, error) {
+		return saCacheSchema.ToRow(rows[i]), nil
+	}, &dataset.DimensionType2DatasetWriteConfig{
+		MissingMeansDeleted: true,
+	}); err != nil {
+		return fmt.Errorf("msdp: write sa-cache: %w", err)
+	}
+	return nil
+}

--- a/indexer/pkg/dz/msdp/store_test.go
+++ b/indexer/pkg/dz/msdp/store_test.go
@@ -1,0 +1,150 @@
+package msdp
+
+import (
+	"testing"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStore_SACache_SCD2_RoundTrip exercises the most complex of the
+// three MSDP dimensions: dim_dz_ip_msdp_sa_cache, which has a 5-column
+// PK including the `status` discriminator that lets the same (S,G)
+// appear in both accepted and rejected buckets simultaneously.
+//
+// Three batches:
+//   - batch1 inserts 3 rows (2 accepted + 1 rejected); _current shows all.
+//   - batch2 drops one accepted row, flips a rejected row to accepted (new
+//     entity_id, since status is in the PK), keeps one row unchanged.
+//   - batch3 re-runs batch2 identically and asserts no new active history.
+func TestStore_SACache_SCD2_RoundTrip(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	store, err := NewStore(StoreConfig{
+		Logger:     laketesting.NewLogger(),
+		ClickHouse: info.Client,
+	})
+	require.NoError(t, err)
+
+	const devicePK = "DzPkMSDP1111111111111111111111111111111111"
+
+	mk := func(group, source, remote, status string) SACacheRow {
+		return SACacheToRow(devicePK, SACacheEntry{
+			GroupAddress:  group,
+			SourceAddress: source,
+			RemoteAddress: remote,
+			RPAddress:     "10.0.0.0",
+			Status:        SACacheStatus(status),
+		})
+	}
+
+	batch1 := []SACacheRow{
+		mk("233.84.178.1", "148.51.120.1", "172.16.0.1", "accepted"),
+		mk("233.84.178.1", "148.51.120.2", "172.16.0.2", "accepted"),
+		mk("233.84.178.99", "10.99.99.99", "172.16.0.9", "rejected"),
+	}
+
+	t.Run("batch1: initial 3 rows visible in _current", func(t *testing.T) {
+		require.NoError(t, store.ReplaceSACache(t.Context(), batch1))
+		got := queryCurrentSACache(t, info.Client, devicePK)
+		require.Len(t, got, 3)
+		assertHasSACache(t, got, "148.51.120.1", "172.16.0.1", "accepted")
+		assertHasSACache(t, got, "148.51.120.2", "172.16.0.2", "accepted")
+		assertHasSACache(t, got, "10.99.99.99", "172.16.0.9", "rejected")
+	})
+
+	// batch2: drop 148.51.120.2, change the rejected SA to accepted (new
+	// PK because status is in the key — so 99.99.99/rejected becomes
+	// tombstoned and 99.99.99/accepted is created), keep 120.1 as-is.
+	batch2 := []SACacheRow{
+		mk("233.84.178.1", "148.51.120.1", "172.16.0.1", "accepted"),
+		mk("233.84.178.99", "10.99.99.99", "172.16.0.9", "accepted"),
+	}
+
+	t.Run("batch2: missing tombstoned, status flip behaves as PK change", func(t *testing.T) {
+		require.NoError(t, store.ReplaceSACache(t.Context(), batch2))
+		got := queryCurrentSACache(t, info.Client, devicePK)
+		require.Len(t, got, 2, "120.2 tombstoned, 99.99.99/rejected tombstoned, 99.99.99/accepted new")
+
+		for _, r := range got {
+			assert.NotEqual(t, "rejected", r.Status, "no rejected rows should remain in _current")
+			assert.NotEqual(t, "148.51.120.2", r.SourceAddress, "120.2 was omitted")
+		}
+		assertHasSACache(t, got, "148.51.120.1", "172.16.0.1", "accepted")
+		assertHasSACache(t, got, "10.99.99.99", "172.16.0.9", "accepted")
+	})
+
+	t.Run("batch3: identical re-run does not grow active history", func(t *testing.T) {
+		before := historyActiveSACacheCount(t, info.Client, devicePK)
+		require.NoError(t, store.ReplaceSACache(t.Context(), batch2))
+		after := historyActiveSACacheCount(t, info.Client, devicePK)
+		assert.Equal(t, before, after,
+			"identical batch should produce no new active history rows (attrs_hash unchanged)")
+
+		got := queryCurrentSACache(t, info.Client, devicePK)
+		require.Len(t, got, 2)
+	})
+}
+
+type currentSACache struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RemoteAddress string
+	Status        string
+	RPAddress     string
+}
+
+func queryCurrentSACache(t *testing.T, client clickhouse.Client, devicePK string) []currentSACache {
+	t.Helper()
+	conn, err := client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rows, err := conn.Query(t.Context(), `
+		SELECT device_pubkey, group_address, source_address, remote_address, status, rp_address
+		FROM dz_ip_msdp_sa_cache_current
+		WHERE device_pubkey = ?
+		ORDER BY group_address, source_address, remote_address, status
+	`, devicePK)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []currentSACache
+	for rows.Next() {
+		var r currentSACache
+		require.NoError(t, rows.Scan(&r.DevicePubkey, &r.GroupAddress, &r.SourceAddress, &r.RemoteAddress, &r.Status, &r.RPAddress))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func historyActiveSACacheCount(t *testing.T, client clickhouse.Client, devicePK string) uint64 {
+	t.Helper()
+	conn, err := client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rows, err := conn.Query(t.Context(), `
+		SELECT count() FROM dim_dz_ip_msdp_sa_cache_history
+		WHERE device_pubkey = ? AND is_deleted = 0
+	`, devicePK)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var n uint64
+	require.NoError(t, rows.Scan(&n))
+	return n
+}
+
+func assertHasSACache(t *testing.T, got []currentSACache, source, remote, status string) {
+	t.Helper()
+	for _, r := range got {
+		if r.SourceAddress == source && r.RemoteAddress == remote && r.Status == status {
+			return
+		}
+	}
+	t.Errorf("no row for (source=%s, remote=%s, status=%s) in: %+v", source, remote, status, got)
+}

--- a/indexer/pkg/dz/msdp/sync.go
+++ b/indexer/pkg/dz/msdp/sync.go
@@ -1,0 +1,87 @@
+package msdp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Sync parses per-device dumps for all three MSDP kinds and replaces
+// them in ClickHouse via three separate dim writes.
+//
+// Fail-fast contract (same as mroute): on any parse failure across any
+// kind, return an error and write nothing. The store uses
+// MissingMeansDeleted=true, so silently dropping a device from one of
+// the batches would tombstone that device's prior state. Refusing to
+// write preserves all prior state until the underlying parse issue is
+// investigated.
+func (s *Store) Sync(ctx context.Context, dumpsByKind map[string][]*Dump) error {
+	var parseErrs []error
+
+	peerRows := make([]PeerRow, 0)
+	for _, d := range dumpsByKind[SnapshotKindSummary] {
+		if d == nil {
+			continue
+		}
+		peers, err := ParseSummary(d.RawJSON)
+		if err != nil {
+			parseErrs = append(parseErrs, fmt.Errorf("summary %s (%s): %w", d.DevicePubkey, d.FileName, err))
+			continue
+		}
+		for _, p := range peers {
+			peerRows = append(peerRows, PeerToRow(d.DevicePubkey, p))
+		}
+	}
+
+	pimRows := make([]PimSACacheRow, 0)
+	for _, d := range dumpsByKind[SnapshotKindPimSACache] {
+		if d == nil {
+			continue
+		}
+		entries, err := ParsePimSACache(d.RawJSON)
+		if err != nil {
+			parseErrs = append(parseErrs, fmt.Errorf("pim sa-cache %s (%s): %w", d.DevicePubkey, d.FileName, err))
+			continue
+		}
+		for _, e := range entries {
+			pimRows = append(pimRows, PimSACacheToRow(d.DevicePubkey, e))
+		}
+	}
+
+	saRows := make([]SACacheRow, 0)
+	for _, d := range dumpsByKind[SnapshotKindSACacheRejected] {
+		if d == nil {
+			continue
+		}
+		entries, err := ParseSACacheRejected(d.RawJSON)
+		if err != nil {
+			parseErrs = append(parseErrs, fmt.Errorf("sa-cache rejected %s (%s): %w", d.DevicePubkey, d.FileName, err))
+			continue
+		}
+		for _, e := range entries {
+			saRows = append(saRows, SACacheToRow(d.DevicePubkey, e))
+		}
+	}
+
+	if len(parseErrs) > 0 {
+		return fmt.Errorf("msdp: %d dumps failed to parse, refusing to write: %w",
+			len(parseErrs), errors.Join(parseErrs...))
+	}
+
+	if err := s.ReplacePeers(ctx, peerRows); err != nil {
+		return fmt.Errorf("msdp: sync peers: %w", err)
+	}
+	if err := s.ReplacePimSACache(ctx, pimRows); err != nil {
+		return fmt.Errorf("msdp: sync pim sa-cache: %w", err)
+	}
+	if err := s.ReplaceSACache(ctx, saRows); err != nil {
+		return fmt.Errorf("msdp: sync sa-cache: %w", err)
+	}
+
+	s.log.Info("msdp: synced to ClickHouse",
+		"peers", len(peerRows),
+		"pim_sa_cache", len(pimRows),
+		"sa_cache", len(saRows),
+	)
+	return nil
+}

--- a/indexer/pkg/dz/msdp/types.go
+++ b/indexer/pkg/dz/msdp/types.go
@@ -1,0 +1,79 @@
+package msdp
+
+import "time"
+
+// Kind names that this package consumes from S3. They match the
+// state-ingest server's `defaultStateToCollectShowCommands` map keys.
+const (
+	// SnapshotKindSummary corresponds to `show ip msdp summary | json`.
+	SnapshotKindSummary = "ip-msdp-summary"
+
+	// SnapshotKindPimSACache corresponds to
+	// `show ip msdp pim sa-cache | json`. The local PIM SA cache that
+	// this device is advertising over MSDP — no remoteAddress field.
+	SnapshotKindPimSACache = "ip-msdp-pim-sa-cache"
+
+	// SnapshotKindSACacheRejected corresponds to
+	// `show ip msdp sa-cache rejected | json`. Per Arista docs, the
+	// `rejected` keyword returns rejected SAs *in addition to* the
+	// accepted ones, so this single command supplies both arrays.
+	SnapshotKindSACacheRejected = "ip-msdp-sa-cache-rejected"
+)
+
+// SACacheStatus distinguishes accepted vs rejected SAs in the
+// sa_cache table. The same source command (`sa-cache rejected`)
+// produces both via the `acceptedSaMsg` and `rejectedSaMsg` arrays.
+type SACacheStatus string
+
+const (
+	SACacheStatusAccepted SACacheStatus = "accepted"
+	SACacheStatusRejected SACacheStatus = "rejected"
+)
+
+// Dump represents a single device's raw MSDP snapshot of one kind.
+type Dump struct {
+	Kind         string
+	FetchedAt    time.Time
+	SnapshotTS   time.Time
+	DevicePubkey string
+	RawJSON      []byte
+	FileName     string
+}
+
+// Peer is one parsed row from `show ip msdp summary | json`. One row per
+// MSDP peer; (device_pubkey, peer_address) is the natural primary key.
+type Peer struct {
+	DevicePubkey     string
+	PeerIPAddress    string
+	State            string    // "established" | "connecting" | "listen" | ...
+	SessionStartTime time.Time // zero when state is not "established"
+	SACount          int64
+	ResetCount       int64
+}
+
+// PimSACacheEntry is one parsed row from
+// `show ip msdp pim sa-cache | json`. PIM SA cache being advertised
+// locally via MSDP. (device_pubkey, group_address, source_address) is
+// the natural primary key.
+type PimSACacheEntry struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RPAddress     string
+}
+
+// SACacheEntry is one parsed row from
+// `show ip msdp sa-cache rejected | json`, combining both the
+// `acceptedSaMsg` array (Status="accepted") and the `rejectedSaMsg`
+// array (Status="rejected"). (device_pubkey, group_address,
+// source_address, remote_address, status) is the natural primary key —
+// the same (S,G) can legitimately appear from multiple remote_addresses
+// and in multiple status buckets.
+type SACacheEntry struct {
+	DevicePubkey  string
+	GroupAddress  string
+	SourceAddress string
+	RemoteAddress string
+	RPAddress     string
+	Status        SACacheStatus
+}

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -11,6 +11,7 @@ import (
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -44,6 +45,8 @@ type Activities struct {
 	ISISStore      *isis.Store        // nil when ISIS is not enabled
 	MrouteSource   mroute.Source      // nil when mroute ingest is not enabled
 	MrouteStore    *mroute.Store      // nil when mroute ingest is not enabled
+	MSDPSource     msdp.Source        // nil when MSDP ingest is not enabled
+	MSDPStore      *msdp.Store        // nil when MSDP ingest is not enabled
 
 	// failures tracks consecutive-failure counts per activity name.
 	// map[string]*atomic.Int32; populated lazily.
@@ -230,6 +233,25 @@ func (a *Activities) SyncIPMroute(ctx context.Context) error {
 			return result, fmt.Errorf("mroute fetch: %w", err)
 		}
 		return result, a.MrouteStore.Sync(ctx, dumps)
+	})
+}
+
+// SyncMSDP fetches per-device `show ip msdp ...` snapshots from S3
+// (uploaded by doublezero-telemetry --state-collect-enable) for all
+// three MSDP kinds and replaces the dz_ip_msdp_* dimensions in
+// ClickHouse. No-op if MSDP ingest is not configured.
+func (a *Activities) SyncMSDP(ctx context.Context) error {
+	if a.MSDPSource == nil || a.MSDPStore == nil {
+		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncMSDP", a.Network)
+		return nil
+	}
+	return a.refresh(ctx, "SyncMSDP", func() (ingestionlog.RefreshResult, error) {
+		var result ingestionlog.RefreshResult
+		dumps, err := a.MSDPSource.FetchLatest(ctx)
+		if err != nil {
+			return result, fmt.Errorf("msdp fetch: %w", err)
+		}
+		return result, a.MSDPStore.Sync(ctx, dumps)
 	})
 }
 

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -19,6 +19,7 @@ import (
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -48,6 +49,8 @@ type Config struct {
 	ISISStore      *isis.Store        // optional
 	MrouteSource   mroute.Source      // optional
 	MrouteStore    *mroute.Store      // optional
+	MSDPSource     msdp.Source        // optional
+	MSDPStore      *msdp.Store        // optional
 }
 
 // TaskQueue returns the Temporal task queue name for the given network.
@@ -95,6 +98,8 @@ func Start(ctx context.Context, cfg Config) error {
 		ISISStore:      cfg.ISISStore,
 		MrouteSource:   cfg.MrouteSource,
 		MrouteStore:    cfg.MrouteStore,
+		MSDPSource:     cfg.MSDPSource,
+		MSDPStore:      cfg.MSDPStore,
 	}
 
 	w := worker.New(tc, tq, worker.Options{})

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -61,6 +61,7 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		escrowEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShredEscrowEvents)
 		isisSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncISIS)
 		mrouteSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncIPMroute)
+		msdpSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncMSDP)
 		graphSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncGraph)
 
 		// Telemetry usage runs less frequently (~5 minutes).
@@ -104,6 +105,12 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 				return ctx.Err()
 			}
 			logger.Error("mroute sync failed", "error", err)
+		}
+		if err := msdpSyncFuture.Get(ctx, nil); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			logger.Error("msdp sync failed", "error", err)
 		}
 		if err := graphSyncFuture.Get(ctx, nil); err != nil {
 			if ctx.Err() != nil {

--- a/indexer/pkg/indexer/config.go
+++ b/indexer/pkg/indexer/config.go
@@ -86,6 +86,16 @@ type Config struct {
 	MrouteS3KeyPrefix   string // Optional matching state-ingest BucketPathPrefix
 	MrouteS3EndpointURL string // Custom S3 endpoint URL (for testing)
 
+	// MSDP (state-collect) configuration (optional).
+	// When enabled, periodically pulls `show ip msdp ...` snapshots for
+	// summary, pim sa-cache, and sa-cache-rejected kinds and writes the
+	// parsed entries to ClickHouse as three type-2 dimensions.
+	MSDPEnabled       bool
+	MSDPS3Bucket      string // Same state-collect bucket as MrouteS3Bucket in practice
+	MSDPS3Region      string // AWS region (default: us-east-1)
+	MSDPS3KeyPrefix   string // Optional matching state-ingest BucketPathPrefix
+	MSDPS3EndpointURL string // Custom S3 endpoint URL (for testing)
+
 	// validators.app configuration (optional, mainnet-beta only).
 	ValidatorsAppClient          validatorsapp.Client
 	ValidatorsAppRefreshInterval time.Duration

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -11,6 +11,7 @@ import (
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/isis"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
@@ -39,6 +40,8 @@ type Indexer struct {
 	isisStore     *isis.Store
 	mrouteSource  mroute.Source
 	mrouteStore   *mroute.Store
+	msdpSource    msdp.Source
+	msdpStore     *msdp.Store
 	validatorsApp *validatorsapp.View
 }
 
@@ -276,6 +279,32 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 			"key_prefix", cfg.MrouteS3KeyPrefix)
 	}
 
+	// Initialize MSDP source and store if enabled
+	var msdpSource msdp.Source
+	var msdpStore *msdp.Store
+	if cfg.MSDPEnabled {
+		msdpSource, err = msdp.NewS3Source(ctx, msdp.S3SourceConfig{
+			Bucket:      cfg.MSDPS3Bucket,
+			Region:      cfg.MSDPS3Region,
+			KeyPrefix:   cfg.MSDPS3KeyPrefix,
+			EndpointURL: cfg.MSDPS3EndpointURL,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create MSDP S3 source: %w", err)
+		}
+		msdpStore, err = msdp.NewStore(msdp.StoreConfig{
+			Logger:     cfg.Logger,
+			ClickHouse: cfg.ClickHouse,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create MSDP store: %w", err)
+		}
+		cfg.Logger.Info("MSDP state-collect source initialized",
+			"bucket", cfg.MSDPS3Bucket,
+			"region", cfg.MSDPS3Region,
+			"key_prefix", cfg.MSDPS3KeyPrefix)
+	}
+
 	// Initialize validators.app view (optional)
 	var validatorsAppView *validatorsapp.View
 	if cfg.ValidatorsAppClient != nil {
@@ -308,6 +337,8 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 		isisStore:     isisStore,
 		mrouteSource:  mrouteSource,
 		mrouteStore:   mrouteStore,
+		msdpSource:    msdpSource,
+		msdpStore:     msdpStore,
 		validatorsApp: validatorsAppView,
 	}
 
@@ -339,6 +370,12 @@ func (i *Indexer) Close() error {
 		if err := i.mrouteSource.Close(); err != nil {
 			i.log.Warn("failed to close mroute source", "error", err)
 			errs = append(errs, fmt.Errorf("failed to close mroute source: %w", err))
+		}
+	}
+	if i.msdpSource != nil {
+		if err := i.msdpSource.Close(); err != nil {
+			i.log.Warn("failed to close MSDP source", "error", err)
+			errs = append(errs, fmt.Errorf("failed to close MSDP source: %w", err))
 		}
 	}
 	if len(errs) > 0 {
@@ -397,6 +434,16 @@ func (i *Indexer) MrouteSource() mroute.Source {
 // MrouteStore returns the mroute ClickHouse store, or nil if not configured.
 func (i *Indexer) MrouteStore() *mroute.Store {
 	return i.mrouteStore
+}
+
+// MSDPSource returns the state-collect MSDP data source, or nil if not configured.
+func (i *Indexer) MSDPSource() msdp.Source {
+	return i.msdpSource
+}
+
+// MSDPStore returns the MSDP ClickHouse store, or nil if not configured.
+func (i *Indexer) MSDPStore() *msdp.Store {
+	return i.msdpStore
 }
 
 // Geolocation returns the geolocation view, or nil if not configured.


### PR DESCRIPTION
## Summary

- Add `lake/indexer/pkg/dz/msdp/` that consumes three Arista MSDP show-command snapshots from S3 (uploaded by `doublezero-telemetry --state-collect-enable`) and writes them into three independent type-2 dimensions in ClickHouse:
  - `dim_dz_ip_msdp_peers` ← `show ip msdp summary` (PK: device, peer_address)
  - `dim_dz_ip_msdp_pim_sa_cache` ← `show ip msdp pim sa-cache` (PK: device, group, source)
  - `dim_dz_ip_msdp_sa_cache` ← `show ip msdp sa-cache rejected` (PK: device, group, source, remote_address, status)
- The sa-cache table uses a 5-column PK with `status` ('accepted' | 'rejected') as a first-class discriminator. This is the right shape because the same (S,G) can be accepted from one peer and rejected from another; both rows coexist in `_current` simultaneously, and a status flip is naturally a new SCD2 entity rather than an attribute update.
- Lake consumes only the `sa-cache rejected` variant (which returns the full cache — accepted SAs in `acceptedSaMsg` plus rejected ones in `rejectedSaMsg`, per the Arista docs). The plain `sa-cache` kind is ignored even when present in S3; the companion doublezero PR drops it from device-side defaults.
- New `SyncMSDP` Temporal activity in `dzingest` alongside `SyncIPMroute`. Gated behind `--msdp-enabled` / `MSDP_ENABLED` + `MSDP_S3_BUCKET` (off by default). `Sync` fails fast on any parse error across any kind so `MissingMeansDeleted=true` tombstoning never fires on partially-parsed batches — same contract as mroute.

Pairs with malbeclabs/doublezero#3825 which drops the redundant `ip-msdp-sa-cache` kind from the device-side default-commands list (the `rejected` variant is a strict superset).

## Why

This is the lake-side delivery for malbeclabs/infra#1417. With this merged plus the doublezero side already shipped (PR #3801, releases v0.25.x), devnet/testnet/mainnet DZDs will start uploading MSDP snapshots to S3 within one collector tick of the deploys being enabled, and lake will write them into ClickHouse — making MSDP peer state, locally-advertised SA cache, and inter-domain SA exchange (accepted + rejected with reasons) queryable alongside mroute OIL state for the multicast demo.

## Testing Verification

Three test layers, same shape as the mroute PR (#609):

| Layer | What it proves | How |
|---|---|---|
| A — migration apply | Migration SQL is valid; 3 history tables + 3 staging + 3 current views materialize with correct engines | `TestMigration_Applies` against a ClickHouse testcontainer |
| B — SCD2 round-trip | Column types bind through `WriteBatch`; `attrs_hash` is stable on identical input; `MissingMeansDeleted=true` tombstones correctly; status-flip behaves as PK change | `TestStore_SACache_SCD2_RoundTrip` against a ClickHouse testcontainer (exercises sa-cache, the most demanding of the 3 schemas) |
| C — S3 envelope round-trip | Source unwraps `statecollect.Envelope` correctly; per-kind device enumeration is independent (devA on 3 kinds, devB only on summary); the inner JSON parses through each kind's `Parse*` function | `TestS3Source_FetchLatest_MinIO` against a MinIO testcontainer with envelope-wrapped objects matching what the producer writes |

`Parse*` unit tests cover the prod-JSON edge cases the parser must handle (missing `sessionStartTime` on connecting peers, mixed accepted+rejected arrays, empty maps).

## Notes

PR is ~1850 lines (758 production code, 770 tests, ~125 SQL migration, ~120 wiring) — above the 500-line guideline. The bulk is necessary because of the 3-table fan-out (each kind has its own schema, its own dim type-2 dataset, its own Replace method on the Store, and its own integration tests); splitting into 3 PRs would force three repeated PR-review cycles for the same Source/Sync infrastructure and three migration files instead of one. If the reviewer prefers I can split into a "package + tests" PR and a "wiring" PR — let me know.

Closes malbeclabs/infra#1417.
