### PR TITLE
indexer: parse flat shape from show ip mroute | json

### DIFF
--- a/indexer/pkg/dz/mroute/parser.go
+++ b/indexer/pkg/dz/mroute/parser.go
@@ -8,8 +8,13 @@ import (
 )
 
 // rawDump matches the top-level shape of `show ip mroute | json` on Arista EOS.
+// Arista emits two shapes:
+//   - Wrapped (used by `show ip mroute vrf all | json`): {"vrfs": {<name>: rawVRF}}
+//   - Flat   (used by `show ip mroute | json`):          rawVRF at top level, default VRF
 type rawDump struct {
-	VRFs map[string]rawVRF `json:"vrfs"`
+	VRFs          map[string]rawVRF `json:"vrfs"`
+	SparseMode    *rawModeGroups    `json:"sparseMode,omitempty"`
+	Bidirectional *rawModeGroups    `json:"bidirectional,omitempty"`
 }
 
 type rawVRF struct {
@@ -56,9 +61,18 @@ func Parse(raw []byte) ([]Entry, error) {
 	}
 
 	var out []Entry
-	for vrfName, vrf := range d.VRFs {
-		out = appendEntries(out, vrfName, ModeSparse, vrf.SparseMode)
-		out = appendEntries(out, vrfName, ModeBidirectional, vrf.Bidirectional)
+	if len(d.VRFs) > 0 {
+		for vrfName, vrf := range d.VRFs {
+			out = appendEntries(out, vrfName, ModeSparse, vrf.SparseMode)
+			out = appendEntries(out, vrfName, ModeBidirectional, vrf.Bidirectional)
+		}
+		return out, nil
+	}
+	if d.SparseMode != nil {
+		out = appendEntries(out, "default", ModeSparse, *d.SparseMode)
+	}
+	if d.Bidirectional != nil {
+		out = appendEntries(out, "default", ModeBidirectional, *d.Bidirectional)
 	}
 	return out, nil
 }

--- a/indexer/pkg/dz/mroute/parser_test.go
+++ b/indexer/pkg/dz/mroute/parser_test.go
@@ -194,7 +194,22 @@ func TestParse_Empty(t *testing.T) {
 // envelopes use the flat form; the parser must treat it as VRF "default".
 func TestParse_FlatShape(t *testing.T) {
 	const flat = `{
-	  "bidirectional": { "groups": {} },
+	  "bidirectional": {
+	    "groups": {
+	      "239.1.1.1": {
+	        "groupSources": {
+	          "10.0.0.1": {
+	            "sourceAddress": "10.0.0.1",
+	            "creationTime": 1779894656.0,
+	            "routeFlags": "B",
+	            "registerInOifList": false,
+	            "rpfInterface": "Null0",
+	            "oifList": []
+	          }
+	        }
+	      }
+	    }
+	  },
 	  "sparseMode": {
 	    "groups": {
 	      "233.84.178.6": {
@@ -214,11 +229,18 @@ func TestParse_FlatShape(t *testing.T) {
 	}`
 	entries, err := Parse([]byte(flat))
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "default", entries[0].VRF)
-	assert.Equal(t, ModeSparse, entries[0].Mode)
-	assert.Equal(t, "233.84.178.6", entries[0].GroupAddress)
-	assert.Equal(t, "148.51.120.0", entries[0].SourceAddress)
+	require.Len(t, entries, 2)
+
+	byKey := indexByKey(entries)
+	sparse := byKey["default|sparse|233.84.178.6|148.51.120.0"]
+	require.NotNil(t, sparse)
+	assert.Equal(t, "default", sparse.VRF)
+	assert.Equal(t, ModeSparse, sparse.Mode)
+
+	bidir := byKey["default|bidirectional|239.1.1.1|10.0.0.1"]
+	require.NotNil(t, bidir)
+	assert.Equal(t, "default", bidir.VRF)
+	assert.Equal(t, ModeBidirectional, bidir.Mode)
 }
 
 func TestParse_InvalidJSON(t *testing.T) {

--- a/indexer/pkg/dz/mroute/parser_test.go
+++ b/indexer/pkg/dz/mroute/parser_test.go
@@ -188,6 +188,39 @@ func TestParse_Empty(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+// TestParse_FlatShape verifies the parser handles the shape Arista actually
+// emits from `show ip mroute | json` — flat (no `vrfs` wrapper). The wrapped
+// form only appears when the device is queried with `vrf all`. Real S3
+// envelopes use the flat form; the parser must treat it as VRF "default".
+func TestParse_FlatShape(t *testing.T) {
+	const flat = `{
+	  "bidirectional": { "groups": {} },
+	  "sparseMode": {
+	    "groups": {
+	      "233.84.178.6": {
+	        "groupSources": {
+	          "148.51.120.0": {
+	            "sourceAddress": "148.51.120.0",
+	            "creationTime": 1779894656.0,
+	            "routeFlags": "MPE",
+	            "registerInOifList": false,
+	            "rpfInterface": "Null0",
+	            "oifList": []
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+	entries, err := Parse([]byte(flat))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "default", entries[0].VRF)
+	assert.Equal(t, ModeSparse, entries[0].Mode)
+	assert.Equal(t, "233.84.178.6", entries[0].GroupAddress)
+	assert.Equal(t, "148.51.120.0", entries[0].SourceAddress)
+}
+
 func TestParse_InvalidJSON(t *testing.T) {
 	_, err := Parse([]byte("not json"))
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary
- Arista's `show ip mroute | json` returns a flat `{sparseMode, bidirectional}` object for the default VRF — only `vrf all` produces the `{"vrfs": {<name>: ...}}` wrapper. The parser only handled the wrapper, so every prod upload parsed to zero entries.
- Make the parser accept both shapes; treat flat input as VRF `"default"`.
- Parsing a real mainnet S3 envelope now yields 612 entries (was 0).

## Symptom
`SyncIPMroute` activity reported `success` with `entries=0` for all three networks despite devices having live mroute state (verified by `show ip mroute | json` on `frk-dz001` testnet and `sea10-dz001` mainnet). The bucket received envelopes; the parser dropped them.

## Testing Verification
- Added `TestParse_FlatShape` covering the flat envelope shape pulled from a real S3 object.
- Parsed an actual mainnet S3 envelope (`s3://malbeclabs-device-telemetry-state-snapshots-mainnet-beta/snapshots/ip-mroute/.../20260530T033834Z.json`) — 612 entries, correct VRF/group/source/flags on the first row.
- Existing `parser_test.go` and full mroute suite still green.



Closes malbeclabs/infra#1416.

