### PR TITLE
edge-scoreboard: add dz_root feed for turbine-root publish

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -137,22 +137,29 @@ const maxValidSlot = 1_000_000_000_000
 // the per-validator local re-broadcast (dz_rebop) plus three regional retransmit feeds.
 const retransmitFeeds = `'dz_rebop', 'edge-solana-retrans-amer', 'edge-solana-retrans-eu', 'edge-solana-retrans-apac'`
 
-// dzFeeds combines the DZ leader feed with every retransmit variant.
+// dzFeeds combines the DZ leader feed with every retransmit variant. It backs the
+// dz_slots completeness count (q1) and the all-slots lead-time pool (q2b), so the root
+// feed is deliberately excluded here to keep those metrics on the existing 'dz' baseline.
 const dzFeeds = `'dz', ` + retransmitFeeds
 
+// rootFeed is the multicast group validators publish to when they are the root of the
+// turbine tree — the earliest hop of the DZ shred path, before regional retransmit.
+const rootFeed = `'edge-solana-root'`
+
 // scoreboardFeeds is the whitelist of feed names included in edge scoreboard results.
-const scoreboardFeeds = dzFeeds + `, 'jito', 'turbine'`
+const scoreboardFeeds = dzFeeds + `, ` + rootFeed + `, 'jito', 'turbine'`
 
 // scoreboardLoserFeeds is the whitelist of competitor feeds shown in lead-time comparisons.
 const scoreboardLoserFeeds = `'jito', 'turbine'`
 
-// retransmitRollup is a SQL CASE expression that aggregates every DZ retransmit variant
-// (dz_rebop + regional retransmits) into a single 'dz_retransmit' key, shrinking per-feed
-// result sets and keeping the scoreboard's retransmit column stable as the feed set evolves.
+// feedRollup is a SQL CASE expression that maps raw feed names to the keys surfaced in the
+// scoreboard: the root feed becomes 'dz_root' and every DZ retransmit variant (dz_rebop +
+// regional retransmits) collapses into 'dz_retransmit'. This shrinks per-feed result sets
+// and keeps the scoreboard's columns stable as the feed set evolves.
 // Callers alias this as something other than `feed` (e.g. `feed_key`) to avoid shadowing
 // the raw column — if an outer WHERE/GROUP BY also references `feed`, ClickHouse resolves
 // it back to the alias and silently filters/groups against the mapped value.
