### PR TITLE
indexer: enriched MSDP views (peers, pim_sa_cache, sa_cache)

### DIFF
--- a/indexer/db/clickhouse/migrations/20260602000002_enriched_ip_msdp_views.sql
+++ b/indexer/db/clickhouse/migrations/20260602000002_enriched_ip_msdp_views.sql
@@ -1,0 +1,183 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- enriched_ip_msdp_peers
+-- Joins dz_ip_msdp_peers_current with the local device and (via
+-- dz_device_interface_ips) the peer device. Mesh-space peer addresses
+-- (172.16.x.x) map back to whichever device has that IP on one of its
+-- interfaces. Every entity pubkey is paired with its human-readable code.
+CREATE OR REPLACE VIEW enriched_ip_msdp_peers
+AS
+SELECT
+    p.entity_id AS msdp_peer_entity_id,
+    p.snapshot_ts,
+    p.ingested_at,
+
+    -- local device
+    p.device_pubkey AS device_pk,
+    d.code AS device_code,
+    d.status AS device_status,
+    d.metro_pk,
+    m.code AS metro_code,
+    m.name AS metro_name,
+    d.contributor_pk,
+    c.code AS contributor_code,
+    c.name AS contributor_name,
+
+    -- session payload
+    p.peer_address,
+    p.state,
+    p.session_start_time,
+    p.sa_count,
+    p.reset_count,
+
+    -- peer device (resolved from peer_address via interface IPs)
+    peer_iface.device_pk AS peer_device_pk,
+    peer_iface.device_code AS peer_device_code,
+    peer_iface.interface_name AS peer_interface_name
+FROM dz_ip_msdp_peers_current p
+LEFT ANY JOIN dz_devices_current d ON p.device_pubkey = d.pk
+LEFT ANY JOIN dz_metros_current m ON d.metro_pk = m.pk
+LEFT ANY JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+LEFT ANY JOIN dz_device_interface_ips peer_iface ON p.peer_address = peer_iface.ip_address;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- enriched_ip_msdp_pim_sa_cache
+-- Joins dz_ip_msdp_pim_sa_cache_current with local device, multicast group,
+-- and publisher-user metadata. rp_address is left raw — current production
+-- uses anycast `10.0.0.0` which doesn't map to a specific device.
+CREATE OR REPLACE VIEW enriched_ip_msdp_pim_sa_cache
+AS
+SELECT
+    sa.entity_id AS msdp_pim_sa_entity_id,
+    sa.snapshot_ts,
+    sa.ingested_at,
+
+    -- local device
+    sa.device_pubkey AS device_pk,
+    d.code AS device_code,
+    d.metro_pk,
+    m.code AS metro_code,
+    d.contributor_pk,
+    c.code AS contributor_code,
+
+    -- SA payload
+    sa.group_address,
+    sa.source_address,
+    sa.rp_address,
+
+    -- group enrichment
+    g.pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.owner_pubkey AS multicast_group_owner_pubkey,
+    g.status AS multicast_group_status,
+
+    -- publisher enrichment
+    pub.pk AS publisher_user_pk,
+    pub.owner_pubkey AS publisher_owner_pubkey,
+    pub.device_pk AS publisher_device_pk,
+    pub_dev.code AS publisher_device_code,
+    pub.dz_ip AS publisher_dz_ip,
+    pub.tunnel_id AS publisher_tunnel_id,
+
+    CASE
+        WHEN pub.pk != '' THEN 'publisher_matched'
+        WHEN sa.source_address = '' OR sa.source_address = '*' THEN 'group_only'
+        ELSE 'unknown_source'
+    END AS source_match_status
+FROM dz_ip_msdp_pim_sa_cache_current sa
+LEFT ANY JOIN dz_devices_current d ON sa.device_pubkey = d.pk
+LEFT ANY JOIN dz_metros_current m ON d.metro_pk = m.pk
+LEFT ANY JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+LEFT ANY JOIN dz_multicast_groups_current g ON sa.group_address = g.multicast_ip
+LEFT ANY JOIN (
+    SELECT pk, owner_pubkey, dz_ip, tunnel_id, device_pk, publishers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+) pub
+    ON sa.source_address = pub.dz_ip
+    AND has(JSONExtract(pub.publishers, 'Array(String)'), assumeNotNull(g.pk))
+LEFT ANY JOIN dz_devices_current pub_dev ON pub.device_pk = pub_dev.pk;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- enriched_ip_msdp_sa_cache
+-- Joins dz_ip_msdp_sa_cache_current with local device, remote device (via
+-- dz_device_interface_ips), multicast group, and publisher user. `status`
+-- column on the source row reports accepted vs rejected.
+CREATE OR REPLACE VIEW enriched_ip_msdp_sa_cache
+AS
+SELECT
+    sa.entity_id AS msdp_sa_entity_id,
+    sa.snapshot_ts,
+    sa.ingested_at,
+
+    -- local device
+    sa.device_pubkey AS device_pk,
+    d.code AS device_code,
+    d.metro_pk,
+    m.code AS metro_code,
+    d.contributor_pk,
+    c.code AS contributor_code,
+
+    -- SA payload
+    sa.group_address,
+    sa.source_address,
+    sa.remote_address,
+    sa.status AS accept_status,
+    sa.rp_address,
+
+    -- remote device (resolved from remote_address via interface IPs)
+    remote_iface.device_pk AS remote_device_pk,
+    remote_iface.device_code AS remote_device_code,
+    remote_iface.interface_name AS remote_interface_name,
+
+    -- group enrichment
+    g.pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.owner_pubkey AS multicast_group_owner_pubkey,
+    g.status AS multicast_group_status,
+
+    -- publisher enrichment
+    pub.pk AS publisher_user_pk,
+    pub.owner_pubkey AS publisher_owner_pubkey,
+    pub.device_pk AS publisher_device_pk,
+    pub_dev.code AS publisher_device_code,
+    pub.dz_ip AS publisher_dz_ip,
+    pub.tunnel_id AS publisher_tunnel_id,
+
+    CASE
+        WHEN pub.pk != '' THEN 'publisher_matched'
+        WHEN sa.source_address = '' OR sa.source_address = '*' THEN 'group_only'
+        ELSE 'unknown_source'
+    END AS source_match_status
+FROM dz_ip_msdp_sa_cache_current sa
+LEFT ANY JOIN dz_devices_current d ON sa.device_pubkey = d.pk
+LEFT ANY JOIN dz_metros_current m ON d.metro_pk = m.pk
+LEFT ANY JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+LEFT ANY JOIN dz_device_interface_ips remote_iface ON sa.remote_address = remote_iface.ip_address
+LEFT ANY JOIN dz_multicast_groups_current g ON sa.group_address = g.multicast_ip
+LEFT ANY JOIN (
+    SELECT pk, owner_pubkey, dz_ip, tunnel_id, device_pk, publishers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+) pub
+    ON sa.source_address = pub.dz_ip
+    AND has(JSONExtract(pub.publishers, 'Array(String)'), assumeNotNull(g.pk))
+LEFT ANY JOIN dz_devices_current pub_dev ON pub.device_pk = pub_dev.pk;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS enriched_ip_msdp_sa_cache;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS enriched_ip_msdp_pim_sa_cache;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS enriched_ip_msdp_peers;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/msdp/enriched_view_test.go
+++ b/indexer/pkg/dz/msdp/enriched_view_test.go
@@ -1,0 +1,177 @@
+package msdp
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrichedView_MSDPPeers verifies that an MSDP peer row joins to the
+// local device, and that the mesh-space peer_address resolves to a remote
+// device via the dz_device_interface_ips lookup.
+func TestEnrichedView_MSDPPeers(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name, longitude, latitude)
+		VALUES
+			('metro-sea', now(), now(), generateUUIDv4(), 0, 1, 'metro-sea', 'sea', 'Seattle', 0, 0),
+			('metro-nyc', now(), now(), generateUUIDv4(), 0, 2, 'metro-nyc', 'nyc', 'New York', 0, 0)
+	`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_contributors_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name)
+		VALUES
+			('contrib-jump', now(), now(), generateUUIDv4(), 0, 1, 'contrib-jump', 'jump_', 'Jump Trading')
+	`))
+
+	// Two devices: local (sea) and remote (nyc). Remote has the peer_address on a Loopback.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('dev-sea', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'activated', 'edge', 'sea001-dz001', '63.243.225.62',
+			 'contrib-jump', 'metro-sea', 0, '[]'),
+			('dev-nyc', now(), now(), generateUUIDv4(), 0, 2,
+			 'dev-nyc', 'activated', 'edge', 'nyc001-dz001', '169.150.226.117',
+			 'contrib-jump', 'metro-nyc', 0,
+			 '[{"name":"Loopback255","ip":"172.16.0.28/32","status":"activated"}]')
+	`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_msdp_peers_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, peer_address, state, session_start_time, sa_count, reset_count)
+		VALUES
+			('peer-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', '172.16.0.28', 'established', now(), 5, 0)
+	`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT device_pk, device_code, metro_code, contributor_code,
+			peer_address, peer_device_pk, peer_device_code, peer_interface_name,
+			state, sa_count
+		FROM enriched_ip_msdp_peers
+		WHERE msdp_peer_entity_id = 'peer-1'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next(), "expected one enriched peer row")
+	var devicePK, deviceCode, metroCode, contributorCode string
+	var peerAddress, peerDevicePK, peerDeviceCode, peerInterfaceName string
+	var state string
+	var saCount int64
+	require.NoError(t, rows.Scan(
+		&devicePK, &deviceCode, &metroCode, &contributorCode,
+		&peerAddress, &peerDevicePK, &peerDeviceCode, &peerInterfaceName,
+		&state, &saCount,
+	))
+	assert.Equal(t, "dev-sea", devicePK)
+	assert.Equal(t, "sea001-dz001", deviceCode)
+	assert.Equal(t, "sea", metroCode)
+	assert.Equal(t, "172.16.0.28", peerAddress)
+	assert.Equal(t, "dev-nyc", peerDevicePK)
+	assert.Equal(t, "nyc001-dz001", peerDeviceCode)
+	assert.Equal(t, "Loopback255", peerInterfaceName)
+	assert.Equal(t, "established", state)
+	assert.EqualValues(t, 5, saCount)
+}
+
+// TestEnrichedView_MSDPSACache verifies the SA cache enrichment: local
+// device join, remote device lookup via mesh address, group + publisher
+// enrichment via source_address.
+func TestEnrichedView_MSDPSACache(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name, longitude, latitude)
+		VALUES
+			('metro-sea', now(), now(), generateUUIDv4(), 0, 1, 'metro-sea', 'sea', 'Seattle', 0, 0),
+			('metro-nyc', now(), now(), generateUUIDv4(), 0, 2, 'metro-nyc', 'nyc', 'New York', 0, 0)
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_contributors_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name)
+		VALUES
+			('contrib-jump', now(), now(), generateUUIDv4(), 0, 1, 'contrib-jump', 'jump_', 'Jump Trading')
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('dev-sea', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'activated', 'edge', 'sea001-dz001', '', 'contrib-jump', 'metro-sea', 0, '[]'),
+			('dev-nyc', now(), now(), generateUUIDv4(), 0, 2,
+			 'dev-nyc', 'activated', 'edge', 'nyc001-dz001', '', 'contrib-jump', 'metro-nyc', 0,
+			 '[{"name":"Loopback255","ip":"172.16.1.195/32","status":"activated"}]')
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-shreds', now(), now(), generateUUIDv4(), 0, 1,
+			 'grp-shreds', 'owner-pub', 'edge-solana-shreds', '233.84.178.1', 100000000, 'activated', 1, 0)
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('user-pub', now(), now(), generateUUIDv4(), 0, 1,
+			 'user-pub', 'pub-owner', 'activated', 'multicast', '203.0.113.10', '148.51.122.190', 'dev-sea', 'tenant-1', 0, '["grp-shreds"]', '[]')
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_msdp_sa_cache_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, group_address, source_address, remote_address, status, rp_address)
+		VALUES
+			('sa-1', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', '233.84.178.1', '148.51.122.190', '172.16.1.195', 'accepted', '10.0.0.0')
+	`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT device_pk, device_code,
+			remote_address, remote_device_pk, remote_device_code,
+			multicast_group_code, publisher_user_pk, publisher_device_code,
+			accept_status, source_match_status
+		FROM enriched_ip_msdp_sa_cache
+		WHERE msdp_sa_entity_id = 'sa-1'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next(), "expected one enriched SA row")
+	var devicePK, deviceCode, remoteAddress, remoteDevicePK, remoteDeviceCode string
+	var groupCode, publisherUserPK, publisherDeviceCode, acceptStatus, sourceMatch string
+	require.NoError(t, rows.Scan(
+		&devicePK, &deviceCode,
+		&remoteAddress, &remoteDevicePK, &remoteDeviceCode,
+		&groupCode, &publisherUserPK, &publisherDeviceCode,
+		&acceptStatus, &sourceMatch,
+	))
+	assert.Equal(t, "dev-sea", devicePK)
+	assert.Equal(t, "172.16.1.195", remoteAddress)
+	assert.Equal(t, "dev-nyc", remoteDevicePK)
+	assert.Equal(t, "nyc001-dz001", remoteDeviceCode)
+	assert.Equal(t, "edge-solana-shreds", groupCode)
+	assert.Equal(t, "user-pub", publisherUserPK)
+	assert.Equal(t, "sea001-dz001", publisherDeviceCode)
+	assert.Equal(t, "accepted", acceptStatus)
+	assert.Equal(t, "publisher_matched", sourceMatch)
+}

--- a/indexer/pkg/dz/msdp/migration_test.go
+++ b/indexer/pkg/dz/msdp/migration_test.go
@@ -33,6 +33,10 @@ func TestMigration_Applies(t *testing.T) {
 		{"dim_dz_ip_msdp_sa_cache_history", "table"},
 		{"stg_dim_dz_ip_msdp_sa_cache_snapshot", "table"},
 		{"dz_ip_msdp_sa_cache_current", "view"},
+		// Enriched MSDP views
+		{"enriched_ip_msdp_peers", "view"},
+		{"enriched_ip_msdp_pim_sa_cache", "view"},
+		{"enriched_ip_msdp_sa_cache", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Adds three ClickHouse views enriching `dz_ip_msdp_*_current` with device, group, and publisher attribution:

- **`enriched_ip_msdp_peers`** — joins each MSDP peer session to the local device and (via `dz_device_interface_ips` from the parent PR) the remote peer device. The 172.16.x.x mesh-space `peer_address` resolves to whichever device has that IP on one of its interfaces, exposing `peer_device_pk` + `peer_device_code` + `peer_interface_name`. Verified empirically: 96/96 production mainnet MSDP peers map to a device this way.
- **`enriched_ip_msdp_pim_sa_cache`** — joins each PIM SA cache entry to local device, multicast group, and publisher user (via `source_address` → user's `dz_ip` when the group is in the publishers list). `rp_address` left raw — production uses anycast `10.0.0.0` which doesn't map to a specific device.
- **`enriched_ip_msdp_sa_cache`** — same enrichments as PIM SA cache, plus remote device resolution via `dz_device_interface_ips` (mapping the 172.16.x.x `remote_address` to a device pubkey + code). `sa.status` is aliased to `accept_status` to disambiguate from `multicast_group_status`. Verified empirically: 617/616 production mainnet SA cache rows match a device this way (one source matched two devices, handled by LEFT ANY JOIN).

## Stacking

PR 2 of 3 for infra#1418. **Base: `bc/enriched-mroute`** (PR 1) — this branch depends on the `dz_device_interface_ips` view introduced there. Merge PR 1 first; this should be rebased / merged onto main afterwards.

## Testing Verification

- `TestMigration_Applies` extended to cover all three new views.
- `TestEnrichedView_MSDPPeers` — inserts two devices (sea + nyc, nyc has the peer address on a Loopback interface), then an MSDP peer row. Asserts the peer_address resolves to nyc's device pubkey + code + interface name.
- `TestEnrichedView_MSDPSACache` — full round-trip exercising remote-device resolution + group join + publisher attribution, asserts `accept_status = 'accepted'`, `source_match_status = 'publisher_matched'`, plus all peer/publisher codes are populated.

Refs malbeclabs/infra#1418.
