### PR TITLE
indexer: health_publisher_subscriber_path view (endpoint-only verification)

### DIFF
--- a/indexer/db/clickhouse/migrations/20260603000004_health_publisher_subscriber_path_view.sql
+++ b/indexer/db/clickhouse/migrations/20260603000004_health_publisher_subscriber_path_view.sql
@@ -1,0 +1,150 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_publisher_subscriber_path
+--
+-- One row per (multicast group, publisher user, subscriber user). Verifies
+-- that the endpoints of the delivery path are correctly wired into the
+-- dataplane:
+--   publisher_endpoint_observed: pub.device has an (S,G) for pub.dz_ip
+--                                with rpf_interface = Tunnel<pub.tunnel_id>
+--   subscriber_endpoint_observed: sub.device has an (S,G) for pub.dz_ip
+--                                 with Tunnel<sub.tunnel_id> in oif_list
+--
+-- Third view of Track 1 (malbeclabs/infra#1501). Current implementation is
+-- ENDPOINTS-ONLY: it does not verify that intermediate transit devices on
+-- the path have (S,G) entries. A follow-up phase will add recursive OIF
+-- chain walking (CH 25.12 supports WITH RECURSIVE; verified) and populate
+-- additional columns (visited_devices, hop_count, missing_segments).
+-- Consumers should check verification_method to know which checks ran.
+CREATE OR REPLACE VIEW health_publisher_subscriber_path
+AS
+WITH
+multicast_users AS (
+    SELECT
+        u.pk AS mu_user_pk,
+        u.owner_pubkey AS mu_owner_pubkey,
+        u.dz_ip AS mu_dz_ip,
+        u.tunnel_id AS mu_tunnel_id,
+        u.device_pk AS mu_device_pk,
+        d.code AS mu_device_code,
+        JSONExtract(u.publishers, 'Array(String)') AS mu_publisher_groups,
+        JSONExtract(u.subscribers, 'Array(String)') AS mu_subscriber_groups
+    FROM dz_users_current u
+    LEFT ANY JOIN dz_devices_current d ON u.device_pk = d.pk
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+),
+publishers AS (
+    SELECT
+        mu_user_pk AS p_user_pk,
+        mu_owner_pubkey AS p_owner_pubkey,
+        mu_dz_ip AS p_dz_ip,
+        mu_tunnel_id AS p_tunnel_id,
+        mu_device_pk AS p_device_pk,
+        mu_device_code AS p_device_code,
+        gpk AS p_group_pk
+    FROM multicast_users
+    ARRAY JOIN mu_publisher_groups AS gpk
+),
+subscribers AS (
+    SELECT
+        mu_user_pk AS s_user_pk,
+        mu_owner_pubkey AS s_owner_pubkey,
+        mu_dz_ip AS s_dz_ip,
+        mu_tunnel_id AS s_tunnel_id,
+        mu_device_pk AS s_device_pk,
+        mu_device_code AS s_device_code,
+        gpk AS s_group_pk
+    FROM multicast_users
+    ARRAY JOIN mu_subscriber_groups AS gpk
+),
+-- For each (device, group, source): does Tunnel<N> appear as rpf_interface
+-- on an (S,G) row on this device for this source?
+publisher_iif_per_device AS (
+    SELECT
+        device_pk AS pi_device_pk,
+        group_address AS pi_group_address,
+        source_address AS pi_source_address,
+        groupUniqArrayIf(
+            toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')),
+            match(rpf_interface, '^Tunnel\\d+$')
+        ) AS pi_iif_tunnel_ids
+    FROM enriched_ip_mroute
+    WHERE source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address, source_address
+),
+-- For each (device, group, source): which subscriber Tunnel<N> values appear
+-- in oif_list?
+subscriber_oif_per_device AS (
+    SELECT
+        device_pk AS so_device_pk,
+        group_address AS so_group_address,
+        source_address AS so_source_address,
+        groupUniqArray(toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$'))) AS so_oif_tunnel_ids
+    FROM enriched_ip_mroute_oifs
+    WHERE source_address != '0.0.0.0' AND match(oif_name, '^Tunnel\\d+$')
+    GROUP BY device_pk, group_address, source_address
+)
+SELECT
+    p.p_group_pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.multicast_ip AS group_address,
+
+    p.p_user_pk AS publisher_user_pk,
+    p.p_owner_pubkey AS publisher_owner_pubkey,
+    p.p_dz_ip AS publisher_dz_ip,
+    p.p_tunnel_id AS publisher_tunnel_id,
+    p.p_device_pk AS publisher_device_pk,
+    p.p_device_code AS publisher_device_code,
+
+    s.s_user_pk AS subscriber_user_pk,
+    s.s_owner_pubkey AS subscriber_owner_pubkey,
+    s.s_dz_ip AS subscriber_dz_ip,
+    s.s_tunnel_id AS subscriber_tunnel_id,
+    s.s_device_pk AS subscriber_device_pk,
+    s.s_device_code AS subscriber_device_code,
+
+    has(coalesce(pi.pi_iif_tunnel_ids, []), p.p_tunnel_id) AS publisher_endpoint_observed,
+    has(coalesce(so.so_oif_tunnel_ids, []), s.s_tunnel_id) AS subscriber_endpoint_observed,
+
+    has(coalesce(pi.pi_iif_tunnel_ids, []), p.p_tunnel_id)
+        AND has(coalesce(so.so_oif_tunnel_ids, []), s.s_tunnel_id) AS endpoints_reconciled,
+
+    multiIf(
+        has(coalesce(pi.pi_iif_tunnel_ids, []), p.p_tunnel_id)
+            AND has(coalesce(so.so_oif_tunnel_ids, []), s.s_tunnel_id), 'healthy',
+        'unhealthy'
+    ) AS health_status,
+
+    'endpoints_only' AS verification_method,
+
+    arrayFilter(x -> x != '', [
+        if(NOT has(coalesce(pi.pi_iif_tunnel_ids, []), p.p_tunnel_id),
+            concat('publisher Tunnel', toString(p.p_tunnel_id),
+                   ' not seen as RPF interface on ', p.p_device_code,
+                   ' for source ', p.p_dz_ip), ''),
+        if(NOT has(coalesce(so.so_oif_tunnel_ids, []), s.s_tunnel_id),
+            concat('subscriber Tunnel', toString(s.s_tunnel_id),
+                   ' not in any OIF list on ', s.s_device_code,
+                   ' for source ', p.p_dz_ip), '')
+    ]) AS missing_endpoint_reasons
+
+FROM publishers p
+INNER JOIN subscribers s ON p.p_group_pk = s.s_group_pk
+LEFT JOIN dz_multicast_groups_current g ON p.p_group_pk = g.pk
+LEFT JOIN publisher_iif_per_device pi
+    ON pi.pi_device_pk = p.p_device_pk
+    AND pi.pi_group_address = g.multicast_ip
+    AND pi.pi_source_address = p.p_dz_ip
+LEFT JOIN subscriber_oif_per_device so
+    ON so.so_device_pk = s.s_device_pk
+    AND so.so_group_address = g.multicast_ip
+    AND so.so_source_address = p.p_dz_ip
+WHERE p.p_user_pk != s.s_user_pk;  -- exclude self-loops (a user that is both pub and sub of the same group, against itself)
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS health_publisher_subscriber_path;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/health_path_test.go
+++ b/indexer/pkg/dz/mroute/health_path_test.go
@@ -1,0 +1,123 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthPublisherSubscriberPath_Endpoints exercises the endpoint-only
+// verification. One publisher + two subscribers in a group:
+//   - sub-good: subscriber whose Tunnel<N> appears in the OIF list of the
+//     publisher's mroute on the subscriber's device → endpoints_reconciled
+//   - sub-bad:  subscriber whose Tunnel<N> isn't in any OIF list →
+//     unhealthy, missing_endpoint_reasons contains the explanation
+func TestHealthPublisherSubscriberPath_Endpoints(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-sea', now(), now(), generateUUIDv4(), 0, 1, 'd-sea', 'activated', 'edge', 'sea001-dz001', '', '', '', 0, '[]'),
+			('d-nyc', now(), now(), generateUUIDv4(), 0, 2, 'd-nyc', 'activated', 'edge', 'nyc001-dz001', '', '', '', 0, '[]'),
+			('d-fra', now(), now(), generateUUIDv4(), 0, 3, 'd-fra', 'activated', 'edge', 'fra001-dz001', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-p', now(), now(), generateUUIDv4(), 0, 1,
+			'grp-p', 'owner', 'test-path', '233.99.99.3', 100000000, 'activated', 1, 2)`))
+
+	// One publisher, two subscribers
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-pub',  now(), now(), generateUUIDv4(), 0, 1, 'u-pub',  'o', 'activated', 'multicast', '203.0.113.20', '10.99.0.20', 'd-sea', 't1', 505, '["grp-p"]', '[]'),
+			('u-good', now(), now(), generateUUIDv4(), 0, 2, 'u-good', 'o', 'activated', 'multicast', '203.0.113.21', '10.99.0.21', 'd-nyc', 't1', 603, '[]', '["grp-p"]'),
+			('u-bad',  now(), now(), generateUUIDv4(), 0, 3, 'u-bad',  'o', 'activated', 'multicast', '203.0.113.22', '10.99.0.22', 'd-fra', 't1', 604, '[]', '["grp-p"]')`))
+
+	// Publisher FHR on d-sea with Tunnel505 as RPF interface (publisher endpoint OK)
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-fhr-p', now(), now(), generateUUIDv4(), 0, 1,
+			'd-sea', 'default', 'sparse', '233.99.99.3', '10.99.0.20',
+			'SBNP', 0, 'Tunnel505', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// LHR on d-nyc with u-good's Tunnel603 in OIF list (sub-good endpoint OK)
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES ('mr-lhr-good', now(), now(), generateUUIDv4(), 0, 1,
+			'd-nyc', 'default', 'sparse', '233.99.99.3', '10.99.0.20',
+			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel603"]', 1, now())`))
+
+	// NO LHR mroute on d-fra → u-bad's endpoint will be missing
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT subscriber_user_pk,
+			publisher_endpoint_observed, subscriber_endpoint_observed,
+			endpoints_reconciled, health_status,
+			length(missing_endpoint_reasons), arrayStringConcat(missing_endpoint_reasons, ' | ') AS reasons,
+			verification_method
+		FROM health_publisher_subscriber_path
+		WHERE multicast_group_pk = 'grp-p'
+		ORDER BY subscriber_user_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		subPK, healthStatus, reasons, verification string
+		pubObs, subObs, reconciled                 bool
+		missingCount                               uint64
+	}
+	got := []row{}
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.subPK, &r.pubObs, &r.subObs, &r.reconciled, &r.healthStatus, &r.missingCount, &r.reasons, &r.verification))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 2)
+
+	// u-bad first alphabetically
+	assert.Equal(t, "u-bad", got[0].subPK)
+	assert.True(t, got[0].pubObs, "publisher endpoint observed on d-sea")
+	assert.False(t, got[0].subObs, "subscriber endpoint NOT observed (no mroute on d-fra)")
+	assert.False(t, got[0].reconciled)
+	assert.Equal(t, "unhealthy", got[0].healthStatus)
+	assert.EqualValues(t, 1, got[0].missingCount)
+	assert.Contains(t, got[0].reasons, "Tunnel604")
+	assert.Contains(t, got[0].reasons, "fra001-dz001")
+	assert.Equal(t, "endpoints_only", got[0].verification)
+
+	// u-good
+	assert.Equal(t, "u-good", got[1].subPK)
+	assert.True(t, got[1].pubObs)
+	assert.True(t, got[1].subObs)
+	assert.True(t, got[1].reconciled)
+	assert.Equal(t, "healthy", got[1].healthStatus)
+	assert.EqualValues(t, 0, got[1].missingCount)
+}