-const retransmitRollup = `CASE WHEN feed = 'dz_rebop' OR feed LIKE 'edge-solana-retrans-%' THEN 'dz_retransmit' ELSE feed END`
+const feedRollup = `CASE WHEN feed = 'edge-solana-root' THEN 'dz_root' WHEN feed = 'dz_rebop' OR feed LIKE 'edge-solana-retrans-%' THEN 'dz_retransmit' ELSE feed END`
 
 // validWindows maps window parameter values to ClickHouse interval expressions.
 var validWindows = map[string]string{
@@ -702,8 +709,8 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 			// by the race's observer host (the DZ edge box that saw the winning feed deliver
 			// first), so a validator's win rates reflect what it experiences as a receiver.
 			// denom = sum(shreds_won) across all scoreboard feeds for that observer in scope —
-			// so dz + dz_retransmit + jito + turbine sum to 100% and dz_edge (synthesized
-			// below from dz + dz_retransmit) is additive.
+			// so dz + dz_root + dz_retransmit + jito + turbine sum to 100% and dz_edge
+			// (synthesized below from dz + dz_root + dz_retransmit) is additive.
 			// This excludes shreds won first by untracked feeds (provider_one etc.) so the
 			// scoreboard isn't diluted by new feeds we don't yet track.
 			var q2 string
@@ -737,7 +744,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				FROM feed_totals ft
 				INNER JOIN host_denom hd ON ft.host = hd.host
 			SETTINGS final=1
-`, dzLeaderCTE, shredderDB, scoreboardFeeds, rangeFilter, retransmitRollup)
+`, dzLeaderCTE, shredderDB, scoreboardFeeds, rangeFilter, feedRollup)
 			} else {
 				q2 = fmt.Sprintf(`
 				WITH feed_totals AS (
@@ -762,7 +769,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				FROM feed_totals ft
 				INNER JOIN host_denom hd ON ft.host = hd.host
 			SETTINGS final=1
-`, shredderDB, scoreboardFeeds, rangeFilter, retransmitRollup)
+`, shredderDB, scoreboardFeeds, rangeFilter, feedRollup)
 			}
 
 			t := time.Now()
@@ -789,24 +796,31 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				return fmt.Errorf("query2 rows: %w", err)
 			}
 
-			// Synthesize dz_edge = dz + dz_retransmit (dz_rebop plus regional retransmits) on
-			// the shared per-host denominator. All DZ feeds carry the same host_denom as
-			// TotalShreds, so summing ShredsWon and dividing by the shared denominator gives
-			// the correct combined win rate.
+			// Synthesize dz_edge = dz + dz_root + dz_retransmit (root publish, leader feed, and
+			// dz_rebop plus regional retransmits) on the shared per-host denominator. All DZ
+			// feeds carry the same host_denom as TotalShreds, so summing ShredsWon and dividing
+			// by the shared denominator gives the correct combined win rate.
 			hosts := make(map[string]struct{})
 			for k := range localFeedStats {
 				hosts[k.nodeID] = struct{}{}
 			}
 			for nodeID := range hosts {
 				dz := localFeedStats[feedKey{nodeID, "dz"}]
+				root := localFeedStats[feedKey{nodeID, "dz_root"}]
 				retrans := localFeedStats[feedKey{nodeID, "dz_retransmit"}]
-				if dz == nil && retrans == nil {
+				if dz == nil && root == nil && retrans == nil {
 					continue
 				}
 				var denom, won uint64
 				if dz != nil {
 					denom = dz.TotalShreds
 					won += dz.ShredsWon
+				}
+				if root != nil {
+					if denom == 0 {
+						denom = root.TotalShreds
+					}
+					won += root.ShredsWon
 				}
 				if retrans != nil {
 					if denom == 0 {
@@ -1075,7 +1089,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				)
 				ORDER BY host, slot, feed
 			SETTINGS final=1
-`, dzLeaderCTEForRecent, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, scoreboardFeeds, retransmitRollup)
+`, dzLeaderCTEForRecent, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, scoreboardFeeds, feedRollup)
 		} else {
 			query5 = fmt.Sprintf(`
 				WITH active_hosts AS (
@@ -1119,7 +1133,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				)
 				ORDER BY host, slot, feed
 			SETTINGS final=1
-`, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, scoreboardFeeds, retransmitRollup)
+`, shredderDB, slotWindowMin, slotWindowMax, slotFilter, orderDir, slotLimit, scoreboardFeeds, feedRollup)
 		}
 		t := time.Now()
 		rows5, err := a.envDB(gctx).Query(gctx, query5)
@@ -1334,7 +1348,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				JOIN bucket_totals bt ON f.host = bt.host AND f.slot_bucket = bt.slot_bucket
 				ORDER BY f.host, f.slot_bucket, f.feed
 			SETTINGS final=1
