### PR TITLE
api: read multicast health from rate view (B2 of infra#1501)

### DIFF
--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -61,7 +61,7 @@ func (a *API) queryMulticastHealthCounts(ctx context.Context, groupPK string) (M
 		SELECT source, health_status, count() AS n FROM (
 			SELECT 'mroutes' AS source, health_status FROM health_mroute WHERE multicast_group_pk = ?
 			UNION ALL
-			SELECT 'users' AS source, health_status FROM health_multicast_user WHERE multicast_group_pk = ?
+			SELECT 'users' AS source, health_status FROM health_multicast_user_rate WHERE multicast_group_pk = ?
 			UNION ALL
 			SELECT 'paths' AS source, health_status FROM health_publisher_subscriber_path WHERE multicast_group_pk = ?
 		)

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -46,6 +46,16 @@ func insertMulticastHealthFixtures(t *testing.T, api *handlers.API) {
 			'dev-nyc1', 'default', 'sparse', '233.0.0.1', '10.0.0.1',
 			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel502"]', 1, now())`))
 
+	// Rate fixtures — publisher RX = 10 Mbps; subscriber TX = 10 Mbps → reconciled.
+	// Without these the rate dimension would collapse health_status to 'unknown'
+	// via 'no_data' for both endpoints.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'dev-ams1', 'Tunnel501', 501, 'user-pub', 10000000, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'dev-nyc1', 'Tunnel502', 502, 'user-sub', 0, 10000000, now())`))
+
 	require.NoError(t, api.DB.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
 	require.NoError(t, api.DB.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
 }
@@ -124,11 +134,32 @@ func TestGetMulticastGroupHealth_Users(t *testing.T) {
 	require.Len(t, resp.Items, 2)
 	assert.EqualValues(t, 2, resp.Total)
 
-	// Both items should be reconciled and healthy.
-	for _, it := range resp.Items {
+	// Both items should be reconciled on both dimensions.
+	var pub, sub *handlers.MulticastHealthUserItem
+	for i := range resp.Items {
+		it := &resp.Items[i]
 		assert.True(t, it.Reconciled, "user %s expected reconciled", it.UserPK)
-		assert.Equal(t, "healthy", it.HealthStatus)
+		assert.Equal(t, "healthy", it.ControlPlaneStatus, "user %s expected CP healthy", it.UserPK)
+		assert.Equal(t, "reconciled", it.RateStatus, "user %s expected rate reconciled", it.UserPK)
+		assert.Equal(t, "healthy", it.HealthStatus, "user %s expected combined healthy", it.UserPK)
+		assert.NotNil(t, it.ObservedBps5m, "user %s missing observed rate", it.UserPK)
+		assert.NotNil(t, it.RateBucketTS, "user %s missing rate bucket ts", it.UserPK)
+		switch it.Mode {
+		case "P":
+			pub = it
+		case "S":
+			sub = it
+		}
 	}
+	// Publisher's rate reason is 'active' (transmitting). Subscriber's is 'reconciled'
+	// (TX matches sum of publishers).
+	require.NotNil(t, pub)
+	require.NotNil(t, sub)
+	assert.Equal(t, "active", pub.RateStatusReason)
+	assert.Equal(t, "reconciled", sub.RateStatusReason)
+	require.NotNil(t, sub.ExpectedBps5m)
+	assert.InDelta(t, 10_000_000, *sub.ExpectedBps5m, 1)
+	assert.InDelta(t, 10_000_000, *sub.ObservedBps5m, 1)
 }
 
 func TestGetMulticastGroupHealth_Paths(t *testing.T) {

--- a/api/handlers/multicast_health_types.go
+++ b/api/handlers/multicast_health_types.go
@@ -1,5 +1,7 @@
 package handlers
 
+import "time"
+
 // Response shapes for the multicast health endpoints (infra#1501 Track 2).
 // Each is a thin packaging around the underlying health_* ClickHouse views.
 
@@ -26,24 +28,32 @@ type MulticastHealthStatusCounts struct {
 	Total     uint64 `json:"total"`
 }
 
-// MulticastHealthUserItem matches one row of health_multicast_user.
+// MulticastHealthUserItem matches one row of health_multicast_user_rate.
+// HealthStatus is the combined CP × rate verdict; ControlPlaneStatus and
+// RateStatus carry the per-dimension verdicts so callers can drill in.
 type MulticastHealthUserItem struct {
-	UserPK                string `json:"user_pk"`
-	UserOwnerPubkey       string `json:"user_owner_pubkey"`
-	UserDZIP              string `json:"user_dz_ip"`
-	UserTunnelID          int32  `json:"user_tunnel_id"`
-	UserDevicePK          string `json:"user_device_pk"`
-	UserDeviceCode        string `json:"user_device_code"`
-	MulticastGroupPK      string `json:"multicast_group_pk"`
-	MulticastGroupCode    string `json:"multicast_group_code"`
-	GroupAddress          string `json:"group_address"`
-	Mode                  string `json:"mode"`
-	ExpectedTunnelPos     string `json:"expected_tunnel_position"`
-	PublisherIIFObserved  bool   `json:"publisher_iif_observed"`
-	SubscriberOIFObserved bool   `json:"subscriber_oif_observed"`
-	Reconciled            bool   `json:"reconciled"`
-	HealthStatus          string `json:"health_status"`
-	MismatchReason        string `json:"mismatch_reason,omitempty"`
+	UserPK                string     `json:"user_pk"`
+	UserOwnerPubkey       string     `json:"user_owner_pubkey"`
+	UserDZIP              string     `json:"user_dz_ip"`
+	UserTunnelID          int32      `json:"user_tunnel_id"`
+	UserDevicePK          string     `json:"user_device_pk"`
+	UserDeviceCode        string     `json:"user_device_code"`
+	MulticastGroupPK      string     `json:"multicast_group_pk"`
+	MulticastGroupCode    string     `json:"multicast_group_code"`
+	GroupAddress          string     `json:"group_address"`
+	Mode                  string     `json:"mode"`
+	ExpectedTunnelPos     string     `json:"expected_tunnel_position"`
+	PublisherIIFObserved  bool       `json:"publisher_iif_observed"`
+	SubscriberOIFObserved bool       `json:"subscriber_oif_observed"`
+	Reconciled            bool       `json:"reconciled"`
+	ControlPlaneStatus    string     `json:"control_plane_status"`
+	MismatchReason        string     `json:"mismatch_reason,omitempty"`
+	RateBucketTS          *time.Time `json:"rate_bucket_ts,omitempty"`
+	ObservedBps5m         *float64   `json:"observed_bps_5m,omitempty"`
+	ExpectedBps5m         *float64   `json:"expected_bps_5m,omitempty"`
+	RateStatus            string     `json:"rate_status"`
+	RateStatusReason      string     `json:"rate_status_reason"`
+	HealthStatus          string     `json:"health_status"`
 }
 
 type MulticastHealthGroupUsersResponse struct {

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -96,8 +96,11 @@ func (a *API) GetUserHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// queryMulticastHealthUsers reads from health_multicast_user with a single
-// WHERE clause filter (either "multicast_group_pk = ?" or "user_pk = ?").
+// queryMulticastHealthUsers reads from health_multicast_user_rate with a
+// single WHERE clause filter (either "multicast_group_pk = ?" or
+// "user_pk = ?"). The view exposes both the CP-only verdict
+// (control_plane_status) and the combined verdict (health_status); we
+// surface both so consumers can drill in.
 func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string, arg any) ([]MulticastHealthUserItem, error) {
 	query := `
 		SELECT
@@ -115,9 +118,15 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			publisher_iif_observed,
 			subscriber_oif_observed,
 			reconciled,
-			health_status,
-			mismatch_reason
-		FROM health_multicast_user
+			control_plane_status,
+			mismatch_reason,
+			rate_bucket_ts,
+			observed_bps_5m,
+			expected_bps_5m,
+			rate_status,
+			rate_status_reason,
+			health_status
+		FROM health_multicast_user_rate
 		WHERE ` + whereClause + `
 		ORDER BY multicast_group_code, user_pk
 		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
@@ -148,8 +157,14 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			&it.PublisherIIFObserved,
 			&it.SubscriberOIFObserved,
 			&it.Reconciled,
-			&it.HealthStatus,
+			&it.ControlPlaneStatus,
 			&it.MismatchReason,
+			&it.RateBucketTS,
+			&it.ObservedBps5m,
+			&it.ExpectedBps5m,
+			&it.RateStatus,
+			&it.RateStatusReason,
+			&it.HealthStatus,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

B2 of infra#1501. Wires the per-user health endpoints to the new `health_multicast_user_rate` view (PR #631) and surfaces the rate dimension.

| Endpoint | Change |
| --- | --- |
| `GET /api/dz/multicast-groups/{pk}/health` | Summary counts now reflect the **combined** CP × rate verdict. |
| `GET /api/dz/multicast-groups/{pk}/health/users` | Per-user rows now expose the rate fields below. |
| `GET /api/dz/users/{pk}/health` | Same — per-(user, group) rows include rate fields. |
| `GET /api/dz/multicast-groups/{pk}/health/paths` | Untouched. Path-level full-path walk is the next follow-up. |

## Response-shape additions

```jsonc
{
  "rate_bucket_ts":   "2026-06-04T01:13:00Z",  // null when no counter row in 15-min window
  "observed_bps_5m":  10000000,                // publisher RX or subscriber TX
  "expected_bps_5m":  10000000,                // subscribers only; null otherwise
  "rate_status":       "reconciled",            // reconciled | mismatch | unknown
  "rate_status_reason": "active",               // active/idle/no_data (publisher) or
                                                // reconciled/mismatch/monitoring_gap/group_idle (subscriber)
  "control_plane_status": "healthy",            // CP-only verdict (drill-in)
  "health_status": "healthy"                    // COMBINED verdict per matrix — semantic change
}
```

The `health_status` field's semantic meaning is upgraded — it now means "healthy on both CP and rate" instead of "healthy on CP only". No JSON shape change to existing fields; the rate fields are additive.

## Stacking

`bc/mcast-health-rate-api` → `bc/mcast-health-rate-view` (#631).

## Testing Verification

- `insertMulticastHealthFixtures` now also inserts publisher RX = 10 Mbps and subscriber TX = 10 Mbps into `device_interface_rollup_5m`, exercising the round-trip of the new fields.
- `TestGetMulticastGroupHealth_Users` now asserts each row carries `control_plane_status = healthy`, `rate_status = reconciled`, combined `health_status = healthy`, and that observed/expected bps round-trip with the right reasons (`active` for publisher, `reconciled` for subscriber).
- All four existing health endpoint tests stay green; full `api/handlers` package run passes (`go test ./api/handlers` 27s).

## What's next

- **B3**: web UI — per-user table gains a rate column with the per-row badge, hover-card shows actual vs expected, the existing combined `health_status` flows through.

Refs malbeclabs/infra#1501.
