### PR TITLE
indexer: health_multicast_user view (per-user onchain↔dataplane reconciliation)

### DIFF
--- a/indexer/db/clickhouse/migrations/20260603000003_health_multicast_user_view.sql
+++ b/indexer/db/clickhouse/migrations/20260603000003_health_multicast_user_view.sql
@@ -1,0 +1,168 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_multicast_user
+--
+-- One row per (multicast user, group) reconciling onchain membership
+-- (dz_users_current.publishers / .subscribers) against the observed
+-- dataplane mroute state on the user's device.
+--
+-- A user is healthy for a group iff their Tunnel<tunnel_id> appears in
+-- the expected position(s) on the device's mroute entries for that group:
+--   - mode 'P' (publisher):   Tunnel<N> appears as rpf_interface (IIF)
+--   - mode 'S' (subscriber):  Tunnel<N> appears in oif_list (OIF)
+--   - mode 'P+S' (both):      both of the above
+--
+-- Second track of malbeclabs/infra#1501. The third view —
+-- health_publisher_subscriber_path — lands in a follow-up.
+CREATE OR REPLACE VIEW health_multicast_user
+AS
+WITH
+multicast_users AS (
+    SELECT
+        u.pk AS mu_user_pk,
+        u.dz_ip AS mu_user_dz_ip,
+        u.tunnel_id AS mu_user_tunnel_id,
+        u.device_pk AS mu_user_device_pk,
+        u.owner_pubkey AS mu_user_owner_pubkey,
+        d.code AS mu_user_device_code,
+        JSONExtract(u.publishers, 'Array(String)') AS mu_publisher_group_pks,
+        JSONExtract(u.subscribers, 'Array(String)') AS mu_subscriber_group_pks
+    FROM dz_users_current u
+    LEFT ANY JOIN dz_devices_current d ON u.device_pk = d.pk
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+),
+publisher_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'P' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_publisher_group_pks AS gpk
+),
+subscriber_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'S' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_subscriber_group_pks AS gpk
+),
+all_memberships AS (
+    SELECT * FROM publisher_memberships
+    UNION ALL
+    SELECT * FROM subscriber_memberships
+),
+user_group_modes AS (
+    SELECT
+        mu_user_pk AS ug_user_pk,
+        mu_user_dz_ip AS ug_user_dz_ip,
+        mu_user_tunnel_id AS ug_user_tunnel_id,
+        mu_user_device_pk AS ug_user_device_pk,
+        mu_user_owner_pubkey AS ug_user_owner_pubkey,
+        any(mu_user_device_code) AS ug_user_device_code,
+        mem_group_pk AS ug_multicast_group_pk,
+        arrayStringConcat(arraySort(groupUniqArray(mem_role)), '+') AS ug_mode
+    FROM all_memberships
+    GROUP BY mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+             mu_user_owner_pubkey, mem_group_pk
+),
+-- For each (device, group), collect the set of tunnel_ids seen as RPF interface
+iif_tunnels_per_device_group AS (
+    SELECT
+        device_pk AS iif_device_pk,
+        group_address AS iif_group_address,
+        groupUniqArrayIf(
+            toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')),
+            match(rpf_interface, '^Tunnel\\d+$')
+        ) AS iif_tunnel_ids
+    FROM enriched_ip_mroute
+    GROUP BY device_pk, group_address
+),
+-- For each (device, group), collect the set of tunnel_ids seen in OIF lists
+oif_tunnels_per_device_group AS (
+    SELECT
+        device_pk AS oif_device_pk,
+        group_address AS oif_group_address,
+        groupUniqArray(toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$'))) AS oif_tunnel_ids
+    FROM enriched_ip_mroute_oifs
+    WHERE match(oif_name, '^Tunnel\\d+$')
+    GROUP BY device_pk, group_address
+)
+SELECT
+    ug.ug_user_pk AS user_pk,
+    ug.ug_user_owner_pubkey AS user_owner_pubkey,
+    ug.ug_user_dz_ip AS user_dz_ip,
+    ug.ug_user_tunnel_id AS user_tunnel_id,
+    ug.ug_user_device_pk AS user_device_pk,
+    ug.ug_user_device_code AS user_device_code,
+    ug.ug_multicast_group_pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.multicast_ip AS group_address,
+    ug.ug_mode AS mode,
+    -- expected_tunnel_position (computed from mode)
+    multiIf(
+        ug.ug_mode = 'P', 'iif',
+        ug.ug_mode = 'S', 'oif',
+        ug.ug_mode = 'P+S', 'iif|oif',
+        ''
+    ) AS expected_tunnel_position,
+    -- observed_positions
+    has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id) AS publisher_iif_observed,
+    has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id) AS subscriber_oif_observed,
+    -- reconciled — every expected position is observed
+    multiIf(
+        ug.ug_mode = 'P',
+            has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
+        ug.ug_mode = 'S',
+            has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+        ug.ug_mode = 'P+S',
+            has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
+            AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+        false
+    ) AS reconciled,
+    -- health_status
+    multiIf(
+        -- both expected positions observed → healthy
+        ug.ug_mode = 'P' AND has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
+        ug.ug_mode = 'S' AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
+        ug.ug_mode = 'P+S'
+            AND has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
+            AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
+        -- P+S with only one half observed → degraded
+        ug.ug_mode = 'P+S'
+            AND (has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
+                 OR has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id)), 'degraded',
+        'unhealthy'
+    ) AS health_status,
+    -- mismatch_reason
+    multiIf(
+        ug.ug_mode = 'P' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
+            concat('publisher Tunnel', toString(ug.ug_user_tunnel_id), ' not seen as RPF interface for any mroute on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+            concat('subscriber Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in any OIF list for the group on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id) AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+            concat('Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in either IIF or OIF position on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
+            concat('publisher half: Tunnel', toString(ug.ug_user_tunnel_id), ' not seen as RPF interface on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+            concat('subscriber half: Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in any OIF list on ', ug.ug_user_device_code),
+        ''
+    ) AS mismatch_reason
+FROM user_group_modes ug
+LEFT JOIN dz_multicast_groups_current g ON ug.ug_multicast_group_pk = g.pk
+LEFT JOIN iif_tunnels_per_device_group iif
+    ON iif.iif_device_pk = ug.ug_user_device_pk
+    AND iif.iif_group_address = g.multicast_ip
+LEFT JOIN oif_tunnels_per_device_group oif
+    ON oif.oif_device_pk = ug.ug_user_device_pk
+    AND oif.oif_group_address = g.multicast_ip;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS health_multicast_user;
+-- +goose StatementEnd

--- a/indexer/db/clickhouse/migrations/20260603000003_health_multicast_user_view.sql
+++ b/indexer/db/clickhouse/migrations/20260603000003_health_multicast_user_view.sql
@@ -7,17 +7,33 @@
 -- (dz_users_current.publishers / .subscribers) against the observed
 -- dataplane mroute state on the user's device.
 --
--- A user is healthy for a group iff their Tunnel<tunnel_id> appears in
--- the expected position(s) on the device's mroute entries for that group:
---   - mode 'P' (publisher):   Tunnel<N> appears as rpf_interface (IIF)
---   - mode 'S' (subscriber):  Tunnel<N> appears in oif_list (OIF)
---   - mode 'P+S' (both):      both of the above
+-- Per-source granularity: this view tracks IIF/OIF tunnel membership at
+-- (device, group, source_address), not just (device, group). A subscriber
+-- whose Tunnel<N> is in the OIF list of (S1, G) but missing from (S2, G)
+-- on its LHR device is "degraded", not "healthy". The verdict reflects
+-- whether every (S, G) mroute carries the expected tunnel.
 --
--- Second track of malbeclabs/infra#1501. The third view —
--- health_publisher_subscriber_path — lands in a follow-up.
+-- (*,G) wildcard mroutes are excluded from the source set — DZ forwards
+-- via SPT, so a (*,G) without any (S,G) is unhealthy by definition.
+--
+-- Verdicts:
+--   - mode 'P' (publisher):   Tunnel<N> is the RPF interface of the
+--                             (S=user.dz_ip, G) mroute at the user's
+--                             device. There's exactly one such mroute.
+--   - mode 'S' (subscriber):  Tunnel<N> is in the OIF list of every
+--                             (S, G) mroute at the user's device.
+--                             Partial coverage → degraded.
+--   - mode 'P+S' (both):      both of the above. Either half failing
+--                             alone → degraded; both → unhealthy.
+--
+-- Second track of malbeclabs/infra#1501.
 CREATE OR REPLACE VIEW health_multicast_user
 AS
 WITH
+-- The full SELECT below uses inlined per-source expressions repeatedly
+-- because ClickHouse aliasing inside multiIf does not consistently
+-- reference SELECT-list aliases. Keep the CTEs as the single source of
+-- truth and inline the count/coverage expressions where needed.
 multicast_users AS (
     SELECT
         u.pk AS mu_user_pk,
@@ -69,27 +85,59 @@ user_group_modes AS (
     GROUP BY mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
              mu_user_owner_pubkey, mem_group_pk
 ),
--- For each (device, group), collect the set of tunnel_ids seen as RPF interface
-iif_tunnels_per_device_group AS (
-    SELECT
-        device_pk AS iif_device_pk,
-        group_address AS iif_group_address,
-        groupUniqArrayIf(
-            toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')),
-            match(rpf_interface, '^Tunnel\\d+$')
-        ) AS iif_tunnel_ids
-    FROM enriched_ip_mroute
-    GROUP BY device_pk, group_address
-),
--- For each (device, group), collect the set of tunnel_ids seen in OIF lists
-oif_tunnels_per_device_group AS (
+-- Per-(device, group, source): the OIF tunnels carried by the (S, G) mroute.
+-- (*,G) entries are excluded; partial OIF coverage manifests by comparing
+-- per-source rows to the device's full set of (S, G) sources for the group.
+oif_per_dgs AS (
     SELECT
         device_pk AS oif_device_pk,
         group_address AS oif_group_address,
-        groupUniqArray(toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$'))) AS oif_tunnel_ids
+        source_address AS oif_source_address,
+        groupUniqArrayIf(
+            toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$')),
+            match(oif_name, '^Tunnel\\d+$')
+        ) AS oif_tunnel_ids
     FROM enriched_ip_mroute_oifs
-    WHERE match(oif_name, '^Tunnel\\d+$')
+    WHERE source_address != '' AND source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address, source_address
+),
+-- Per-(device, group): count of distinct (S, G) mroutes at the device.
+-- Sourced from enriched_ip_mroute (NOT enriched_ip_mroute_oifs) so that
+-- mroutes with an empty OIF list still count toward total_sources — those
+-- represent a real publisher whose source the subscriber should be
+-- reachable for, and an empty OIF is itself a coverage failure.
+sources_per_dg AS (
+    SELECT
+        device_pk AS tg_device_pk,
+        group_address AS tg_group_address,
+        countDistinct(source_address) AS tg_total_sources
+    FROM enriched_ip_mroute
+    WHERE source_address != '' AND source_address != '0.0.0.0'
     GROUP BY device_pk, group_address
+),
+-- Per-(device, group): array of OIF tunnel sets for sources that have any
+-- OIF rows. Sources with empty OIF lists are absent here; the gap is
+-- captured by the difference between this set's size and tg_total_sources.
+oif_sources_per_dg AS (
+    SELECT
+        oif_device_pk AS s_device_pk,
+        oif_group_address AS s_group_address,
+        groupArray(oif_source_address) AS s_sources,
+        groupArray(oif_tunnel_ids) AS s_oifs_per_source
+    FROM oif_per_dgs
+    GROUP BY oif_device_pk, oif_group_address
+),
+-- Per-(device, group, source): RPF interface tunnel id. There's at most
+-- one RPF interface per mroute, so this is a single-valued lookup.
+iif_per_dgs AS (
+    SELECT
+        device_pk AS iif_device_pk,
+        group_address AS iif_group_address,
+        source_address AS iif_source_address,
+        toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')) AS iif_tunnel_id
+    FROM enriched_ip_mroute
+    WHERE match(rpf_interface, '^Tunnel\\d+$')
+      AND source_address != '' AND source_address != '0.0.0.0'
 )
 SELECT
     ug.ug_user_pk AS user_pk,
@@ -109,56 +157,105 @@ SELECT
         ug.ug_mode = 'P+S', 'iif|oif',
         ''
     ) AS expected_tunnel_position,
-    -- observed_positions
-    has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id) AS publisher_iif_observed,
-    has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id) AS subscriber_oif_observed,
-    -- reconciled — every expected position is observed
+    -- Publisher IIF check — the (S=user.dz_ip, G) mroute's RPF interface
+    -- must match the user's tunnel. iif.iif_tunnel_id IS NULL when no such
+    -- (S, G) mroute exists at the device.
+    (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AS publisher_iif_observed,
+    -- Subscriber per-source counts. total_sources is the number of (S, G)
+    -- mroutes for the group at the device; oif_present_sources is how many
+    -- of those carry the user's tunnel in their OIF list.
+    coalesce(tg.tg_total_sources, 0) AS subscriber_total_sources,
+    arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) AS subscriber_oif_present_sources,
+    -- subscriber_oif_observed is TRUE only when fully covered.
+    (subscriber_total_sources > 0
+        AND subscriber_oif_present_sources = subscriber_total_sources) AS subscriber_oif_observed,
+    -- reconciled
     multiIf(
-        ug.ug_mode = 'P',
-            has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
-        ug.ug_mode = 'S',
-            has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
-        ug.ug_mode = 'P+S',
-            has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
-            AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
+        ug.ug_mode = 'P', (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+        ug.ug_mode = 'S', (coalesce(tg.tg_total_sources, 0) > 0
+                           AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
+        ug.ug_mode = 'P+S', (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+                            AND (coalesce(tg.tg_total_sources, 0) > 0
+                                 AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
         false
     ) AS reconciled,
     -- health_status
+    --   publisher: IIF matches → healthy; else unhealthy.
+    --   subscriber: full coverage → healthy; partial → degraded;
+    --               none observed or no (S,G) at all → unhealthy.
+    --   P+S: both halves healthy → healthy; one half degraded/unhealthy
+    --        and the other healthy → degraded; both failing → unhealthy.
     multiIf(
-        -- both expected positions observed → healthy
-        ug.ug_mode = 'P' AND has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
-        ug.ug_mode = 'S' AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
+        -- P
+        ug.ug_mode = 'P' AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'healthy',
+        ug.ug_mode = 'P', 'unhealthy',
+        -- S
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0, 'unhealthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'S', 'unhealthy',
+        -- P+S
         ug.ug_mode = 'P+S'
-            AND has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
-            AND has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id), 'healthy',
-        -- P+S with only one half observed → degraded
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
         ug.ug_mode = 'P+S'
-            AND (has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id)
-                 OR has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id)), 'degraded',
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'degraded',
+        ug.ug_mode = 'P+S'
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'degraded',
         'unhealthy'
     ) AS health_status,
     -- mismatch_reason
     multiIf(
-        ug.ug_mode = 'P' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
-            concat('publisher Tunnel', toString(ug.ug_user_tunnel_id), ' not seen as RPF interface for any mroute on ', ug.ug_user_device_code),
-        ug.ug_mode = 'S' AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
-            concat('subscriber Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in any OIF list for the group on ', ug.ug_user_device_code),
-        ug.ug_mode = 'P+S' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id) AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
-            concat('Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in either IIF or OIF position on ', ug.ug_user_device_code),
-        ug.ug_mode = 'P+S' AND NOT has(coalesce(iif.iif_tunnel_ids, []), ug.ug_user_tunnel_id),
-            concat('publisher half: Tunnel', toString(ug.ug_user_tunnel_id), ' not seen as RPF interface on ', ug.ug_user_device_code),
-        ug.ug_mode = 'P+S' AND NOT has(coalesce(oif.oif_tunnel_ids, []), ug.ug_user_tunnel_id),
-            concat('subscriber half: Tunnel', toString(ug.ug_user_tunnel_id), ' not seen in any OIF list on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0,
+            concat('no (S, ', g.multicast_ip, ') mroutes on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list for the group on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('partial OIF coverage on ', ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('Tunnel', toString(ug.ug_user_tunnel_id),
+                ' missing on both halves: publisher RPF for (', ug.ug_user_dz_ip,
+                ', ', g.multicast_ip, ') and subscriber OIF on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('subscriber half: partial OIF coverage on ',
+                ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
         ''
     ) AS mismatch_reason
 FROM user_group_modes ug
 LEFT JOIN dz_multicast_groups_current g ON ug.ug_multicast_group_pk = g.pk
-LEFT JOIN iif_tunnels_per_device_group iif
+LEFT JOIN iif_per_dgs iif
     ON iif.iif_device_pk = ug.ug_user_device_pk
     AND iif.iif_group_address = g.multicast_ip
-LEFT JOIN oif_tunnels_per_device_group oif
-    ON oif.oif_device_pk = ug.ug_user_device_pk
-    AND oif.oif_group_address = g.multicast_ip;
+    AND iif.iif_source_address = ug.ug_user_dz_ip
+LEFT JOIN oif_sources_per_dg o
+    ON o.s_device_pk = ug.ug_user_device_pk
+    AND o.s_group_address = g.multicast_ip
+LEFT JOIN sources_per_dg tg
+    ON tg.tg_device_pk = ug.ug_user_device_pk
+    AND tg.tg_group_address = g.multicast_ip;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/indexer/pkg/dz/mroute/health_multicast_user_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_test.go
@@ -120,3 +120,104 @@ func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 	assert.True(t, got[2].reconciled)
 	assert.Equal(t, "healthy", got[2].healthStatus)
 }
+
+// TestHealthMulticastUser_PartialDelivery covers the multi-publisher case:
+// a subscriber whose Tunnel<N> is in the OIF list of one publisher's (S, G)
+// mroute but missing from another publisher's (S, G) mroute. The aggregated
+// view would have called this "reconciled"; the per-source view degrades it.
+//
+// Setup at d-lhr:
+//   - (S=10.99.5.10, G=233.99.99.5) → OIF includes Tunnel610  ← subscriber present
+//   - (S=10.99.5.20, G=233.99.99.5) → OIF does NOT include Tunnel610  ← gap
+//
+// Expected result for u-sub-partial:
+//   subscriber_total_sources       = 2
+//   subscriber_oif_present_sources = 1
+//   health_status                  = degraded
+//   mismatch_reason contains "1 of 2"
+func TestHealthMulticastUser_PartialDelivery(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES ('d-lhr-pd', now(), now(), generateUUIDv4(), 0, 1,
+			'd-lhr-pd', 'activated', 'edge', 'lhr-pd-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-pd', now(), now(), generateUUIDv4(), 0, 1,
+			'grp-pd', 'o', 'partial-delivery', '233.99.99.5', 100000000, 'activated', 2, 1)`))
+
+	// Two publishers and a subscriber on the LHR. Publishers don't need to
+	// be onchain users at d-lhr — what matters is their source_address
+	// appearing in the mroute table on d-lhr's perspective.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES ('u-sub-partial', now(), now(), generateUUIDv4(), 0, 1,
+			'u-sub-partial', 'o', 'activated', 'multicast', '203.0.113.50', '10.99.5.50', 'd-lhr-pd', 't1', 610, '[]', '["grp-pd"]')`))
+
+	// (S=10.99.5.10, G=233.99.99.5) — subscriber's tunnel IS in OIF
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-pd-1', now(), now(), generateUUIDv4(), 0, 1,
+			'd-lhr-pd', 'default', 'sparse', '233.99.99.5', '10.99.5.10',
+			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel610"]', 1, now())`))
+
+	// (S=10.99.5.20, G=233.99.99.5) — subscriber's tunnel is NOT in OIF
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-pd-2', now(), now(), generateUUIDv4(), 0, 2,
+			'd-lhr-pd', 'default', 'sparse', '233.99.99.5', '10.99.5.20',
+			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '[]', 0, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT
+			subscriber_total_sources,
+			subscriber_oif_present_sources,
+			subscriber_oif_observed,
+			reconciled,
+			health_status,
+			mismatch_reason
+		FROM health_multicast_user
+		WHERE user_pk = 'u-sub-partial' AND multicast_group_pk = 'grp-pd'`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next(), "expected one row for u-sub-partial")
+
+	var totalSources uint64
+	var oifPresent uint32
+	var oifObserved, reconciled bool
+	var healthStatus, mismatchReason string
+	require.NoError(t, rows.Scan(&totalSources, &oifPresent, &oifObserved, &reconciled, &healthStatus, &mismatchReason))
+
+	assert.EqualValues(t, 2, totalSources, "two (S, G) mroutes on device")
+	assert.EqualValues(t, 1, oifPresent, "tunnel present for one of the two sources")
+	assert.False(t, oifObserved, "partial coverage is NOT 'oif observed'")
+	assert.False(t, reconciled, "partial coverage is NOT reconciled")
+	assert.Equal(t, "degraded", healthStatus, "partial coverage → degraded, not unhealthy or healthy")
+	assert.Contains(t, mismatchReason, "1 of 2", "reason should call out the partial coverage count")
+	assert.Contains(t, mismatchReason, "Tunnel610")
+}

--- a/indexer/pkg/dz/mroute/health_multicast_user_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_test.go
@@ -1,0 +1,122 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthMulticastUser_Reconciliation exercises the per-user
+// onchain ↔ dataplane reconciliation. Three users:
+//   - u-pub-healthy: publisher whose Tunnel<N> appears as RPF interface on
+//     an mroute for the group → healthy
+//   - u-sub-healthy: subscriber whose Tunnel<N> appears in OIF list of an
+//     mroute for the group → healthy
+//   - u-pub-silent: publisher whose Tunnel<N> is NOT present anywhere on
+//     the device → unhealthy with a specific mismatch_reason
+func TestHealthMulticastUser_Reconciliation(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES ('d-sea', now(), now(), generateUUIDv4(), 0, 1,
+			'd-sea', 'activated', 'edge', 'sea001-dz001', '', '', '', 0, '[]'),
+			('d-nyc', now(), now(), generateUUIDv4(), 0, 2,
+			'd-nyc', 'activated', 'edge', 'nyc001-dz001', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-r', now(), now(), generateUUIDv4(), 0, 1,
+			'grp-r', 'owner', 'test-recon', '233.99.99.2', 100000000, 'activated', 2, 1)`))
+
+	// Three multicast users for grp-r
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-pub-healthy', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-healthy', 'o', 'activated', 'multicast', '203.0.113.10', '10.99.0.10', 'd-sea', 't1', 503, '["grp-r"]', '[]'),
+			('u-pub-silent',  now(), now(), generateUUIDv4(), 0, 2, 'u-pub-silent',  'o', 'activated', 'multicast', '203.0.113.11', '10.99.0.11', 'd-sea', 't1', 504, '["grp-r"]', '[]'),
+			('u-sub-healthy', now(), now(), generateUUIDv4(), 0, 3, 'u-sub-healthy', 'o', 'activated', 'multicast', '203.0.113.12', '10.99.0.12', 'd-nyc', 't1', 602, '[]', '["grp-r"]')`))
+
+	// FHR mroute for u-pub-healthy — its tunnel appears as RPF interface
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-fhr-r', now(), now(), generateUUIDv4(), 0, 1,
+			'd-sea', 'default', 'sparse', '233.99.99.2', '10.99.0.10',
+			'SBNP', 0, 'Tunnel503', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// LHR mroute on d-nyc — u-sub-healthy's tunnel in OIF list
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-lhr-r', now(), now(), generateUUIDv4(), 0, 1,
+			'd-nyc', 'default', 'sparse', '233.99.99.2', '10.99.0.10',
+			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel602"]', 1, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT user_pk, mode, publisher_iif_observed, subscriber_oif_observed, reconciled, health_status, mismatch_reason
+		FROM health_multicast_user
+		WHERE multicast_group_pk = 'grp-r'
+		ORDER BY user_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		userPK, mode, mismatchReason, healthStatus string
+		pubIIF, subOIF, reconciled                 bool
+	}
+	got := []row{}
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.userPK, &r.mode, &r.pubIIF, &r.subOIF, &r.reconciled, &r.healthStatus, &r.mismatchReason))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 3)
+
+	// u-pub-healthy
+	assert.Equal(t, "u-pub-healthy", got[0].userPK)
+	assert.Equal(t, "P", got[0].mode)
+	assert.True(t, got[0].pubIIF)
+	assert.True(t, got[0].reconciled)
+	assert.Equal(t, "healthy", got[0].healthStatus)
+
+	// u-pub-silent
+	assert.Equal(t, "u-pub-silent", got[1].userPK)
+	assert.Equal(t, "P", got[1].mode)
+	assert.False(t, got[1].pubIIF, "Tunnel504 isn't on any mroute → IIF not observed")
+	assert.False(t, got[1].reconciled)
+	assert.Equal(t, "unhealthy", got[1].healthStatus)
+	assert.Contains(t, got[1].mismatchReason, "Tunnel504")
+	assert.Contains(t, got[1].mismatchReason, "RPF interface")
+
+	// u-sub-healthy
+	assert.Equal(t, "u-sub-healthy", got[2].userPK)
+	assert.Equal(t, "S", got[2].mode)
+	assert.True(t, got[2].subOIF)
+	assert.True(t, got[2].reconciled)
+	assert.Equal(t, "healthy", got[2].healthStatus)
+}

--- a/indexer/pkg/dz/mroute/health_multicast_user_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_test.go
@@ -131,10 +131,11 @@ func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 //   - (S=10.99.5.20, G=233.99.99.5) → OIF does NOT include Tunnel610  ← gap
 //
 // Expected result for u-sub-partial:
-//   subscriber_total_sources       = 2
-//   subscriber_oif_present_sources = 1
-//   health_status                  = degraded
-//   mismatch_reason contains "1 of 2"
+//
+//	subscriber_total_sources       = 2
+//	subscriber_oif_present_sources = 1
+//	health_status                  = degraded
+//	mismatch_reason contains "1 of 2"
 func TestHealthMulticastUser_PartialDelivery(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -30,6 +30,7 @@ func TestMigration_Applies(t *testing.T) {
 		{"enriched_ip_mroute_oifs", "view"},
 		{"health_mroute", "view"},
 		{"health_missing_sg", "view"},
+		{"health_multicast_user", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Second view of Track 1 (infra#1501). Adds `health_multicast_user` — the per-user onchain↔dataplane reconciliation view.

For every activated multicast user × group they belong to, produces one row with:

| Column | Meaning |
| --- | --- |
| `mode` | `P` / `S` / `P+S` derived from `dz_users_current.publishers` / `subscribers` JSON arrays |
| `expected_tunnel_position` | `iif` for publishers, `oif` for subscribers, `iif\|oif` for both |
| `publisher_iif_observed` | `Tunnel<user.tunnel_id>` appears as `rpf_interface` on an mroute for this group on the user's device |
| `subscriber_oif_observed` | `Tunnel<user.tunnel_id>` appears in `oif_list` of an mroute for this group on the user's device |
| `reconciled` | every expected position observed |
| `health_status` | `healthy` / `degraded` / `unhealthy` |
| `mismatch_reason` | specific free-text explanation when not reconciled |

Directly answers the cross-check the operator called out in the planning discussion: "If a user is connected as tunnel505 on frankry as a multicast publisher, there is a tunnel505 in the Incoming interface on frankry. Similarly, if the user is connected as a subscriber, their tunnel appears in the Outgoing interface list on the device it is connected to."

## Stacking

Stacks on `bc/mcast-health-mroute-view` (#625) — same migration file ordering. Builds on the same `enriched_*` + onchain dim substrate, no dependency on #625's views.

## What's left in Track 1

The third view, `health_publisher_subscriber_path` (strict per-pair path verification), lands as a follow-up. CH SQL's lack of full recursive CTE support means the path-traversal design needs more thought — fixed-depth joins, API-layer Dijkstra over the topology graph, or endpoint-only verification with a documented limitation. Worth its own focused PR.

## Testing Verification

- `TestMigration_Applies` extended to cover `health_multicast_user`.
- `TestHealthMulticastUser_Reconciliation` covers all three paths via synthetic data:
  - `u-pub-healthy`: publisher whose Tunnel appears as RPF interface → `mode='P'`, `reconciled=true`, `health_status=healthy`.
  - `u-pub-silent`: publisher whose Tunnel is absent from every RPF position → `reconciled=false`, `health_status=unhealthy`, `mismatch_reason` mentions "Tunnel504" and "RPF interface".
  - `u-sub-healthy`: subscriber whose Tunnel appears in OIF list → `mode='S'`, `reconciled=true`, `health_status=healthy`.

Refs malbeclabs/infra#1501.