-`, dzLeaderCTE, bucketSize, shredderDB, scoreboardFeeds, nodeList, slotWindowMax, rangeFilter, "" /* unused [8] */, retransmitRollup)
+`, dzLeaderCTE, bucketSize, shredderDB, scoreboardFeeds, nodeList, slotWindowMax, rangeFilter, "" /* unused [8] */, feedRollup)
 			} else {
 				query7 = fmt.Sprintf(`
 				WITH per_feed AS (
@@ -1363,7 +1377,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				JOIN bucket_totals bt ON f.host = bt.host AND f.slot_bucket = bt.slot_bucket
 				ORDER BY f.host, f.slot_bucket, f.feed
 			SETTINGS final=1
-`, bucketSize, shredderDB, scoreboardFeeds, nodeList, slotWindowMax, rangeFilter, retransmitRollup)
+`, bucketSize, shredderDB, scoreboardFeeds, nodeList, slotWindowMax, rangeFilter, feedRollup)
 			}
 
 			t := time.Now()

--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -115,22 +115,26 @@ func insertEdgeScoreboardTestData(t *testing.T, api *handlers.API) {
 	require.NoError(t, err)
 
 	// Insert win-count rows (loser_feed = '') — per-feed summary for each slot
-	// slot1: all 3 feeds (dz, turbine, jito) for both nodes — DZ wins most shreds (DZ-leader slot)
+	// slot1: DZ family (dz leader + edge-solana-root) + turbine + jito for both nodes — the
+	//   per-host wins sum to 100 (the shared denominator), so rates stay clean: edge-solana-root
+	//   rolls up to dz_root and dz_edge = dz + dz_root + dz_retransmit.
 	// slot2: only turbine + jito (no DZ) — tests completeness calculation
 	err = api.DB.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.slot_feed_race_summary_v2
 			(event_ts, host, feed_type, epoch, slot, feed, loser_feed, total_shreds, shreds_won)
 		VALUES
-			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'dz',      '', 100, 80),
-			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'turbine',  '', 100, 15),
-			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'jito',     '', 100,  5),
-			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[4]d, 'turbine',  '', 100, 60),
-			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[4]d, 'jito',     '', 100, 40),
-			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'dz',       '', 100, 70),
-			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'turbine',  '', 100, 20),
-			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'jito',     '', 100, 10),
-			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[4]d, 'turbine',  '', 100, 55),
-			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[4]d, 'jito',     '', 100, 45)
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'dz',               '', 100, 70),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'edge-solana-root', '', 100, 20),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'turbine',          '', 100,  8),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'jito',             '', 100,  2),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[4]d, 'turbine',          '', 100, 60),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[4]d, 'jito',             '', 100, 40),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'dz',               '', 100, 60),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'edge-solana-root', '', 100, 20),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'turbine',          '', 100, 15),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[3]d, 'jito',             '', 100,  5),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[4]d, 'turbine',          '', 100, 55),
+			(now(), 'fra-qa-bm1', 'shred', %[2]d, %[4]d, 'jito',             '', 100, 45)
 	`, "`"+api.ShredderDB+"`", epoch, slot1, slot2))
 	require.NoError(t, err)
 
@@ -208,12 +212,26 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 	assert.Equal(t, uint64(1), slc.SlotsObserved)
 
 	// Check DZ feed win rate for SLC. leaders_only=true by default, so only slot1
-	// (DZ-leader slot) is in scope. Shared denom = slot1 max(total_shreds)=100. dz won 80.
+	// (DZ-leader slot) is in scope. Shared denom = sum of slot1 wins = 100. dz won 70.
 	dzFeed, ok := slc.Feeds["dz"]
 	require.True(t, ok, "dz feed should exist for slc")
-	assert.Equal(t, uint64(80), dzFeed.ShredsWon)
+	assert.Equal(t, uint64(70), dzFeed.ShredsWon)
 	assert.Equal(t, uint64(100), dzFeed.TotalShreds)
-	assert.Equal(t, 80.0, dzFeed.WinRatePct)
+	assert.Equal(t, 70.0, dzFeed.WinRatePct)
+
+	// edge-solana-root rolls up to the dz_root feed key (20 wins on the shared denom of 100).
+	dzRootFeed, ok := slc.Feeds["dz_root"]
+	require.True(t, ok, "dz_root feed should exist for slc")
+	assert.Equal(t, uint64(20), dzRootFeed.ShredsWon)
+	assert.Equal(t, uint64(100), dzRootFeed.TotalShreds)
+	assert.Equal(t, 20.0, dzRootFeed.WinRatePct)
+
+	// dz_edge combines dz + dz_root + dz_retransmit on the shared denom: 70 + 20 = 90.
+	slcDzEdge, ok := slc.Feeds["dz_edge"]
+	require.True(t, ok, "dz_edge feed should exist for slc")
+	assert.Equal(t, uint64(90), slcDzEdge.ShredsWon)
+	assert.Equal(t, uint64(100), slcDzEdge.TotalShreds)
+	assert.Equal(t, 90.0, slcDzEdge.WinRatePct)
 
 	// Check pairwise lead times — now attached to the synthetic dz_edge feed
 	// (combines dz + regional retransmit best-per-slot lead vs each loser).