--- a/indexer/pkg/dz/mroute/migration_test.go
+++ b/indexer/pkg/dz/mroute/migration_test.go
@@ -31,6 +31,7 @@ func TestMigration_Applies(t *testing.T) {
 		{"health_mroute", "view"},
 		{"health_missing_sg", "view"},
 		{"health_multicast_user", "view"},
+		{"health_publisher_subscriber_path", "view"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Third view of Track 1 (infra#1501). Adds `health_publisher_subscriber_path` — one row per `(group, publisher_user, subscriber_user)` reconciling that both endpoints of the multicast delivery path are correctly wired into the dataplane.

| Column | Meaning |
| --- | --- |
| `publisher_endpoint_observed` | `pub.device` has an `(S,G)` for `pub.dz_ip` with `rpf_interface = Tunnel<pub.tunnel_id>` |
| `subscriber_endpoint_observed` | `sub.device` has an `(S,G)` for `pub.dz_ip` with `Tunnel<sub.tunnel_id>` in `oif_list` |
| `endpoints_reconciled` | both true |
| `health_status` | `healthy` / `unhealthy` |
| `verification_method` | `'endpoints_only'` (so consumers know what was checked) |
| `missing_endpoint_reasons` | array of free-text explanations |

## Scope — endpoint-only, recursive walk deferred

Current implementation verifies **endpoints only**. Full strict-path verification (every intermediate device on the publisher → subscriber path has an `(S,G)`) is deferred to a follow-up phase.

ClickHouse 25.12 supports `WITH RECURSIVE` (verified manually), so the follow-up will walk the OIF chain and populate additional columns (`visited_devices`, `hop_count`, `missing_segments`) without breaking this PR's consumers. The `verification_method` field exists for exactly this reason — consumers can branch on it once the recursive variant lands (e.g., `verification_method = 'full_path'`).

Endpoint-only is useful on its own — it catches the operationally common gaps:
- publisher registered onchain but not actually transmitting (no `(S,G)` for their source anywhere)
- subscriber registered onchain but their `Tunnel<N>` is missing from every OIF list on their device (probably a control-plane issue)

What it misses: broken middle-of-path hops. That's what the recursive follow-up adds.

## Stacking

- Base: `bc/mcast-health-user-path` (#626)
- Which is based on: `bc/mcast-health-mroute-view` (#625)
- Both rebase onto main as the chain merges

## Testing Verification

- `TestMigration_Applies` extended to cover `health_publisher_subscriber_path`.
- `TestHealthPublisherSubscriberPath_Endpoints` exercises:
  - `u-good`: subscriber whose Tunnel appears in the OIF list → `endpoints_reconciled=true`, `health_status=healthy`
  - `u-bad`: subscriber whose device has no mroute at all → `subscriber_endpoint_observed=false`, `endpoints_reconciled=false`, `health_status=unhealthy`, `missing_endpoint_reasons` contains the specific tunnel/device

Refs malbeclabs/infra#1501.
