### PR TITLE
web: multicast health tab + per-user health card (Track 3 of infra#1501)

### DIFF
--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -31,6 +31,7 @@ import { useChartLegend } from '@/hooks/use-chart-legend'
 import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import { InlineFilter } from '@/components/inline-filter'
 import { Pagination } from '@/components/pagination'
+import { MulticastGroupHealthTab } from '@/components/multicast-group-health-tab'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -1481,9 +1482,14 @@ export function MulticastGroupDetailPage() {
   const navigate = useNavigate()
   const back = useBackLink({ to: '/dz/multicast-groups', label: 'multicast groups' })
   const [searchParams, setSearchParams] = useSearchParams()
-  const activeTab = (searchParams.get('tab') === 'subscribers' ? 'subscribers' : 'publishers') as
-    | 'publishers'
-    | 'subscribers'
+  const tabParam = searchParams.get('tab')
+  const activeTab = (
+    tabParam === 'subscribers'
+      ? 'subscribers'
+      : tabParam === 'health'
+        ? 'health'
+        : 'publishers'
+  ) as 'publishers' | 'subscribers' | 'health'
   const sortField = (searchParams.get('sort') || 'stake_sol') as MemberSortField
   const sortDirection = (searchParams.get('dir') || 'desc') as SortDirection
   const page = parseInt(searchParams.get('page') || '1')
@@ -1495,7 +1501,7 @@ export function MulticastGroupDetailPage() {
   const [selectedSeriesKeys, setSelectedSeriesKeys] = useState<Set<string>>(new Set())
 
   const setActiveTab = useCallback(
-    (tab: 'publishers' | 'subscribers') => {
+    (tab: 'publishers' | 'subscribers' | 'health') => {
       setSearchParams((prev) => {
         const p = new URLSearchParams(prev)
         if (tab === 'publishers') {
@@ -1895,12 +1901,27 @@ export function MulticastGroupDetailPage() {
             >
               Subscribers ({subscriberCount})
             </button>
-            {membersFetching && (
+            <button
+              onClick={() => setActiveTab('health')}
+              className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                activeTab === 'health'
+                  ? 'border-purple-500 text-purple-500'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Health
+            </button>
+            {membersFetching && activeTab !== 'health' && (
               <div className="flex items-center ml-2">
                 <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
               </div>
             )}
           </div>
+          {activeTab === 'health' && pk && (
+            <MulticastGroupHealthTab groupPkOrCode={pk} />
+          )}
+          {activeTab !== 'health' && (
+          <>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
@@ -2045,8 +2066,11 @@ export function MulticastGroupDetailPage() {
               onPageSizeChange={setPageSize}
             />
           )}
+          </>
+          )}
         </div>
 
+        {activeTab !== 'health' && (
         <div className="space-y-6">
           {/* Shred stats chart — only for groups with shred stats */}
           {pk &&
@@ -2067,7 +2091,7 @@ export function MulticastGroupDetailPage() {
             <MulticastTrafficChart
               groupCode={pk}
               members={group.members}
-              activeTab={activeTab}
+              activeTab={activeTab === 'subscribers' ? 'subscribers' : 'publishers'}
               onHoverMember={setHoveredSeriesKey}
               onSelectMember={setSelectedSeriesKeys}
             />
@@ -2076,6 +2100,7 @@ export function MulticastGroupDetailPage() {
           {/* Member count chart */}
           {pk && <MemberCountChart groupCode={pk} />}
         </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -1,0 +1,255 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { Loader2, AlertCircle } from 'lucide-react'
+import {
+  fetchMulticastGroupHealth,
+  fetchMulticastGroupHealthUsers,
+  fetchMulticastGroupHealthPaths,
+  type MulticastHealthStatus,
+  type MulticastHealthStatusCounts,
+} from '@/lib/api'
+
+const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+}
+
+function HealthBadge({ status }: { status: MulticastHealthStatus }) {
+  const cls = STATUS_BADGE[status] ?? STATUS_BADGE.unknown
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
+      {status}
+    </span>
+  )
+}
+
+function CountsRow({
+  label,
+  counts,
+}: {
+  label: string
+  counts: MulticastHealthStatusCounts
+}) {
+  return (
+    <div className="flex items-center justify-between py-2 text-sm">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="flex items-center gap-3 tabular-nums">
+        <span className="text-emerald-500">{counts.healthy} healthy</span>
+        <span className="text-amber-500">{counts.degraded} degraded</span>
+        <span className="text-red-500">{counts.unhealthy} unhealthy</span>
+        <span className="text-muted-foreground">/ {counts.total}</span>
+      </div>
+    </div>
+  )
+}
+
+export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
+  const summaryQuery = useQuery({
+    queryKey: ['multicast-group-health-summary', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealth(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  const usersQuery = useQuery({
+    queryKey: ['multicast-group-health-users', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  const pathsQuery = useQuery({
+    queryKey: ['multicast-group-health-paths', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  if (summaryQuery.isLoading) {
+    return (
+      <div className="px-4 py-8 text-center text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+      </div>
+    )
+  }
+
+  if (summaryQuery.error) {
+    return (
+      <div className="px-4 py-6 text-sm text-red-500 flex items-center gap-2">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load health data: {(summaryQuery.error as Error).message}
+      </div>
+    )
+  }
+
+  const summary = summaryQuery.data
+  if (!summary) return null
+
+  return (
+    <div className="p-4 space-y-6">
+      {/* Summary counts */}
+      <div className="border border-border rounded-lg bg-card p-4">
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="text-sm font-medium">Reconciliation summary</h3>
+          {!summary.source_available && (
+            <span className="text-xs text-muted-foreground">no state-collect data yet</span>
+          )}
+        </div>
+        <CountsRow label="Users (onchain ↔ mroute IIF/OIF)" counts={summary.counts.users} />
+        <CountsRow label="Paths (publisher → subscriber endpoints)" counts={summary.counts.paths} />
+        <CountsRow label="Mroutes (per-row dataplane state)" counts={summary.counts.mroutes} />
+      </div>
+
+      {/* Per-user reconciliation */}
+      <div className="border border-border rounded-lg bg-card">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+          <h3 className="text-sm font-medium">Per-user reconciliation</h3>
+          {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="text-sm text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">User</th>
+                <th className="px-4 py-3 font-medium">Mode</th>
+                <th className="px-4 py-3 font-medium">Device</th>
+                <th className="px-4 py-3 font-medium text-right">Tunnel</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {usersQuery.data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                    No multicast users
+                  </td>
+                </tr>
+              )}
+              {usersQuery.data?.items.map((u) => (
+                <tr key={`${u.user_pk}-${u.mode}`} className="border-b border-border last:border-b-0 hover:bg-muted">
+                  <td className="px-4 py-3 text-sm">
+                    <Link
+                      to={`/dz/users/${u.user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                    >
+                      {u.user_owner_pubkey ? u.user_owner_pubkey.slice(0, 8) : u.user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <span className="text-xs text-muted-foreground">{u.mode}</span>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {u.user_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${u.user_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
+                        {u.user_device_code || u.user_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm tabular-nums text-right font-mono text-muted-foreground">
+                    {u.user_tunnel_id > 0 ? u.user_tunnel_id : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <HealthBadge status={u.health_status} />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{u.mismatch_reason || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Per-path reconciliation */}
+      <div className="border border-border rounded-lg bg-card">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+          <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
+          {pathsQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="text-sm text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">Publisher</th>
+                <th className="px-4 py-3 font-medium">FHR device</th>
+                <th className="px-4 py-3 font-medium">Subscriber</th>
+                <th className="px-4 py-3 font-medium">LHR device</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Verified</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pathsQuery.data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                    No (publisher, subscriber) pairs
+                  </td>
+                </tr>
+              )}
+              {pathsQuery.data?.items.map((p) => (
+                <tr
+                  key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}
+                  className="border-b border-border last:border-b-0 hover:bg-muted"
+                >
+                  <td className="px-4 py-3 text-sm font-mono">
+                    <Link
+                      to={`/dz/users/${p.publisher_user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    {p.publisher_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${p.publisher_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {p.publisher_device_code || p.publisher_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    <Link
+                      to={`/dz/users/${p.subscriber_user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    {p.subscriber_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${p.subscriber_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {p.subscriber_device_code || p.subscriber_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <HealthBadge status={p.health_status} />
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {p.verification_method === 'endpoints_only' ? 'endpoints only' : p.verification_method}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -5,11 +5,46 @@ import { Loader2, Users, AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react'
 import { CopyableText } from '@/components/copyable-text'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
-import { fetchUser, fetchUserTraffic, fetchUserMulticastGroups, fetchPeeringDBFacility } from '@/lib/api'
+import {
+  fetchUser,
+  fetchUserTraffic,
+  fetchUserMulticastGroups,
+  fetchPeeringDBFacility,
+  fetchUserHealth,
+  type MulticastHealthStatus,
+} from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
 import { useTheme } from '@/hooks/use-theme'
 import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
+
+const HEALTH_BADGE_CLASS: Record<MulticastHealthStatus, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+}
+
+function UserHealthBadge({
+  status,
+  mode,
+  reason,
+}: {
+  status: MulticastHealthStatus
+  mode: string
+  reason?: string
+}) {
+  const cls = HEALTH_BADGE_CLASS[status] ?? HEALTH_BADGE_CLASS.unknown
+  const title = reason ? `${mode}: ${status} — ${reason}` : `${mode}: ${status}`
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${cls}`}
+      title={title}
+    >
+      {status}
+    </span>
+  )
+}
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -449,6 +484,14 @@ export function UserDetailPage() {
     enabled: !!pk,
   })
 
+  const hasMulticast = !!multicastGroups && multicastGroups.length > 0
+  const { data: userHealth } = useQuery({
+    queryKey: ['user-health', pk],
+    queryFn: () => fetchUserHealth(pk!),
+    enabled: !!pk && hasMulticast,
+    refetchInterval: 30_000,
+  })
+
   const { data: peeringdb } = useQuery({
     queryKey: ['peeringdb', user?.facility_loc_id],
     queryFn: () => fetchPeeringDBFacility(user!.facility_loc_id),
@@ -703,11 +746,15 @@ export function UserDetailPage() {
             <div className="border border-border rounded-lg p-4 bg-card">
               <h3 className="text-sm font-medium text-muted-foreground mb-3">Multicast Groups</h3>
               <div className="space-y-2">
-                {multicastGroups.map((g) => (
+                {multicastGroups.map((g) => {
+                  const healthItems = (userHealth?.items ?? []).filter(
+                    (it) => it.multicast_group_pk === g.group_pk,
+                  )
+                  return (
                   <div key={g.group_pk} className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">
                       <Link
-                        to={`/dz/multicast-groups/${g.group_pk}`}
+                        to={`/dz/multicast-groups/${g.group_pk}?tab=health`}
                         className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
                       >
                         {g.group_code}
@@ -723,12 +770,21 @@ export function UserDetailPage() {
                       >
                         {g.mode === 'P' ? 'Publisher' : g.mode === 'S' ? 'Subscriber' : 'Pub + Sub'}
                       </span>
+                      {healthItems.map((it) => (
+                        <UserHealthBadge
+                          key={`${it.multicast_group_pk}-${it.mode}`}
+                          status={it.health_status}
+                          mode={it.mode}
+                          reason={it.mismatch_reason}
+                        />
+                      ))}
                     </div>
                     <span className="text-xs text-muted-foreground font-mono">
                       {g.multicast_ip}
                     </span>
                   </div>
-                ))}
+                  )
+                })}
               </div>
             </div>
           )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2170,6 +2170,156 @@ export async function fetchMulticastGroupShredStats(pkOrCode: string, timeRange?
   return res.json()
 }
 
+// Multicast health (onchain ↔ dataplane reconciliation) types
+
+export type MulticastHealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+
+export interface MulticastHealthStatusCounts {
+  healthy: number
+  degraded: number
+  unhealthy: number
+  total: number
+}
+
+export interface MulticastHealthCounts {
+  mroutes: MulticastHealthStatusCounts
+  users: MulticastHealthStatusCounts
+  paths: MulticastHealthStatusCounts
+}
+
+export interface MulticastHealthGroupRef {
+  pk: string
+  code: string
+  multicast_ip: string
+  status: string
+  publisher_count: number
+  subscriber_count: number
+}
+
+export interface MulticastHealthGroupSummary {
+  group: MulticastHealthGroupRef
+  source_available: boolean
+  generated_at: string
+  counts: MulticastHealthCounts
+}
+
+export interface MulticastHealthUserItem {
+  user_pk: string
+  user_owner_pubkey: string
+  user_dz_ip: string
+  user_tunnel_id: number
+  user_device_pk: string
+  user_device_code: string
+  multicast_group_pk: string
+  multicast_group_code: string
+  group_address: string
+  mode: 'P' | 'S' | 'P+S' | string
+  expected_tunnel_position: string
+  publisher_iif_observed: boolean
+  subscriber_oif_observed: boolean
+  reconciled: boolean
+  health_status: MulticastHealthStatus
+  mismatch_reason?: string
+}
+
+export interface MulticastHealthGroupUsersResponse {
+  group: MulticastHealthGroupRef
+  generated_at: string
+  items: MulticastHealthUserItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface MulticastHealthUserResponse {
+  user_pk: string
+  user_owner_pubkey: string
+  user_dz_ip: string
+  user_tunnel_id: number
+  user_device_pk: string
+  user_device_code: string
+  generated_at: string
+  items: MulticastHealthUserItem[]
+}
+
+export interface MulticastHealthPathItem {
+  publisher_user_pk: string
+  publisher_owner_pubkey: string
+  publisher_dz_ip: string
+  publisher_tunnel_id: number
+  publisher_device_pk: string
+  publisher_device_code: string
+  subscriber_user_pk: string
+  subscriber_owner_pubkey: string
+  subscriber_dz_ip: string
+  subscriber_tunnel_id: number
+  subscriber_device_pk: string
+  subscriber_device_code: string
+  publisher_endpoint_observed: boolean
+  subscriber_endpoint_observed: boolean
+  endpoints_reconciled: boolean
+  health_status: MulticastHealthStatus
+  verification_method: 'endpoints_only' | 'full_path' | string
+  missing_endpoint_reasons?: string[]
+}
+
+export interface MulticastHealthGroupPathsResponse {
+  group: MulticastHealthGroupRef
+  generated_at: string
+  items: MulticastHealthPathItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export async function fetchMulticastGroupHealth(pkOrCode: string): Promise<MulticastHealthGroupSummary> {
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health')
+  }
+  return res.json()
+}
+
+export async function fetchMulticastGroupHealthUsers(
+  pkOrCode: string,
+  limit?: number,
+  offset?: number,
+): Promise<MulticastHealthGroupUsersResponse> {
+  const params = new URLSearchParams()
+  if (limit !== undefined) params.set('limit', String(limit))
+  if (offset !== undefined) params.set('offset', String(offset))
+  const qs = params.toString()
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/users${qs ? `?${qs}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health users')
+  }
+  return res.json()
+}
+
+export async function fetchMulticastGroupHealthPaths(
+  pkOrCode: string,
+  limit?: number,
+  offset?: number,
+): Promise<MulticastHealthGroupPathsResponse> {
+  const params = new URLSearchParams()
+  if (limit !== undefined) params.set('limit', String(limit))
+  if (offset !== undefined) params.set('offset', String(offset))
+  const qs = params.toString()
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/paths${qs ? `?${qs}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health paths')
+  }
+  return res.json()
+}
+
+export async function fetchUserHealth(pk: string): Promise<MulticastHealthUserResponse> {
+  const res = await apiFetch(`/api/dz/users/${encodeURIComponent(pk)}/health`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch user health')
+  }
+  return res.json()
+}
+
 // Critical links types
 export interface CriticalLink {
   sourcePK: string


### PR DESCRIPTION
## Summary

Track 3 of infra#1501. Surfaces the Track 1 health views and Track 2 API endpoints in the lake/web data app — same UX patterns the existing detail pages use, no new top-level routes.

| Page | Change |
| --- | --- |
| `/dz/multicast-groups/{group}?tab=health` | New **Health** tab. Summary counts across three granularities (users, paths, mroutes), a per-user reconciliation table, and a per-path table with verification method. |
| `/dz/users/{user}` | The existing Multicast Groups card gains a health badge per (group, mode) row. The group link now deep-links into the Health tab. |

Status colors: green (healthy) / amber (degraded) / red (unhealthy) / muted (unknown). All classification comes from the views — the web app only renders.

## Stacking

`bc/mcast-health-web` (this) → `bc/mcast-health-api` (#628) → `bc/mcast-health-path` (#627) → `bc/mcast-health-user-path` (#626) → `bc/mcast-health-mroute-view` (#625).

## Testing Verification

- `bun run build` — production tsc + vite build clean.
- `bun run test:run` — 180/180 vitest unit tests pass.
- Browser smoke against `data.malbeclabs.com` via local dev server:
  - `/dz/multicast-groups/tiredsolid?tab=health` — three tabs render (Publishers / Subscribers / Health). On the Health tab, the "Failed to load health data" banner displays cleanly because the prod API hasn't yet been deployed with #628 — confirms error handling.
  - `/dz/users/{publisher_pk}` — Multicast Groups card renders, group link points at `?tab=health`, no health badges yet (expected — depends on #628).

Live happy-path verification against staging once #628 is deployed is the remaining step.

## Out of scope (follow-up)

- Per-row red/yellow/green indicators on the existing Publishers / Subscribers tabs. Currently only the dedicated Health tab carries per-row status. Separable — adds a column to the existing table and another query.
- Track 1 follow-up: recursive OIF chain walk to flip `verification_method` from `endpoints_only` to `full_path`.

Refs malbeclabs/infra#1501.
