### PR TITLE
indexer: add health_multicast_user_rate view (rate reconciliation, B1 of infra#1501)

### DIFF
--- a/api/handlers/multicast_delivery.go
+++ b/api/handlers/multicast_delivery.go
@@ -2,6 +2,11 @@
 // back future per-group and per-user health endpoints (infra#1501 Track 2).
 // They classify mroute rows and surface (active_publisher, group, device)
 // gaps without requiring this package to recompute the joins.
+//
+// The health_multicast_user_rate view (migration 20260604000001) extends
+// the per-user health classification with a 5-min rate dimension, layering
+// data-plane reconciliation on top of the control-plane verdict (Track B1
+// of infra#1501). Endpoints reading from it are added in a follow-up.
 
 package handlers
 

--- a/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
+++ b/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
@@ -1,0 +1,145 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_multicast_user_rate
+--
+-- Extends health_multicast_user with a data-plane rate dimension. The
+-- existing view verifies that the control plane (mroute state) reflects
+-- the onchain expectation. This view adds:
+--
+--   1. observed_bps_5m — the 5-min max rate measured at the user's tunnel.
+--      For publishers: max_in_bps (device's RX from the publisher).
+--      For subscribers: max_out_bps (device's TX toward the subscriber).
+--
+--   2. expected_bps_5m — only defined for subscribers: the sum of every
+--      publisher's RX rate in the same multicast group. A subscriber's TX
+--      should equal this sum.
+--
+--   3. rate_status — reconciled | mismatch | unknown.
+--      Tolerance: |observed - expected| <= max(5%, 1 Mbps).
+--
+--   4. rate_status_reason — a more specific cause behind rate_status.
+--      Distinguishes "no_data" (monitoring gap), "idle" (registered but
+--      zero traffic), "monitoring_gap" / "group_idle" (subscriber-side
+--      reasons), from "reconciled" / "mismatch" / "active".
+--
+--   5. health_status — REPLACES the CP-only verdict with the combined
+--      verdict (per the matrix). control_plane_status carries the
+--      original CP-only value so consumers can drill in.
+--
+-- Strict idle handling: if any publisher in the group has no counter row
+-- in the last 15 minutes, every subscriber's rate_status collapses to
+-- unknown with reason 'monitoring_gap'. We refuse to reconcile against a
+-- deflated expected. If all publishers are idle (sum = 0), subscribers go
+-- unknown with reason 'group_idle'.
+--
+-- Track B1 of malbeclabs/infra#1501 (rate reconciliation).
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+WITH
+-- Latest 5-min bucket per (device, tunnel) within the freshness window.
+recent_bucket AS (
+    SELECT
+        device_pk AS rb_device_pk,
+        user_tunnel_id AS rb_user_tunnel_id,
+        max(bucket_ts) AS rb_bucket_ts
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+    GROUP BY rb_device_pk, rb_user_tunnel_id
+),
+user_rates AS (
+    -- ur_present = 1 lets the outer LEFT JOIN distinguish "no row" (0) from
+    -- "row exists with rate 0" (1). ClickHouse LEFT JOIN with
+    -- non-Nullable right-hand columns returns defaults (0 / epoch) instead
+    -- of NULL, so an explicit sentinel column is needed.
+    SELECT
+        r.device_pk AS ur_device_pk,
+        r.user_tunnel_id AS ur_user_tunnel_id,
+        r.bucket_ts AS ur_bucket_ts,
+        r.max_in_bps AS ur_max_in_bps,
+        r.max_out_bps AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m r
+    INNER JOIN recent_bucket rb
+        ON r.device_pk = rb.rb_device_pk
+       AND r.user_tunnel_id = rb.rb_user_tunnel_id
+       AND r.bucket_ts = rb.rb_bucket_ts
+),
+group_publisher_total AS (
+    SELECT
+        h.multicast_group_pk AS gpt_multicast_group_pk,
+        sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
+        countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        count() AS gpt_publisher_count
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+    WHERE h.mode IN ('P', 'P+S')
+    GROUP BY gpt_multicast_group_pk
+),
+-- Inner layer: compute rate_status_reason / rate_status / control_plane_status
+-- so the outer SELECT can reference them when computing the combined verdict.
+with_rate AS (
+    SELECT
+        h.* EXCEPT (health_status),
+        h.health_status AS control_plane_status,
+        if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+        multiIf(
+            ur.ur_present = 0, NULL,
+            h.mode IN ('P', 'P+S'), toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',          toNullable(ur.ur_max_out_bps),
+            NULL
+        ) AS observed_bps_5m,
+        multiIf(
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps),
+            NULL
+        ) AS expected_bps_5m,
+        multiIf(
+            h.mode IN ('P', 'P+S') AND ur.ur_present = 0, 'no_data',
+            h.mode IN ('P', 'P+S') AND ur.ur_max_in_bps > 0, 'active',
+            h.mode IN ('P', 'P+S'), 'idle',
+            h.mode = 'S' AND ur.ur_present = 0, 'no_data',
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+            h.mode = 'S' AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+            h.mode = 'S' AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                             <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode = 'S', 'mismatch',
+            'no_data'
+        ) AS rate_status_reason
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+    LEFT JOIN group_publisher_total gpt
+        ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
+)
+SELECT
+    w.*,
+    -- Roll rate_status_reason up into the three-value rate_status.
+    if(rate_status_reason IN ('active', 'reconciled'), 'reconciled',
+        if(rate_status_reason = 'mismatch', 'mismatch', 'unknown')
+    ) AS rate_status,
+    -- Combined verdict per the matrix.
+    --                | rate=reconciled | rate=mismatch | rate=unknown
+    --  CP=healthy    | healthy         | degraded      | unknown
+    --  CP=degraded   | degraded        | unhealthy     | degraded
+    --  CP=unhealthy  | unhealthy       | unhealthy     | unhealthy
+    multiIf(
+        control_plane_status = 'unhealthy', 'unhealthy',
+        control_plane_status = 'degraded' AND rate_status_reason = 'mismatch', 'unhealthy',
+        control_plane_status = 'degraded', 'degraded',
+        control_plane_status = 'healthy' AND rate_status_reason IN ('active', 'reconciled'), 'healthy',
+        control_plane_status = 'healthy' AND rate_status_reason = 'mismatch', 'degraded',
+        control_plane_status = 'healthy', 'unknown',
+        'unknown'
+    ) AS health_status
+FROM with_rate w;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP VIEW IF EXISTS health_multicast_user_rate;

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -1,0 +1,206 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthMulticastUserRate exercises the rate-reconciliation view across
+// the three publisher rate states (active / idle / no_data) and the four
+// subscriber reasons (reconciled / mismatch / monitoring_gap / group_idle).
+// Three groups are set up:
+//
+//   grp-rate-clean — full counter data; one active publisher, one matched
+//     subscriber, one mismatched subscriber.
+//   grp-rate-gap — publisher has no counter row in the freshness window;
+//     subscriber's rate goes to unknown via monitoring_gap.
+//   grp-rate-idle — publisher transmits zero; subscriber's rate goes to
+//     unknown via group_idle.
+//
+// The combined health_status column is verified against the rollup matrix.
+func TestHealthMulticastUserRate(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	// Devices
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-fhr', 'activated', 'edge', 'fhr-dz1', '', '', '', 0, '[]'),
+			('d-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-lhr', 'activated', 'edge', 'lhr-dz1', '', '', '', 0, '[]')`))
+
+	// Groups
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-rate-clean', now(), now(), generateUUIDv4(), 0, 1, 'grp-rate-clean', 'o', 'rate-clean', '233.99.1.1', 100000000, 'activated', 1, 2),
+			('grp-rate-gap',   now(), now(), generateUUIDv4(), 0, 2, 'grp-rate-gap',   'o', 'rate-gap',   '233.99.1.2', 100000000, 'activated', 1, 1),
+			('grp-rate-idle',  now(), now(), generateUUIDv4(), 0, 3, 'grp-rate-idle',  'o', 'rate-idle',  '233.99.1.3', 100000000, 'activated', 1, 1)`))
+
+	// Users
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			-- grp-rate-clean: one active publisher at 10 Mbps, two subscribers (one matched, one mismatched).
+			('u-pub-active', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-active', 'o', 'activated', 'multicast', '203.0.113.10', '10.99.1.10', 'd-fhr', 't1', 701, '["grp-rate-clean"]', '[]'),
+			('u-sub-recon',  now(), now(), generateUUIDv4(), 0, 2, 'u-sub-recon',  'o', 'activated', 'multicast', '203.0.113.11', '10.99.1.11', 'd-lhr', 't1', 801, '[]', '["grp-rate-clean"]'),
+			('u-sub-mis',    now(), now(), generateUUIDv4(), 0, 3, 'u-sub-mis',    'o', 'activated', 'multicast', '203.0.113.12', '10.99.1.12', 'd-lhr', 't1', 802, '[]', '["grp-rate-clean"]'),
+			-- grp-rate-gap: publisher will have no counter row.
+			('u-pub-nodata', now(), now(), generateUUIDv4(), 0, 4, 'u-pub-nodata', 'o', 'activated', 'multicast', '203.0.113.13', '10.99.1.13', 'd-fhr', 't1', 702, '["grp-rate-gap"]', '[]'),
+			('u-sub-gap',    now(), now(), generateUUIDv4(), 0, 5, 'u-sub-gap',    'o', 'activated', 'multicast', '203.0.113.14', '10.99.1.14', 'd-lhr', 't1', 803, '[]', '["grp-rate-gap"]'),
+			-- grp-rate-idle: publisher has counter row with 0 bps.
+			('u-pub-idle',   now(), now(), generateUUIDv4(), 0, 6, 'u-pub-idle',   'o', 'activated', 'multicast', '203.0.113.15', '10.99.1.15', 'd-fhr', 't1', 703, '["grp-rate-idle"]', '[]'),
+			('u-sub-idle',   now(), now(), generateUUIDv4(), 0, 7, 'u-sub-idle',   'o', 'activated', 'multicast', '203.0.113.16', '10.99.1.16', 'd-lhr', 't1', 804, '[]', '["grp-rate-idle"]')`))
+
+	// Mroute entries — control plane is healthy for every (user, group) pair below.
+	// FHR mroutes — publisher tunnel as RPF interface.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-fhr-clean', now(), now(), generateUUIDv4(), 0, 1, 'd-fhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SBNP', 0, 'Tunnel701', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-fhr-gap',   now(), now(), generateUUIDv4(), 0, 2, 'd-fhr', 'default', 'sparse', '233.99.1.2', '10.99.1.13', 'SBNP', 0, 'Tunnel702', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-fhr-idle',  now(), now(), generateUUIDv4(), 0, 3, 'd-fhr', 'default', 'sparse', '233.99.1.3', '10.99.1.15', 'SBNP', 0, 'Tunnel703', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// LHR mroutes — subscriber tunnel in OIF list.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-lhr-recon', now(), now(), generateUUIDv4(), 0, 1, 'd-lhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel801"]', 1, now()),
+			('mr-lhr-mis',   now(), now(), generateUUIDv4(), 0, 2, 'd-lhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel802"]', 1, now()),
+			('mr-lhr-gap',   now(), now(), generateUUIDv4(), 0, 3, 'd-lhr', 'default', 'sparse', '233.99.1.2', '10.99.1.13', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel803"]', 1, now()),
+			('mr-lhr-idle',  now(), now(), generateUUIDv4(), 0, 4, 'd-lhr', 'default', 'sparse', '233.99.1.3', '10.99.1.15', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel804"]', 1, now())`))
+
+	// Counter rollup rows. NOTE: u-pub-nodata / Tunnel702 deliberately omitted.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			-- grp-rate-clean: publisher RX = 10 Mbps; matched subscriber TX = 10 Mbps; mismatched subscriber TX = 50 Mbps.
+			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel701', 701, 'u-pub-active', 10000000, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel801', 801, 'u-sub-recon',  0, 10000000, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel802', 802, 'u-sub-mis',    0, 50000000, now()),
+			-- grp-rate-gap: subscriber has data; publisher does not.
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel803', 803, 'u-sub-gap',    0, 5000000,  now()),
+			-- grp-rate-idle: publisher and subscriber both report 0 bps.
+			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel703', 703, 'u-pub-idle',   0, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel804', 804, 'u-sub-idle',   0, 0, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT
+			user_pk, mode, multicast_group_pk,
+			control_plane_status,
+			rate_status, rate_status_reason,
+			observed_bps_5m, expected_bps_5m,
+			health_status
+		FROM health_multicast_user_rate
+		WHERE multicast_group_pk LIKE 'grp-rate-%'
+		ORDER BY multicast_group_pk, user_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		userPK, mode, group              string
+		cp, rate, reason, combined       string
+		observedBps, expectedBps         *float64
+	}
+	got := []row{}
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(
+			&r.userPK, &r.mode, &r.group,
+			&r.cp, &r.rate, &r.reason,
+			&r.observedBps, &r.expectedBps,
+			&r.combined,
+		))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+
+	byKey := map[string]row{}
+	for _, r := range got {
+		byKey[r.userPK] = r
+	}
+
+	// grp-rate-clean: u-pub-active is transmitting → active → reconciled.
+	pub := byKey["u-pub-active"]
+	assert.Equal(t, "healthy", pub.cp, "publisher CP healthy")
+	assert.Equal(t, "active", pub.reason)
+	assert.Equal(t, "reconciled", pub.rate)
+	require.NotNil(t, pub.observedBps)
+	assert.InDelta(t, 10000000, *pub.observedBps, 1)
+	assert.Equal(t, "healthy", pub.combined)
+
+	// u-sub-recon: 10 Mbps matches sum-of-publishers = 10 Mbps → reconciled.
+	subR := byKey["u-sub-recon"]
+	assert.Equal(t, "reconciled", subR.rate)
+	assert.Equal(t, "reconciled", subR.reason)
+	require.NotNil(t, subR.observedBps)
+	require.NotNil(t, subR.expectedBps)
+	assert.InDelta(t, 10000000, *subR.observedBps, 1)
+	assert.InDelta(t, 10000000, *subR.expectedBps, 1)
+	assert.Equal(t, "healthy", subR.combined)
+
+	// u-sub-mis: 50 Mbps vs expected 10 Mbps → mismatch.
+	subM := byKey["u-sub-mis"]
+	assert.Equal(t, "mismatch", subM.rate)
+	assert.Equal(t, "mismatch", subM.reason)
+	require.NotNil(t, subM.observedBps)
+	assert.InDelta(t, 50000000, *subM.observedBps, 1)
+	// CP healthy + rate mismatch → combined degraded.
+	assert.Equal(t, "degraded", subM.combined)
+
+	// grp-rate-gap: publisher has no rate row.
+	pubNoData := byKey["u-pub-nodata"]
+	assert.Equal(t, "no_data", pubNoData.reason)
+	assert.Equal(t, "unknown", pubNoData.rate)
+	assert.Nil(t, pubNoData.observedBps, "no observed rate when no counter row")
+	assert.Equal(t, "unknown", pubNoData.combined)
+
+	// u-sub-gap: subscriber has data but expected is NULL (one+ publisher no_data) → monitoring_gap.
+	subGap := byKey["u-sub-gap"]
+	assert.Equal(t, "monitoring_gap", subGap.reason)
+	assert.Equal(t, "unknown", subGap.rate)
+	assert.Nil(t, subGap.expectedBps, "expected NULL when group has no_data publishers")
+	assert.Equal(t, "unknown", subGap.combined)
+
+	// grp-rate-idle: publisher RX = 0 → idle.
+	pubIdle := byKey["u-pub-idle"]
+	assert.Equal(t, "idle", pubIdle.reason)
+	assert.Equal(t, "unknown", pubIdle.rate)
+	require.NotNil(t, pubIdle.observedBps)
+	assert.InDelta(t, 0, *pubIdle.observedBps, 1)
+	assert.Equal(t, "unknown", pubIdle.combined)
+
+	// u-sub-idle: expected = 0 (publisher present but transmitting 0) → group_idle.
+	subIdle := byKey["u-sub-idle"]
+	assert.Equal(t, "group_idle", subIdle.reason)
+	assert.Equal(t, "unknown", subIdle.rate)
+	require.NotNil(t, subIdle.expectedBps)
+	assert.InDelta(t, 0, *subIdle.expectedBps, 1)
+	assert.Equal(t, "unknown", subIdle.combined)
+}


