### PR TITLE
indexer: enable mroute ingest for the devnet/testnet secondary path

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -1029,6 +1029,8 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		GraphStore:     idx.GraphStore(),
 		ISISSource:     idx.ISISSource(),
 		ISISStore:      idx.ISISStore(),
+		MrouteSource:   idx.MrouteSource(),
+		MrouteStore:    idx.MrouteStore(),
 	})
 
 	select {

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -699,6 +699,7 @@ func run() error {
 		database       string
 		dzLedgerRPCURL string
 		noInflux       bool
+		mrouteS3Bucket string // empty = mroute ingest disabled for this env
 	}
 	secondaryEnvs := map[string]secondaryEnvConfig{
 		"devnet":  {database: "lake_devnet"},
@@ -734,6 +735,19 @@ func run() error {
 		cfg.noInflux = true
 		secondaryEnvs["testnet"] = cfg
 	}
+	// Mroute ingest is per-env; the bucket the state-ingest server writes to
+	// differs between devnet/testnet/mainnet. Setting the env-specific bucket
+	// enables mroute ingest for that secondary network.
+	if b := os.Getenv("MROUTE_S3_BUCKET_DEVNET"); b != "" {
+		cfg := secondaryEnvs["devnet"]
+		cfg.mrouteS3Bucket = b
+		secondaryEnvs["devnet"] = cfg
+	}
+	if b := os.Getenv("MROUTE_S3_BUCKET_TESTNET"); b != "" {
+		cfg := secondaryEnvs["testnet"]
+		cfg.mrouteS3Bucket = b
+		secondaryEnvs["testnet"] = cfg
+	}
 	if *noDevnetFlag {
 		delete(secondaryEnvs, "devnet")
 	}
@@ -767,6 +781,9 @@ func run() error {
 				skipReadyWait:              *skipReadyWaitFlag,
 				isisS3Bucket:               "doublezero-" + env + "-isis-db",
 				isisS3Region:               *isisS3RegionFlag,
+				mrouteS3Bucket:             envCfg.mrouteS3Bucket,
+				mrouteS3Region:             *mrouteS3RegionFlag,
+				mrouteS3KeyPrefix:          *mrouteS3KeyPrefixFlag,
 				influxURL:                  secondaryInfluxURL,
 				influxToken:                secondaryInfluxToken,
 				influxOrg:                  influxOrg,
@@ -843,6 +860,12 @@ type secondaryNetworkConfig struct {
 	// ISIS configuration (optional).
 	isisS3Bucket string
 	isisS3Region string
+
+	// Mroute (state-collect) configuration (optional, per-env).
+	// mrouteS3Bucket="" means mroute ingest is disabled for this network.
+	mrouteS3Bucket    string
+	mrouteS3Region    string
+	mrouteS3KeyPrefix string
 
 	// InfluxDB configuration (optional).
 	influxURL                  string
@@ -958,6 +981,13 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 		ISISEnabled:  cfg.isisS3Bucket != "",
 		ISISS3Bucket: cfg.isisS3Bucket,
 		ISISS3Region: cfg.isisS3Region,
+
+		// Mroute (state-collect) configuration. Enabled iff a per-env
+		// bucket was provided via MROUTE_S3_BUCKET_<ENV>.
+		MrouteEnabled:     cfg.mrouteS3Bucket != "",
+		MrouteS3Bucket:    cfg.mrouteS3Bucket,
+		MrouteS3Region:    cfg.mrouteS3Region,
+		MrouteS3KeyPrefix: cfg.mrouteS3KeyPrefix,
 	}
 	if shredsClient != nil {
 		secondaryIdxCfg.ShredsRPC = shredsClient


### PR DESCRIPTION
## Summary

- Add `mrouteS3Bucket` / `mrouteS3Region` / `mrouteS3KeyPrefix` fields to `secondaryNetworkConfig` and wire them through into the indexer `Config`, mirroring the existing `isisS3Bucket` pattern.
- Read per-env bucket name from `MROUTE_S3_BUCKET_DEVNET` / `MROUTE_S3_BUCKET_TESTNET`; ingest stays off when the bucket env var is unset.
- Region and key-prefix reuse the global `--mroute-s3-region` / `--mroute-s3-key-prefix` flags.

## Why

The secondary-indexer wiring for mroute was originally part of PR #609 (final commit `856e5fe`) but got dropped during the squash-merge. Without it, the secondary indexer instances (devnet and testnet, both spawned by `startSecondaryNetwork`) have no code path to receive a per-env state-collect bucket name, so `cfg.MrouteEnabled` is always `false` and `SyncIPMroute` skips on every workflow tick regardless of how the `lake-indexer-env` SealedSecret is configured.

Confirmed via the ingestion log:

```sql
SELECT 'devnet' AS env, status, count() FROM lake_devnet.log_ingestion_runs
WHERE activity = 'SyncIPMroute' AND started_at > now() - INTERVAL 1 HOUR
GROUP BY status
UNION ALL
SELECT 'testnet' AS env, status, count() FROM lake_testnet.log_ingestion_runs
WHERE activity = 'SyncIPMroute' AND started_at > now() - INTERVAL 1 HOUR
GROUP BY status
UNION ALL
SELECT 'mainnet-beta' AS env, status, count() FROM lake.log_ingestion_runs
WHERE activity = 'SyncIPMroute' AND started_at > now() - INTERVAL 1 HOUR
GROUP BY status
```

returns `skipped` across all three networks. After this PR + the SealedSecret edits to add `MROUTE_S3_BUCKET_DEVNET=malbeclabs-device-telemetry-state-snapshots-devnet` (and the matching testnet/mainnet env vars + AWS creds for the bucket), `SyncIPMroute` will start producing rows.

## Notes

- MSDP needs the same secondary wiring, but the msdp package only lands when #612 merges, so the matching change for MSDP will be added there in a follow-up commit (no point duplicating the work in this PR — it would conflict on the same lines).
- No test changes: the existing mroute integration tests cover the parser/store/sync path; this PR is wiring only.
- The deploy gap that was the actual cause of "no data in ClickHouse" is the lake-indexer-env SealedSecret missing the mroute env vars + AWS credentials. That's a SealedSecret edit owned by whoever runs lake-prod ops; this PR is the prerequisite that makes those env vars functional for the secondary indexers.



Closes malbeclabs/infra#1416.

