### PR TITLE
indexer: enriched_ip_mroute view + device interface IP lookup

### DIFF
--- a/indexer/db/clickhouse/migrations/20260602000001_enriched_ip_mroute_view.sql
+++ b/indexer/db/clickhouse/migrations/20260602000001_enriched_ip_mroute_view.sql
@@ -1,0 +1,126 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- dz_device_interface_ips
+-- Parses dz_devices_current.interfaces JSON into one row per (device, interface IP).
+-- Used by enriched views to map mesh-space addresses (172.16.x.x for MSDP, etc.)
+-- back to the device pubkey that owns them. The CIDR mask is stripped to give a
+-- plain IP suitable for equality joins.
+CREATE OR REPLACE VIEW dz_device_interface_ips
+AS
+SELECT
+    d.pk AS device_pk,
+    d.code AS device_code,
+    d.status AS device_status,
+    JSONExtractString(iface, 'name') AS interface_name,
+    JSONExtractString(iface, 'status') AS interface_status,
+    splitByChar('/', JSONExtractString(iface, 'ip'))[1] AS ip_address
+FROM dz_devices_current d
+ARRAY JOIN JSONExtractArrayRaw(d.interfaces) AS iface
+WHERE d.status = 'activated'
+  AND JSONExtractString(iface, 'ip') != '';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- enriched_ip_mroute
+-- Joins dz_ip_mroute_entries_current with device, metro, contributor, multicast
+-- group, and publisher-user metadata in one row per mroute entry. The PK columns
+-- (device_pk, group_pk, publisher_user_pk, etc.) are paired with their
+-- human-readable codes wherever the underlying dim provides one.
+--
+-- Source attribution: source_address matches the publisher user's dz_ip
+-- (when an activated multicast user has the group in its publishers list).
+-- source_match_status reports whether the match landed: 'publisher_matched'
+-- when both the dz_ip and the publisher membership line up, 'group_only' when
+-- the source is wildcard/empty, otherwise 'unknown_source'.
+CREATE OR REPLACE VIEW enriched_ip_mroute
+AS
+SELECT
+    -- mroute identity
+    concat(r.device_pubkey, '|', r.vrf, '|', r.mode, '|', r.group_address, '|', r.source_address) AS mroute_id,
+    r.entity_id AS mroute_entity_id,
+    r.snapshot_ts,
+    r.ingested_at,
+    r.device_pubkey AS device_pk,
+    d.code AS device_code,
+    d.status AS device_status,
+    d.device_type,
+    d.metro_pk,
+    m.code AS metro_code,
+    m.name AS metro_name,
+    d.contributor_pk,
+    c.code AS contributor_code,
+    c.name AS contributor_name,
+
+    -- mroute payload
+    r.vrf,
+    r.mode,
+    r.group_address,
+    r.source_address,
+    r.route_flags,
+    r.register_in_oif_list,
+    r.rpf_interface,
+    r.rpf_rib,
+    r.rpf_prefix,
+    r.rpf_preference,
+    r.rpf_metric,
+    r.rpf_neighbor,
+    r.rpf_attached,
+    r.rpf_has_block,
+    r.oif_list,
+    r.oif_count,
+    r.creation_time,
+
+    -- group enrichment
+    g.pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.owner_pubkey AS multicast_group_owner_pubkey,
+    g.max_bandwidth AS multicast_group_max_bandwidth,
+    g.status AS multicast_group_status,
+
+    -- publisher enrichment (publisher = the user owning the source_address)
+    pub.pk AS publisher_user_pk,
+    pub.owner_pubkey AS publisher_owner_pubkey,
+    pub.tenant_pk AS publisher_tenant_pk,
+    pub.client_ip AS publisher_client_ip,
+    pub.dz_ip AS publisher_dz_ip,
+    pub.tunnel_id AS publisher_tunnel_id,
+    pub.device_pk AS publisher_device_pk,
+    pub_dev.code AS publisher_device_code,
+    pub_dev.metro_pk AS publisher_metro_pk,
+    pub_m.code AS publisher_metro_code,
+    pub_dev.contributor_pk AS publisher_contributor_pk,
+    pub_c.code AS publisher_contributor_code,
+
+    -- source-match diagnostic
+    CASE
+        WHEN pub.pk != '' THEN 'publisher_matched'
+        WHEN r.source_address = '' OR r.source_address = '*' THEN 'group_only'
+        ELSE 'unknown_source'
+    END AS source_match_status
+FROM dz_ip_mroute_entries_current r
+LEFT ANY JOIN dz_devices_current d ON r.device_pubkey = d.pk
+LEFT ANY JOIN dz_metros_current m ON d.metro_pk = m.pk
+LEFT ANY JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+LEFT ANY JOIN dz_multicast_groups_current g ON r.group_address = g.multicast_ip
+LEFT ANY JOIN (
+    SELECT pk, owner_pubkey, tenant_pk, client_ip, dz_ip, tunnel_id, device_pk, publishers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+) pub
+    ON r.source_address = pub.dz_ip
+    AND has(JSONExtract(pub.publishers, 'Array(String)'), assumeNotNull(g.pk))
+LEFT ANY JOIN dz_devices_current pub_dev ON pub.device_pk = pub_dev.pk
+LEFT ANY JOIN dz_metros_current pub_m ON pub_dev.metro_pk = pub_m.pk
+LEFT ANY JOIN dz_contributors_current pub_c ON pub_dev.contributor_pk = pub_c.pk;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS enriched_ip_mroute;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS dz_device_interface_ips;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/enriched_view_test.go
+++ b/indexer/pkg/dz/mroute/enriched_view_test.go
@@ -1,0 +1,167 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrichedView_DeviceInterfaceIPs verifies that dz_device_interface_ips
+// parses dz_devices_current.interfaces JSON into one row per (device, IP)
+// with the CIDR mask stripped. This is the lookup view used by enriched
+// MSDP/mroute joins for mesh-space → device mapping.
+func TestEnrichedView_DeviceInterfaceIPs(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	err = conn.Exec(t.Context(), `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('dev-sea', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'activated', 'edge', 'sea001-dz001', '63.243.225.62', 'contrib-jump', 'metro-sea', 0,
+			 '[{"name":"Loopback255","ip":"172.16.0.3/32","status":"activated"},{"name":"Port-Channel2000","ip":"172.16.0.10/31","status":"activated"}]')
+	`)
+	require.NoError(t, err)
+
+	rows, err := conn.Query(t.Context(), `
+		SELECT device_pk, device_code, interface_name, ip_address
+		FROM dz_device_interface_ips
+		WHERE device_pk = 'dev-sea'
+		ORDER BY interface_name
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type record struct {
+		DevicePK, DeviceCode, InterfaceName, IPAddress string
+	}
+	var got []record
+	for rows.Next() {
+		var r record
+		require.NoError(t, rows.Scan(&r.DevicePK, &r.DeviceCode, &r.InterfaceName, &r.IPAddress))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "sea001-dz001", got[0].DeviceCode)
+	assert.Equal(t, "Loopback255", got[0].InterfaceName)
+	assert.Equal(t, "172.16.0.3", got[0].IPAddress) // CIDR stripped
+	assert.Equal(t, "Port-Channel2000", got[1].InterfaceName)
+	assert.Equal(t, "172.16.0.10", got[1].IPAddress)
+}
+
+// TestEnrichedView_IPMroute verifies that enriched_ip_mroute correctly joins
+// an mroute entry to device/metro/contributor/group/publisher with every
+// pubkey paired with its human-readable code.
+func TestEnrichedView_IPMroute(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	ctx := t.Context()
+
+	// Metro
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name, longitude, latitude)
+		VALUES
+			('metro-sea', now(), now(), generateUUIDv4(), 0, 1, 'metro-sea', 'sea', 'Seattle', 0, 0)
+	`))
+
+	// Contributor
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_contributors_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name)
+		VALUES
+			('contrib-jump', now(), now(), generateUUIDv4(), 0, 1, 'contrib-jump', 'jump_', 'Jump Trading')
+	`))
+
+	// Device — RP that owns the source address as one of its interface IPs
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('dev-sea', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'activated', 'edge', 'sea001-dz001', '63.243.225.62', 'contrib-jump', 'metro-sea', 0,
+			 '[]')
+	`))
+
+	// Multicast group
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-shreds', now(), now(), generateUUIDv4(), 0, 1,
+			 'grp-shreds', 'owner-pub', 'edge-solana-shreds', '233.84.178.1', 100000000, 'activated', 1, 0)
+	`))
+
+	// Publisher user attached to the device, whose dz_ip is the mroute source
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('user-pub', now(), now(), generateUUIDv4(), 0, 1,
+			 'user-pub', 'pub-owner', 'activated', 'multicast', '203.0.113.10', '148.51.122.190', 'dev-sea', 'tenant-1', 0, '["grp-shreds"]', '[]')
+	`))
+
+	// Mroute entry
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mroute-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'default', 'sparse', '233.84.178.1', '148.51.122.190',
+			 'SBNP', 0, 'Tunnel501', '', '', 0, 0, '', 0, 0,
+			 '["Switch1/11/1","Port-Channel1000.2035"]', 2, now())
+	`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT
+			device_pk, device_code, metro_code, contributor_code,
+			multicast_group_pk, multicast_group_code,
+			publisher_user_pk, publisher_device_code, publisher_metro_code, publisher_contributor_code,
+			source_match_status
+		FROM enriched_ip_mroute
+		WHERE mroute_entity_id = 'mroute-1'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next(), "expected one enriched row")
+	var devicePK, deviceCode, metroCode, contributorCode string
+	var groupPK, groupCode string
+	var pubUserPK, pubDeviceCode, pubMetroCode, pubContributorCode string
+	var sourceMatch string
+	require.NoError(t, rows.Scan(
+		&devicePK, &deviceCode, &metroCode, &contributorCode,
+		&groupPK, &groupCode,
+		&pubUserPK, &pubDeviceCode, &pubMetroCode, &pubContributorCode,
+		&sourceMatch,
+	))
+
+	assert.Equal(t, "dev-sea", devicePK)
+	assert.Equal(t, "sea001-dz001", deviceCode)
+	assert.Equal(t, "sea", metroCode)
+	assert.Equal(t, "jump_", contributorCode)
+	assert.Equal(t, "grp-shreds", groupPK)
+	assert.Equal(t, "edge-solana-shreds", groupCode)
+	assert.Equal(t, "user-pub", pubUserPK)
+	assert.Equal(t, "sea001-dz001", pubDeviceCode)
+	assert.Equal(t, "sea", pubMetroCode)
+	assert.Equal(t, "jump_", pubContributorCode)
+	assert.Equal(t, "publisher_matched", sourceMatch)
+}

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -25,6 +25,8 @@ func TestMigration_Applies(t *testing.T) {
 		{"dim_dz_ip_mroute_entries_history", "table"},
 		{"stg_dim_dz_ip_mroute_entries_snapshot", "table"},
 		{"dz_ip_mroute_entries_current", "view"},
+		{"dz_device_interface_ips", "view"},
+		{"enriched_ip_mroute", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Adds two ClickHouse views as the foundation for serving enriched multicast forwarding data:

- **`dz_device_interface_ips`** — parses `dz_devices_current.interfaces` JSON into one row per `(device, interface IP)`, strips the CIDR mask. Becomes the lookup view that other enriched views use to map mesh-space addresses (e.g. the 172.16.x.x MSDP peer addresses) back to a device pubkey + code.
- **`enriched_ip_mroute`** — joins `dz_ip_mroute_entries_current` with device, metro, contributor, multicast group, and publisher-user metadata. Every entity pubkey is paired with its human-readable code (`device_code`, `metro_code`, `contributor_code`, `multicast_group_code`, `publisher_device_code`, etc.). `source_match_status` reports whether the source address resolved to an activated multicast publisher for this group.

This is PR 1 of 3 for infra#1418. PR 2 (MSDP enriched views) stacks on this branch because the MSDP views consume `dz_device_interface_ips`. PR 3 (enriched_ip_mroute_oifs) is independent.

The enriched views are intended to become the substrate that lake-api endpoints (and any other consumers — Grafana, ad-hoc ops queries, future operator tools) query for multicast data. Discussion of the wider plan in `lake#617` review.

## Testing Verification

- `TestMigration_Applies` extended to cover both new views.
- `TestEnrichedView_DeviceInterfaceIPs` — inserts a device with two `interfaces` JSON entries, verifies the view returns one row per IP with the CIDR mask stripped (`172.16.0.3/32` → `172.16.0.3`).
- `TestEnrichedView_IPMroute` — round-trip: inserts metro + contributor + device + multicast group + publisher user + mroute entry, queries `enriched_ip_mroute`, asserts every joined column is populated with the correct code (`device_code = 'sea001-dz001'`, `metro_code = 'sea'`, `contributor_code = 'jump_'`, `multicast_group_code = 'edge-solana-shreds'`, `source_match_status = 'publisher_matched'`).

Refs malbeclabs/infra#1418.
