### PR TITLE
web,api: add maintenance calendar page at /ops/maintenance

### DIFF
--- a/api/handlers/ops_tickets.go
+++ b/api/handlers/ops_tickets.go
@@ -10,7 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 var opsMgmtBaseURL = "https://doublezero.xyz/api/network_incidents/v1"
@@ -49,12 +52,15 @@ type OpsTicket struct {
 	AffectedLinks       []OpsTicketEntity `json:"affected_links,omitempty"`
 	AffectedDevices     []OpsTicketEntity `json:"affected_devices,omitempty"`
 	ReporterName        string            `json:"reporter_name"`
-	ReporterEmail       string            `json:"reporter_email"`
+	ReporterEmail       string            `json:"reporter_email,omitempty"`
+	ContributorName     *string           `json:"contributor_name,omitempty"`
 	StartAt             *string           `json:"start_at,omitempty"`
 	EndAt               *string           `json:"end_at,omitempty"`
 	SlackMessageURL     *string           `json:"slack_message_url,omitempty"`
 	CreatedAt           string            `json:"created_at"`
 	UpdatedAt           string            `json:"updated_at"`
+	MetroCodes          []string          `json:"metro_codes,omitempty"`
+	EnrichedDeviceCodes []string          `json:"enriched_device_codes,omitempty"`
 }
 
 // OpsTicketsListResponse wraps a paginated list of tickets.
@@ -149,20 +155,29 @@ func (c *opsClient) post(ctx context.Context, path string, payload any) ([]byte,
 }
 
 // GetOpsTickets proxies GET /api/ops-tickets
