### PR TITLE
indexer: enriched_ip_mroute_oifs view (per-OIF expansion + classification)

### DIFF
--- a/indexer/db/clickhouse/migrations/20260602000003_enriched_ip_mroute_oifs_view.sql
+++ b/indexer/db/clickhouse/migrations/20260602000003_enriched_ip_mroute_oifs_view.sql
@@ -1,0 +1,157 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- enriched_ip_mroute_oifs
+-- Expands each mroute entry's `oif_list` (a JSON string) into one row per
+-- outgoing interface, then classifies each OIF and joins to whichever
+-- entity it represents:
+--
+--   - oif_kind = 'underlay_link'       → joined to dz_links_current
+--                                         (side_a or side_z matched on
+--                                         (device_pubkey, interface_name))
+--   - oif_kind = 'subscriber_tunnel'   → joined to a multicast user whose
+--                                         tunnel_id matches Tunnel<N> on
+--                                         the same device AND who subscribes
+--                                         to the multicast group
+--   - oif_kind = 'local_interface'     → joined to dz_device_interfaces_current
+--                                         (interface metadata only; no link)
+--   - oif_kind = 'register' | 'null'   → recognised by name prefix; no join
+--   - oif_kind = 'unknown'             → fell through every match
+--
+-- observed_delivery_role gives a coarser semantic label:
+--   toward_network, toward_subscriber, local_register, unclassified.
+--
+-- Every entity pubkey is paired with its human-readable code.
+CREATE OR REPLACE VIEW enriched_ip_mroute_oifs
+AS
+WITH expanded AS (
+    SELECT
+        r.entity_id AS mroute_entity_id,
+        r.snapshot_ts,
+        r.ingested_at,
+        r.device_pubkey,
+        r.vrf,
+        r.mode,
+        r.group_address,
+        r.source_address,
+        oif_name
+    FROM dz_ip_mroute_entries_current r
+    ARRAY JOIN JSONExtract(r.oif_list, 'Array(String)') AS oif_name
+    WHERE r.oif_list != ''
+)
+SELECT
+    -- mroute identity (matches the composite id from enriched_ip_mroute)
+    concat(o.device_pubkey, '|', o.vrf, '|', o.mode, '|', o.group_address, '|', o.source_address) AS mroute_id,
+    o.mroute_entity_id,
+    o.snapshot_ts,
+    o.ingested_at,
+
+    -- local device (same enrichment shape as enriched_ip_mroute)
+    o.device_pubkey AS device_pk,
+    d.code AS device_code,
+    d.metro_pk,
+    m.code AS metro_code,
+    d.contributor_pk,
+    c.code AS contributor_code,
+
+    -- (S,G) keys
+    o.vrf,
+    o.mode,
+    o.group_address,
+    o.source_address,
+
+    -- group enrichment
+    g.pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.owner_pubkey AS multicast_group_owner_pubkey,
+    g.status AS multicast_group_status,
+
+    -- publisher enrichment (publisher = user whose dz_ip is the source)
+    pub.pk AS publisher_user_pk,
+    pub.device_pk AS publisher_device_pk,
+    pub_dev.code AS publisher_device_code,
+
+    -- OIF identity
+    o.oif_name,
+
+    -- Underlay link enrichment (matched on either side of the link)
+    if(la.pk != '', la.pk, lz.pk) AS link_pk,
+    if(la.pk != '', la.code, lz.code) AS link_code,
+    if(la.pk != '', 'a', if(lz.pk != '', 'z', '')) AS link_side,
+    if(la.pk != '', la.side_z_pk, if(lz.pk != '', lz.side_a_pk, '')) AS peer_device_pk,
+    if(la.pk != '', peer_a.code, if(lz.pk != '', peer_z.code, '')) AS peer_device_code,
+    if(la.pk != '', la.side_z_iface_name, if(lz.pk != '', lz.side_a_iface_name, '')) AS peer_interface_name,
+    if(la.pk != '', la.link_type, lz.link_type) AS link_type,
+    if(la.pk != '', la.bandwidth_bps, lz.bandwidth_bps) AS bandwidth_bps,
+    if(la.pk != '', la.link_topologies, lz.link_topologies) AS link_topologies,
+    if(la.pk != '', la.unicast_drained, lz.unicast_drained) AS unicast_drained,
+
+    -- Local interface enrichment (for OIFs that aren't link sides)
+    iface.interface_type,
+    iface.routing_mode,
+    iface.bandwidth AS interface_bandwidth,
+    iface.mtu AS interface_mtu,
+    iface.user_tunnel_endpoint,
+
+    -- Subscriber tunnel enrichment (Tunnel<N> on this device matching a
+    -- multicast user that subscribes to this group)
+    sub.pk AS subscriber_user_pk,
+    sub.device_pk AS subscriber_device_pk,
+    sub_dev.code AS subscriber_device_code,
+    sub.tunnel_id AS subscriber_tunnel_id,
+    sub.owner_pubkey AS subscriber_owner_pubkey,
+    sub.dz_ip AS subscriber_dz_ip,
+    sub.client_ip AS subscriber_client_ip,
+
+    -- Classification
+    multiIf(
+        la.pk != '' OR lz.pk != '', 'underlay_link',
+        sub.pk != '',                'subscriber_tunnel',
+        iface.intf != '',            'local_interface',
+        startsWith(lower(o.oif_name), 'register'), 'register',
+        startsWith(lower(o.oif_name), 'null'),     'null',
+        'unknown'
+    ) AS oif_kind,
+    multiIf(
+        la.pk != '' OR lz.pk != '', 'toward_network',
+        sub.pk != '',                'toward_subscriber',
+        startsWith(lower(o.oif_name), 'register'), 'local_register',
+        'unclassified'
+    ) AS observed_delivery_role
+
+FROM expanded o
+LEFT ANY JOIN dz_devices_current d ON o.device_pubkey = d.pk
+LEFT ANY JOIN dz_metros_current m ON d.metro_pk = m.pk
+LEFT ANY JOIN dz_contributors_current c ON d.contributor_pk = c.pk
+LEFT ANY JOIN dz_multicast_groups_current g ON o.group_address = g.multicast_ip
+LEFT ANY JOIN (
+    SELECT pk, dz_ip, device_pk, publishers FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+) pub
+    ON o.source_address = pub.dz_ip
+    AND has(JSONExtract(pub.publishers, 'Array(String)'), assumeNotNull(g.pk))
+LEFT ANY JOIN dz_devices_current pub_dev ON pub.device_pk = pub_dev.pk
+LEFT ANY JOIN dz_links_current la
+    ON o.device_pubkey = la.side_a_pk AND o.oif_name = la.side_a_iface_name
+LEFT ANY JOIN dz_links_current lz
+    ON o.device_pubkey = lz.side_z_pk AND o.oif_name = lz.side_z_iface_name
+LEFT ANY JOIN dz_devices_current peer_a ON la.side_z_pk = peer_a.pk
+LEFT ANY JOIN dz_devices_current peer_z ON lz.side_a_pk = peer_z.pk
+LEFT ANY JOIN dz_device_interfaces_current iface
+    ON o.device_pubkey = iface.device_pk AND o.oif_name = iface.intf
+LEFT ANY JOIN (
+    SELECT pk, dz_ip, owner_pubkey, client_ip, device_pk, tunnel_id, subscribers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast' AND tunnel_id > 0
+) sub
+    ON o.device_pubkey = sub.device_pk
+    AND sub.tunnel_id = toInt32OrZero(extract(o.oif_name, '^Tunnel(\\d+)$'))
+    AND has(JSONExtract(sub.subscribers, 'Array(String)'), assumeNotNull(g.pk))
+LEFT ANY JOIN dz_devices_current sub_dev ON sub.device_pk = sub_dev.pk;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS enriched_ip_mroute_oifs;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/enriched_oifs_view_test.go
+++ b/indexer/pkg/dz/mroute/enriched_oifs_view_test.go
@@ -1,0 +1,161 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrichedView_IPMrouteOIFs verifies that enriched_ip_mroute_oifs
+// expands an mroute's OIF list and classifies each OIF correctly:
+//
+//   - An OIF matching a link side resolves to a link + peer device
+//     (oif_kind = 'underlay_link', toward_network).
+//   - A Tunnel<N> OIF where N matches a user.tunnel_id on the same device,
+//     and that user subscribes to the multicast group, resolves to a
+//     subscriber (oif_kind = 'subscriber_tunnel', toward_subscriber).
+//   - An OIF that matches none of the above falls through to 'unknown'.
+func TestEnrichedView_IPMrouteOIFs(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name, longitude, latitude)
+		VALUES
+			('metro-sea', now(), now(), generateUUIDv4(), 0, 1, 'metro-sea', 'sea', 'Seattle', 0, 0),
+			('metro-nyc', now(), now(), generateUUIDv4(), 0, 2, 'metro-nyc', 'nyc', 'New York', 0, 0)
+	`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_contributors_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name)
+		VALUES
+			('contrib-jump', now(), now(), generateUUIDv4(), 0, 1, 'contrib-jump', 'jump_', 'Jump Trading')
+	`))
+	// Two devices: dev-sea (the local mroute device) and dev-nyc (peer on the link).
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('dev-sea', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'activated', 'edge', 'sea001-dz001', '', 'contrib-jump', 'metro-sea', 0, '[]'),
+			('dev-nyc', now(), now(), generateUUIDv4(), 0, 2,
+			 'dev-nyc', 'activated', 'edge', 'nyc001-dz001', '', 'contrib-jump', 'metro-nyc', 0, '[]')
+	`))
+	// Link between sea (side_a) and nyc (side_z), side_a interface is Switch1/11/1.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_links_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, code, tunnel_net, contributor_pk,
+			 side_a_pk, side_z_pk, side_a_iface_name, side_z_iface_name,
+			 side_a_ip, side_z_ip, link_type, committed_rtt_ns, committed_jitter_ns,
+			 bandwidth_bps, isis_delay_override_ns, link_topologies, unicast_drained)
+		VALUES
+			('link-sea-nyc', now(), now(), generateUUIDv4(), 0, 1,
+			 'link-sea-nyc', 'activated', 'sea001-dz001:nyc001-dz001', '', 'contrib-jump',
+			 'dev-sea', 'dev-nyc', 'Switch1/11/1', 'Ethernet1/1',
+			 '', '', 'DZX', 1000000, 0,
+			 10000000000, 0, '[]', 0)
+	`))
+	// Multicast group
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-shreds', now(), now(), generateUUIDv4(), 0, 1,
+			 'grp-shreds', 'owner-pub', 'edge-solana-shreds', '233.84.178.1', 100000000, 'activated', 1, 1)
+	`))
+	// Subscriber on dev-sea with tunnel_id 504, subscribed to the group.
+	// Publisher elsewhere; not needed for the OIF resolution.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('user-sub', now(), now(), generateUUIDv4(), 0, 1,
+			 'user-sub', 'sub-owner', 'activated', 'multicast', '203.0.113.10', '148.51.122.55', 'dev-sea', 'tenant-1', 504, '[]', '["grp-shreds"]')
+	`))
+	// Mroute on dev-sea with three OIFs:
+	//   - Switch1/11/1     → matches link side_a → underlay_link
+	//   - Tunnel504        → matches user-sub on dev-sea → subscriber_tunnel
+	//   - Mystery0         → matches nothing → unknown
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mroute-multi-oif', now(), now(), generateUUIDv4(), 0, 1,
+			 'dev-sea', 'default', 'sparse', '233.84.178.1', '148.51.122.190',
+			 'SMP', 0, 'Tunnel501', '', '', 0, 0, '', 0, 0,
+			 '["Switch1/11/1","Tunnel504","Mystery0"]', 3, now())
+	`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT oif_name, oif_kind, observed_delivery_role,
+			link_pk, link_code, peer_device_pk, peer_device_code,
+			subscriber_user_pk, subscriber_device_pk, subscriber_device_code, subscriber_tunnel_id
+		FROM enriched_ip_mroute_oifs
+		WHERE mroute_entity_id = 'mroute-multi-oif'
+		ORDER BY oif_name
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type rec struct {
+		oifName, oifKind, role string
+		linkPK, linkCode       string
+		peerDevicePK, peerCode string
+		subUserPK, subDevicePK string
+		subDeviceCode          string
+		subTunnelID            int32
+	}
+	var got []rec
+	for rows.Next() {
+		var r rec
+		require.NoError(t, rows.Scan(
+			&r.oifName, &r.oifKind, &r.role,
+			&r.linkPK, &r.linkCode, &r.peerDevicePK, &r.peerCode,
+			&r.subUserPK, &r.subDevicePK, &r.subDeviceCode, &r.subTunnelID,
+		))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 3)
+
+	// Mystery0 — no link, no user, no interface dim row → unknown
+	mystery := got[0]
+	assert.Equal(t, "Mystery0", mystery.oifName)
+	assert.Equal(t, "unknown", mystery.oifKind)
+	assert.Equal(t, "unclassified", mystery.role)
+
+	// Switch1/11/1 — link side_a match
+	link := got[1]
+	assert.Equal(t, "Switch1/11/1", link.oifName)
+	assert.Equal(t, "underlay_link", link.oifKind)
+	assert.Equal(t, "toward_network", link.role)
+	assert.Equal(t, "link-sea-nyc", link.linkPK)
+	assert.Equal(t, "sea001-dz001:nyc001-dz001", link.linkCode)
+	assert.Equal(t, "dev-nyc", link.peerDevicePK)
+	assert.Equal(t, "nyc001-dz001", link.peerCode)
+
+	// Tunnel504 — subscriber tunnel match on dev-sea (user-sub, tunnel_id 504,
+	// subscribed to grp-shreds)
+	tunnel := got[2]
+	assert.Equal(t, "Tunnel504", tunnel.oifName)
+	assert.Equal(t, "subscriber_tunnel", tunnel.oifKind)
+	assert.Equal(t, "toward_subscriber", tunnel.role)
+	assert.Equal(t, "user-sub", tunnel.subUserPK)
+	assert.Equal(t, "dev-sea", tunnel.subDevicePK)
+	assert.Equal(t, "sea001-dz001", tunnel.subDeviceCode)
+	assert.EqualValues(t, 504, tunnel.subTunnelID)
+}

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -27,6 +27,7 @@ func TestMigration_Applies(t *testing.T) {
 		{"dz_ip_mroute_entries_current", "view"},
 		{"dz_device_interface_ips", "view"},
 		{"enriched_ip_mroute", "view"},
+		{"enriched_ip_mroute_oifs", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Adds the `enriched_ip_mroute_oifs` ClickHouse view, which expands each mroute entry's `oif_list` (a JSON string) into one row per outgoing interface and classifies each OIF.

### What the view does

1. **ARRAY JOIN expansion** — `JSONExtract(oif_list, 'Array(String)')` splits the JSON-encoded OIF list into individual rows.

2. **Classification** — each OIF is labelled `oif_kind`:
   - `underlay_link` — OIF matches a `dz_links_current` side (either `side_a` or `side_z`) on the device's `(device_pubkey, interface_name)`.
   - `subscriber_tunnel` — OIF is `Tunnel<N>` where N matches a multicast user's `tunnel_id` on the same device AND that user subscribes to the multicast group.
   - `local_interface` — OIF appears in `dz_device_interfaces_current` for this device.
   - `register` / `null` — recognised by name prefix.
   - `unknown` — fell through every match.

3. **Enrichment per kind** — the appropriate columns are populated:
   - underlay_link: `link_pk`, `link_code`, `link_side`, `peer_device_pk`, `peer_device_code`, `peer_interface_name`, `link_type`, `bandwidth_bps`, `link_topologies`, `unicast_drained`.
   - subscriber_tunnel: `subscriber_user_pk`, `subscriber_device_pk`, `subscriber_device_code`, `subscriber_tunnel_id`, `subscriber_owner_pubkey`, `subscriber_dz_ip`, `subscriber_client_ip`.
   - local_interface: `interface_type`, `routing_mode`, `interface_bandwidth`, `interface_mtu`, `user_tunnel_endpoint`.

4. **Pubkey/code pairing** — every entity pubkey is paired with its human-readable code (`device_code`, `peer_device_code`, `subscriber_device_code`, `metro_code`, `contributor_code`, `multicast_group_code`).

PR 3 of 3 for infra#1418. **Independent of PR 1/2 — base is `main`**, can be merged in any order relative to the other two.

## Note on production data

Today the only mainnet device with state-collect-enabled mroute data is the RP (`sea001-dz001`). Its OIFs are link-attached (`Switch1/11/1`, `Port-Channel1000.2035`), so production responses currently classify everything as `underlay_link`. The `subscriber_tunnel` branch will start firing once state-collect is enabled on last-hop routers (where the user GRE tunnels terminate as `Tunnel<N>` OIFs) — see infra#1463.

## Testing Verification

- `TestMigration_Applies` extended to cover `enriched_ip_mroute_oifs`.
- `TestEnrichedView_IPMrouteOIFs` — inserts a single mroute with three OIFs (`Switch1/11/1`, `Tunnel504`, `Mystery0`) and asserts:
  - `Switch1/11/1` → `underlay_link`, `toward_network`, with `link_pk`, `peer_device_pk` (`dev-nyc`), `peer_device_code` (`nyc001-dz001`) populated.
  - `Tunnel504` → `subscriber_tunnel`, `toward_subscriber`, resolved to the subscriber user on the same device with `tunnel_id = 504`.
  - `Mystery0` → `unknown`, `unclassified`.

Refs malbeclabs/infra#1418.