### PR DESCRIPTION
## Summary

First PR of the rate-reconciliation stack (B1 of infra#1501). Adds a ClickHouse view that layers a 5-min data-plane rate dimension on top of the existing control-plane health classification.

After this lands, "healthy" means both:
- onchain ↔ mroute reconciliation passes (existing `health_multicast_user`), **and**
- every subscriber's TX rate matches the sum of its group's publishers' RX rates (new).

The new view, `health_multicast_user_rate`, wraps the existing view — additive, not a replacement.

## What the view exposes

| Column | Description |
| --- | --- |
| `rate_bucket_ts` | 5-min bucket the rate was read from. NULL when no counter row in the freshness window. |
| `observed_bps_5m` | Publisher RX or subscriber TX at the user's tunnel. |
| `expected_bps_5m` | For subscribers: sum of all publishers' RX. NULL for publishers; NULL when any publisher in the group has no counter row. |
| `rate_status` | `reconciled \| mismatch \| unknown`. |
| `rate_status_reason` | Fine-grained: `active \| idle \| no_data` (publishers) or `reconciled \| mismatch \| monitoring_gap \| group_idle` (subscribers). |
| `control_plane_status` | The existing CP-only verdict, preserved for drill-in. |
| `health_status` | **REPLACED** with the combined CP × rate verdict per the spec matrix. |

## Behavioral knobs (baked into the view)

- **Tolerance**: `|observed - expected| <= max(5%, 1 Mbps)`.
- **Freshness window**: 15 min (3× the 5-min bucket cadence). Older counter data is treated as missing.
- **Strict idle**: any publisher in the group with no counter row collapses every subscriber's `rate_status` to `unknown` (reason: `monitoring_gap`). We refuse to reconcile against a deflated expected.
- **Group-idle**: all publishers transmitting zero → subscribers go `unknown` (reason: `group_idle`).

## Combined-status matrix

|  | rate=reconciled | rate=mismatch | rate=unknown |
|---|---|---|---|
| CP=healthy | healthy | degraded | unknown |
| CP=degraded | degraded | unhealthy | degraded |
| CP=unhealthy | unhealthy | unhealthy | unhealthy |

## Implementation notes

- **ClickHouse footgun fixed**: `LEFT JOIN` with non-Nullable right-side columns returns defaults (`0`, epoch) rather than NULL. That made "row missing" indistinguishable from "row with zero rate" via NULL checks. The view plumbs a `1 AS ur_present` sentinel column through the `user_rates` CTE so the outer joins can tell those cases apart.
- **No new data sources**: `device_interface_rollup_5m` already carries per-(device, tunnel) 5-minute rate aggregates indexed by `user_pk` and `user_tunnel_id`. No new ingestion required.

## Stacking

`bc/mcast-health-rate-view` → `bc/mcast-health-web-polish` (#630). Additive — no rebase of existing PRs needed.

Follow-ups:
- **B2**: API endpoints (`/health/users` switches to read from this view, gains rate fields).
- **B3**: web UI (per-user table gains a rate column; combined `health_status` flows through).

## Testing Verification

`TestHealthMulticastUserRate` exercises three groups (clean / monitoring-gap / idle) covering all seven rate-state combinations:

| User | Setup | rate_status | rate_status_reason | combined health |
| --- | --- | --- | --- | --- |
| `u-pub-active` | publisher, RX = 10 Mbps | reconciled | active | healthy |
| `u-sub-recon` | subscriber, TX = 10 Mbps | reconciled | reconciled | healthy |
| `u-sub-mis` | subscriber, TX = 50 Mbps | mismatch | mismatch | degraded |
| `u-pub-nodata` | publisher, no counter row | unknown | no_data | unknown |
| `u-sub-gap` | subscriber w/ no-data publisher | unknown | monitoring_gap | unknown |
| `u-pub-idle` | publisher, RX = 0 | unknown | idle | unknown |
| `u-sub-idle` | subscriber w/ idle publisher | unknown | group_idle | unknown |

Full `mroute` test package green (`go test ./indexer/pkg/dz/mroute/` 58s).

Refs malbeclabs/infra#1501.