-// Query param: status=active (default) or any single status value.
-// The upstream API understands "active" and "not_active" as presets.
+// Query params: status (default "active"), type (optional), limit (optional).
+// The upstream API understands "active" and "not_active" as status presets.
 // No auth required.
 func (a *API) GetOpsTickets(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	client := newOpsClient()
 
-	// Pass status param directly to the upstream API; default to "active".
-	status := r.URL.Query().Get("status")
+	q := r.URL.Query()
+	status := q.Get("status")
 	if status == "" {
 		status = "active"
 	}
 
-	body, err := client.get(ctx, "/tickets?status="+url.QueryEscape(status))
+	upstream := url.Values{}
+	upstream.Set("status", status)
+	if t := q.Get("type"); t != "" {
+		upstream.Set("type", t)
+	}
+	if lim := q.Get("limit"); lim != "" {
+		upstream.Set("limit", lim)
+	}
+
+	body, err := client.get(ctx, "/tickets?"+upstream.Encode())
 	if err != nil {
 		http.Error(w, "failed to fetch ops tickets", http.StatusBadGateway)
 		return
@@ -170,6 +185,234 @@ func (a *API) GetOpsTickets(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(body)
+}
+
+// GetMaintenanceCalendar serves GET /api/ops-tickets/maintenance.
+// Public endpoint — returns only maintenance tickets with reporter_email stripped
+// and metro_codes enriched from ClickHouse.
+func (a *API) GetMaintenanceCalendar(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	client := newOpsClient()
+
+	status := r.URL.Query().Get("status")
+	if status == "" {
+		status = "active"
+	}
+
+	tickets, err := fetchAllMaintenanceTickets(ctx, client, status)
+	if err != nil {
+		http.Error(w, "failed to fetch maintenance calendar", http.StatusBadGateway)
+		return
+	}
+
+	if a.DB != nil {
+		tickets = enrichTicketsWithMetros(ctx, a.DB, tickets)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": OpsTicketsListResponse{Tickets: tickets, Total: len(tickets)},
+	})
+}
+
+// fetchAllMaintenanceTickets fetches all maintenance tickets for the given status,
+// paginating through the upstream API using offset until all pages are collected.
+func fetchAllMaintenanceTickets(ctx context.Context, client *opsClient, status string) ([]OpsTicket, error) {
+	const (
+		maxPages = 50
+		pageSize = 50
+	)
+	seen := make(map[string]struct{})
+	var all []OpsTicket
+
+	for page := 0; page < maxPages; page++ {
+		offset := page * pageSize
+		// limit= is sent explicitly so the offset step always matches the server page size.
+		path := fmt.Sprintf("/tickets?status=%s&type=maintenance&limit=%d&offset=%d",
+			url.QueryEscape(status), pageSize, offset)
+		body, err := client.get(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+
+		tickets, gotSize, upstreamTotal, err := parseMaintenanceTickets(body)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, t := range tickets {
+			// Skip tickets with empty IDs (upstream data quality issue).
+			if t.ID == "" {
+				continue
+			}
+			if _, dup := seen[t.ID]; !dup {
+				seen[t.ID] = struct{}{}
+				all = append(all, t)
+			}
+		}
+		log.Printf("maintenance calendar: status=%s offset=%d upstream_total=%d page_size=%d collected=%d",
+			status, offset, upstreamTotal, gotSize, len(all))
+
+		// Stop when the page was empty or we've received all upstream items.
+		// upstreamTotal=0 with gotSize=0 also exits via the first guard.
+		if gotSize == 0 || offset+gotSize >= upstreamTotal {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+// parseMaintenanceTickets extracts maintenance tickets from the upstream response
+// envelope { "data": { "tickets": [...], "total": N } }, stripping reporter_email.
+// Returns the filtered tickets, count of all upstream tickets in the page, and the upstream total.
+func parseMaintenanceTickets(body []byte) (tickets []OpsTicket, pageSize int, upstreamTotal int, err error) {
+	var envelope struct {
+		Data struct {
+			Tickets []OpsTicket `json:"tickets"`
+			Total   int         `json:"total"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(body, &envelope); err != nil {
+		return
+	}
+	pageSize = len(envelope.Data.Tickets)
+	upstreamTotal = envelope.Data.Total
+	tickets = make([]OpsTicket, 0)
+	for _, t := range envelope.Data.Tickets {
+		if t.Type != OpsTicketTypeMaintenance {
+			continue
+		}
+		t.ReporterEmail = ""
+		tickets = append(tickets, t)
+	}
+	return
+}
+
+// enrichTicketsWithMetros queries ClickHouse to resolve actual metro codes for the
+// link and device pubkeys referenced by each ticket, populating MetroCodes.
+func enrichTicketsWithMetros(ctx context.Context, db driver.Conn, tickets []OpsTicket) []OpsTicket {
+	linkPKSet := make(map[string]struct{})
+	devicePKSet := make(map[string]struct{})
+	for _, t := range tickets {
+		for _, pk := range t.AffectedLinkPubkeys {
+			if pk != "" {
+				linkPKSet[pk] = struct{}{}
+			}
+		}
+		for _, pk := range t.DevicePubkeys {
+			if pk != "" {
+				devicePKSet[pk] = struct{}{}
+			}
+		}
+	}
+
+	linkMetros := make(map[string][]string)
+	linkDevices := make(map[string][]string) // link pk → side device codes
+	deviceMetros := make(map[string][]string)
+
+	if len(devicePKSet) > 0 {
+		pks := make([]string, 0, len(devicePKSet))
+		for pk := range devicePKSet {
+			pks = append(pks, pk)
+		}
+		devRows, err := db.Query(ctx, `
+			SELECT d.pk, m.code
+			FROM dz_devices_current d
+			LEFT JOIN dz_metros_current m ON d.metro_pk = m.pk
+			WHERE d.pk IN ($1) AND m.code != ''`, pks)
+		if err == nil {
+			for devRows.Next() {
+				var pk, code string
+				if devRows.Scan(&pk, &code) == nil {
+					deviceMetros[pk] = append(deviceMetros[pk], code)
+				}
+			}
+			if err := devRows.Err(); err != nil {
+				log.Printf("enrichTicketsWithMetros: device rows error: %v", err)
+			}
+			devRows.Close()
+		}
+	}
+
+	if len(linkPKSet) > 0 {
+		pks := make([]string, 0, len(linkPKSet))
+		for pk := range linkPKSet {
+			pks = append(pks, pk)
+		}
+		linkRows, err := db.Query(ctx, `
+			SELECT l.pk, COALESCE(ma.code, ''), COALESCE(mz.code, ''), COALESCE(da.code, ''), COALESCE(dz.code, '')
+			FROM dz_links_current l
+			LEFT JOIN dz_devices_current da ON l.side_a_pk = da.pk
+			LEFT JOIN dz_metros_current ma ON da.metro_pk = ma.pk
+			LEFT JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
+			LEFT JOIN dz_metros_current mz ON dz.metro_pk = mz.pk
+			WHERE l.pk IN ($1)`, pks)
+		if err == nil {
+			for linkRows.Next() {
+				var pk, aMetro, zMetro, aDevice, zDevice string
+				if linkRows.Scan(&pk, &aMetro, &zMetro, &aDevice, &zDevice) == nil {
+					if aMetro != "" {
+						linkMetros[pk] = append(linkMetros[pk], aMetro)
+					}
+					if zMetro != "" {
+						linkMetros[pk] = append(linkMetros[pk], zMetro)
+					}
+					if aDevice != "" {
+						linkDevices[pk] = append(linkDevices[pk], aDevice)
+					}
+					if zDevice != "" {
+						linkDevices[pk] = append(linkDevices[pk], zDevice)
+					}
+				}
+			}
+			if err := linkRows.Err(); err != nil {
+				log.Printf("enrichTicketsWithMetros: link rows error: %v", err)
+			}
+			linkRows.Close()
+		}
+	}
+
+	for i := range tickets {
+		metroSeen := make(map[string]bool)
+		var metros []string
+		devSeen := make(map[string]bool)
+		var enrichedDevices []string
+
+		// Seed devSeen with explicitly listed device codes so we don't duplicate them.
+		for _, d := range tickets[i].AffectedDevices {
+			devSeen[d.Code] = true
+		}
+
+		for _, pk := range tickets[i].AffectedLinkPubkeys {
+			for _, code := range linkMetros[pk] {
+				if !metroSeen[code] {
+					metroSeen[code] = true
+					metros = append(metros, code)
+				}
+			}
+			for _, code := range linkDevices[pk] {
+				if !devSeen[code] {
+					devSeen[code] = true
+					enrichedDevices = append(enrichedDevices, code)
+				}
+			}
+		}
+		for _, pk := range tickets[i].DevicePubkeys {
+			for _, code := range deviceMetros[pk] {
+				if !metroSeen[code] {
+					metroSeen[code] = true
+					metros = append(metros, code)
+				}
+			}
+		}
+		sort.Strings(metros)
+		sort.Strings(enrichedDevices)
+		tickets[i].MetroCodes = metros
+		tickets[i].EnrichedDeviceCodes = enrichedDevices
+	}
+
+	return tickets
 }
 
 // CreateOpsTicket proxies POST /api/ops-tickets.

--- a/api/main.go
+++ b/api/main.go
@@ -546,6 +546,7 @@ func main() {
 		r.Get("/api/incidents/devices/csv", api.GetDeviceIncidentsCSV)
 
 		// Ops Management tickets proxy (auth required — tickets contain reporter PII)
+		r.Get("/api/ops-tickets/maintenance", api.GetMaintenanceCalendar)
 		r.With(api.RequireAuth).Get("/api/ops-tickets", api.GetOpsTickets)
 		r.With(api.RequireAuth).Get("/api/ops-tickets/history", api.GetOpsTicketHistory)
 		r.With(api.RequireAuth).Get("/api/ops-tickets/assignees", api.GetOpsAssignees)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import { MaintenancePlannerPage } from '@/components/maintenance-planner-page'
 import { StatusPage } from '@/components/status-page'
 import { TimelinePage } from '@/components/timeline-page'
 import { IncidentsPage } from '@/components/incidents-page'
+import { MaintenanceCalendarPage } from '@/components/maintenance-calendar-page'
 import { StatusAppendix } from '@/components/status-appendix'
 import { DevicesPage } from '@/components/devices-page'
 import { LinksPage } from '@/components/links-page'
@@ -671,10 +672,16 @@ function AppContent() {
             {/* Timeline route */}
             <Route path="/timeline" element={<TimelinePage />} />
 
-            {/* Incidents routes */}
-            <Route path="/incidents" element={<Navigate to="/incidents/links" replace />} />
-            <Route path="/incidents/links" element={<IncidentsPage />} />
-            <Route path="/incidents/devices" element={<IncidentsPage />} />
+            {/* Incidents redirects — keep old URLs working */}
+            <Route path="/incidents" element={<Navigate to="/ops/incidents/links" replace />} />
+            <Route path="/incidents/links" element={<Navigate to="/ops/incidents/links" replace />} />
+            <Route path="/incidents/devices" element={<Navigate to="/ops/incidents/devices" replace />} />
+
+            {/* Ops routes */}
+            <Route path="/ops/incidents" element={<Navigate to="/ops/incidents/links" replace />} />
+            <Route path="/ops/incidents/links" element={<IncidentsPage />} />
+            <Route path="/ops/incidents/devices" element={<IncidentsPage />} />
+            <Route path="/ops/maintenance" element={<MaintenanceCalendarPage />} />
 
 
             {/* Settings */}

--- a/web/src/components/incidents-page.tsx
+++ b/web/src/components/incidents-page.tsx
@@ -431,7 +431,7 @@ export function IncidentsPage() {
   const location = useLocation()
 
   // Scope from path
-  const scope: IncidentScope = location.pathname === '/incidents/devices' ? 'devices' : 'links'
+  const scope: IncidentScope = location.pathname.endsWith('/devices') ? 'devices' : 'links'
 
   // Parse URL params with defaults
   const range = (searchParams.get('range') as IncidentTimeRange) || '24h'
@@ -902,7 +902,7 @@ export function IncidentsPage() {
         <div className="flex items-center gap-2 mb-4">
           <div className="flex items-center gap-1 bg-muted rounded-md p-1">
             <button
-              onClick={() => navigate('/incidents/links')}
+              onClick={() => navigate('/ops/incidents/links')}
               className={`px-3 py-1 text-sm rounded transition-colors ${
                 scope === 'links'
                   ? 'bg-background text-foreground shadow-sm'
@@ -912,7 +912,7 @@ export function IncidentsPage() {
               Links
             </button>
             <button
-              onClick={() => navigate('/incidents/devices')}
+              onClick={() => navigate('/ops/incidents/devices')}
               className={`px-3 py-1 text-sm rounded transition-colors ${
                 scope === 'devices'
                   ? 'bg-background text-foreground shadow-sm'

--- a/web/src/components/maintenance-calendar-page.tsx
+++ b/web/src/components/maintenance-calendar-page.tsx
@@ -1,0 +1,143 @@
+import { useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useMaintenanceEvents } from './maintenance-calendar/use-maintenance-events'
+import { MaintenanceFilters } from './maintenance-calendar/filters'
+import { GanttView } from './maintenance-calendar/gantt-view'
+import { DayView } from './maintenance-calendar/day-view'
+import {
+  startOfDay,
+  getDays,
+  formatDateRange,
+} from './maintenance-calendar/date-utils'
+import type { CalendarView } from './maintenance-calendar/date-utils'
+
+function navigate(anchor: Date, view: CalendarView, dir: -1 | 1): Date {
+  const next = new Date(anchor)
+  if (view === 'day') next.setDate(next.getDate() + dir)
+  else if (view === 'week') next.setDate(next.getDate() + dir * 7)
+  else if (view === '2week') next.setDate(next.getDate() + dir * 14)
+  else next.setMonth(next.getMonth() + dir)
+  return next
+}
+
+export function MaintenanceCalendarPage() {
+  const [view, setView] = useState<CalendarView>('2week')
+  const [anchor, setAnchor] = useState(() => startOfDay(new Date()))
+
+  const {
+    events,
+    allContributors,
+    allMetros,
+    allDevices,
+    allLinks,
+    rawCount,
+    filters,
+    setFilters,
+    hasActiveFilters,
+    isLoading,
+    error,
+  } = useMaintenanceEvents()
+
+  const days = view === 'day' ? [anchor] : getDays(view, anchor)
+
+  const handleNavigate = useCallback(
+    (dir: -1 | 1) => setAnchor((a) => navigate(a, view, dir)),
+    [view]
+  )
+
+  const handleViewChange = useCallback((v: CalendarView) => {
+    setView(v)
+  }, [])
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Page header */}
+      <div className="flex items-center justify-between gap-4 px-6 py-3 border-b border-border flex-shrink-0">
+        <h1 className="text-xl font-medium">Maintenance Calendar</h1>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setAnchor(startOfDay(new Date()))}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Go to today
+          </button>
+          <div className="flex items-center border border-border">
+            <button
+              type="button"
+              onClick={() => handleNavigate(-1)}
+              className="h-[30px] w-[30px] flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/30 border-r border-border transition-colors"
+              aria-label="Previous period"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="h-[30px] flex items-center px-4 text-sm text-muted-foreground bg-[var(--input)] whitespace-nowrap min-w-[200px] justify-center">
+              {formatDateRange(view, anchor, days)}
+            </span>
+            <button
+              type="button"
+              onClick={() => handleNavigate(1)}
+              className="h-[30px] w-[30px] flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/30 border-l border-border transition-colors"
+              aria-label="Next period"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters toolbar */}
+      <MaintenanceFilters
+        filters={filters}
+        onFiltersChange={setFilters}
+        hasActiveFilters={hasActiveFilters}
+        allContributors={allContributors}
+        allMetros={allMetros}
+        allDevices={allDevices}
+        allLinks={allLinks}
+        view={view}
+        onViewChange={handleViewChange}
+      />
+
+      {/* Calendar body */}
+      {isLoading ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+          Loading maintenance events…
+        </div>
+      ) : error ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-destructive">
+          Failed to load maintenance events: {String(error)}
+        </div>
+      ) : rawCount === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+          No maintenance tickets found in the system.
+        </div>
+      ) : view === 'day' ? (
+        <DayView events={events} anchor={anchor} />
+      ) : (
+        <GanttView events={events} view={view} anchor={anchor} />
+      )}
+
+      {/* Legend */}
+      <div className="flex items-center gap-5 px-6 py-2 border-t border-border bg-card text-xs text-muted-foreground flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <div className="w-5 h-2.5 border-l-[3px] bg-[oklch(0.5_0.1_250/30%)] border-l-[oklch(0.65_0.12_250/80%)]" />
+          Planned
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-5 h-2.5 border-l-[3px] border-dashed bg-[oklch(0.5_0.1_140/30%)] border-l-[oklch(0.65_0.12_140/80%)]" />
+          In progress
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-0.5 w-5 bg-accent" />
+          Current time
+        </div>
+        <span className="ml-auto">
+          {events.length === rawCount
+            ? `${events.length} event${events.length !== 1 ? 's' : ''}`
+            : `${events.length} of ${rawCount} event${rawCount !== 1 ? 's' : ''} (filtered)`}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/maintenance-calendar/colors.test.ts
+++ b/web/src/components/maintenance-calendar/colors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { contributorHue, evBg, evBorderColor, evText, dotColor } from './colors'
+
+describe('contributorHue', () => {
+  it('returns a value in [0, 360)', () => {
+    expect(contributorHue('RockawayX')).toBeGreaterThanOrEqual(0)
+    expect(contributorHue('RockawayX')).toBeLessThan(360)
+  })
+
+  it('is deterministic — same name always returns same hue', () => {
+    expect(contributorHue('Malbec Labs')).toBe(contributorHue('Malbec Labs'))
+  })
+
+  it('different names produce different hues', () => {
+    expect(contributorHue('RockawayX')).not.toBe(contributorHue('Malbec Labs'))
+  })
+
+  it('handles empty string without throwing', () => {
+    expect(() => contributorHue('')).not.toThrow()
+  })
+})
+
+describe('color helpers', () => {
+  it('evBg returns oklch string with hue and default alpha', () => {
+    expect(evBg(120)).toBe('oklch(0.62 0.14 120 / 30%)')
+  })
+
+  it('evBg accepts custom alpha', () => {
+    expect(evBg(120, 50)).toBe('oklch(0.62 0.14 120 / 50%)')
+  })
+
+  it('evBorderColor returns oklch string with hue and default alpha', () => {
+    expect(evBorderColor(240)).toBe('oklch(0.68 0.16 240 / 90%)')
+  })
+
+  it('evText returns oklch string with hue', () => {
+    expect(evText(60)).toBe('oklch(0.78 0.14 60)')
+  })
+
+  it('dotColor returns oklch string with hue', () => {
+    expect(dotColor(300)).toBe('oklch(0.65 0.15 300)')
+  })
+})

--- a/web/src/components/maintenance-calendar/colors.ts
+++ b/web/src/components/maintenance-calendar/colors.ts
@@ -16,8 +16,8 @@ export function evBorderColor(hue: number, alpha = 90): string {
   return `oklch(0.68 0.16 ${hue} / ${alpha}%)`
 }
 
-export function evText(hue: number): string {
-  return `oklch(0.78 0.14 ${hue})`
+export function evText(hue: number, light = false): string {
+  return light ? `oklch(0.38 0.16 ${hue})` : `oklch(0.78 0.14 ${hue})`
 }
 
 export function dotColor(hue: number): string {

--- a/web/src/components/maintenance-calendar/colors.ts
+++ b/web/src/components/maintenance-calendar/colors.ts
@@ -1,0 +1,25 @@
+// djb2 hash → stable hue angle [0, 360) for a contributor name
+export function contributorHue(name: string): number {
+  let hash = 5381
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) + hash) + name.charCodeAt(i)
+    hash = hash >>> 0  // keep unsigned 32-bit
+  }
+  return hash % 360
+}
+
+export function evBg(hue: number, alpha = 30): string {
+  return `oklch(0.62 0.14 ${hue} / ${alpha}%)`
+}
+
+export function evBorderColor(hue: number, alpha = 90): string {
+  return `oklch(0.68 0.16 ${hue} / ${alpha}%)`
+}
+
+export function evText(hue: number): string {
+  return `oklch(0.78 0.14 ${hue})`
+}
+
+export function dotColor(hue: number): string {
+  return `oklch(0.65 0.15 ${hue})`
+}

--- a/web/src/components/maintenance-calendar/date-utils.ts
+++ b/web/src/components/maintenance-calendar/date-utils.ts
@@ -1,0 +1,94 @@
+export type CalendarView = 'day' | 'week' | '2week' | 'month'
+
+export function startOfDay(d: Date): Date {
+  const r = new Date(d)
+  r.setHours(0, 0, 0, 0)
+  return r
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+// Calendar days from a to b (positive when b is later)
+export function daysBetween(a: Date, b: Date): number {
+  return Math.round(
+    (startOfDay(b).getTime() - startOfDay(a).getTime()) / 86_400_000
+  )
+}
+
+export function addDays(d: Date, n: number): Date {
+  const r = new Date(d)
+  r.setDate(r.getDate() + n)
+  return r
+}
+
+// Monday of the ISO week containing d
+export function getMondayOf(d: Date): Date {
+  const r = startOfDay(d)
+  const dow = r.getDay()
+  r.setDate(r.getDate() - (dow === 0 ? 6 : dow - 1))
+  return r
+}
+
+export function isWeekend(d: Date): boolean {
+  const dow = d.getDay()
+  return dow === 0 || dow === 6
+}
+
+const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const MONTH_FULL = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+
+export function getDays(view: CalendarView, anchor: Date): Date[] {
+  if (view === 'day') return [startOfDay(anchor)]
+  if (view === 'week') {
+    const start = getMondayOf(anchor)
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i))
+  }
+  if (view === '2week') {
+    const start = getMondayOf(anchor)
+    return Array.from({ length: 14 }, (_, i) => addDays(start, i))
+  }
+  // month — exactly the days in the current month, no week-padding
+  const y = anchor.getFullYear()
+  const m = anchor.getMonth()
+  const daysInMonth = new Date(y, m + 1, 0).getDate()
+  return Array.from({ length: daysInMonth }, (_, i) => new Date(y, m, i + 1))
+}
+
+export function formatDateRange(view: CalendarView, anchor: Date, days: Date[]): string {
+  if (view === 'day') {
+    const d = anchor
+    return `${DAY_ABBR[d.getDay()]}, ${MONTH_FULL[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
+  }
+  if (view === 'month') {
+    return `${MONTH_FULL[anchor.getMonth()]} ${anchor.getFullYear()}`
+  }
+  const s = days[0], e = days[days.length - 1]
+  if (s.getMonth() === e.getMonth()) {
+    return `${MONTH_FULL[s.getMonth()]} ${s.getDate()}–${e.getDate()}, ${s.getFullYear()}`
+  }
+  return `${MONTH_SHORT[s.getMonth()]} ${s.getDate()} – ${MONTH_SHORT[e.getMonth()]} ${e.getDate()}, ${s.getFullYear()}`
+}
+
+// "1:00 am", "12:00 pm", etc.
+export function formatHour(h: number): string {
+  if (h === 0 || h === 24) return '12:00 am'
+  if (h === 12) return '12:00 pm'
+  const ampm = h < 12 ? 'am' : 'pm'
+  return `${h < 12 ? h : h - 12}:00 ${ampm}`
+}
+
+// "Mon, Jun 15 · 1 am" / "Tue, Jun 16 · 1:30 pm"
+export function fmtDT(d: Date): string {
+  const h = d.getHours(), m = d.getMinutes()
+  const ampm = h < 12 ? 'am' : 'pm'
+  const h12 = h % 12 || 12
+  const time = m === 0 ? `${h12} ${ampm}` : `${h12}:${String(m).padStart(2, '0')} ${ampm}`
+  return `${DAY_ABBR[d.getDay()]}, ${MONTH_SHORT[d.getMonth()]} ${d.getDate()} · ${time}`
+}

--- a/web/src/components/maintenance-calendar/day-view.tsx
+++ b/web/src/components/maintenance-calendar/day-view.tsx
@@ -1,0 +1,265 @@
+import { useRef, useEffect, useState, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { evBg, evBorderColor, evText } from './colors'
+import { isSameDay, startOfDay, formatHour } from './date-utils'
+import { EventTooltipPanel } from './event-tooltip'
+import type { TooltipState } from './event-tooltip'
+import type { MaintenanceEvent } from './use-maintenance-events'
+
+const HOUR_H = 64  // px per hour
+
+interface DayViewProps {
+  events: MaintenanceEvent[]
+  anchor: Date
+}
+
+interface TimedEvent {
+  ev: MaintenanceEvent
+  sh: number
+  eh: number
+  colIdx: number
+}
+
+function assignColumns(items: Omit<TimedEvent, 'colIdx'>[]): TimedEvent[] {
+  const cols: Array<Array<{ sh: number; eh: number }>> = []
+  return items.map((item) => {
+    let colIdx = -1
+    for (let c = 0; c < cols.length; c++) {
+      if (!cols[c].some((x) => item.sh < x.eh && item.eh > x.sh)) {
+        cols[c].push(item)
+        colIdx = c
+        break
+      }
+    }
+    if (colIdx === -1) {
+      colIdx = cols.length
+      cols.push([item])
+    }
+    return { ...item, colIdx }
+  })
+}
+
+function fmtTime(d: Date): string {
+  const h = d.getHours()
+  const m = d.getMinutes()
+  const ampm = h < 12 ? 'am' : 'pm'
+  const h12 = h % 12 || 12
+  return m === 0 ? `${h12} ${ampm}` : `${h12}:${String(m).padStart(2, '0')} ${ampm}`
+}
+
+export function DayView({ events, anchor }: DayViewProps) {
+  const anchorDay = startOfDay(anchor)
+  const today = startOfDay(new Date())
+  const isToday = isSameDay(anchor, today)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    if (isToday) {
+      const now = new Date()
+      const nowY = (now.getHours() + now.getMinutes() / 60) * HOUR_H
+      el.scrollTop = Math.max(0, nowY - 80)
+    } else {
+      el.scrollTop = 6 * HOUR_H
+    }
+  }, [anchor, isToday])
+
+  // Tooltip with grace-period hide so links are clickable
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const showTooltip = useCallback((ev: MaintenanceEvent, e: React.MouseEvent) => {
+    clearTimeout(hideTimer.current)
+    setTooltip({ ev, x: e.clientX, y: e.clientY })
+  }, [])
+
+  const startHide = useCallback(() => {
+    hideTimer.current = setTimeout(() => setTooltip(null), 200)
+  }, [])
+
+  const cancelHide = useCallback(() => {
+    clearTimeout(hideTimer.current)
+  }, [])
+
+  // Only events overlapping this day
+  const dayEnd = new Date(anchorDay.getTime() + 86_400_000)
+  const dayEvents = events.filter((ev) => ev.startAt < dayEnd && ev.endAt > anchorDay)
+
+  // All-day banner: events whose total duration exceeds 24 hours.
+  // Overnight events (e.g. 9 pm → 4 am, 7 h) stay in the hour grid.
+  const MS_24H = 24 * 60 * 60 * 1000
+  const allDayEvents = dayEvents.filter(
+    (ev) => ev.endAt.getTime() - ev.startAt.getTime() > MS_24H
+  )
+
+  // Hour grid: events ≤ 24 h duration (including overnight cross-midnight events)
+  const rawItems = dayEvents
+    .filter((ev) => ev.endAt.getTime() - ev.startAt.getTime() <= MS_24H)
+    .map((ev) => {
+      // Clamp to this day's bounds so cross-midnight events don't overflow the grid
+      const sh = isSameDay(ev.startAt, anchorDay)
+        ? ev.startAt.getHours() + ev.startAt.getMinutes() / 60
+        : 0
+      const eh = isSameDay(ev.endAt, anchorDay)
+        ? ev.endAt.getHours() + ev.endAt.getMinutes() / 60
+        : 24
+      return { ev, sh, eh: Math.max(eh, sh + 0.5) }
+    })
+    .sort((a, b) => a.sh - b.sh)
+
+  const timedItems = assignColumns(rawItems)
+  const numCols = timedItems.length > 0
+    ? Math.max(...timedItems.map((x) => x.colIdx)) + 1
+    : 1
+
+  const nowDate = new Date()
+  const nowFrac = isToday
+    ? nowDate.getHours() + nowDate.getMinutes() / 60
+    : null
+
+  return (
+    <>
+      <div className="flex flex-col flex-1 min-h-0">
+        {/* All-day banner for multi-day maintenance events */}
+        {allDayEvents.length > 0 && (
+          <div className="flex-shrink-0 border-b border-border bg-card">
+            <div className="flex">
+              {/* Align with hour label column */}
+              <div className="flex-shrink-0 w-14 text-[10px] text-muted-foreground text-right pr-2.5 pt-1.5">
+                all-day
+              </div>
+              <div className="flex-1 border-l border-border py-1 space-y-0.5">
+                {allDayEvents.map((ev) => (
+                  <div
+                    key={ev.id}
+                    className={cn(
+                      'mx-2 h-[22px] flex items-center px-2 text-[11px] truncate border-l-[3px] cursor-pointer',
+                      ev.status === 'in-progress' ? 'border-dashed' : ''
+                    )}
+                    style={{
+                      background: evBg(ev.hue, 30),
+                      borderLeftColor: evBorderColor(ev.hue, 90),
+                      color: evText(ev.hue),
+                    }}
+                    onMouseEnter={(e) => showTooltip(ev, e)}
+                    onMouseLeave={startHide}
+                  >
+                    {ev.title}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Hour grid (same-day events only) */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto">
+          <div className="flex" style={{ minHeight: 24 * HOUR_H }}>
+            {/* Hour labels — each label is centered on its grid line */}
+            <div className="flex-shrink-0 w-14 relative" style={{ minHeight: 24 * HOUR_H }}>
+              {Array.from({ length: 24 }, (_, h) =>
+                h === 0 ? null : (
+                  <div
+                    key={h}
+                    className="absolute right-0 pr-2.5 text-[10px] leading-none text-muted-foreground select-none whitespace-nowrap"
+                    style={{ top: h * HOUR_H - 5 }}
+                  >
+                    {formatHour(h)}
+                  </div>
+                )
+              )}
+            </div>
+
+            {/* Events area */}
+            <div className="flex-1 relative border-l border-border" style={{ minHeight: 24 * HOUR_H }}>
+              {/* Hour grid lines */}
+              {Array.from({ length: 24 }, (_, h) => (
+                <div
+                  key={h}
+                  className="absolute left-0 right-0 border-t border-border/40"
+                  style={{ top: h * HOUR_H }}
+                />
+              ))}
+              {/* Half-hour dotted lines */}
+              {Array.from({ length: 24 }, (_, h) => (
+                <div
+                  key={`h-${h}`}
+                  className="absolute left-0 right-0 border-t border-dashed border-border/20"
+                  style={{ top: h * HOUR_H + HOUR_H / 2 }}
+                />
+              ))}
+
+              {/* Current time indicator */}
+              {nowFrac !== null && (
+                <div
+                  className="absolute left-0 right-0 z-10"
+                  style={{ top: nowFrac * HOUR_H }}
+                >
+                  <div className="absolute left-[-4px] w-2 h-2 rounded-full bg-accent" style={{ top: -4 }} />
+                  <div className="h-0.5 bg-accent w-full" />
+                </div>
+              )}
+
+              {/* Empty state — only when no events at all today */}
+              {timedItems.length === 0 && allDayEvents.length === 0 && (
+                <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+                  No maintenance scheduled.
+                </div>
+              )}
+              {timedItems.length === 0 && allDayEvents.length > 0 && (
+                <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+                  No same-day maintenance events.
+                </div>
+              )}
+
+              {/* Event blocks */}
+              {timedItems.map(({ ev, sh, eh, colIdx }) => {
+                const topPx = sh * HOUR_H
+                const heightPx = Math.max((eh - sh) * HOUR_H - 2, 28)
+                const leftPct = (colIdx / numCols) * 100
+                const widthPct = 100 / numCols
+
+                return (
+                  <div
+                    key={ev.id}
+                    className={cn(
+                      'absolute border-l-[3px] overflow-hidden px-2 py-1 cursor-pointer',
+                      ev.status === 'in-progress' && 'border-dashed'
+                    )}
+                    style={{
+                      top: topPx,
+                      height: heightPx,
+                      left: `calc(${leftPct}% + 8px)`,
+                      width: `calc(${widthPct}% - 12px)`,
+                      background: evBg(ev.hue, 30),
+                      borderLeftColor: evBorderColor(ev.hue, 90),
+                      color: evText(ev.hue),
+                    }}
+                    onMouseEnter={(e) => showTooltip(ev, e)}
+                    onMouseLeave={startHide}
+                  >
+                    <div className="text-xs font-medium leading-tight truncate">{ev.title}</div>
+                    {heightPx > 42 && (
+                      <div className="text-[10px] mt-0.5 opacity-70 truncate">
+                        {ev.contributorName} · {fmtTime(ev.startAt)}–{fmtTime(ev.endAt)}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {tooltip && (
+        <EventTooltipPanel
+          state={tooltip}
+          onMouseEnter={cancelHide}
+          onMouseLeave={startHide}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/components/maintenance-calendar/day-view.tsx
+++ b/web/src/components/maintenance-calendar/day-view.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { cn } from '@/lib/utils'
+import { useTheme } from '@/hooks/use-theme'
 import { evBg, evBorderColor, evText } from './colors'
 import { isSameDay, startOfDay, formatHour } from './date-utils'
 import { EventTooltipPanel } from './event-tooltip'
@@ -48,6 +49,8 @@ function fmtTime(d: Date): string {
 }
 
 export function DayView({ events, anchor }: DayViewProps) {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
   const anchorDay = startOfDay(anchor)
   const today = startOfDay(new Date())
   const isToday = isSameDay(anchor, today)
@@ -138,9 +141,9 @@ export function DayView({ events, anchor }: DayViewProps) {
                       ev.status === 'in-progress' ? 'border-dashed' : ''
                     )}
                     style={{
-                      background: evBg(ev.hue, 30),
-                      borderLeftColor: evBorderColor(ev.hue, 90),
-                      color: evText(ev.hue),
+                      background: isDark ? evBg(ev.hue, 30) : evBg(ev.hue, 55),
+                      borderLeftColor: isDark ? evBorderColor(ev.hue, 90) : evBorderColor(ev.hue, 100),
+                      color: isDark ? evText(ev.hue) : evText(ev.hue, true),
                     }}
                     onMouseEnter={(e) => showTooltip(ev, e)}
                     onMouseLeave={startHide}
@@ -232,9 +235,9 @@ export function DayView({ events, anchor }: DayViewProps) {
                       height: heightPx,
                       left: `calc(${leftPct}% + 8px)`,
                       width: `calc(${widthPct}% - 12px)`,
-                      background: evBg(ev.hue, 30),
-                      borderLeftColor: evBorderColor(ev.hue, 90),
-                      color: evText(ev.hue),
+                      background: isDark ? evBg(ev.hue, 30) : evBg(ev.hue, 55),
+                      borderLeftColor: isDark ? evBorderColor(ev.hue, 90) : evBorderColor(ev.hue, 100),
+                      color: isDark ? evText(ev.hue) : evText(ev.hue, true),
                     }}
                     onMouseEnter={(e) => showTooltip(ev, e)}
                     onMouseLeave={startHide}

--- a/web/src/components/maintenance-calendar/event-tooltip.tsx
+++ b/web/src/components/maintenance-calendar/event-tooltip.tsx
@@ -1,0 +1,86 @@
+import { opsTicketUrl } from '@/lib/ops-api'
+import { useIsOpsUser } from '@/hooks/use-is-ops-user'
+import { fmtDT } from './date-utils'
+import type { MaintenanceEvent } from './use-maintenance-events'
+
+export interface TooltipState { ev: MaintenanceEvent; x: number; y: number }
+
+export function EventTooltipPanel({
+  state,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  state: TooltipState
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}) {
+  const { ev, x, y } = state
+  const isOpsUser = useIsOpsUser()
+  const W = 288
+  const left = x + 16 + W > window.innerWidth ? x - W - 8 : x + 16
+  const top = y + 12
+
+  return (
+    <div
+      className="fixed z-50 shadow-xl"
+      style={{ left, top, width: W }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="bg-popover border border-border rounded-md p-3 text-xs">
+        <div className="font-medium text-sm leading-snug mb-0.5">{ev.title}</div>
+        <div className="text-muted-foreground mb-2">{ev.contributorName}</div>
+
+        <div className="space-y-1 border-t border-border/50 pt-2">
+          <div className="flex gap-2">
+            <span className="text-muted-foreground w-14 flex-shrink-0">Status</span>
+            <span className="capitalize">{ev.status.replace(/-/g, ' ')}</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="text-muted-foreground w-14 flex-shrink-0">Start</span>
+            <span>{fmtDT(ev.startAt)}</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="text-muted-foreground w-14 flex-shrink-0">End</span>
+            <span>{fmtDT(ev.endAt)}</span>
+          </div>
+          {ev.affectedLinks.length > 0 && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground w-14 flex-shrink-0">Links</span>
+              <span className="break-all">{ev.affectedLinks.map((l) => l.code).join(', ')}</span>
+            </div>
+          )}
+          {ev.affectedDevices.length > 0 && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground w-14 flex-shrink-0">Devices</span>
+              <span className="break-all">{ev.affectedDevices.map((d) => d.code).join(', ')}</span>
+            </div>
+          )}
+        </div>
+
+        {isOpsUser && (
+          <div className="flex flex-col mt-2 pt-2 border-t border-border/50">
+            <a
+              href={opsTicketUrl(ev.id)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 dark:text-blue-300 hover:underline"
+            >
+              View in ops management →
+            </a>
+            {ev.slackUrl && (
+              <a
+                href={ev.slackUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 dark:text-blue-300 hover:underline"
+              >
+                View Slack thread →
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/maintenance-calendar/filters.tsx
+++ b/web/src/components/maintenance-calendar/filters.tsx
@@ -1,0 +1,357 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { Search, Filter, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { CalendarFilters } from './use-maintenance-events'
+import type { CalendarView } from './date-utils'
+
+const FIELD_PREFIXES = [
+  { prefix: 'contributor:', description: 'Filter by contributor name' },
+  { prefix: 'status:', description: 'Filter by status' },
+  { prefix: 'metro:', description: 'Filter by metro code' },
+  { prefix: 'device:', description: 'Filter by device code' },
+  { prefix: 'link:', description: 'Filter by link code' },
+]
+
+const STATUS_VALUES = [
+  'planned', 'in-progress', 'open', 'acknowledged',
+  'investigating', 'mitigating', 'monitoring',
+  'completed', 'resolved', 'closed',
+]
+
+const VIEWS: { value: CalendarView; label: string }[] = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: '2week', label: '2 weeks' },
+  { value: 'month', label: 'Month' },
+]
+
+// ── chip helpers ──────────────────────────────────────────────────────────────
+
+interface FilterChip { field: string; value: string; label: string }
+
+function filtersToChips(f: CalendarFilters): FilterChip[] {
+  const chips: FilterChip[] = []
+  if (f.search) chips.push({ field: 'search', value: f.search, label: f.search })
+  for (const v of f.contributors) chips.push({ field: 'contributor', value: v, label: `contributor:${v}` })
+  if (f.status) chips.push({ field: 'status', value: f.status, label: `status:${f.status}` })
+  for (const v of f.metros) chips.push({ field: 'metro', value: v, label: `metro:${v}` })
+  for (const v of f.devices) chips.push({ field: 'device', value: v, label: `device:${v}` })
+  for (const v of f.links) chips.push({ field: 'link', value: v, label: `link:${v}` })
+  return chips
+}
+
+function removeChip(f: CalendarFilters, chip: FilterChip): CalendarFilters {
+  if (chip.field === 'search') return { ...f, search: '' }
+  if (chip.field === 'status') return { ...f, status: '' }
+  if (chip.field === 'contributor') { const s = new Set(f.contributors); s.delete(chip.value); return { ...f, contributors: s } }
+  if (chip.field === 'metro') { const s = new Set(f.metros); s.delete(chip.value); return { ...f, metros: s } }
+  if (chip.field === 'device') { const s = new Set(f.devices); s.delete(chip.value); return { ...f, devices: s } }
+  if (chip.field === 'link') { const s = new Set(f.links); s.delete(chip.value); return { ...f, links: s } }
+  return f
+}
+
+function applyToken(f: CalendarFilters, token: string): CalendarFilters {
+  const colonIdx = token.indexOf(':')
+  if (colonIdx <= 0) return { ...f, search: token }
+  const field = token.slice(0, colonIdx).toLowerCase()
+  const value = token.slice(colonIdx + 1)
+  if (field === 'contributor') { const s = new Set(f.contributors); s.add(value); return { ...f, contributors: s } }
+  if (field === 'status') return { ...f, status: value }
+  if (field === 'metro') { const s = new Set(f.metros); s.add(value); return { ...f, metros: s } }
+  if (field === 'device') { const s = new Set(f.devices); s.add(value); return { ...f, devices: s } }
+  if (field === 'link') { const s = new Set(f.links); s.add(value); return { ...f, links: s } }
+  return { ...f, search: token }
+}
+
+// ── CalendarInlineFilter ──────────────────────────────────────────────────────
+
+interface InlineFilterProps {
+  filters: CalendarFilters
+  onChange: (f: CalendarFilters) => void
+  allContributors: string[]
+  allMetros: string[]
+  allDevices: string[]
+  allLinks: string[]
+}
+
+type DropdownItem =
+  | { type: 'prefix'; prefix: string; description: string }
+  | { type: 'field-value'; field: string; value: string }
+  | { type: 'apply-filter' }
+
+function CalendarInlineFilter({
+  filters, onChange, allContributors, allMetros, allDevices, allLinks,
+}: InlineFilterProps) {
+  const [query, setQuery] = useState('')
+  const [isFocused, setIsFocused] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const fieldValueMatch = useMemo(() => {
+    const colonIdx = query.indexOf(':')
+    if (colonIdx <= 0) return null
+    return { field: query.slice(0, colonIdx).toLowerCase(), value: query.slice(colonIdx + 1) }
+  }, [query])
+
+  const fieldValues = useMemo(() => {
+    if (!fieldValueMatch) return []
+    const { field, value } = fieldValueMatch
+    const list: Record<string, string[]> = {
+      contributor: allContributors,
+      status: STATUS_VALUES,
+      metro: allMetros,
+      device: allDevices,
+      link: allLinks,
+    }
+    const src = list[field] ?? []
+    return value ? src.filter(v => v.toLowerCase().includes(value.toLowerCase())) : src
+  }, [fieldValueMatch, allContributors, allMetros, allDevices, allLinks])
+
+  const matchingPrefixes = useMemo(() => {
+    if (!query || query.includes(':')) return []
+    return FIELD_PREFIXES.filter(p => p.prefix.toLowerCase().startsWith(query.toLowerCase()))
+  }, [query])
+
+  const showAllPrefixes = isFocused && query.length === 0
+
+  const items: DropdownItem[] = useMemo(() => {
+    const out: DropdownItem[] = []
+    if (fieldValues.length > 0 && fieldValueMatch) {
+      out.push(...fieldValues.map(v => ({ type: 'field-value' as const, field: fieldValueMatch.field, value: v })))
+    } else if (query.length >= 1 && !query.endsWith(':') && fieldValues.length === 0 && matchingPrefixes.length === 0) {
+      out.push({ type: 'apply-filter' })
+    }
+    if (showAllPrefixes) {
+      out.push(...FIELD_PREFIXES.map(p => ({ type: 'prefix' as const, ...p })))
+    } else if (matchingPrefixes.length > 0 && fieldValues.length === 0) {
+      out.push(...matchingPrefixes.map(p => ({ type: 'prefix' as const, ...p })))
+    }
+    return out
+  }, [query, fieldValues, fieldValueMatch, showAllPrefixes, matchingPrefixes])
+
+  useEffect(() => { setSelectedIndex(-1) }, [query])
+
+  const commit = useCallback((token: string) => {
+    onChange(applyToken(filters, token))
+    setQuery('')
+    inputRef.current?.focus()
+  }, [filters, onChange])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const isOpen = isFocused && items.length > 0
+    switch (e.key) {
+      case 'ArrowDown':
+        if (isOpen) { e.preventDefault(); setSelectedIndex(p => Math.min(p + 1, items.length - 1)) }
+        break
+      case 'ArrowUp':
+        if (isOpen) { e.preventDefault(); setSelectedIndex(p => Math.max(p - 1, -1)) }
+        break
+      case 'Enter': {
+        e.preventDefault()
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+          const item = items[selectedIndex]
+          if (item.type === 'prefix') setQuery(item.prefix)
+          else if (item.type === 'field-value') commit(`${item.field}:${item.value}`)
+          else if (item.type === 'apply-filter' && query.trim()) commit(query.trim())
+        } else if (query.trim()) {
+          commit(query.trim())
+        }
+        break
+      }
+      case 'Tab':
+        if (selectedIndex >= 0) {
+          const item = items[selectedIndex]
+          if (item?.type === 'prefix') { e.preventDefault(); setQuery(item.prefix) }
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        setQuery('')
+        inputRef.current?.blur()
+        break
+    }
+  }, [items, selectedIndex, query, commit, isFocused])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setIsFocused(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const chips = filtersToChips(filters)
+  const showDropdown = isFocused && items.length > 0
+
+  return (
+    <div ref={containerRef} className="relative flex items-center gap-1.5 flex-wrap">
+      {/* Input */}
+      <div className="flex items-center gap-1.5 px-2.5 h-[30px] border border-border bg-[var(--input)] hover:bg-muted/50 focus-within:border-border/80 transition-colors">
+        <Search className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => setIsFocused(true)}
+          placeholder="Filter maintenance…"
+          className="w-44 bg-transparent border-0 focus:outline-none placeholder:text-muted-foreground text-sm"
+        />
+      </div>
+
+      {/* Active filter chips */}
+      {chips.map(chip => (
+        <div
+          key={`${chip.field}:${chip.value}`}
+          className="flex items-center gap-1 h-[30px] px-2 text-xs border border-border/70 bg-accent/10 text-foreground"
+        >
+          <span className="font-mono max-w-[180px] truncate">{chip.label}</span>
+          <button
+            type="button"
+            onClick={() => onChange(removeChip(filters, chip))}
+            className="ml-0.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      ))}
+
+      {/* Dropdown */}
+      {showDropdown && (
+        <div className="absolute top-full left-0 mt-1 w-72 max-h-72 overflow-y-auto bg-card border border-border shadow-lg z-40">
+          {showAllPrefixes && (
+            <div className="px-3 py-1.5 text-xs text-muted-foreground border-b border-border flex items-center gap-1">
+              <Filter className="h-3 w-3" />
+              Filter by field
+            </div>
+          )}
+
+          {items.map((item, idx) => {
+            if (item.type === 'apply-filter') {
+              return (
+                <button
+                  key="apply"
+                  onClick={() => commit(query.trim())}
+                  className={cn('w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted transition-colors', idx === selectedIndex && 'bg-muted')}
+                >
+                  <Filter className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <span>Filter by "<span className="font-medium">{query}</span>"</span>
+                </button>
+              )
+            }
+            if (item.type === 'field-value') {
+              return (
+                <button
+                  key={`fv-${item.value}`}
+                  onClick={() => commit(`${item.field}:${item.value}`)}
+                  className={cn('w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted transition-colors', idx === selectedIndex && 'bg-muted')}
+                >
+                  <span className="flex-1 truncate">{item.value}</span>
+                  <span className="text-xs px-1.5 py-0.5 bg-muted text-muted-foreground">{item.field}</span>
+                </button>
+              )
+            }
+            if (item.type === 'prefix') {
+              return (
+                <button
+                  key={item.prefix}
+                  onClick={() => { setQuery(item.prefix); inputRef.current?.focus() }}
+                  className={cn('w-full flex flex-col gap-0.5 px-3 py-2 text-left text-sm hover:bg-muted transition-colors', idx === selectedIndex && 'bg-muted')}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{item.prefix.slice(0, -1)}</span>
+                    <span className="text-xs px-1.5 py-0.5 bg-muted text-muted-foreground">filter</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">{item.description}</span>
+                </button>
+              )
+            }
+            return null
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── MaintenanceFilters (toolbar) ──────────────────────────────────────────────
+
+interface FiltersProps {
+  filters: CalendarFilters
+  onFiltersChange: (f: CalendarFilters) => void
+  hasActiveFilters: boolean
+  allContributors: string[]
+  allMetros: string[]
+  allDevices: string[]
+  allLinks: string[]
+  view: CalendarView
+  onViewChange: (v: CalendarView) => void
+}
+
+export function MaintenanceFilters({
+  filters,
+  onFiltersChange,
+  hasActiveFilters,
+  allContributors,
+  allMetros,
+  allDevices,
+  allLinks,
+  view,
+  onViewChange,
+}: FiltersProps) {
+  function clearAll() {
+    onFiltersChange({
+      search: '',
+      contributors: new Set(),
+      metros: new Set(),
+      devices: new Set(),
+      links: new Set(),
+      status: '',
+    })
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-card flex-wrap">
+      <CalendarInlineFilter
+        filters={filters}
+        onChange={onFiltersChange}
+        allContributors={allContributors}
+        allMetros={allMetros}
+        allDevices={allDevices}
+        allLinks={allLinks}
+      />
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={clearAll}
+          className="flex items-center gap-1.5 h-[30px] px-2.5 text-sm text-muted-foreground hover:text-foreground border border-border/50 hover:border-border transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear filters
+        </button>
+      )}
+
+      {/* View toggle — right-aligned */}
+      <div className="ml-auto flex border border-border overflow-hidden">
+        {VIEWS.map((v) => (
+          <button
+            key={v.value}
+            type="button"
+            onClick={() => onViewChange(v.value)}
+            className={cn(
+              'h-[30px] px-3 text-sm transition-colors border-r border-border last:border-r-0',
+              view === v.value
+                ? 'bg-muted text-foreground font-medium'
+                : 'text-muted-foreground hover:text-foreground bg-[var(--input)]'
+            )}
+          >
+            {v.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/maintenance-calendar/gantt-view.tsx
+++ b/web/src/components/maintenance-calendar/gantt-view.tsx
@@ -1,0 +1,237 @@
+import { Fragment, useState, useRef, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { evBg, evBorderColor, evText, dotColor } from './colors'
+import {
+  startOfDay,
+  isSameDay,
+  daysBetween,
+  isWeekend,
+  getDays,
+} from './date-utils'
+import { EventTooltipPanel } from './event-tooltip'
+import type { TooltipState } from './event-tooltip'
+import type { MaintenanceEvent } from './use-maintenance-events'
+
+const LBL_W = 220
+const DAY_W_NORMAL = 54
+const DAY_W_MONTH = 34
+const MIN_BAR_TEXT_PX = 18  // hide only sub-icon-width bars
+const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+interface ContributorGroup {
+  contributorName: string
+  hue: number
+  events: MaintenanceEvent[]
+}
+
+function groupByContributor(events: MaintenanceEvent[]): ContributorGroup[] {
+  const map = new Map<string, ContributorGroup>()
+  for (const ev of events) {
+    if (!map.has(ev.contributorName)) {
+      map.set(ev.contributorName, { contributorName: ev.contributorName, hue: ev.hue, events: [] })
+    }
+    map.get(ev.contributorName)!.events.push(ev)
+  }
+  return [...map.values()].sort((a, b) => a.contributorName.localeCompare(b.contributorName))
+}
+
+interface GanttViewProps {
+  events: MaintenanceEvent[]
+  view: 'week' | '2week' | 'month'
+  anchor: Date
+}
+
+export function GanttView({ events, view, anchor }: GanttViewProps) {
+  const today = startOfDay(new Date())
+  const days = getDays(view, anchor)
+  const DAY_W = view === 'month' ? DAY_W_MONTH : DAY_W_NORMAL
+  const rangeStart = startOfDay(days[0])
+  const rangeEnd = startOfDay(days[days.length - 1])
+
+  const rangeEndInclusive = new Date(rangeEnd)
+  rangeEndInclusive.setHours(23, 59, 59, 999)
+
+  const visibleEvents = events.filter(
+    (ev) => ev.startAt <= rangeEndInclusive && ev.endAt >= rangeStart
+  )
+  const groups = groupByContributor(visibleEvents)
+
+  // Tooltip state with grace-period hide so links are clickable
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const showTooltip = useCallback((ev: MaintenanceEvent, e: React.MouseEvent) => {
+    clearTimeout(hideTimer.current)
+    setTooltip({ ev, x: e.clientX, y: e.clientY })
+  }, [])
+
+  const startHide = useCallback(() => {
+    hideTimer.current = setTimeout(() => setTooltip(null), 200)
+  }, [])
+
+  const cancelHide = useCallback(() => {
+    clearTimeout(hideTimer.current)
+  }, [])
+
+  return (
+    <>
+      <div className="flex-1 overflow-auto">
+        <table
+          style={{
+            tableLayout: 'fixed',
+            borderCollapse: 'collapse',
+            width: LBL_W + days.length * DAY_W,
+          }}
+        >
+          <colgroup>
+            <col style={{ width: LBL_W }} />
+            {days.map((_, i) => (
+              <col key={i} style={{ width: DAY_W }} />
+            ))}
+          </colgroup>
+
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-20 text-left text-[10px] font-normal text-muted-foreground/70 uppercase tracking-widest px-4 py-2 border-b border-r border-border bg-[var(--sidebar)] h-10">
+                Contributor / Event
+              </th>
+              {days.map((day, i) => {
+                const isToday = isSameDay(day, today)
+                const weekend = isWeekend(day)
+                return (
+                  <th
+                    key={i}
+                    className={cn(
+                      'text-center text-[10px] font-normal border-b border-r border-border h-10',
+                      isToday
+                        ? 'bg-[oklch(0.55_0.06_250/6%)] text-[oklch(0.7_0.12_250)]'
+                        : weekend
+                        ? 'bg-[oklch(0_0_0/40%)] text-muted-foreground/60'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    <div className="leading-none">{DAY_ABBR[day.getDay()]}</div>
+                    <div className={cn('text-sm mt-0.5', isToday && 'font-semibold')}>
+                      {day.getDate()}
+                    </div>
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            {groups.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={days.length + 1}
+                  className="text-center text-sm text-muted-foreground py-12"
+                >
+                  No maintenance events in this period.
+                </td>
+              </tr>
+            ) : (
+              groups.map(({ contributorName, hue, events: groupEvents }) => (
+                <Fragment key={contributorName}>
+                  {/* Contributor header row */}
+                  <tr className="bg-[oklch(0.17_0.003_285.823)]">
+                    <td className="sticky left-0 z-10 border-b border-r border-border bg-[oklch(0.17_0.003_285.823)] h-8">
+                      <div className="flex items-center gap-2 px-4 h-full text-sm font-medium text-foreground">
+                        <span
+                          className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                          style={{ background: dotColor(hue) }}
+                        />
+                        <span className="truncate">{contributorName}</span>
+                        <span className="ml-auto text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 flex-shrink-0">
+                          {groupEvents.length}
+                        </span>
+                      </div>
+                    </td>
+                    {days.map((day, i) => (
+                      <td
+                        key={i}
+                        className={cn(
+                          'border-b border-r border-border h-8',
+                          isSameDay(day, today)
+                            ? 'bg-[oklch(0.55_0.06_250/8%)]'
+                            : isWeekend(day)
+                            ? 'bg-[oklch(0_0_0/40%)]'
+                            : ''
+                        )}
+                      />
+                    ))}
+                  </tr>
+
+                  {/* One row per event */}
+                  {groupEvents.map((ev) => {
+                    const clampedStart = ev.startAt < rangeStart ? rangeStart : startOfDay(ev.startAt)
+                    const clampedEnd = ev.endAt > rangeEndInclusive ? rangeEnd : startOfDay(ev.endAt)
+                    const startDayIdx = daysBetween(rangeStart, clampedStart)
+                    const spanDays = daysBetween(clampedStart, clampedEnd) + 1
+                    // Cap width so bar never overflows the right grid boundary
+                    const maxSpan = days.length - startDayIdx
+                    const barWidth = Math.min(spanDays, maxSpan) * DAY_W - 1
+
+                    return (
+                      <tr key={ev.id}>
+                        <td className="sticky left-0 z-10 px-4 py-0 text-xs text-muted-foreground border-b border-r border-border bg-card h-[30px] truncate">
+                          {ev.title}
+                        </td>
+                        {days.map((day, dayIdx) => {
+                          const isBarStart = dayIdx === startDayIdx
+                          return (
+                            <td
+                              key={dayIdx}
+                              className={cn(
+                                'relative border-b border-r border-border h-[30px] p-0',
+                                isSameDay(day, today)
+                                  ? 'bg-[oklch(0.55_0.06_250/6%)]'
+                                  : isWeekend(day)
+                                  ? 'bg-[oklch(0_0_0/40%)]'
+                                  : ''
+                              )}
+                            >
+                              {isBarStart && (
+                                <div
+                                  className={cn(
+                                    'absolute top-[4px] bottom-[4px] z-[4] flex items-center px-2 text-[11px] whitespace-nowrap overflow-hidden cursor-pointer',
+                                    ev.status === 'in-progress'
+                                      ? 'border-l-[3px] border-dashed'
+                                      : 'border-l-[3px]'
+                                  )}
+                                  style={{
+                                    left: 0,
+                                    width: barWidth,
+                                    background: evBg(hue),
+                                    borderLeftColor: evBorderColor(hue),
+                                    color: evText(hue),
+                                  }}
+                                  onMouseEnter={(e) => showTooltip(ev, e)}
+                                  onMouseLeave={startHide}
+                                >
+                                  {barWidth >= MIN_BAR_TEXT_PX && ev.title}
+                                </div>
+                              )}
+                            </td>
+                          )
+                        })}
+                      </tr>
+                    )
+                  })}
+                </Fragment>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {tooltip && (
+        <EventTooltipPanel
+          state={tooltip}
+          onMouseEnter={cancelHide}
+          onMouseLeave={startHide}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/components/maintenance-calendar/gantt-view.tsx
+++ b/web/src/components/maintenance-calendar/gantt-view.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useRef, useCallback } from 'react'
 import { cn } from '@/lib/utils'
+import { useTheme } from '@/hooks/use-theme'
 import { evBg, evBorderColor, evText, dotColor } from './colors'
 import {
   startOfDay,
@@ -42,6 +43,8 @@ interface GanttViewProps {
 }
 
 export function GanttView({ events, view, anchor }: GanttViewProps) {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
   const today = startOfDay(new Date())
   const days = getDays(view, anchor)
   const DAY_W = view === 'month' ? DAY_W_MONTH : DAY_W_NORMAL
@@ -106,7 +109,7 @@ export function GanttView({ events, view, anchor }: GanttViewProps) {
                       isToday
                         ? 'bg-[oklch(0.55_0.06_250/6%)] text-[oklch(0.7_0.12_250)]'
                         : weekend
-                        ? 'bg-[oklch(0_0_0/40%)] text-muted-foreground/60'
+                        ? 'bg-muted/60 dark:bg-[oklch(0_0_0/40%)] text-muted-foreground/60'
                         : 'text-muted-foreground'
                     )}
                   >
@@ -134,8 +137,8 @@ export function GanttView({ events, view, anchor }: GanttViewProps) {
               groups.map(({ contributorName, hue, events: groupEvents }) => (
                 <Fragment key={contributorName}>
                   {/* Contributor header row */}
-                  <tr className="bg-[oklch(0.17_0.003_285.823)]">
-                    <td className="sticky left-0 z-10 border-b border-r border-border bg-[oklch(0.17_0.003_285.823)] h-8">
+                  <tr className="bg-muted dark:bg-[oklch(0.17_0.003_285.823)]">
+                    <td className="sticky left-0 z-10 border-b border-r border-border bg-muted dark:bg-[oklch(0.17_0.003_285.823)] h-8">
                       <div className="flex items-center gap-2 px-4 h-full text-sm font-medium text-foreground">
                         <span
                           className="inline-block w-2 h-2 rounded-full flex-shrink-0"
@@ -155,7 +158,7 @@ export function GanttView({ events, view, anchor }: GanttViewProps) {
                           isSameDay(day, today)
                             ? 'bg-[oklch(0.55_0.06_250/8%)]'
                             : isWeekend(day)
-                            ? 'bg-[oklch(0_0_0/40%)]'
+                            ? 'bg-muted/60 dark:bg-[oklch(0_0_0/40%)]'
                             : ''
                         )}
                       />
@@ -187,7 +190,7 @@ export function GanttView({ events, view, anchor }: GanttViewProps) {
                                 isSameDay(day, today)
                                   ? 'bg-[oklch(0.55_0.06_250/6%)]'
                                   : isWeekend(day)
-                                  ? 'bg-[oklch(0_0_0/40%)]'
+                                  ? 'bg-muted/60 dark:bg-[oklch(0_0_0/40%)]'
                                   : ''
                               )}
                             >
@@ -202,9 +205,9 @@ export function GanttView({ events, view, anchor }: GanttViewProps) {
                                   style={{
                                     left: 0,
                                     width: barWidth,
-                                    background: evBg(hue),
-                                    borderLeftColor: evBorderColor(hue),
-                                    color: evText(hue),
+                                    background: isDark ? evBg(hue) : evBg(hue, 55),
+                                    borderLeftColor: isDark ? evBorderColor(hue) : evBorderColor(hue, 100),
+                                    color: isDark ? evText(hue) : evText(hue, true),
                                   }}
                                   onMouseEnter={(e) => showTooltip(ev, e)}
                                   onMouseLeave={startHide}

--- a/web/src/components/maintenance-calendar/multi-select.tsx
+++ b/web/src/components/maintenance-calendar/multi-select.tsx
@@ -1,0 +1,126 @@
+import { useRef, useEffect, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface MultiSelectProps {
+  allLabel: string          // e.g. "All contributors"
+  activeLabel: string       // e.g. "Contributors"
+  options: string[]
+  selected: Set<string>
+  onChange: (next: Set<string>) => void
+  renderOption?: (value: string) => React.ReactNode  // optional leading element per option
+  searchable?: boolean
+}
+
+export function MultiSelect({
+  allLabel,
+  activeLabel,
+  options,
+  selected,
+  onChange,
+  renderOption,
+  searchable = false,
+}: MultiSelectProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  const filtered = query
+    ? options.filter((o) => o.toLowerCase().includes(query.toLowerCase()))
+    : options
+
+  function toggle(value: string) {
+    const next = new Set(selected)
+    if (next.has(value)) next.delete(value)
+    else next.add(value)
+    onChange(next)
+  }
+
+  const label = selected.size === 0 ? allLabel : activeLabel
+  const count = selected.size > 0 ? selected.size : null
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          'h-[30px] flex items-center gap-1.5 px-3 text-sm border border-border bg-[var(--input)] text-muted-foreground hover:text-foreground transition-colors',
+          open && 'border-border/80'
+        )}
+      >
+        <span>{label}</span>
+        {count !== null && (
+          <span className="text-[10px] bg-accent text-white px-1.5 leading-5 rounded-sm">
+            {count}
+          </span>
+        )}
+        <ChevronDown className="h-3.5 w-3.5 ml-0.5 opacity-60" />
+      </button>
+
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 min-w-[200px] bg-[var(--input)] border border-border shadow-lg">
+          {searchable && (
+            <div className="p-2 border-b border-border">
+              <input
+                type="text"
+                placeholder="Search…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="w-full h-7 px-2 text-sm bg-[var(--card)] border border-border text-foreground placeholder:text-muted-foreground outline-none"
+                autoFocus
+              />
+            </div>
+          )}
+          <div className="max-h-56 overflow-y-auto">
+            {filtered.map((option) => (
+              <label
+                key={option}
+                className="flex items-center gap-2.5 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/30 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(option)}
+                  onChange={() => toggle(option)}
+                  className="accent-[var(--accent)]"
+                />
+                {renderOption?.(option)}
+                <span>{option}</span>
+              </label>
+            ))}
+            {filtered.length === 0 && (
+              <div className="px-3 py-2 text-sm text-muted-foreground">No results</div>
+            )}
+          </div>
+          <div className="flex border-t border-border">
+            <button
+              type="button"
+              onClick={() => onChange(new Set())}
+              className="flex-1 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Clear
+            </button>
+            <div className="w-px bg-border" />
+            <button
+              type="button"
+              onClick={() => onChange(new Set(options))}
+              className="flex-1 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Select all
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/maintenance-calendar/use-maintenance-events.test.ts
+++ b/web/src/components/maintenance-calendar/use-maintenance-events.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { transformTickets, applyFilters, extractMetros } from './use-maintenance-events'
+import type { OpsTicket } from '@/lib/ops-api'
+
+const makeTicket = (overrides: Partial<OpsTicket> = {}): OpsTicket => ({
+  id: 'test-id',
+  human_readable_id: 'M20260529-0001',
+  type: 'maintenance',
+  title: 'Arista EOS upgrade sea-rox1',
+  description: '',
+  status: 'planned',
+  affected_link_pubkey: [],
+  device_pubkey: [],
+  reporter_name: 'Test User',
+  reporter_email: 'test@test.com',
+  contributor_name: 'RockawayX',
+  start_at: '2026-06-15T01:00:00Z',
+  end_at: '2026-06-15T05:00:00Z',
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('extractMetros', () => {
+  it('returns metro_codes from ticket', () => {
+    const t = makeTicket({ metro_codes: ['nyc', 'lon'] })
+    expect(extractMetros(t)).toEqual(['nyc', 'lon'])
+  })
+
+  it('returns empty array when metro_codes is absent', () => {
+    const t = makeTicket({ metro_codes: undefined })
+    expect(extractMetros(t)).toEqual([])
+  })
+})
+
+describe('transformTickets', () => {
+  it('filters out non-maintenance tickets', () => {
+    const incident = makeTicket({ type: 'incident' })
+    expect(transformTickets([incident])).toHaveLength(0)
+  })
+
+  it('filters out tickets missing start_at', () => {
+    const t = makeTicket({ start_at: undefined })
+    expect(transformTickets([t])).toHaveLength(0)
+  })
+
+  it('includes tickets missing end_at, using updated_at for closed status', () => {
+    const t = makeTicket({ end_at: undefined, status: 'closed', updated_at: '2026-06-20T00:00:00Z' })
+    const [ev] = transformTickets([t])
+    expect(ev).toBeDefined()
+    expect(ev.endAt).toEqual(new Date('2026-06-20T00:00:00Z'))
+  })
+
+  it('includes planned tickets missing end_at, falling back to start_at', () => {
+    const t = makeTicket({ end_at: undefined, status: 'planned' })
+    const [ev] = transformTickets([t])
+    expect(ev).toBeDefined()
+    expect(ev.endAt).toEqual(new Date(t.start_at!))
+  })
+
+  it('falls back to start_at when closed ticket has empty updated_at', () => {
+    const t = makeTicket({ end_at: undefined, status: 'closed', updated_at: '' })
+    const [ev] = transformTickets([t])
+    expect(ev).toBeDefined()
+    expect(ev.endAt).toEqual(new Date(t.start_at!))
+  })
+
+  it('converts ISO timestamps to Dates', () => {
+    const t = makeTicket()
+    const [ev] = transformTickets([t])
+    expect(ev.startAt).toBeInstanceOf(Date)
+    expect(ev.endAt).toBeInstanceOf(Date)
+  })
+
+  it('falls back to reporter_name when contributor_name is absent', () => {
+    const t = makeTicket({ contributor_name: undefined })
+    const [ev] = transformTickets([t])
+    expect(ev.contributorName).toBe('Test User')
+  })
+})
+
+describe('applyFilters', () => {
+  const events = transformTickets([
+    makeTicket({ id: '1', title: 'Arista EOS upgrade sea-rox1', contributor_name: 'RockawayX', metro_codes: ['sea'], affected_links: [{ code: 'sea-rox1', pubkey: 'pk1' }] }),
+    makeTicket({ id: '2', title: 'Device reboot chi-mlb1', contributor_name: 'Malbec Labs', metro_codes: ['chi'], affected_links: [{ code: 'chi-mlb1', pubkey: 'pk2' }], status: 'in-progress' }),
+  ])
+
+  it('returns all events when filters are empty', () => {
+    expect(applyFilters(events, { search: '', contributors: new Set(), metros: new Set(), devices: new Set(), links: new Set(), status: '' })).toHaveLength(2)
+  })
+
+  it('filters by contributor', () => {
+    const result = applyFilters(events, { search: '', contributors: new Set(['RockawayX']), metros: new Set(), devices: new Set(), links: new Set(), status: '' })
+    expect(result).toHaveLength(1)
+    expect(result[0].contributorName).toBe('RockawayX')
+  })
+
+  it('filters by status', () => {
+    const result = applyFilters(events, { search: '', contributors: new Set(), metros: new Set(), devices: new Set(), links: new Set(), status: 'in-progress' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('2')
+  })
+
+  it('filters by metro', () => {
+    const result = applyFilters(events, { search: '', contributors: new Set(), metros: new Set(['chi']), devices: new Set(), links: new Set(), status: '' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('2')
+  })
+
+  it('filters by search text (title)', () => {
+    const result = applyFilters(events, { search: 'arista', contributors: new Set(), metros: new Set(), devices: new Set(), links: new Set(), status: '' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+
+  it('filters by search text (contributor name)', () => {
+    const result = applyFilters(events, { search: 'malbec', contributors: new Set(), metros: new Set(), devices: new Set(), links: new Set(), status: '' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('2')
+  })
+})

--- a/web/src/components/maintenance-calendar/use-maintenance-events.ts
+++ b/web/src/components/maintenance-calendar/use-maintenance-events.ts
@@ -1,0 +1,174 @@
+import { useState, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchMaintenanceTickets, isTicketClosed } from '@/lib/ops-api'
+import { contributorHue } from './colors'
+import type { OpsTicket, OpsTicketStatus } from '@/lib/ops-api'
+
+export interface MaintenanceEvent {
+  id: string
+  title: string
+  contributorName: string
+  hue: number
+  startAt: Date
+  endAt: Date
+  status: OpsTicketStatus
+  affectedLinks: Array<{ code: string; pubkey: string }>
+  affectedDevices: Array<{ code: string; pubkey: string }>
+  enrichedDeviceCodes: string[]  // includes link-side devices from ClickHouse
+  metros: string[]
+  slackUrl?: string
+}
+
+export interface CalendarFilters {
+  search: string
+  contributors: Set<string>
+  metros: Set<string>
+  devices: Set<string>
+  links: Set<string>
+  status: string
+}
+
+// Extract metro codes enriched by the API from ClickHouse.
+export function extractMetros(ticket: OpsTicket): string[] {
+  return ticket.metro_codes ?? []
+}
+
+function resolveEndAt(t: OpsTicket): Date {
+  if (t.end_at) return new Date(t.end_at)
+  // Closed tickets with no end_at: use updated_at as a proxy for when it closed.
+  if (isTicketClosed(t.status)) {
+    const d = new Date(t.updated_at)
+    return isNaN(d.getTime()) ? new Date(t.start_at!) : d
+  }
+  // Active/planned with no end_at: treat as same-day.
+  return new Date(t.start_at!)
+}
+
+export function transformTickets(tickets: OpsTicket[]): MaintenanceEvent[] {
+  return tickets
+    .filter((t) => t.type === 'maintenance' && t.start_at)
+    .map((t) => {
+      const name = t.contributor_name ?? t.reporter_name
+      return {
+        id: t.id,
+        title: t.title,
+        contributorName: name,
+        hue: contributorHue(name),
+        startAt: new Date(t.start_at!),
+        endAt: resolveEndAt(t),
+        status: t.status,
+        affectedLinks: t.affected_links ?? [],
+        affectedDevices: t.affected_devices ?? [],
+        enrichedDeviceCodes: t.enriched_device_codes ?? [],
+        metros: extractMetros(t),
+        slackUrl: t.slack_message_url,
+      }
+    })
+}
+
+export function applyFilters(
+  events: MaintenanceEvent[],
+  filters: CalendarFilters
+): MaintenanceEvent[] {
+  const q = filters.search.toLowerCase()
+  return events.filter((ev) => {
+    if (filters.contributors.size > 0 && !filters.contributors.has(ev.contributorName)) return false
+    if (filters.status && ev.status !== filters.status) return false
+    if (filters.metros.size > 0 && !ev.metros.some((m) => filters.metros.has(m))) return false
+    if (filters.devices.size > 0 &&
+        !ev.affectedDevices.some((d) => filters.devices.has(d.code)) &&
+        !ev.enrichedDeviceCodes.some((c) => filters.devices.has(c))) return false
+    if (filters.links.size > 0 && !ev.affectedLinks.some((l) => filters.links.has(l.code))) return false
+    if (q && !ev.title.toLowerCase().includes(q) && !ev.contributorName.toLowerCase().includes(q)) return false
+    return true
+  })
+}
+
+export function useMaintenanceEvents() {
+  const { data: activeData, isLoading: activeLoading, error: activeError } = useQuery({
+    queryKey: ['maintenance-tickets', 'active'],
+    queryFn: () => fetchMaintenanceTickets('active'),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    throwOnError: false,
+  })
+  const { data: completedData, isLoading: completedLoading, error: completedError } = useQuery({
+    queryKey: ['maintenance-tickets', 'not_active'],
+    queryFn: () => fetchMaintenanceTickets('not_active'),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    throwOnError: false,
+  })
+
+  const allEvents = useMemo(() => {
+    const raw = [
+      ...(activeData?.tickets ?? []),
+      ...(completedData?.tickets ?? []),
+    ]
+    return transformTickets(raw)
+  }, [activeData, completedData])
+
+  const rawCount = (activeData?.tickets.length ?? 0) + (completedData?.tickets.length ?? 0)
+
+  const isLoading = activeLoading || completedLoading
+  const error = activeError ?? completedError
+
+  const [filters, setFilters] = useState<CalendarFilters>({
+    search: '',
+    contributors: new Set(),
+    metros: new Set(),
+    devices: new Set(),
+    links: new Set(),
+    status: '',
+  })
+
+  const filteredEvents = useMemo(
+    () => applyFilters(allEvents, filters),
+    [allEvents, filters]
+  )
+
+  const allContributors = useMemo(
+    () => [...new Set(allEvents.map((e) => e.contributorName))].sort(),
+    [allEvents]
+  )
+
+  const allMetros = useMemo(
+    () => [...new Set(allEvents.flatMap((e) => e.metros))].sort(),
+    [allEvents]
+  )
+
+  const allDevices = useMemo(
+    () => [...new Set(allEvents.flatMap((e) => [
+      ...e.affectedDevices.map((d) => d.code),
+      ...e.enrichedDeviceCodes,
+    ]))].sort(),
+    [allEvents]
+  )
+
+  const allLinks = useMemo(
+    () => [...new Set(allEvents.flatMap((e) => e.affectedLinks.map((l) => l.code)))].sort(),
+    [allEvents]
+  )
+
+  const hasActiveFilters =
+    filters.search !== '' ||
+    filters.contributors.size > 0 ||
+    filters.metros.size > 0 ||
+    filters.devices.size > 0 ||
+    filters.links.size > 0 ||
+    filters.status !== ''
+
+  return {
+    events: filteredEvents,
+    allContributors,
+    allMetros,
+    allDevices,
+    allLinks,
+    rawCount,
+    filters,
+    setFilters,
+    hasActiveFilters,
+    isLoading,
+    error,
+  }
+}

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   Wrench,
   ShieldAlert,
+  CalendarClock,
   Gauge,
   BarChart3,
   Zap,
@@ -63,7 +64,11 @@ const { resolvedTheme, setTheme } = useTheme()
 
   // Route detection
   const isStatusRoute = location.pathname.startsWith('/status')
-  const isIncidentsRoute = location.pathname.startsWith('/incidents')
+  const isOpsRoute = location.pathname.startsWith('/ops')
+  const isOpsIncidentsRoute = location.pathname.startsWith('/ops/incidents')
+  const isOpsIncidentsLinksRoute = location.pathname === '/ops/incidents/links'
+  const isOpsIncidentsDevicesRoute = location.pathname === '/ops/incidents/devices'
+  const isOpsMaintenanceRoute = location.pathname === '/ops/maintenance'
   const isChatRoute = location.pathname.startsWith('/chat')
   const isChatSessions = location.pathname === '/chat/sessions'
   const isTopologyRoute = location.pathname === '/topology' || location.pathname.startsWith('/topology/')
@@ -253,7 +258,7 @@ const { resolvedTheme, setTheme } = useTheme()
           <Link to="/performance/dz-vs-internet" className={collapsedIconClass(isPerformanceRoute)} title="Performance">
             <Gauge className="h-4 w-4" />
           </Link>
-          <Link to="/incidents/links" className={collapsedIconClass(isIncidentsRoute)} title="Incidents">
+          <Link to="/ops/incidents/links" className={collapsedIconClass(isOpsRoute)} title="Ops">
             <ShieldAlert className="h-4 w-4" />
           </Link>
           <button
@@ -458,10 +463,7 @@ const { resolvedTheme, setTheme } = useTheme()
                 )}
               </>
             )}
-            <Link to="/incidents/links" className={navItemClass(isIncidentsRoute)}>
-              <ShieldAlert className="h-4 w-4" />
-              Incidents
-            </Link>
+
             {/* Chat with inline sub-items */}
             <button
               onClick={(e) => {
@@ -506,6 +508,38 @@ const { resolvedTheme, setTheme } = useTheme()
               <span className="flex-1 text-left">Search</span>
               <kbd className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">⌘K</kbd>
             </button>
+          </div>
+        </div>
+
+        {/* Ops section */}
+        <div className="px-3 pt-4">
+          <div className="px-3 mb-2">
+            <span className="text-[11px] font-normal text-muted-foreground/70 uppercase tracking-widest">Ops</span>
+          </div>
+          <div className="space-y-1">
+            <Link
+              to="/ops/incidents/links"
+              className={isOpsIncidentsRoute ? navItemExpandedClass : navItemClass(false)}
+            >
+              <ShieldAlert className="h-4 w-4" />
+              Incidents
+            </Link>
+            {isOpsIncidentsRoute && (
+              <>
+                <Link to="/ops/incidents/links" className={subNavItemClass(isOpsIncidentsLinksRoute)}>
+                  <Link2 className="h-4 w-4" />
+                  Links
+                </Link>
+                <Link to="/ops/incidents/devices" className={subNavItemClass(isOpsIncidentsDevicesRoute)}>
+                  <Server className="h-4 w-4" />
+                  Devices
+                </Link>
+              </>
+            )}
+            <Link to="/ops/maintenance" className={navItemClass(isOpsMaintenanceRoute)}>
+              <CalendarClock className="h-4 w-4" />
+              Maintenance
+            </Link>
           </div>
         </div>
 

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -740,23 +740,16 @@ function IssueDetails({
                       {link.link_type}
                       {link.bandwidth_bps > 0 && ` · ${formatBandwidthShort(link.bandwidth_bps)}`}
                     </div>
-                    {link.status !== "provisioning" && (
+                    {link.status !== "provisioning" && link.active_incident_types && link.active_incident_types.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-1">
-                        {link.active_incident_types &&
-                        link.active_incident_types.length > 0 ? (
-                          link.active_incident_types.map((t) => (
-                            <span
-                              key={t}
-                              className={`text-xs rounded-full px-2 py-0.5 font-medium ${drainIncidentColor(t)}`}
-                            >
-                              {drainIncidentLabel(t)}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="text-xs rounded-full px-2 py-0.5 font-medium bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-                            Planned Maintenance
+                        {link.active_incident_types.map((t) => (
+                          <span
+                            key={t}
+                            className={`text-xs rounded-full px-2 py-0.5 font-medium ${drainIncidentColor(t)}`}
+                          >
+                            {drainIncidentLabel(t)}
                           </span>
-                        )}
+                        ))}
                       </div>
                     )}
                   </div>

--- a/web/src/lib/ops-api.ts
+++ b/web/src/lib/ops-api.ts
@@ -33,6 +33,8 @@ export interface OpsTicket {
   start_at?: string                  // ISO timestamp
   end_at?: string                    // ISO timestamp
   slack_message_url?: string
+  metro_codes?: string[]             // injected by our API from ClickHouse
+  enriched_device_codes?: string[]  // link-side device codes from ClickHouse
   created_at: string
   updated_at: string
 }
@@ -60,6 +62,23 @@ export interface CreateOpsTicketInput {
 export async function fetchActiveOpsTickets(): Promise<OpsTicketsListResponse> {
   const res = await apiFetch('/api/ops-tickets?status=active')
   if (!res.ok) throw new Error(`Failed to fetch ops tickets: ${res.status}`)
+  const json = await res.json()
+  return json.data ?? json
+}
+
+// Fetch all completed/closed tickets — used by the maintenance calendar to show past windows.
+export async function fetchCompletedOpsTickets(): Promise<OpsTicketsListResponse> {
+  const res = await apiFetch('/api/ops-tickets?status=not_active')
+  if (!res.ok) throw new Error(`Failed to fetch completed ops tickets: ${res.status}`)
+  const json = await res.json()
+  return json.data ?? json
+}
+
+// Fetch maintenance tickets by status — public endpoint, no auth required.
+// Uses /api/ops-tickets/maintenance which filters to type=maintenance and strips PII.
+export async function fetchMaintenanceTickets(status: 'active' | 'not_active'): Promise<OpsTicketsListResponse> {
+  const res = await apiFetch(`/api/ops-tickets/maintenance?status=${status}`)
+  if (!res.ok) throw new Error(`Failed to fetch maintenance tickets (${status}): ${res.status}`)
   const json = await res.json()
   return json.data ?? json
 }


### PR DESCRIPTION
## Summary of Changes
- Adds a new `/ops/maintenance` page showing a visual maintenance calendar (Gantt and day views) backed by the Ops Management API, with filters for contributor, metro, device, link, and status
- Adds `GET /api/ops-tickets/maintenance` endpoint that paginates through all upstream maintenance tickets (offset-based, `type=maintenance` filter), strips PII, and enriches results with ClickHouse-resolved metro codes and side-device codes
- Gates ops management and Slack links in the maintenance event tooltip behind `useIsOpsUser()` (internal-domain users only), consistent with the status page
- Removes the misleading "Planned Maintenance" fallback label from the status page that appeared on drained links even without an associated ops ticket

## Diff Breakdown
| Category    | Files | Lines (+/-)     | Net    |
|-------------|-------|-----------------|--------|
| Core logic  |     9 | +1,669 / -21    | +1,648 |
| Tests       |     2 | +164 / -0       |  +164  |
| Scaffolding |     7 | +175 / -13      |  +162  |

Primarily additive: new calendar feature with full filter and tooltip support.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/ops_tickets.go` — adds `GetMaintenanceCalendar` with offset-based pagination (up to 50 pages), ClickHouse enrichment for metro codes and side-device codes, deduplication by ID, and PII stripping
- `web/src/components/maintenance-calendar/gantt-view.tsx` — Gantt/timeline view rendering events as proportional bars across day/week/2-week/month grids with hover tooltips
- `web/src/components/maintenance-calendar/day-view.tsx` — day-column view with hour-grid positioning, event overlap layout, and scroll-to-current-time
- `web/src/components/maintenance-calendar/filters.tsx` — multi-select filter panel for contributor, metro, device, link, and status
- `web/src/components/maintenance-calendar/use-maintenance-events.ts` — fetches active + completed ticket sets via TanStack Query, transforms to `MaintenanceEvent`, applies filters; handles missing `end_at` via `resolveEndAt` fallback
- `web/src/components/maintenance-calendar-page.tsx` — top-level page with view switcher (Gantt/day), date navigation, filter panel, and loading/error states
- `web/src/components/maintenance-calendar/event-tooltip.tsx` — hover tooltip with status, times, affected links/devices; ops/Slack links gated behind `useIsOpsUser()`
- `web/src/components/status-page.tsx` — removes "Planned Maintenance" fallback label from drained links that had no associated ops ticket

</details>

## Testing Verification
- 15 unit tests for `transformTickets`, `extractMetros`, `applyFilters`, and `resolveEndAt` (including empty `updated_at` edge case); all passing
- Contributor colors use a hash function over the full hue range (0–360), supporting any number of contributors without a fixed palette
- Manually verified the calendar shows all active and historical maintenance events, including tickets missing `end_at`
- Verified in both light and dark themes — event bars use higher opacity and darker text in light mode, dark mode unchanged
- Confirmed the "Planned Maintenance" label no longer appears on the status page