### PR TITLE
indexer: convert dz_device_interface_ips to a refreshable materialized view

### DIFF
--- a/api/testing/clickhouse.go
+++ b/api/testing/clickhouse.go
@@ -274,6 +274,14 @@ func SetupClickHouseWithMigrationsForTest(t *testing.T, db *ClickHouseDB) (drive
 	require.NoError(t, err, "failed to list template tables")
 	defer rows.Close()
 
+	// Collect all clone queries first, then apply with dependency-aware retries.
+	// system.tables returns rows in arbitrary order; plain VIEWs are created
+	// lazily so order doesn't matter for them, but MATERIALIZED VIEWs eagerly
+	// validate their AS SELECT against the source table at CREATE time. A
+	// repeat-until-no-progress loop resolves dependency ordering without
+	// having to parse SQL.
+	type pending struct{ name, query string }
+	var queries []pending
 	for rows.Next() {
 		var name, engineFull, createQuery string
 		require.NoError(t, rows.Scan(&name, &engineFull, &createQuery))
@@ -284,8 +292,30 @@ func SetupClickHouseWithMigrationsForTest(t *testing.T, db *ClickHouseDB) (drive
 		cloneQuery = strings.Replace(cloneQuery, fmt.Sprintf("CREATE TABLE %s", templateDB), fmt.Sprintf("CREATE TABLE %s", databaseName), 1)
 		cloneQuery = strings.Replace(cloneQuery, fmt.Sprintf("CREATE VIEW %s", templateDB), fmt.Sprintf("CREATE VIEW %s", databaseName), 1)
 		cloneQuery = strings.Replace(cloneQuery, fmt.Sprintf("CREATE MATERIALIZED VIEW %s", templateDB), fmt.Sprintf("CREATE MATERIALIZED VIEW %s", databaseName), 1)
-		err := adminConn.Exec(ctx, cloneQuery)
-		require.NoError(t, err, "failed to clone table %s: query=%s", name, cloneQuery)
+		queries = append(queries, pending{name: name, query: cloneQuery})
+	}
+	for {
+		var deferred []pending
+		var lastErrs map[string]error
+		for _, p := range queries {
+			if err := adminConn.Exec(ctx, p.query); err != nil {
+				if lastErrs == nil {
+					lastErrs = map[string]error{}
+				}
+				lastErrs[p.name] = err
+				deferred = append(deferred, p)
+			}
+		}
+		if len(deferred) == 0 {
+			break
+		}
+		// No progress made — remaining failures are real, not ordering. Report.
+		if len(deferred) == len(queries) {
+			for name, err := range lastErrs {
+				require.NoError(t, err, "failed to clone table %s", name)
+			}
+		}
+		queries = deferred
 	}
 
 	testConn, err := createClickHouseConn(ctx, db.addr, databaseName, db.cfg.Username, db.cfg.Password)

--- a/indexer/db/clickhouse/migrations/20260603000001_dz_device_interface_ips_refreshable.sql
+++ b/indexer/db/clickhouse/migrations/20260603000001_dz_device_interface_ips_refreshable.sql
@@ -1,0 +1,60 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- dz_device_interface_ips was originally defined as a plain VIEW that did
+-- ARRAY JOIN JSONExtractArrayRaw on dz_devices_current.interfaces. That
+-- works for direct SELECT, but ClickHouse 25.12's optimizer fails to
+-- estimate sizes when downstream queries JOIN against a column derived
+-- from ARRAY JOIN + JSONExtract — the planner allocates max-int sized
+-- hash tables and the query OOMs (observed in production: enriched_ip_msdp_peers
+-- and enriched_ip_msdp_sa_cache both crash with 128 TiB allocation
+-- attempts when their peer_device / remote_device columns are selected).
+--
+-- Fix: drop the regular view and recreate dz_device_interface_ips as a
+-- REFRESHABLE MATERIALIZED VIEW. The JSON parsing happens once per refresh
+-- and the result is stored in a real MergeTree table, so downstream JOINs
+-- see a normal table with proper size statistics. Refresh cadence is 60
+-- seconds — device interface lists change rarely (only when devices are
+-- added/removed/reconfigured) so the freshness lag is acceptable.
+DROP VIEW IF EXISTS dz_device_interface_ips;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW dz_device_interface_ips
+REFRESH EVERY 1 MINUTE
+ENGINE = MergeTree()
+ORDER BY (device_pk, interface_name)
+AS SELECT
+    d.pk AS device_pk,
+    d.code AS device_code,
+    d.status AS device_status,
+    JSONExtractString(iface, 'name') AS interface_name,
+    JSONExtractString(iface, 'status') AS interface_status,
+    splitByChar('/', JSONExtractString(iface, 'ip'))[1] AS ip_address
+FROM dz_devices_current d
+ARRAY JOIN JSONExtractArrayRaw(d.interfaces) AS iface
+WHERE d.status = 'activated'
+  AND JSONExtractString(iface, 'ip') != '';
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS dz_device_interface_ips;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dz_device_interface_ips
+AS
+SELECT
+    d.pk AS device_pk,
+    d.code AS device_code,
+    d.status AS device_status,
+    JSONExtractString(iface, 'name') AS interface_name,
+    JSONExtractString(iface, 'status') AS interface_status,
+    splitByChar('/', JSONExtractString(iface, 'ip'))[1] AS ip_address
+FROM dz_devices_current d
+ARRAY JOIN JSONExtractArrayRaw(d.interfaces) AS iface
+WHERE d.status = 'activated'
+  AND JSONExtractString(iface, 'ip') != '';
+-- +goose StatementEnd

--- a/indexer/db/clickhouse/migrations/20260603000001_dz_device_interface_ips_refreshable.sql
+++ b/indexer/db/clickhouse/migrations/20260603000001_dz_device_interface_ips_refreshable.sql
@@ -23,7 +23,7 @@ DROP VIEW IF EXISTS dz_device_interface_ips;
 CREATE MATERIALIZED VIEW dz_device_interface_ips
 REFRESH EVERY 1 MINUTE
 ENGINE = MergeTree()
-ORDER BY (device_pk, interface_name)
+ORDER BY (ip_address, device_pk, interface_name)
 AS SELECT
     d.pk AS device_pk,
     d.code AS device_code,

--- a/indexer/pkg/dz/mroute/enriched_view_test.go
+++ b/indexer/pkg/dz/mroute/enriched_view_test.go
@@ -29,6 +29,11 @@ func TestEnrichedView_DeviceInterfaceIPs(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
+	// dz_device_interface_ips is a refreshable MV (60s cadence in prod).
+	// Force a sync refresh so the just-inserted device row is visible.
+	require.NoError(t, conn.Exec(t.Context(), `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(t.Context(), `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
 	rows, err := conn.Query(t.Context(), `
 		SELECT device_pk, device_code, interface_name, ip_address
 		FROM dz_device_interface_ips

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -20,12 +20,12 @@ func TestMigration_Applies(t *testing.T) {
 
 	cases := []struct {
 		name string
-		kind string // "table" or "view"
+		kind string // "table", "view", or "mv" (refreshable materialized view)
 	}{
 		{"dim_dz_ip_mroute_entries_history", "table"},
 		{"stg_dim_dz_ip_mroute_entries_snapshot", "table"},
 		{"dz_ip_mroute_entries_current", "view"},
-		{"dz_device_interface_ips", "view"},
+		{"dz_device_interface_ips", "mv"},
 		{"enriched_ip_mroute", "view"},
 		{"enriched_ip_mroute_oifs", "view"},
 	}
@@ -42,9 +42,12 @@ func TestMigration_Applies(t *testing.T) {
 			require.True(t, rows.Next(), "%s did not materialize", c.name)
 			var got string
 			require.NoError(t, rows.Scan(&got))
-			if c.kind == "view" {
+			switch c.kind {
+			case "view":
 				assert.Equal(t, "View", got, "%s should be a view, got engine %q", c.name, got)
-			} else {
+			case "mv":
+				assert.Equal(t, "MaterializedView", got, "%s should be a MaterializedView, got engine %q", c.name, got)
+			default:
 				assert.Equal(t, "MergeTree", got, "%s should be MergeTree, got engine %q", c.name, got)
 			}
 		})

--- a/indexer/pkg/dz/msdp/enriched_view_test.go
+++ b/indexer/pkg/dz/msdp/enriched_view_test.go
@@ -1,6 +1,7 @@
 package msdp
 
 import (
+	"fmt"
 	"testing"
 
 	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
@@ -185,4 +186,69 @@ func TestEnrichedView_MSDPSACache(t *testing.T) {
 	assert.Equal(t, "sea001-dz001", publisherDeviceCode)
 	assert.Equal(t, "accepted", acceptStatus)
 	assert.Equal(t, "publisher_matched", sourceMatch)
+}
+
+// TestEnrichedView_MSDPJoinDoesNotExplode is the regression guard for
+// the dz_device_interface_ips → materialized view conversion. With the
+// previous plain VIEW definition, ClickHouse's optimizer allocated
+// max-int hash tables when JOINing the IP-to-device lookup against MSDP
+// peer/SA cache rows; selecting peer_device_pk / remote_device_pk would
+// OOM with a 128 TiB allocation. Running the same JOIN under a tight
+// max_memory_usage cap surfaces a regression to the plain-VIEW shape:
+// the buggy plan trips the cap immediately, the MV-backed plan stays
+// well under it.
+func TestEnrichedView_MSDPJoinDoesNotExplode(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	// A handful of devices, one peer per device, all addresses resolvable.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, conn.Exec(ctx, `
+			INSERT INTO dim_dz_devices_history
+				(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+				 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+			VALUES
+				(?, now(), now(), generateUUIDv4(), 0, ?,
+				 ?, 'activated', 'edge', ?, '', '', '', 0,
+				 ?)
+		`,
+			fmt.Sprintf("dev-%d", i), uint64(i+1),
+			fmt.Sprintf("dev-%d", i), fmt.Sprintf("d%d-dz001", i),
+			fmt.Sprintf(`[{"name":"Loopback255","ip":"172.16.0.%d/32","status":"activated"}]`, i+1),
+		))
+		require.NoError(t, conn.Exec(ctx, `
+			INSERT INTO dim_dz_ip_msdp_peers_history
+				(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+				 device_pubkey, peer_address, state, session_start_time, sa_count, reset_count)
+			VALUES
+				(?, now(), now(), generateUUIDv4(), 0, ?,
+				 ?, ?, 'established', now(), 0, 0)
+		`,
+			fmt.Sprintf("peer-%d", i), uint64(i+1),
+			fmt.Sprintf("dev-%d", i),
+			fmt.Sprintf("172.16.0.%d", ((i+1)%10)+1), // each peer points at the next device's loopback
+		))
+	}
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	// 256 MB is generous for 10 devices × 10 peers. The plain-VIEW shape
+	// would attempt a 128 TiB allocation and trip this cap immediately;
+	// the MV-backed shape stays well under it.
+	rows, err := conn.Query(ctx, `
+		SELECT count(), sum(if(peer_device_pk != '', 1, 0)) AS resolved
+		FROM enriched_ip_msdp_peers
+		SETTINGS max_memory_usage = 268435456
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var total, resolved uint64
+	require.NoError(t, rows.Scan(&total, &resolved))
+	assert.EqualValues(t, 10, total)
+	assert.EqualValues(t, 10, resolved, "expected every peer_address to resolve to a peer_device_pk")
 }

--- a/indexer/pkg/dz/msdp/enriched_view_test.go
+++ b/indexer/pkg/dz/msdp/enriched_view_test.go
@@ -48,6 +48,11 @@ func TestEnrichedView_MSDPPeers(t *testing.T) {
 			 '[{"name":"Loopback255","ip":"172.16.0.28/32","status":"activated"}]')
 	`))
 
+	// Force a sync refresh of the dz_device_interface_ips MV so the peer
+	// address resolution finds dev-nyc's loopback.
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO dim_dz_ip_msdp_peers_history
 			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
@@ -121,6 +126,12 @@ func TestEnrichedView_MSDPSACache(t *testing.T) {
 			 'dev-nyc', 'activated', 'edge', 'nyc001-dz001', '', 'contrib-jump', 'metro-nyc', 0,
 			 '[{"name":"Loopback255","ip":"172.16.1.195/32","status":"activated"}]')
 	`))
+
+	// Force a sync refresh of the dz_device_interface_ips MV so the SA
+	// remote_address resolution finds dev-nyc's loopback.
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO dim_dz_multicast_groups_history
 			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,


### PR DESCRIPTION
## Summary

Converts `dz_device_interface_ips` from a plain VIEW to a REFRESHABLE MATERIALIZED VIEW. Fixes the JOIN explosion that crashes `enriched_ip_msdp_peers` and `enriched_ip_msdp_sa_cache` on real production data.

## Symptom

Querying either of the two affected views — for any column that references the peer/remote device resolution — OOMs with a `128 TiB allocation attempted` error. Observed against `lake_testnet` on lake-staging:

```
SELECT device_code, peer_address, peer_device_code FROM lake_testnet.enriched_ip_msdp_peers LIMIT 1
→ Code: 241. Query memory limit exceeded: would use 128.00 TiB (attempt to allocate chunk of 128.00 TiB)
```

The basic `count()` succeeds (returns 56) but any projection through the JOIN explodes. The other four enriched views are unaffected and return data normally.

## Root cause

ClickHouse 25.12.11's query optimizer fails to estimate result sizes when a JOIN's right side is derived from `ARRAY JOIN JSONExtractArrayRaw(...)`. `dz_device_interface_ips` was defined as:

```sql
CREATE OR REPLACE VIEW dz_device_interface_ips AS
SELECT ... , splitByChar('/', JSONExtractString(iface, 'ip'))[1] AS ip_address
FROM dz_devices_current d
ARRAY JOIN JSONExtractArrayRaw(d.interfaces) AS iface
WHERE ...
```

The view itself works for direct `SELECT`. The bug surfaces only when something `LEFT ANY JOIN`s against the `ip_address` column. CH allocates a max-int sized hash table and the query OOMs.

Reproduced and isolated: same explosion happens with the JOIN inlined, with explicit `toString()` casts on the join key, with `extract()` instead of `splitByChar()`, and with `join_algorithm='hash'` forced.

## Fix

Replace the plain VIEW with a REFRESHABLE MATERIALIZED VIEW. The JSON parsing + ARRAY JOIN runs once per refresh and the result lands in a real `MergeTree` table. Downstream JOINs see a normal table with proper size statistics and plan correctly.

Refresh cadence: 60 seconds. Device interface lists change rarely (only when devices are added/removed/reconfigured), so the freshness lag is acceptable.

The view's name and column shape are unchanged, so `enriched_ip_msdp_peers` and `enriched_ip_msdp_sa_cache` need no modification.

## Testing Verification

- Reproduced the OOM on `lake_testnet.enriched_ip_msdp_peers` against staging's CH (25.12.11). Created a test refreshable MV with the same definition; `LEFT ANY JOIN` against it returned three rows correctly (`172.16.0.17 → fra-dz-001-x`, `172.16.0.39 → lon-dz001`).
- `TestMigration_Applies` extended to accept the new `mv` kind for `dz_device_interface_ips` (engine reports as `MaterializedView` in `system.tables`).

## Why this blocks the rollout

Promoting the current `:edge` to prod without this fix means mainnet's `enriched_ip_msdp_peers` and `enriched_ip_msdp_sa_cache` would crash on every query. Both are intended consumers for the per-multicast-group dashboard (infra#1428).

Refs malbeclabs/infra#1418.