@@ -241,9 +259,15 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 
 	dzFeed, ok = fra.Feeds["dz"]
 	require.True(t, ok, "dz feed should exist for fra")
-	assert.Equal(t, uint64(70), dzFeed.ShredsWon)
+	assert.Equal(t, uint64(60), dzFeed.ShredsWon)
 	assert.Equal(t, uint64(100), dzFeed.TotalShreds)
-	assert.Equal(t, 70.0, dzFeed.WinRatePct)
+	assert.Equal(t, 60.0, dzFeed.WinRatePct)
+
+	// FRA also has an edge-solana-root → dz_root feed (20 wins on the shared denom of 100).
+	dzRootFeed, ok = fra.Feeds["dz_root"]
+	require.True(t, ok, "dz_root feed should exist for fra")
+	assert.Equal(t, uint64(20), dzRootFeed.ShredsWon)
+	assert.Equal(t, 20.0, dzRootFeed.WinRatePct)
 
 	// Check pairwise lead times for FRA — attached to dz_edge synthetic feed.
 	dzEdgeFeed, ok = fra.Feeds["dz_edge"]

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -134,6 +134,7 @@ function WinRateGauge({ feedRates, labelPct }: { feedRates: Record<string, numbe
 
 const FEED_COLORS: Record<string, string> = {
   dz_edge: '#34d399',       // emerald-400 — primary DZ
+  dz_root: '#10b981',       // emerald-500 — turbine-root publish (between Leaders and Retransmits)
   dz: '#34d399',            // emerald-400
   dz_retransmit: '#059669', // emerald-600 — rolled up regional retransmit feeds
   jito: '#fbbf24',          // amber-400 — brighter
@@ -144,6 +145,7 @@ const FEED_COLORS: Record<string, string> = {
 
 const FEED_LABELS: Record<string, string> = {
   dz_edge: 'DZ Edge',
+  dz_root: 'DZ Edge turbine-root',
   dz: 'DZ Edge Leaders',
   dz_retransmit: 'DZ Edge Retransmits',
   jito: 'Jito Shredstream',
@@ -175,18 +177,19 @@ function StackedBar({ segments, children, popoverSide = 'top', dzTotalPct }: { s
         const dzSegs = segments.filter(s => DZ_FEED_KEYS.has(s.key))
         const otherSegs = segments.filter(s => !DZ_FEED_KEYS.has(s.key))
         const dzBySubKey = new Map(dzSegs.map(s => [s.key, s]))
-        // Granular-DZ mode: we're breaking DZ into Leaders/Retransmits. Always show both,
-        // synthesizing a 0% entry for whichever is missing so the layout stays stable
-        // across rows (e.g. a node with no retransmit feed still shows "Retransmits 0.00%").
-        const hasGranularDz = dzBySubKey.has('dz') || dzBySubKey.has('dz_retransmit')
+        // Granular-DZ mode: we're breaking DZ into Leaders/Root/Retransmits (delivery order).
+        // Always show all three, synthesizing a 0% entry for whichever is missing so the layout
+        // stays stable across rows (e.g. a node with no retransmit feed still shows "Retransmits 0.00%").
+        const hasGranularDz = dzBySubKey.has('dz_root') || dzBySubKey.has('dz') || dzBySubKey.has('dz_retransmit')
         const groupDz = hasGranularDz || dzSegs.length > 1
         const dzDisplaySegs: FeedSegment[] = hasGranularDz
           ? [
               dzBySubKey.get('dz') ?? { key: 'dz', pct: 0, rawPct: 0, color: FEED_COLORS.dz },
+              dzBySubKey.get('dz_root') ?? { key: 'dz_root', pct: 0, rawPct: 0, color: FEED_COLORS.dz_root },
               dzBySubKey.get('dz_retransmit') ?? { key: 'dz_retransmit', pct: 0, rawPct: 0, color: FEED_COLORS.dz_retransmit },
             ]
           : dzSegs
-        const dzSubLabels: Record<string, string> = { dz_edge: 'Edge', dz: 'Leaders', dz_retransmit: 'Retransmits' }
+        const dzSubLabels: Record<string, string> = { dz_edge: 'Edge', dz_root: 'turbine-root', dz: 'Leaders', dz_retransmit: 'Retransmits' }
         const flatSegs = groupDz ? otherSegs : segments
         return (
           <div className={cn('absolute z-30 bg-popover border border-border rounded-lg shadow-lg px-3 py-2 text-xs whitespace-nowrap', popoverClass)}>
@@ -221,7 +224,7 @@ function StackedBar({ segments, children, popoverSide = 'top', dzTotalPct }: { s
 }
 
 // Feeds considered "DZ" for simplified view grouping.
-const DZ_FEED_KEYS = new Set(['dz_edge', 'dz', 'dz_retransmit'])
+const DZ_FEED_KEYS = new Set(['dz_edge', 'dz_root', 'dz', 'dz_retransmit'])
 
 // Map a raw feed name to the key used in the chart/bar data.
 // The API returns 'dz_edge' (server-computed aggregate of dz + retransmit), 'dz' (Leaders),
@@ -242,6 +245,7 @@ function feedKeyForMode(feed: string, granular: boolean): string | null {
 function feedSortPriority(f: string): number {
   if (f === 'dz_edge') return 0
   if (f === 'dz') return 1
+  if (f === 'dz_root') return 1.5
   if (f === 'dz_retransmit') return 2
   if (f === 'jito') return 5
   if (f === 'turbine') return 6
@@ -1200,6 +1204,7 @@ function RecentSlotsChart({
   const infoFeedBarFillRefs = useRef<Map<string, HTMLDivElement>>(new Map())
   const infoFeedLegendItemRefs = useRef<Map<string, HTMLDivElement>>(new Map())
   const infoDzEdgeTotalRef = useRef<HTMLSpanElement>(null)
+  const infoDzRootBarRef = useRef<HTMLDivElement>(null)
   const infoDzLeaderBarRef = useRef<HTMLDivElement>(null)
   const infoDzRetransBarRef = useRef<HTMLDivElement>(null)
   const defaultInfoRef = useRef<SlotHoverInfo | null>(null)
@@ -1230,19 +1235,21 @@ function RecentSlotsChart({
     }
     for (const [f, span] of infoFeedValueRefs.current) { const v = info.feedData[f] ?? 0; span.textContent = v >= 100 ? '100%' : `${v.toFixed(1)}%` }
     for (const [f, bar] of infoFeedBarFillRefs.current) { bar.style.width = `${Math.min(100, info.feedData[f] ?? 0)}%` }
-    // Update combined DZ Edge split bar (granular mode)
+    // Update combined DZ Edge split bar (granular mode): root + leader + retransmit
+    const dzRootPct = info.feedData['dz_root'] ?? 0
     const dzLeaderPct = info.feedData['dz'] ?? 0
     const dzRetransPct = info.feedData['dz_retransmit'] ?? 0
-    const dzTotal = dzLeaderPct + dzRetransPct
+    const dzTotal = dzRootPct + dzLeaderPct + dzRetransPct
     if (infoDzEdgeTotalRef.current) infoDzEdgeTotalRef.current.textContent = dzTotal >= 100 ? '100%' : `${dzTotal.toFixed(1)}%`
+    if (infoDzRootBarRef.current) infoDzRootBarRef.current.style.width = `${dzRootPct}%`
     if (infoDzLeaderBarRef.current) infoDzLeaderBarRef.current.style.width = `${dzLeaderPct}%`
     if (infoDzRetransBarRef.current) infoDzRetransBarRef.current.style.width = `${dzRetransPct}%`
     // Winner highlighting — group DZ sub-feeds as one unit so the DZ group
-    // competes against jito/turbine rather than leaders vs retransmit.
+    // competes against jito/turbine rather than root vs leaders vs retransmit.
     const grouped: Record<string, number> = {}
     for (const [f, v] of Object.entries(info.feedData)) {
       if (v == null) continue
-      if (f === 'dz' || f === 'dz_retransmit') { grouped['_dz_group'] = (grouped['_dz_group'] ?? 0) + v }
+      if (f === 'dz_root' || f === 'dz' || f === 'dz_retransmit') { grouped['_dz_group'] = (grouped['_dz_group'] ?? 0) + v }
       else { grouped[f] = v }
     }
     const winnerKey = Object.entries(grouped).reduce<string | null>(
@@ -1860,11 +1867,11 @@ function RecentSlotsChart({
           <span ref={infoSlotRef} className="text-xs font-medium tabular-nums mb-4" />
           <div className="flex flex-col gap-3">
             {(() => {
-              const isDzSub = (f: string) => f === 'dz' || f === 'dz_retransmit'
+              const isDzSub = (f: string) => f === 'dz_root' || f === 'dz' || f === 'dz_retransmit'
               const dzSubs = feeds.filter(isDzSub)
               const showGroup = dzSubs.length > 1
               const topFeeds = showGroup ? feeds.filter(f => !isDzSub(f)) : feeds
-              const dzSubLabels: Record<string, string> = { dz: 'Leaders', dz_retransmit: 'Retransmits' }
+              const dzSubLabels: Record<string, string> = { dz_root: 'turbine-root', dz: 'Leaders', dz_retransmit: 'Retransmits' }
               return (
                 <>
                   {showGroup && (
@@ -1877,6 +1884,7 @@ function RecentSlotsChart({
                       <div className="h-1 rounded-full bg-muted-foreground/20 overflow-hidden">
                         <div className="flex h-full">
                           <div ref={infoDzLeaderBarRef} className="h-full transition-all duration-150" style={{ backgroundColor: FEED_COLORS.dz, width: '0%' }} />
+                          <div ref={infoDzRootBarRef} className="h-full transition-all duration-150" style={{ backgroundColor: FEED_COLORS.dz_root, width: '0%' }} />
                           <div ref={infoDzRetransBarRef} className="h-full transition-all duration-150" style={{ backgroundColor: FEED_COLORS.dz_retransmit, width: '0%' }} />
                         </div>
                       </div>


### PR DESCRIPTION
## Summary of Changes
- Add a new `dz_root` feed to the edge scoreboard, surfacing the `edge-solana-root` multicast group validators publish to as turbine-tree roots — the earliest hop of the DZ shred path, before regional retransmit.
- Roll `edge-solana-root` into the `dz_root` key and include it in the synthesized `dz_edge` aggregate (`dz + dz_root + dz_retransmit`) on the shared per-host denominator, so combined DZ win rates stay correct.
- Render the new feed in the UI: granular DZ Edge breakdown now shows Leaders / turbine-root / Retransmits in delivery order, with color, label, sort priority, and the hover split-bar updated accordingly.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +53 / -31   |  +22 |
| Tests        |     1 | +40 / -16   |  +24 |
| **Total**    |     3 | +93 / -47   |  +46 |

Mostly core logic across the API handler and the React page, with matching test fixtures and assertions for the new feed.

<details>
<summary>Key files (click to expand)</summary>

- `api/handlers/edge_scoreboard.go` — rename `retransmitRollup` → `feedRollup` (now maps `edge-solana-root` → `dz_root`), add `rootFeed` to the feed whitelist, and fold `dz_root` into the `dz_edge` synthesis.
- `web/src/components/edge-scoreboard-page.tsx` — add `dz_root` color/label/sort-priority, include it in `DZ_FEED_KEYS`, and render it in the granular split bar and hover info.
- `api/handlers/edge_scoreboard_test.go` — update fixtures so per-host wins sum to 100 and assert `dz_root` (20) and combined `dz_edge` (90) win rates.

</details>

## Testing Verification
- Updated `TestGetEdgeScoreboard_WithData` with `edge-solana-root` fixture rows; asserts `dz_root` win rate (20%) and that `dz_edge` correctly sums `dz + dz_root` (90%) on the shared per-host denominator for both SLC and FRA observers.
