### PR TITLE
indexer: multicast health views (health_mroute + health_missing_sg)

### DIFF
--- a/api/handlers/multicast_delivery.go
+++ b/api/handlers/multicast_delivery.go
@@ -1,3 +1,8 @@
+// The health_mroute and health_missing_sg views (migration 20260603000002)
+// back future per-group and per-user health endpoints (infra#1501 Track 2).
+// They classify mroute rows and surface (active_publisher, group, device)
+// gaps without requiring this package to recompute the joins.
+
 package handlers
 
 import (

--- a/indexer/db/clickhouse/migrations/20260603000002_multicast_health_views.sql
+++ b/indexer/db/clickhouse/migrations/20260603000002_multicast_health_views.sql
@@ -1,0 +1,209 @@
+-- +goose Up
+
+-- ============================================================================
+-- Multicast end-to-end health views.
+--
+-- Two complementary views answering different questions about multicast
+-- delivery state per malbeclabs/infra#1501:
+--
+--   * health_mroute      — classifies each row in enriched_ip_mroute as
+--                          healthy / degraded / unhealthy, with a device
+--                          role and a flag-correctness check.
+--   * health_missing_sg  — surfaces (active_publisher, group, device) tuples
+--                          where an (S,G) entry is expected but absent.
+--
+-- Health definition reflects the DZ multicast forwarding model:
+--   - SPT (source-specific tree) is the desired steady state. Every device
+--     should have an (S,G) row for every active publisher of every group.
+--   - (*,G) entries exist as part of normal PIM-SM but are unhealthy ALONE:
+--     an (*,G) without matching (S,G) for every active publisher means
+--     receivers are stuck on the shared tree.
+--   - Flag interpretation (Arista PIM-SM):
+--       S = SPT bit set, P = Programmed in hardware,
+--       M = Learned via MSDP, E = Forwarding on RPT,
+--       B = Learned via Border Router, N = May notify MSDP,
+--       W = Wildcard entry.
+-- ============================================================================
+
+-- +goose StatementBegin
+-- health_mroute
+CREATE OR REPLACE VIEW health_mroute
+AS
+WITH
+oif_role_hints AS (
+    SELECT
+        mroute_entity_id AS hint_mroute_entity_id,
+        max(if(oif_kind = 'subscriber_tunnel', 1, 0)) AS hint_has_subscriber_tunnel,
+        max(if(oif_kind = 'underlay_link', 1, 0)) AS hint_has_underlay_link
+    FROM enriched_ip_mroute_oifs
+    GROUP BY mroute_entity_id
+),
+sg_sources_on_device AS (
+    SELECT
+        device_pk AS sg_device_pk,
+        group_address AS sg_group_address,
+        groupUniqArray(source_address) AS sg_sources_with_sg
+    FROM enriched_ip_mroute
+    WHERE source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address
+),
+active_publishers_for_group AS (
+    SELECT
+        g.multicast_ip AS ap_group_address,
+        groupUniqArray(u.dz_ip) AS ap_active_publisher_ips
+    FROM dz_multicast_groups_current g
+    LEFT ARRAY JOIN [g.pk] AS gpk
+    INNER JOIN dz_users_current u
+        ON has(JSONExtract(u.publishers, 'Array(String)'), gpk)
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+    GROUP BY g.multicast_ip
+)
+SELECT
+    r.mroute_id AS mroute_id,
+    r.mroute_entity_id AS mroute_entity_id,
+    r.device_pk AS device_pk,
+    r.device_code AS device_code,
+    r.metro_code AS metro_code,
+    r.contributor_code AS contributor_code,
+    r.multicast_group_pk AS multicast_group_pk,
+    r.multicast_group_code AS multicast_group_code,
+    r.group_address AS group_address,
+    r.source_address AS source_address,
+    r.route_flags AS route_flags,
+    r.rpf_interface AS rpf_interface,
+    r.oif_count AS oif_count,
+    r.publisher_user_pk AS publisher_user_pk,
+    r.publisher_device_pk AS publisher_device_pk,
+    r.publisher_device_code AS publisher_device_code,
+
+    -- Role classification
+    multiIf(
+        r.source_address = '0.0.0.0', 'star_g',
+        r.publisher_device_pk != '' AND r.publisher_device_pk = r.device_pk, 'fhr',
+        coalesce(h.hint_has_subscriber_tunnel, 0) = 1, 'lhr',
+        coalesce(h.hint_has_underlay_link, 0) = 1, 'transit',
+        r.oif_count = 0 AND position(r.route_flags, 'M') > 0 AND position(r.route_flags, 'E') > 0, 'learned_passive',
+        'unknown'
+    ) AS role,
+
+    -- For (*,G): which active publishers' (S,G) are missing on this device
+    if(
+        r.source_address = '0.0.0.0',
+        arrayFilter(x -> NOT has(coalesce(sg.sg_sources_with_sg, []), x), coalesce(ap.ap_active_publisher_ips, [])),
+        []
+    ) AS missing_publisher_ips,
+
+    -- Active publishers expected for this group
+    length(coalesce(ap.ap_active_publisher_ips, [])) AS active_publisher_count,
+
+    -- Health status
+    multiIf(
+        -- (*,G) unhealthy if any active publisher's (S,G) is missing on this device
+        r.source_address = '0.0.0.0'
+            AND length(coalesce(ap.ap_active_publisher_ips, [])) > 0
+            AND length(arrayFilter(x -> NOT has(coalesce(sg.sg_sources_with_sg, []), x), coalesce(ap.ap_active_publisher_ips, []))) > 0,
+            'unhealthy',
+        r.source_address = '0.0.0.0', 'healthy',
+
+        -- FHR: needs S + P
+        r.publisher_device_pk != '' AND r.publisher_device_pk = r.device_pk
+            AND position(r.route_flags, 'S') > 0 AND position(r.route_flags, 'P') > 0, 'healthy',
+        r.publisher_device_pk != '' AND r.publisher_device_pk = r.device_pk, 'degraded',
+
+        -- LHR: needs S + P
+        coalesce(h.hint_has_subscriber_tunnel, 0) = 1
+            AND position(r.route_flags, 'S') > 0 AND position(r.route_flags, 'P') > 0, 'healthy',
+        coalesce(h.hint_has_subscriber_tunnel, 0) = 1, 'degraded',
+
+        -- Transit: needs S + P
+        coalesce(h.hint_has_underlay_link, 0) = 1
+            AND position(r.route_flags, 'S') > 0 AND position(r.route_flags, 'P') > 0, 'healthy',
+        coalesce(h.hint_has_underlay_link, 0) = 1, 'degraded',
+
+        -- Learned passive: M + E expected, no OIFs
+        r.oif_count = 0 AND position(r.route_flags, 'M') > 0 AND position(r.route_flags, 'E') > 0, 'healthy',
+
+        'degraded'
+    ) AS health_status,
+
+    -- Free-text reasons
+    arrayFilter(x -> x != '', [
+        if(r.source_address = '0.0.0.0'
+            AND length(coalesce(ap.ap_active_publisher_ips, [])) > 0
+            AND length(arrayFilter(x -> NOT has(coalesce(sg.sg_sources_with_sg, []), x), coalesce(ap.ap_active_publisher_ips, []))) > 0,
+            '(*,G) missing (S,G) for active publisher(s)', ''),
+        if((r.publisher_device_pk != '' AND r.publisher_device_pk = r.device_pk
+             OR coalesce(h.hint_has_subscriber_tunnel, 0) = 1
+             OR coalesce(h.hint_has_underlay_link, 0) = 1)
+            AND position(r.route_flags, 'S') > 0
+            AND position(r.route_flags, 'P') = 0,
+            'SPT established but not HW-programmed (slow path)', ''),
+        if((r.publisher_device_pk != '' AND r.publisher_device_pk = r.device_pk
+             OR coalesce(h.hint_has_subscriber_tunnel, 0) = 1
+             OR coalesce(h.hint_has_underlay_link, 0) = 1)
+            AND position(r.route_flags, 'S') = 0,
+            'forwarding role but SPT bit not set', '')
+    ]) AS degraded_reasons
+FROM enriched_ip_mroute r
+LEFT JOIN oif_role_hints h ON r.mroute_entity_id = h.hint_mroute_entity_id
+LEFT JOIN sg_sources_on_device sg ON r.device_pk = sg.sg_device_pk AND r.group_address = sg.sg_group_address
+LEFT JOIN active_publishers_for_group ap ON r.group_address = ap.ap_group_address;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- health_missing_sg
+CREATE OR REPLACE VIEW health_missing_sg
+AS
+WITH
+devices_with_mroute AS (
+    SELECT device_pk AS d_device_pk, any(device_code) AS d_device_code
+    FROM enriched_ip_mroute
+    GROUP BY device_pk
+),
+active_pubs AS (
+    SELECT
+        g.pk AS p_multicast_group_pk,
+        g.code AS p_multicast_group_code,
+        g.multicast_ip AS p_group_address,
+        u.pk AS p_publisher_user_pk,
+        u.dz_ip AS p_publisher_dz_ip,
+        u.device_pk AS p_publisher_device_pk
+    FROM dz_multicast_groups_current g
+    LEFT ARRAY JOIN [g.pk] AS gpk
+    INNER JOIN dz_users_current u
+        ON has(JSONExtract(u.publishers, 'Array(String)'), gpk)
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+),
+sg_present AS (
+    SELECT device_pk AS s_device_pk, group_address AS s_group_address, source_address AS s_source_address
+    FROM enriched_ip_mroute
+    WHERE source_address != '0.0.0.0'
+)
+SELECT
+    d.d_device_pk AS device_pk,
+    d.d_device_code AS device_code,
+    p.p_multicast_group_pk AS multicast_group_pk,
+    p.p_multicast_group_code AS multicast_group_code,
+    p.p_group_address AS group_address,
+    p.p_publisher_user_pk AS publisher_user_pk,
+    p.p_publisher_dz_ip AS publisher_dz_ip,
+    p.p_publisher_device_pk AS publisher_device_pk,
+    if(p.p_publisher_device_pk = d.d_device_pk, 'fhr_missing', 'downstream_missing') AS severity
+FROM devices_with_mroute d
+CROSS JOIN active_pubs p
+LEFT JOIN sg_present sg
+    ON sg.s_device_pk = d.d_device_pk
+    AND sg.s_group_address = p.p_group_address
+    AND sg.s_source_address = p.p_publisher_dz_ip
+WHERE sg.s_source_address = '';
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS health_missing_sg;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS health_mroute;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/health_view_test.go
+++ b/indexer/pkg/dz/mroute/health_view_test.go
@@ -1,0 +1,187 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthMroute_Classifier exercises the health_mroute role + status
+// classifier against a synthetic group with two publishers — one transmitting
+// (full SPT delivery), one registered but silent. The view should:
+//   - Classify the FHR row as 'fhr / healthy' (SBNP flags).
+//   - Classify the LHR row as 'lhr / healthy' (SMP flags + subscriber OIF).
+//   - Classify the learned-passive ME row as 'learned_passive / healthy'.
+//   - Classify the (*,G) row as 'star_g / unhealthy' because the silent
+//     publisher's (S,G) is missing on the LHR.
+//   - Surface the missing publisher dz_ip in `missing_publisher_ips` on the (*,G) row.
+func TestHealthMroute_Classifier(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_metros_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name, longitude, latitude)
+		VALUES ('m-sea', now(), now(), generateUUIDv4(), 0, 1, 'm-sea', 'sea', 'Seattle', 0, 0),
+			('m-nyc', now(), now(), generateUUIDv4(), 0, 2, 'm-nyc', 'nyc', 'New York', 0, 0),
+			('m-fra', now(), now(), generateUUIDv4(), 0, 3, 'm-fra', 'fra', 'Frankfurt', 0, 0)`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_contributors_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, pk, code, name)
+		VALUES ('c-jump', now(), now(), generateUUIDv4(), 0, 1, 'c-jump', 'jump_', 'Jump Trading')`))
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-sea', now(), now(), generateUUIDv4(), 0, 1, 'd-sea', 'activated', 'edge', 'sea001-dz001', '', 'c-jump', 'm-sea', 0, '[]'),
+			('d-nyc', now(), now(), generateUUIDv4(), 0, 2, 'd-nyc', 'activated', 'edge', 'nyc001-dz001', '', 'c-jump', 'm-nyc', 0, '[]'),
+			('d-fra', now(), now(), generateUUIDv4(), 0, 3, 'd-fra', 'activated', 'edge', 'fra001-dz001', '', 'c-jump', 'm-fra', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-test', now(), now(), generateUUIDv4(), 0, 1,
+			'grp-test', 'owner', 'test-mcast', '233.99.99.1', 100000000, 'activated', 2, 1)`))
+
+	// Two publishers on d-sea: pub-active (transmits, has (S,G) everywhere)
+	// and pub-silent (registered onchain, no (S,G) anywhere → triggers strict-mode anomaly)
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-pub-active', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-active', 'o', 'activated', 'multicast', '203.0.113.1', '10.99.0.1', 'd-sea', 't1', 501, '["grp-test"]', '[]'),
+			('u-pub-silent', now(), now(), generateUUIDv4(), 0, 2, 'u-pub-silent', 'o', 'activated', 'multicast', '203.0.113.2', '10.99.0.2', 'd-sea', 't1', 502, '["grp-test"]', '[]'),
+			('u-sub',        now(), now(), generateUUIDv4(), 0, 3, 'u-sub',        'o', 'activated', 'multicast', '203.0.113.3', '10.99.0.3', 'd-nyc', 't1', 601, '[]', '["grp-test"]')`))
+
+	// SBNP on FHR (d-sea) for pub-active — healthy publisher state
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			device_pubkey, vrf, mode, group_address, source_address,
+			route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix, rpf_preference, rpf_metric,
+			rpf_neighbor, rpf_attached, rpf_has_block, oif_list, oif_count, creation_time)
+		VALUES ('mr-fhr-active', now(), now(), generateUUIDv4(), 0, 1,
+			'd-sea', 'default', 'sparse', '233.99.99.1', '10.99.0.1',
+			'SBNP', 0, 'Tunnel501', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// SMP on LHR (d-nyc) for pub-active forwarding to u-sub
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			device_pubkey, vrf, mode, group_address, source_address,
+			route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix, rpf_preference, rpf_metric,
+			rpf_neighbor, rpf_attached, rpf_has_block, oif_list, oif_count, creation_time)
+		VALUES ('mr-lhr-active', now(), now(), generateUUIDv4(), 0, 1,
+			'd-nyc', 'default', 'sparse', '233.99.99.1', '10.99.0.1',
+			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel601"]', 1, now())`))
+
+	// Passive ME on d-fra for pub-active (learned via MSDP, not forwarding)
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			device_pubkey, vrf, mode, group_address, source_address,
+			route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix, rpf_preference, rpf_metric,
+			rpf_neighbor, rpf_attached, rpf_has_block, oif_list, oif_count, creation_time)
+		VALUES ('mr-pass-active', now(), now(), generateUUIDv4(), 0, 1,
+			'd-fra', 'default', 'sparse', '233.99.99.1', '10.99.0.1',
+			'ME', 0, 'Null0', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// (*,G) on the LHR — the unhealthy entry: receiver pulling on shared tree
+	// AND pub-silent has no (S,G) anywhere → triggers strict-mode unhealthy.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			device_pubkey, vrf, mode, group_address, source_address,
+			route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix, rpf_preference, rpf_metric,
+			rpf_neighbor, rpf_attached, rpf_has_block, oif_list, oif_count, creation_time)
+		VALUES ('mr-star-g', now(), now(), generateUUIDv4(), 0, 1,
+			'd-nyc', 'default', 'sparse', '233.99.99.1', '0.0.0.0',
+			'W', 0, 'Register0', '', '', 0, 0, '', 0, 0, '["Tunnel601"]', 1, now())`))
+
+	// Subscriber OIF expansion (so health_mroute's lhr role classifier finds the tunnel OIF)
+	// is materialised by enriched_ip_mroute_oifs automatically — no separate insert needed.
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	// Verify per-row classification
+	type row struct {
+		device, source, role, status string
+		missingCount                 uint64
+	}
+	queryRows := func() []row {
+		t.Helper()
+		got := []row{}
+		rs, err := conn.Query(ctx, `
+			SELECT device_code, source_address, role, health_status, length(missing_publisher_ips) AS missing_count
+			FROM health_mroute
+			WHERE group_address = '233.99.99.1'
+			ORDER BY source_address, device_code`)
+		require.NoError(t, err)
+		defer rs.Close()
+		for rs.Next() {
+			var r row
+			require.NoError(t, rs.Scan(&r.device, &r.source, &r.role, &r.status, &r.missingCount))
+			got = append(got, r)
+		}
+		return got
+	}
+
+	rows := queryRows()
+	require.Len(t, rows, 4)
+
+	// (*,G) first (source_address = "0.0.0.0" sorts first lexically)
+	assert.Equal(t, "0.0.0.0", rows[0].source)
+	assert.Equal(t, "nyc001-dz001", rows[0].device)
+	assert.Equal(t, "star_g", rows[0].role)
+	assert.Equal(t, "unhealthy", rows[0].status)
+	assert.EqualValues(t, 1, rows[0].missingCount, "missing_publisher_ips should contain pub-silent's dz_ip")
+
+	// (S,G) on d-fra (passive) — sorted next by device_code
+	assert.Equal(t, "10.99.0.1", rows[1].source)
+	assert.Equal(t, "fra001-dz001", rows[1].device)
+	assert.Equal(t, "learned_passive", rows[1].role)
+	assert.Equal(t, "healthy", rows[1].status)
+
+	// (S,G) on d-nyc (LHR)
+	assert.Equal(t, "10.99.0.1", rows[2].source)
+	assert.Equal(t, "nyc001-dz001", rows[2].device)
+	assert.Equal(t, "lhr", rows[2].role)
+	assert.Equal(t, "healthy", rows[2].status)
+
+	// (S,G) on d-sea (FHR)
+	assert.Equal(t, "10.99.0.1", rows[3].source)
+	assert.Equal(t, "sea001-dz001", rows[3].device)
+	assert.Equal(t, "fhr", rows[3].role)
+	assert.Equal(t, "healthy", rows[3].status)
+
+	// health_missing_sg should surface pub-silent on every device with mroute data
+	missingRows, err := conn.Query(ctx, `
+		SELECT device_code, publisher_dz_ip, severity
+		FROM health_missing_sg
+		WHERE multicast_group_pk = 'grp-test'
+		ORDER BY device_code`)
+	require.NoError(t, err)
+	defer missingRows.Close()
+	type missing struct{ device, dzIP, severity string }
+	var missingGot []missing
+	for missingRows.Next() {
+		var m missing
+		require.NoError(t, missingRows.Scan(&m.device, &m.dzIP, &m.severity))
+		missingGot = append(missingGot, m)
+	}
+
+	// Three devices have mroute data (d-sea, d-nyc, d-fra). pub-silent (10.99.0.2)
+	// has no (S,G) on any of them. d-sea is the silent publisher's FHR so it's
+	// the most severe; the other two are downstream.
+	require.Len(t, missingGot, 3, "expected pub-silent to be missing on all 3 devices")
+	for _, m := range missingGot {
+		assert.Equal(t, "10.99.0.2", m.dzIP)
+	}
+	severities := map[string]bool{}
+	for _, m := range missingGot {
+		severities[m.severity] = true
+	}
+	assert.True(t, severities["fhr_missing"], "d-sea should report fhr_missing severity")
+	assert.True(t, severities["downstream_missing"], "d-nyc / d-fra should report downstream_missing")
+}

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -28,6 +28,8 @@ func TestMigration_Applies(t *testing.T) {
 		{"dz_device_interface_ips", "mv"},
 		{"enriched_ip_mroute", "view"},
 		{"enriched_ip_mroute_oifs", "view"},
+		{"health_mroute", "view"},
+		{"health_missing_sg", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

First track of infra#1501 — the data foundation for end-to-end multicast health. Two complementary ClickHouse views:

- **`health_mroute`** — per-row classification of every mroute entry: `role` (fhr / lhr / transit / learned_passive / star_g / unknown), `health_status` (healthy / degraded / unhealthy), `missing_publisher_ips` array (for `(*,G)`: which active publishers' co-located `(S,G)` are missing on this device), `degraded_reasons` array (free-text).

- **`health_missing_sg`** — pivots the data the other way: one row per `(active_publisher, group, device)` where an `(S,G)` is expected but absent. Scoped to devices that actually report mroute data, so coverage gaps don't produce noise. `severity` = `fhr_missing` (publisher's own device — most severe) or `downstream_missing`.

Together they cover both directions of "what does my multicast forwarding state look like?":
- Looking at observed rows: are they classified correctly and forwarding healthily? (`health_mroute`)
- Looking at expected state: where should I see `(S,G)` but don't? (`health_missing_sg`)

## Health model

Strict — every active publisher must have an `(S,G)` entry on every device that has state-collect data. `(*,G)` is healthy iff matching `(S,G)` entries exist for every active publisher on the same device. SPT (source-specific tree) is the desired steady state for DZ.

Flag semantics decoded from the Arista PIM-SM glossary (`S` = SPT bit, `P` = HW-programmed, `M` = MSDP-learned, `E` = RPT-forwarding, `B` = Border-router-learned, `N` = MSDP-notify-capable, `W` = wildcard).

| Role | Expected flags |
| --- | --- |
| fhr (publisher's own device) | `S` + `P` (typically `SBNP`) |
| lhr (device with subscriber-tunnel OIF) | `S` + `P` (typically `SMP`), OIL includes expected subscriber tunnels |
| transit (device with link-side OIFs only) | `S` + `P` (typically `SMP`) |
| learned_passive (no OIFs, has MSDP-learn marker) | `M` + `E` (typically `ME` or `MPE`) |
| star_g (`source_address = '0.0.0.0'`) | always paired with `(S,G)` for every active publisher on same device |

## Validation against real data before encoding

- **Mainnet** (3 devices with state-collect, 765 active multicast publishers across all groups): **765/765 `(S,G)` entries present per device. Zero missing. All clean.** Confirms the strict rule produces no false positives on healthy steady-state data.
- **Testnet `tiredsolid`**: surfaces real anomaly. Publisher `GQRR2oDcdMcvWQCuQDsMS5sqmQKYjfwKf8qtD8QQHvp4` is registered onchain (connected to tyo-dz001 on Tunnel516, dz_ip `148.51.120.9`), but no `(S,G)` exists anywhere on the network for that source. The two `(*,G)` entries on nyc-dz001 and tyo-dz001 correctly flag as `unhealthy` with `missing_publisher_ips = ['148.51.120.9']`. The `health_missing_sg` view returns a `fhr_missing` row for the publisher's own device (severe) and `downstream_missing` for the rest. **The silent-publisher anomaly was detected before the migration was written.**

## Out of scope / planned follow-ups (infra#1501 Track 2 / 3)

- **`health_multicast_user`** — per `(user, group)` reconciliation row (next migration).
- **`health_publisher_subscriber_path`** — strict path verification.
- **API endpoints + UI** — Tracks 2 + 3.
- **Re-aliasing `r.snapshot_ts` / `r.ingested_at` columns in `enriched_ip_mroute`** — separate cleanup migration. JOIN-name-conflict means those columns currently surface as `` `r.snapshot_ts` `` requiring escape; health views work around it by not depending on freshness columns.

## Testing Verification

- `TestMigration_Applies` extended to cover both new views.
- `TestHealthMroute_Classifier` — full synthetic round-trip: inserts two publishers (one transmitting, one silent), one subscriber, and four mroute rows (FHR, LHR, learned-passive, `(*,G)`); asserts:
  - FHR row → `fhr / healthy`
  - LHR row → `lhr / healthy`
  - Learned-passive ME row → `learned_passive / healthy`
  - `(*,G)` row → `star_g / unhealthy`, with `missing_publisher_ips` count = 1
  - `health_missing_sg` returns 3 rows for the silent publisher (1 `fhr_missing`, 2 `downstream_missing`)

Refs malbeclabs/infra#1501.
