### PR TITLE
multicast: health UI + rate reconciliation (infra#1501)

### DIFF
--- a/api/handlers/multicast_delivery.go
+++ b/api/handlers/multicast_delivery.go
@@ -2,6 +2,11 @@
 // back future per-group and per-user health endpoints (infra#1501 Track 2).
 // They classify mroute rows and surface (active_publisher, group, device)
 // gaps without requiring this package to recompute the joins.
+//
+// The health_multicast_user_rate view (migration 20260604000001) extends
+// the per-user health classification with a 5-min rate dimension, layering
+// data-plane reconciliation on top of the control-plane verdict (Track B1
+// of infra#1501). Endpoints reading from it are added in a follow-up.
 
 package handlers
 

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -109,6 +109,8 @@ func addStatusCount(bucket *MulticastHealthStatusCounts, status string, n uint64
 		bucket.Degraded += n
 	case "unhealthy":
 		bucket.Unhealthy += n
+	case "unknown":
+		bucket.Unknown += n
 	}
 	bucket.Total += n
 }

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -61,7 +61,7 @@ func (a *API) queryMulticastHealthCounts(ctx context.Context, groupPK string) (M
 		SELECT source, health_status, count() AS n FROM (
 			SELECT 'mroutes' AS source, health_status FROM health_mroute WHERE multicast_group_pk = ?
 			UNION ALL
-			SELECT 'users' AS source, health_status FROM health_multicast_user WHERE multicast_group_pk = ?
+			SELECT 'users' AS source, health_status FROM health_multicast_user_rate WHERE multicast_group_pk = ?
 			UNION ALL
 			SELECT 'paths' AS source, health_status FROM health_publisher_subscriber_path WHERE multicast_group_pk = ?
 		)

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -46,6 +46,16 @@ func insertMulticastHealthFixtures(t *testing.T, api *handlers.API) {
 			'dev-nyc1', 'default', 'sparse', '233.0.0.1', '10.0.0.1',
 			'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel502"]', 1, now())`))
 
+	// Rate fixtures — publisher RX = 10 Mbps; subscriber TX = 10 Mbps → reconciled.
+	// Without these the rate dimension would collapse health_status to 'unknown'
+	// via 'no_data' for both endpoints.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'dev-ams1', 'Tunnel501', 501, 'user-pub', 10000000, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'dev-nyc1', 'Tunnel502', 502, 'user-sub', 0, 10000000, now())`))
+
 	require.NoError(t, api.DB.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
 	require.NoError(t, api.DB.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
 }
@@ -124,11 +134,32 @@ func TestGetMulticastGroupHealth_Users(t *testing.T) {
 	require.Len(t, resp.Items, 2)
 	assert.EqualValues(t, 2, resp.Total)
 
-	// Both items should be reconciled and healthy.
-	for _, it := range resp.Items {
+	// Both items should be reconciled on both dimensions.
+	var pub, sub *handlers.MulticastHealthUserItem
+	for i := range resp.Items {
+		it := &resp.Items[i]
 		assert.True(t, it.Reconciled, "user %s expected reconciled", it.UserPK)
-		assert.Equal(t, "healthy", it.HealthStatus)
+		assert.Equal(t, "healthy", it.ControlPlaneStatus, "user %s expected CP healthy", it.UserPK)
+		assert.Equal(t, "reconciled", it.RateStatus, "user %s expected rate reconciled", it.UserPK)
+		assert.Equal(t, "healthy", it.HealthStatus, "user %s expected combined healthy", it.UserPK)
+		assert.NotNil(t, it.ObservedBps5m, "user %s missing observed rate", it.UserPK)
+		assert.NotNil(t, it.RateBucketTS, "user %s missing rate bucket ts", it.UserPK)
+		switch it.Mode {
+		case "P":
+			pub = it
+		case "S":
+			sub = it
+		}
 	}
+	// Publisher's rate reason is 'active' (transmitting). Subscriber's is 'reconciled'
+	// (TX matches sum of publishers).
+	require.NotNil(t, pub)
+	require.NotNil(t, sub)
+	assert.Equal(t, "active", pub.RateStatusReason)
+	assert.Equal(t, "reconciled", sub.RateStatusReason)
+	require.NotNil(t, sub.ExpectedBps5m)
+	assert.InDelta(t, 10_000_000, *sub.ExpectedBps5m, 1)
+	assert.InDelta(t, 10_000_000, *sub.ObservedBps5m, 1)
 }
 
 func TestGetMulticastGroupHealth_Paths(t *testing.T) {

--- a/api/handlers/multicast_health_types.go
+++ b/api/handlers/multicast_health_types.go
@@ -1,5 +1,7 @@
 package handlers
 
+import "time"
+
 // Response shapes for the multicast health endpoints (infra#1501 Track 2).
 // Each is a thin packaging around the underlying health_* ClickHouse views.
 
@@ -26,24 +28,32 @@ type MulticastHealthStatusCounts struct {
 	Total     uint64 `json:"total"`
 }
 
-// MulticastHealthUserItem matches one row of health_multicast_user.
+// MulticastHealthUserItem matches one row of health_multicast_user_rate.
+// HealthStatus is the combined CP × rate verdict; ControlPlaneStatus and
+// RateStatus carry the per-dimension verdicts so callers can drill in.
 type MulticastHealthUserItem struct {
-	UserPK                string `json:"user_pk"`
-	UserOwnerPubkey       string `json:"user_owner_pubkey"`
-	UserDZIP              string `json:"user_dz_ip"`
-	UserTunnelID          int32  `json:"user_tunnel_id"`
-	UserDevicePK          string `json:"user_device_pk"`
-	UserDeviceCode        string `json:"user_device_code"`
-	MulticastGroupPK      string `json:"multicast_group_pk"`
-	MulticastGroupCode    string `json:"multicast_group_code"`
-	GroupAddress          string `json:"group_address"`
-	Mode                  string `json:"mode"`
-	ExpectedTunnelPos     string `json:"expected_tunnel_position"`
-	PublisherIIFObserved  bool   `json:"publisher_iif_observed"`
-	SubscriberOIFObserved bool   `json:"subscriber_oif_observed"`
-	Reconciled            bool   `json:"reconciled"`
-	HealthStatus          string `json:"health_status"`
-	MismatchReason        string `json:"mismatch_reason,omitempty"`
+	UserPK                string     `json:"user_pk"`
+	UserOwnerPubkey       string     `json:"user_owner_pubkey"`
+	UserDZIP              string     `json:"user_dz_ip"`
+	UserTunnelID          int32      `json:"user_tunnel_id"`
+	UserDevicePK          string     `json:"user_device_pk"`
+	UserDeviceCode        string     `json:"user_device_code"`
+	MulticastGroupPK      string     `json:"multicast_group_pk"`
+	MulticastGroupCode    string     `json:"multicast_group_code"`
+	GroupAddress          string     `json:"group_address"`
+	Mode                  string     `json:"mode"`
+	ExpectedTunnelPos     string     `json:"expected_tunnel_position"`
+	PublisherIIFObserved  bool       `json:"publisher_iif_observed"`
+	SubscriberOIFObserved bool       `json:"subscriber_oif_observed"`
+	Reconciled            bool       `json:"reconciled"`
+	ControlPlaneStatus    string     `json:"control_plane_status"`
+	MismatchReason        string     `json:"mismatch_reason,omitempty"`
+	RateBucketTS          *time.Time `json:"rate_bucket_ts,omitempty"`
+	ObservedBps5m         *float64   `json:"observed_bps_5m,omitempty"`
+	ExpectedBps5m         *float64   `json:"expected_bps_5m,omitempty"`
+	RateStatus            string     `json:"rate_status"`
+	RateStatusReason      string     `json:"rate_status_reason"`
+	HealthStatus          string     `json:"health_status"`
 }
 
 type MulticastHealthGroupUsersResponse struct {

--- a/api/handlers/multicast_health_types.go
+++ b/api/handlers/multicast_health_types.go
@@ -25,6 +25,7 @@ type MulticastHealthStatusCounts struct {
 	Healthy   uint64 `json:"healthy"`
 	Degraded  uint64 `json:"degraded"`
 	Unhealthy uint64 `json:"unhealthy"`
+	Unknown   uint64 `json:"unknown"`
 	Total     uint64 `json:"total"`
 }
 

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -96,8 +96,11 @@ func (a *API) GetUserHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// queryMulticastHealthUsers reads from health_multicast_user with a single
-// WHERE clause filter (either "multicast_group_pk = ?" or "user_pk = ?").
+// queryMulticastHealthUsers reads from health_multicast_user_rate with a
+// single WHERE clause filter (either "multicast_group_pk = ?" or
+// "user_pk = ?"). The view exposes both the CP-only verdict
+// (control_plane_status) and the combined verdict (health_status); we
+// surface both so consumers can drill in.
 func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string, arg any) ([]MulticastHealthUserItem, error) {
 	query := `
 		SELECT
@@ -115,9 +118,15 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			publisher_iif_observed,
 			subscriber_oif_observed,
 			reconciled,
-			health_status,
-			mismatch_reason
-		FROM health_multicast_user
+			control_plane_status,
+			mismatch_reason,
+			rate_bucket_ts,
+			observed_bps_5m,
+			expected_bps_5m,
+			rate_status,
+			rate_status_reason,
+			health_status
+		FROM health_multicast_user_rate
 		WHERE ` + whereClause + `
 		-- Stream every row in this group/user; sort actionable rows first
 		-- (unhealthy → degraded → unknown → healthy) so any consumer that
@@ -156,8 +165,14 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			&it.PublisherIIFObserved,
 			&it.SubscriberOIFObserved,
 			&it.Reconciled,
-			&it.HealthStatus,
+			&it.ControlPlaneStatus,
 			&it.MismatchReason,
+			&it.RateBucketTS,
+			&it.ObservedBps5m,
+			&it.ExpectedBps5m,
+			&it.RateStatus,
+			&it.RateStatusReason,
+			&it.HealthStatus,
 		); err != nil {
 			return nil, err
 		}

--- a/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
+++ b/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
@@ -48,13 +48,22 @@
 -- more than one multicast group, the observed rate is a per-tunnel
 -- aggregate that cannot be cleanly attributed to any one group, so this
 -- view refuses to reconcile it: rate_status_reason becomes
--- 'multi_group_ambiguity' and rate_status becomes 'unknown'. The
--- 'multi_group_ambiguity' verdict only kicks in for rows whose mode
--- requires reading the observed rate (P with active/idle distinction
--- and S / P+S which reconcile against an expected). Pure 'idle' / 'no_data'
--- semantics still hold even with one shared tunnel, so we don't mask them.
--- A future schema split (per-group counters) would let this view drop the
--- guard.
+-- 'multi_group_ambiguity' and rate_status becomes 'unknown'.
+--
+-- Ambiguity propagates two ways:
+--
+--   1. Per-row: the user's own (device, tunnel, user) participates in
+--      multiple groups → that user's row in this view is ambiguous.
+--
+--   2. Per-group: at least one publisher in the user's group is itself
+--      multi-group → gpt_total_publisher_rx_bps is contaminated by
+--      cross-group traffic, so every subscriber/P+S row in the group is
+--      ambiguous regardless of whether they themselves are single- or
+--      multi-group.
+--
+-- Pure 'idle' / 'no_data' semantics still hold even with shared tunnels,
+-- so we don't mask them. A future schema split (per-group counters)
+-- would let this view drop the guard.
 --
 -- Track B1 of malbeclabs/infra#1501 (rate reconciliation).
 CREATE OR REPLACE VIEW health_multicast_user_rate
@@ -107,17 +116,27 @@ user_group_counts AS (
     GROUP BY ugc_device_pk, ugc_user_tunnel_id, ugc_user_pk
 ),
 -- Per-publisher RX so P+S subscriber expected can subtract self's contribution.
+-- gpt_ambiguous_publisher_count tracks publishers whose (device, tunnel, user)
+-- participates in more than one multicast group — their RX is a cross-group
+-- aggregate that contaminates the group_total. If any publisher is ambiguous,
+-- every subscriber in this group is downgraded to multi_group_ambiguity since
+-- their expected can't be cleanly derived.
 group_publisher_total AS (
     SELECT
         h.multicast_group_pk AS gpt_multicast_group_pk,
         sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
         countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        countIf(ur.ur_present = 1 AND ugc.ugc_group_count > 1) AS gpt_ambiguous_publisher_count,
         count() AS gpt_publisher_count
     FROM health_multicast_user h
     LEFT JOIN user_rates ur
         ON ur.ur_device_pk = h.user_device_pk
        AND ur.ur_user_tunnel_id = h.user_tunnel_id
        AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN user_group_counts ugc
+        ON ugc.ugc_device_pk = h.user_device_pk
+       AND ugc.ugc_user_tunnel_id = h.user_tunnel_id
+       AND ugc.ugc_user_pk = h.user_pk
     WHERE h.mode IN ('P', 'P+S')
     GROUP BY gpt_multicast_group_pk
 ),
@@ -136,9 +155,11 @@ with_rate AS (
             NULL
         ) AS observed_bps_5m,
         multiIf(
-            -- Multi-group ambiguity: there is no per-group expected for a
-            -- tunnel shared across groups.
+            -- Multi-group ambiguity: either this user's own tunnel is shared
+            -- across groups, OR any publisher contributing to the group sum
+            -- is multi-group (which contaminates gpt_total_publisher_rx_bps).
             ugc.ugc_group_count > 1, NULL,
+            gpt.gpt_ambiguous_publisher_count > 0, NULL,
             -- S: expected is the full group_total (only set when no missing publishers).
             h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
                 toNullable(gpt.gpt_total_publisher_rx_bps),
@@ -152,13 +173,21 @@ with_rate AS (
             -- nothing for this tunnel, we don't know any of it anyway.
             ur.ur_present = 0, 'no_data',
 
-            -- Multi-group ambiguity: a single (device, tunnel, user) shared
-            -- across N>1 groups has a per-tunnel aggregate rate that can't
-            -- be cleanly attributed to any one group. Refuse to reconcile.
-            -- Exempt: pure 'idle' (max_in_bps = 0) on a publisher still
-            -- means "publishing nothing" per-group, which is correct.
+            -- Multi-group ambiguity, this user's own tunnel: a single
+            -- (device, tunnel, user) shared across N>1 groups has a per-
+            -- tunnel aggregate rate that can't be cleanly attributed to any
+            -- one group. Refuse to reconcile. Exempt: pure 'idle' (max_in_bps
+            -- = 0) on a publisher still means "publishing nothing" per-group,
+            -- which is correct.
             ugc.ugc_group_count > 1 AND h.mode = 'P' AND ur.ur_max_in_bps = 0, 'idle',
             ugc.ugc_group_count > 1, 'multi_group_ambiguity',
+
+            -- Multi-group ambiguity, propagated: if any publisher in this
+            -- group is multi-group, gpt_total_publisher_rx_bps is a
+            -- cross-group aggregate. Every subscriber/P+S in the group
+            -- must fall through to multi_group_ambiguity; we can't say
+            -- whether their TX matches a contaminated expected.
+            h.mode IN ('S', 'P+S') AND gpt.gpt_ambiguous_publisher_count > 0, 'multi_group_ambiguity',
 
             -- Pure publisher: just observe activity.
             h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',

--- a/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
+++ b/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
@@ -8,15 +8,19 @@
 -- the onchain expectation. This view adds:
 --
 --   1. observed_bps_5m — the 5-min max rate measured at the user's tunnel.
---      For publishers: max_in_bps (device's RX from the publisher).
---      For subscribers: max_out_bps (device's TX toward the subscriber).
+--      For publishers (P):       max_in_bps (device's RX from the publisher).
+--      For subscribers (S):      max_out_bps (device's TX toward the subscriber).
+--      For dual-role users (P+S): max_out_bps — the side reconciled.
 --
---   2. expected_bps_5m — only defined for subscribers: the sum of every
---      publisher's RX rate in the same multicast group. A subscriber's TX
---      should equal this sum.
+--   2. expected_bps_5m — only defined for the reconciled side.
+--      For S:   sum of every publisher's RX in the same multicast group.
+--      For P+S: sum of every OTHER publisher's RX in the same group
+--               (i.e., gpt_total - self.max_in_bps). Excluding self matches
+--               PIM-SM behaviour where a source does not receive its own
+--               multicast back via the tree.
+--      Tolerance: |observed - expected| <= max(5%, 1 Mbps).
 --
 --   3. rate_status — reconciled | mismatch | unknown.
---      Tolerance: |observed - expected| <= max(5%, 1 Mbps).
 --
 --   4. rate_status_reason — a more specific cause behind rate_status.
 --      Distinguishes "no_data" (monitoring gap), "idle" (registered but
@@ -30,23 +34,30 @@
 -- Strict idle handling: if any publisher in the group has no counter row
 -- in the last 15 minutes, every subscriber's rate_status collapses to
 -- unknown with reason 'monitoring_gap'. We refuse to reconcile against a
--- deflated expected. If all publishers are idle (sum = 0), subscribers go
--- unknown with reason 'group_idle'.
+-- deflated expected. If all publishers are idle (sum = 0, or for P+S the
+-- subtracted sum = 0), subscribers go unknown with reason 'group_idle'.
+--
+-- Join keys: (device_pk, user_tunnel_id, user_pk). Including user_pk
+-- defends against tunnel-ID reuse within the freshness window — without
+-- it, a tunnel reassigned from user A to user B could pull B's rate for
+-- A's row.
 --
 -- Track B1 of malbeclabs/infra#1501 (rate reconciliation).
 CREATE OR REPLACE VIEW health_multicast_user_rate
 AS
 WITH
--- Latest 5-min bucket per (device, tunnel) within the freshness window.
+-- Latest 5-min bucket per (device, tunnel, user) within the freshness window.
 recent_bucket AS (
     SELECT
         device_pk AS rb_device_pk,
         user_tunnel_id AS rb_user_tunnel_id,
+        user_pk AS rb_user_pk,
         max(bucket_ts) AS rb_bucket_ts
     FROM device_interface_rollup_5m
     WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
       AND user_tunnel_id IS NOT NULL
-    GROUP BY rb_device_pk, rb_user_tunnel_id
+      AND user_pk != ''
+    GROUP BY rb_device_pk, rb_user_tunnel_id, rb_user_pk
 ),
 user_rates AS (
     -- ur_present = 1 lets the outer LEFT JOIN distinguish "no row" (0) from
@@ -56,6 +67,7 @@ user_rates AS (
     SELECT
         r.device_pk AS ur_device_pk,
         r.user_tunnel_id AS ur_user_tunnel_id,
+        r.user_pk AS ur_user_pk,
         r.bucket_ts AS ur_bucket_ts,
         r.max_in_bps AS ur_max_in_bps,
         r.max_out_bps AS ur_max_out_bps,
@@ -64,8 +76,10 @@ user_rates AS (
     INNER JOIN recent_bucket rb
         ON r.device_pk = rb.rb_device_pk
        AND r.user_tunnel_id = rb.rb_user_tunnel_id
+       AND r.user_pk = rb.rb_user_pk
        AND r.bucket_ts = rb.rb_bucket_ts
 ),
+-- Per-publisher RX so P+S subscriber expected can subtract self's contribution.
 group_publisher_total AS (
     SELECT
         h.multicast_group_pk AS gpt_multicast_group_pk,
@@ -76,6 +90,7 @@ group_publisher_total AS (
     LEFT JOIN user_rates ur
         ON ur.ur_device_pk = h.user_device_pk
        AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
     WHERE h.mode IN ('P', 'P+S')
     GROUP BY gpt_multicast_group_pk
 ),
@@ -88,32 +103,48 @@ with_rate AS (
         if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
         multiIf(
             ur.ur_present = 0, NULL,
-            h.mode IN ('P', 'P+S'), toNullable(ur.ur_max_in_bps),
-            h.mode = 'S',          toNullable(ur.ur_max_out_bps),
+            h.mode = 'P',   toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',   toNullable(ur.ur_max_out_bps),
+            h.mode = 'P+S', toNullable(ur.ur_max_out_bps),
             NULL
         ) AS observed_bps_5m,
         multiIf(
+            -- S: expected is the full group_total (only set when no missing publishers).
             h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
                 toNullable(gpt.gpt_total_publisher_rx_bps),
+            -- P+S: expected excludes self's contribution.
+            h.mode = 'P+S' AND ur.ur_present = 1 AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps),
             NULL
         ) AS expected_bps_5m,
         multiIf(
-            h.mode IN ('P', 'P+S') AND ur.ur_present = 0, 'no_data',
-            h.mode IN ('P', 'P+S') AND ur.ur_max_in_bps > 0, 'active',
-            h.mode IN ('P', 'P+S'), 'idle',
-            h.mode = 'S' AND ur.ur_present = 0, 'no_data',
-            h.mode = 'S' AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
-            h.mode = 'S' AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
-            h.mode = 'S' AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
-                             <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+            -- Pure publisher: just observe activity.
+            h.mode = 'P' AND ur.ur_present = 0, 'no_data',
+            h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',
+            h.mode = 'P', 'idle',
+
+            -- Subscriber-side reconciliation (S and P+S).
+            h.mode IN ('S', 'P+S') AND ur.ur_present = 0, 'no_data',
+            h.mode IN ('S', 'P+S') AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+
+            -- Expected for P+S excludes self; for S it's the full group total.
+            h.mode = 'P+S' AND (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps) = 0, 'group_idle',
+            h.mode = 'S'   AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+
+            h.mode = 'P+S' AND abs(ur.ur_max_out_bps - (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps))
+                                <= greatest(0.05 * (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps), 1000000.0),
                 'reconciled',
-            h.mode = 'S', 'mismatch',
+            h.mode = 'S'   AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                                <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode IN ('S', 'P+S'), 'mismatch',
             'no_data'
         ) AS rate_status_reason
     FROM health_multicast_user h
     LEFT JOIN user_rates ur
         ON ur.ur_device_pk = h.user_device_pk
        AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
     LEFT JOIN group_publisher_total gpt
         ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
 )

--- a/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
+++ b/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
@@ -42,6 +42,20 @@
 -- it, a tunnel reassigned from user A to user B could pull B's rate for
 -- A's row.
 --
+-- Multi-group ambiguity: device_interface_rollup_5m is keyed by
+-- (device_pk, user_tunnel_id, user_pk) — it does NOT split rate by
+-- multicast group. When a single (device, tunnel, user) participates in
+-- more than one multicast group, the observed rate is a per-tunnel
+-- aggregate that cannot be cleanly attributed to any one group, so this
+-- view refuses to reconcile it: rate_status_reason becomes
+-- 'multi_group_ambiguity' and rate_status becomes 'unknown'. The
+-- 'multi_group_ambiguity' verdict only kicks in for rows whose mode
+-- requires reading the observed rate (P with active/idle distinction
+-- and S / P+S which reconcile against an expected). Pure 'idle' / 'no_data'
+-- semantics still hold even with one shared tunnel, so we don't mask them.
+-- A future schema split (per-group counters) would let this view drop the
+-- guard.
+--
 -- Track B1 of malbeclabs/infra#1501 (rate reconciliation).
 CREATE OR REPLACE VIEW health_multicast_user_rate
 AS
@@ -79,6 +93,19 @@ user_rates AS (
        AND r.user_pk = rb.rb_user_pk
        AND r.bucket_ts = rb.rb_bucket_ts
 ),
+-- Count distinct multicast groups per (device, tunnel, user). A count > 1
+-- means the rollup row's bps is shared across groups and per-group
+-- attribution is ambiguous (see view header). count() suffices because
+-- health_multicast_user holds one row per (user, group, mode).
+user_group_counts AS (
+    SELECT
+        h.user_device_pk AS ugc_device_pk,
+        h.user_tunnel_id AS ugc_user_tunnel_id,
+        h.user_pk        AS ugc_user_pk,
+        countDistinct(h.multicast_group_pk) AS ugc_group_count
+    FROM health_multicast_user h
+    GROUP BY ugc_device_pk, ugc_user_tunnel_id, ugc_user_pk
+),
 -- Per-publisher RX so P+S subscriber expected can subtract self's contribution.
 group_publisher_total AS (
     SELECT
@@ -109,6 +136,9 @@ with_rate AS (
             NULL
         ) AS observed_bps_5m,
         multiIf(
+            -- Multi-group ambiguity: there is no per-group expected for a
+            -- tunnel shared across groups.
+            ugc.ugc_group_count > 1, NULL,
             -- S: expected is the full group_total (only set when no missing publishers).
             h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
                 toNullable(gpt.gpt_total_publisher_rx_bps),
@@ -118,13 +148,23 @@ with_rate AS (
             NULL
         ) AS expected_bps_5m,
         multiIf(
+            -- no_data wins over multi_group_ambiguity: if the rollup has
+            -- nothing for this tunnel, we don't know any of it anyway.
+            ur.ur_present = 0, 'no_data',
+
+            -- Multi-group ambiguity: a single (device, tunnel, user) shared
+            -- across N>1 groups has a per-tunnel aggregate rate that can't
+            -- be cleanly attributed to any one group. Refuse to reconcile.
+            -- Exempt: pure 'idle' (max_in_bps = 0) on a publisher still
+            -- means "publishing nothing" per-group, which is correct.
+            ugc.ugc_group_count > 1 AND h.mode = 'P' AND ur.ur_max_in_bps = 0, 'idle',
+            ugc.ugc_group_count > 1, 'multi_group_ambiguity',
+
             -- Pure publisher: just observe activity.
-            h.mode = 'P' AND ur.ur_present = 0, 'no_data',
             h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',
             h.mode = 'P', 'idle',
 
             -- Subscriber-side reconciliation (S and P+S).
-            h.mode IN ('S', 'P+S') AND ur.ur_present = 0, 'no_data',
             h.mode IN ('S', 'P+S') AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
 
             -- Expected for P+S excludes self; for S it's the full group total.
@@ -145,6 +185,10 @@ with_rate AS (
         ON ur.ur_device_pk = h.user_device_pk
        AND ur.ur_user_tunnel_id = h.user_tunnel_id
        AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN user_group_counts ugc
+        ON ugc.ugc_device_pk = h.user_device_pk
+       AND ugc.ugc_user_tunnel_id = h.user_tunnel_id
+       AND ugc.ugc_user_pk = h.user_pk
     LEFT JOIN group_publisher_total gpt
         ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
 )

--- a/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
+++ b/indexer/db/clickhouse/migrations/20260604000001_health_multicast_user_rate_view.sql
@@ -1,0 +1,145 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_multicast_user_rate
+--
+-- Extends health_multicast_user with a data-plane rate dimension. The
+-- existing view verifies that the control plane (mroute state) reflects
+-- the onchain expectation. This view adds:
+--
+--   1. observed_bps_5m — the 5-min max rate measured at the user's tunnel.
+--      For publishers: max_in_bps (device's RX from the publisher).
+--      For subscribers: max_out_bps (device's TX toward the subscriber).
+--
+--   2. expected_bps_5m — only defined for subscribers: the sum of every
+--      publisher's RX rate in the same multicast group. A subscriber's TX
+--      should equal this sum.
+--
+--   3. rate_status — reconciled | mismatch | unknown.
+--      Tolerance: |observed - expected| <= max(5%, 1 Mbps).
+--
+--   4. rate_status_reason — a more specific cause behind rate_status.
+--      Distinguishes "no_data" (monitoring gap), "idle" (registered but
+--      zero traffic), "monitoring_gap" / "group_idle" (subscriber-side
+--      reasons), from "reconciled" / "mismatch" / "active".
+--
+--   5. health_status — REPLACES the CP-only verdict with the combined
+--      verdict (per the matrix). control_plane_status carries the
+--      original CP-only value so consumers can drill in.
+--
+-- Strict idle handling: if any publisher in the group has no counter row
+-- in the last 15 minutes, every subscriber's rate_status collapses to
+-- unknown with reason 'monitoring_gap'. We refuse to reconcile against a
+-- deflated expected. If all publishers are idle (sum = 0), subscribers go
+-- unknown with reason 'group_idle'.
+--
+-- Track B1 of malbeclabs/infra#1501 (rate reconciliation).
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+WITH
+-- Latest 5-min bucket per (device, tunnel) within the freshness window.
+recent_bucket AS (
+    SELECT
+        device_pk AS rb_device_pk,
+        user_tunnel_id AS rb_user_tunnel_id,
+        max(bucket_ts) AS rb_bucket_ts
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+    GROUP BY rb_device_pk, rb_user_tunnel_id
+),
+user_rates AS (
+    -- ur_present = 1 lets the outer LEFT JOIN distinguish "no row" (0) from
+    -- "row exists with rate 0" (1). ClickHouse LEFT JOIN with
+    -- non-Nullable right-hand columns returns defaults (0 / epoch) instead
+    -- of NULL, so an explicit sentinel column is needed.
+    SELECT
+        r.device_pk AS ur_device_pk,
+        r.user_tunnel_id AS ur_user_tunnel_id,
+        r.bucket_ts AS ur_bucket_ts,
+        r.max_in_bps AS ur_max_in_bps,
+        r.max_out_bps AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m r
+    INNER JOIN recent_bucket rb
+        ON r.device_pk = rb.rb_device_pk
+       AND r.user_tunnel_id = rb.rb_user_tunnel_id
+       AND r.bucket_ts = rb.rb_bucket_ts
+),
+group_publisher_total AS (
+    SELECT
+        h.multicast_group_pk AS gpt_multicast_group_pk,
+        sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
+        countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        count() AS gpt_publisher_count
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+    WHERE h.mode IN ('P', 'P+S')
+    GROUP BY gpt_multicast_group_pk
+),
+-- Inner layer: compute rate_status_reason / rate_status / control_plane_status
+-- so the outer SELECT can reference them when computing the combined verdict.
+with_rate AS (
+    SELECT
+        h.* EXCEPT (health_status),
+        h.health_status AS control_plane_status,
+        if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+        multiIf(
+            ur.ur_present = 0, NULL,
+            h.mode IN ('P', 'P+S'), toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',          toNullable(ur.ur_max_out_bps),
+            NULL
+        ) AS observed_bps_5m,
+        multiIf(
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps),
+            NULL
+        ) AS expected_bps_5m,
+        multiIf(
+            h.mode IN ('P', 'P+S') AND ur.ur_present = 0, 'no_data',
+            h.mode IN ('P', 'P+S') AND ur.ur_max_in_bps > 0, 'active',
+            h.mode IN ('P', 'P+S'), 'idle',
+            h.mode = 'S' AND ur.ur_present = 0, 'no_data',
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+            h.mode = 'S' AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+            h.mode = 'S' AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                             <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode = 'S', 'mismatch',
+            'no_data'
+        ) AS rate_status_reason
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+    LEFT JOIN group_publisher_total gpt
+        ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
+)
+SELECT
+    w.*,
+    -- Roll rate_status_reason up into the three-value rate_status.
+    if(rate_status_reason IN ('active', 'reconciled'), 'reconciled',
+        if(rate_status_reason = 'mismatch', 'mismatch', 'unknown')
+    ) AS rate_status,
+    -- Combined verdict per the matrix.
+    --                | rate=reconciled | rate=mismatch | rate=unknown
+    --  CP=healthy    | healthy         | degraded      | unknown
+    --  CP=degraded   | degraded        | unhealthy     | degraded
+    --  CP=unhealthy  | unhealthy       | unhealthy     | unhealthy
+    multiIf(
+        control_plane_status = 'unhealthy', 'unhealthy',
+        control_plane_status = 'degraded' AND rate_status_reason = 'mismatch', 'unhealthy',
+        control_plane_status = 'degraded', 'degraded',
+        control_plane_status = 'healthy' AND rate_status_reason IN ('active', 'reconciled'), 'healthy',
+        control_plane_status = 'healthy' AND rate_status_reason = 'mismatch', 'degraded',
+        control_plane_status = 'healthy', 'unknown',
+        'unknown'
+    ) AS health_status
+FROM with_rate w;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP VIEW IF EXISTS health_multicast_user_rate;

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -13,12 +13,12 @@ import (
 // subscriber reasons (reconciled / mismatch / monitoring_gap / group_idle).
 // Three groups are set up:
 //
-//   grp-rate-clean — full counter data; one active publisher, one matched
-//     subscriber, one mismatched subscriber.
-//   grp-rate-gap — publisher has no counter row in the freshness window;
-//     subscriber's rate goes to unknown via monitoring_gap.
-//   grp-rate-idle — publisher transmits zero; subscriber's rate goes to
-//     unknown via group_idle.
+//	grp-rate-clean — full counter data; one active publisher, one matched
+//	  subscriber, one mismatched subscriber.
+//	grp-rate-gap — publisher has no counter row in the freshness window;
+//	  subscriber's rate goes to unknown via monitoring_gap.
+//	grp-rate-idle — publisher transmits zero; subscriber's rate goes to
+//	  unknown via group_idle.
 //
 // The combined health_status column is verified against the rollup matrix.
 func TestHealthMulticastUserRate(t *testing.T) {
@@ -124,9 +124,9 @@ func TestHealthMulticastUserRate(t *testing.T) {
 	defer rows.Close()
 
 	type row struct {
-		userPK, mode, group              string
-		cp, rate, reason, combined       string
-		observedBps, expectedBps         *float64
+		userPK, mode, group        string
+		cp, rate, reason, combined string
+		observedBps, expectedBps   *float64
 	}
 	got := []row{}
 	for rows.Next() {
@@ -368,6 +368,6 @@ func TestHealthMulticastUserRate_TunnelReuse(t *testing.T) {
 	require.NoError(t, rows.Err())
 
 	// Each user attributed only to their own rollup row, not to each other's.
-	assert.InDelta(t, 1000000,  observed["u-A"], 1, "u-A keeps its own 1 Mbps")
+	assert.InDelta(t, 1000000, observed["u-A"], 1, "u-A keeps its own 1 Mbps")
 	assert.InDelta(t, 99000000, observed["u-B"], 1, "u-B keeps its own 99 Mbps")
 }

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -371,3 +371,97 @@ func TestHealthMulticastUserRate_TunnelReuse(t *testing.T) {
 	assert.InDelta(t, 1000000, observed["u-A"], 1, "u-A keeps its own 1 Mbps")
 	assert.InDelta(t, 99000000, observed["u-B"], 1, "u-B keeps its own 99 Mbps")
 }
+
+// TestHealthMulticastUserRate_MultiGroupAmbiguity verifies that when one
+// (device, tunnel, user) tuple subscribes to multiple multicast groups —
+// so its per-tunnel rate is a cross-group aggregate that cannot be
+// attributed per-group — every rate row for that user is marked
+// rate_status='unknown' with reason 'multi_group_ambiguity', not
+// silently reconciled or mismatched.
+func TestHealthMulticastUserRate_MultiGroupAmbiguity(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-mga-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-mga-fhr', 'activated', 'edge', 'mga-fhr-dz1', '', '', '', 0, '[]'),
+			('d-mga-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-mga-lhr', 'activated', 'edge', 'mga-lhr-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-mga-A', now(), now(), generateUUIDv4(), 0, 1, 'grp-mga-A', 'o', 'mga-A', '233.99.4.1', 100000000, 'activated', 1, 1),
+			('grp-mga-B', now(), now(), generateUUIDv4(), 0, 2, 'grp-mga-B', 'o', 'mga-B', '233.99.4.2', 100000000, 'activated', 1, 1)`))
+
+	// u-mga-sub subscribes to BOTH grp-mga-A and grp-mga-B via the same tunnel.
+	// Each group has its own publisher contributing 5 Mbps.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-mga-pub-A', now(), now(), generateUUIDv4(), 0, 1, 'u-mga-pub-A', 'o', 'activated', 'multicast', '203.0.116.1', '10.99.4.1', 'd-mga-fhr', 't1', 950, '["grp-mga-A"]', '[]'),
+			('u-mga-pub-B', now(), now(), generateUUIDv4(), 0, 2, 'u-mga-pub-B', 'o', 'activated', 'multicast', '203.0.116.2', '10.99.4.2', 'd-mga-fhr', 't1', 951, '["grp-mga-B"]', '[]'),
+			('u-mga-sub',   now(), now(), generateUUIDv4(), 0, 3, 'u-mga-sub',   'o', 'activated', 'multicast', '203.0.116.3', '10.99.4.3', 'd-mga-lhr', 't1', 952, '[]', '["grp-mga-A","grp-mga-B"]')`))
+
+	// CP healthy for both groups for the shared subscriber.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-mga-fhr-A', now(), now(), generateUUIDv4(), 0, 1, 'd-mga-fhr', 'default', 'sparse', '233.99.4.1', '10.99.4.1', 'SBNP', 0, 'Tunnel950', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-mga-fhr-B', now(), now(), generateUUIDv4(), 0, 2, 'd-mga-fhr', 'default', 'sparse', '233.99.4.2', '10.99.4.2', 'SBNP', 0, 'Tunnel951', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-mga-lhr-A', now(), now(), generateUUIDv4(), 0, 3, 'd-mga-lhr', 'default', 'sparse', '233.99.4.1', '10.99.4.1', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel952"]', 1, now()),
+			('mr-mga-lhr-B', now(), now(), generateUUIDv4(), 0, 4, 'd-mga-lhr', 'default', 'sparse', '233.99.4.2', '10.99.4.2', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel952"]', 1, now())`))
+
+	// Subscriber's tunnel reports 10 Mbps total (aggregate of both groups).
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'd-mga-fhr', 'Tunnel950', 950, 'u-mga-pub-A', 5000000, 0,        now()),
+			(now() - INTERVAL 1 MINUTE, 'd-mga-fhr', 'Tunnel951', 951, 'u-mga-pub-B', 5000000, 0,        now()),
+			(now() - INTERVAL 1 MINUTE, 'd-mga-lhr', 'Tunnel952', 952, 'u-mga-sub',   0,       10000000, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT multicast_group_pk, rate_status, rate_status_reason, expected_bps_5m
+		FROM health_multicast_user_rate
+		WHERE user_pk = 'u-mga-sub'
+		ORDER BY multicast_group_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type r struct {
+		group, rate, reason string
+		expected            *float64
+	}
+	got := []r{}
+	for rows.Next() {
+		var x r
+		require.NoError(t, rows.Scan(&x.group, &x.rate, &x.reason, &x.expected))
+		got = append(got, x)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 2, "subscriber should produce one row per group")
+
+	for _, row := range got {
+		assert.Equal(t, "unknown", row.rate, "multi-group subscriber rate must not reconcile (group=%s)", row.group)
+		assert.Equal(t, "multi_group_ambiguity", row.reason, "group=%s", row.group)
+		assert.Nil(t, row.expected, "no per-group expected when ambiguous (group=%s)", row.group)
+	}
+}

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -204,3 +204,170 @@ func TestHealthMulticastUserRate(t *testing.T) {
 	assert.InDelta(t, 0, *subIdle.expectedBps, 1)
 	assert.Equal(t, "unknown", subIdle.combined)
 }
+
+// TestHealthMulticastUserRate_PlusSubscriber covers a dual-role (P+S) user.
+// The P+S user publishes at 5 Mbps and is also a subscriber to the same
+// group; the group has one other publisher transmitting at 5 Mbps too.
+// Group total = 10 Mbps. The P+S user's expected subscriber rate excludes
+// its own contribution, so expected = 10M - 5M = 5M. Their subscriber TX
+// is 5 Mbps → reconciled.
+func TestHealthMulticastUserRate_PlusSubscriber(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-ps-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-ps-fhr', 'activated', 'edge', 'ps-fhr-dz1', '', '', '', 0, '[]'),
+			('d-ps-mid', now(), now(), generateUUIDv4(), 0, 2, 'd-ps-mid', 'activated', 'edge', 'ps-mid-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-ps', now(), now(), generateUUIDv4(), 0, 1, 'grp-ps', 'o', 'rate-ps', '233.99.2.1', 100000000, 'activated', 2, 1)`))
+
+	// u-ps is publisher + subscriber; u-pub-other contributes the other half.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-ps',        now(), now(), generateUUIDv4(), 0, 1, 'u-ps',        'o', 'activated', 'multicast', '203.0.114.1', '10.99.2.1', 'd-ps-mid', 't1', 901, '["grp-ps"]', '["grp-ps"]'),
+			('u-pub-other', now(), now(), generateUUIDv4(), 0, 2, 'u-pub-other', 'o', 'activated', 'multicast', '203.0.114.2', '10.99.2.2', 'd-ps-fhr', 't1', 902, '["grp-ps"]', '[]')`))
+
+	// CP healthy: mroute on u-ps's device shows their tunnel both as RPF (publisher)
+	// and in OIF (subscriber); u-pub-other's device shows their RPF.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			-- u-ps is both publisher and subscriber on d-ps-mid: RPF=Tunnel901 (pub),
+			-- and OIF contains Tunnel901 reflecting OTHER publisher's traffic to it.
+			('mr-ps-pub',   now(), now(), generateUUIDv4(), 0, 1, 'd-ps-mid', 'default', 'sparse', '233.99.2.1', '10.99.2.1', 'SBNP', 0, 'Tunnel901',     '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-ps-sub',   now(), now(), generateUUIDv4(), 0, 2, 'd-ps-mid', 'default', 'sparse', '233.99.2.1', '10.99.2.2', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel901"]', 1, now()),
+			('mr-other-pub',now(), now(), generateUUIDv4(), 0, 3, 'd-ps-fhr', 'default', 'sparse', '233.99.2.1', '10.99.2.2', 'SBNP', 0, 'Tunnel902',     '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// Counter rows: u-ps publishing at 5 Mbps (max_in) AND receiving 5 Mbps (max_out, == other publisher's RX).
+	// u-pub-other publishing at 5 Mbps.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'd-ps-mid', 'Tunnel901', 901, 'u-ps',        5000000, 5000000, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-ps-fhr', 'Tunnel902', 902, 'u-pub-other', 5000000, 0,       now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT user_pk, mode, rate_status, rate_status_reason, observed_bps_5m, expected_bps_5m
+		FROM health_multicast_user_rate
+		WHERE multicast_group_pk = 'grp-ps' AND user_pk = 'u-ps'`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	require.True(t, rows.Next(), "expected one row for u-ps")
+	var userPK, mode, rate, reason string
+	var observed, expected *float64
+	require.NoError(t, rows.Scan(&userPK, &mode, &rate, &reason, &observed, &expected))
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, "P+S", mode)
+	assert.Equal(t, "reconciled", reason, "P+S subscriber side reconciles against group_total minus self")
+	assert.Equal(t, "reconciled", rate)
+	require.NotNil(t, observed)
+	require.NotNil(t, expected)
+	// Observed = max_out_bps = 5 Mbps; expected = group_total (10M) - self.max_in_bps (5M) = 5M.
+	assert.InDelta(t, 5000000, *observed, 1)
+	assert.InDelta(t, 5000000, *expected, 1)
+}
+
+// TestHealthMulticastUserRate_TunnelReuse verifies the user_pk component
+// of the join prevents misattribution when the same tunnel ID is bound to
+// two different user_pks on the same device within the freshness window
+// (e.g. a tunnel reassigned mid-bucket).
+func TestHealthMulticastUserRate_TunnelReuse(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES ('d-reuse', now(), now(), generateUUIDv4(), 0, 1, 'd-reuse', 'activated', 'edge', 'reuse-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-reuse', now(), now(), generateUUIDv4(), 0, 1, 'grp-reuse', 'o', 'reuse', '233.99.3.1', 100000000, 'activated', 2, 0)`))
+
+	// Two publisher users on the SAME device with the SAME tunnel id (777)
+	// but different user_pks.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-A', now(), now(), generateUUIDv4(), 0, 1, 'u-A', 'o', 'activated', 'multicast', '203.0.115.1', '10.99.3.1', 'd-reuse', 't1', 777, '["grp-reuse"]', '[]'),
+			('u-B', now(), now(), generateUUIDv4(), 0, 2, 'u-B', 'o', 'activated', 'multicast', '203.0.115.2', '10.99.3.2', 'd-reuse', 't1', 777, '["grp-reuse"]', '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-reuse-A', now(), now(), generateUUIDv4(), 0, 1, 'd-reuse', 'default', 'sparse', '233.99.3.1', '10.99.3.1', 'SBNP', 0, 'Tunnel777', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-reuse-B', now(), now(), generateUUIDv4(), 0, 2, 'd-reuse', 'default', 'sparse', '233.99.3.1', '10.99.3.2', 'SBNP', 0, 'Tunnel777', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// Two rollup rows in the same window: tunnel 777 bound to u-A at 1 Mbps,
+	// then to u-B at 99 Mbps. Without user_pk in the join, the same row
+	// would be picked for both users.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 2 MINUTE, 'd-reuse', 'Tunnel777', 777, 'u-A',  1000000, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-reuse', 'Tunnel777', 777, 'u-B', 99000000, 0, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT user_pk, observed_bps_5m
+		FROM health_multicast_user_rate
+		WHERE multicast_group_pk = 'grp-reuse'
+		ORDER BY user_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	observed := map[string]float64{}
+	for rows.Next() {
+		var pk string
+		var bps *float64
+		require.NoError(t, rows.Scan(&pk, &bps))
+		require.NotNil(t, bps, "user %s should have a rate row", pk)
+		observed[pk] = *bps
+	}
+	require.NoError(t, rows.Err())
+
+	// Each user attributed only to their own rollup row, not to each other's.
+	assert.InDelta(t, 1000000,  observed["u-A"], 1, "u-A keeps its own 1 Mbps")
+	assert.InDelta(t, 99000000, observed["u-B"], 1, "u-B keeps its own 99 Mbps")
+}

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -465,3 +465,85 @@ func TestHealthMulticastUserRate_MultiGroupAmbiguity(t *testing.T) {
 		assert.Nil(t, row.expected, "no per-group expected when ambiguous (group=%s)", row.group)
 	}
 }
+
+// TestHealthMulticastUserRate_AmbiguousPublisherPropagates verifies that
+// when a multicast group's publisher is multi-group (its per-tunnel RX is
+// a cross-group aggregate), the contamination propagates to every
+// subscriber in that group — even subscribers whose own tunnels are
+// single-group — since gpt_total_publisher_rx_bps cannot be cleanly
+// derived for that group's expected.
+func TestHealthMulticastUserRate_AmbiguousPublisherPropagates(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-ap-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-ap-fhr', 'activated', 'edge', 'ap-fhr-dz1', '', '', '', 0, '[]'),
+			('d-ap-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-ap-lhr', 'activated', 'edge', 'ap-lhr-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-ap-X', now(), now(), generateUUIDv4(), 0, 1, 'grp-ap-X', 'o', 'ap-X', '233.99.5.1', 100000000, 'activated', 1, 1),
+			('grp-ap-Y', now(), now(), generateUUIDv4(), 0, 2, 'grp-ap-Y', 'o', 'ap-Y', '233.99.5.2', 100000000, 'activated', 1, 0)`))
+
+	// u-ap-pub publishes to BOTH grp-ap-X and grp-ap-Y over the same tunnel
+	// — its RX is a cross-group aggregate. u-ap-sub is a single-group
+	// subscriber on grp-ap-X only.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-ap-pub', now(), now(), generateUUIDv4(), 0, 1, 'u-ap-pub', 'o', 'activated', 'multicast', '203.0.117.1', '10.99.5.1', 'd-ap-fhr', 't1', 960, '["grp-ap-X","grp-ap-Y"]', '[]'),
+			('u-ap-sub', now(), now(), generateUUIDv4(), 0, 2, 'u-ap-sub', 'o', 'activated', 'multicast', '203.0.117.2', '10.99.5.2', 'd-ap-lhr', 't1', 961, '[]', '["grp-ap-X"]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-ap-fhr-X', now(), now(), generateUUIDv4(), 0, 1, 'd-ap-fhr', 'default', 'sparse', '233.99.5.1', '10.99.5.1', 'SBNP', 0, 'Tunnel960', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-ap-fhr-Y', now(), now(), generateUUIDv4(), 0, 2, 'd-ap-fhr', 'default', 'sparse', '233.99.5.2', '10.99.5.1', 'SBNP', 0, 'Tunnel960', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-ap-lhr-X', now(), now(), generateUUIDv4(), 0, 3, 'd-ap-lhr', 'default', 'sparse', '233.99.5.1', '10.99.5.1', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel961"]', 1, now())`))
+
+	// Publisher's tunnel reports 10 Mbps (aggregate of X+Y).
+	// Single-group subscriber tunnel reports 5 Mbps.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'd-ap-fhr', 'Tunnel960', 960, 'u-ap-pub', 10000000, 0,       now()),
+			(now() - INTERVAL 1 MINUTE, 'd-ap-lhr', 'Tunnel961', 961, 'u-ap-sub', 0,        5000000, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows2, err := conn.Query(ctx, `
+		SELECT rate_status, rate_status_reason, expected_bps_5m
+		FROM health_multicast_user_rate
+		WHERE user_pk = 'u-ap-sub' AND multicast_group_pk = 'grp-ap-X'`)
+	require.NoError(t, err)
+	defer rows2.Close()
+	require.True(t, rows2.Next(), "expected one row for u-ap-sub on grp-ap-X")
+
+	var rate, reason string
+	var expected *float64
+	require.NoError(t, rows2.Scan(&rate, &reason, &expected))
+	require.NoError(t, rows2.Err())
+	assert.Equal(t, "unknown", rate,
+		"single-group subscriber must not reconcile when group's publisher is multi-group")
+	assert.Equal(t, "multi_group_ambiguity", reason)
+	assert.Nil(t, expected, "expected must be NULL — gpt_total is contaminated")
+}

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -1,0 +1,206 @@
+package mroute
+
+import (
+	"testing"
+
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthMulticastUserRate exercises the rate-reconciliation view across
+// the three publisher rate states (active / idle / no_data) and the four
+// subscriber reasons (reconciled / mismatch / monitoring_gap / group_idle).
+// Three groups are set up:
+//
+//   grp-rate-clean — full counter data; one active publisher, one matched
+//     subscriber, one mismatched subscriber.
+//   grp-rate-gap — publisher has no counter row in the freshness window;
+//     subscriber's rate goes to unknown via monitoring_gap.
+//   grp-rate-idle — publisher transmits zero; subscriber's rate goes to
+//     unknown via group_idle.
+//
+// The combined health_status column is verified against the rollup matrix.
+func TestHealthMulticastUserRate(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	// Devices
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-fhr', 'activated', 'edge', 'fhr-dz1', '', '', '', 0, '[]'),
+			('d-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-lhr', 'activated', 'edge', 'lhr-dz1', '', '', '', 0, '[]')`))
+
+	// Groups
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES
+			('grp-rate-clean', now(), now(), generateUUIDv4(), 0, 1, 'grp-rate-clean', 'o', 'rate-clean', '233.99.1.1', 100000000, 'activated', 1, 2),
+			('grp-rate-gap',   now(), now(), generateUUIDv4(), 0, 2, 'grp-rate-gap',   'o', 'rate-gap',   '233.99.1.2', 100000000, 'activated', 1, 1),
+			('grp-rate-idle',  now(), now(), generateUUIDv4(), 0, 3, 'grp-rate-idle',  'o', 'rate-idle',  '233.99.1.3', 100000000, 'activated', 1, 1)`))
+
+	// Users
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			-- grp-rate-clean: one active publisher at 10 Mbps, two subscribers (one matched, one mismatched).
+			('u-pub-active', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-active', 'o', 'activated', 'multicast', '203.0.113.10', '10.99.1.10', 'd-fhr', 't1', 701, '["grp-rate-clean"]', '[]'),
+			('u-sub-recon',  now(), now(), generateUUIDv4(), 0, 2, 'u-sub-recon',  'o', 'activated', 'multicast', '203.0.113.11', '10.99.1.11', 'd-lhr', 't1', 801, '[]', '["grp-rate-clean"]'),
+			('u-sub-mis',    now(), now(), generateUUIDv4(), 0, 3, 'u-sub-mis',    'o', 'activated', 'multicast', '203.0.113.12', '10.99.1.12', 'd-lhr', 't1', 802, '[]', '["grp-rate-clean"]'),
+			-- grp-rate-gap: publisher will have no counter row.
+			('u-pub-nodata', now(), now(), generateUUIDv4(), 0, 4, 'u-pub-nodata', 'o', 'activated', 'multicast', '203.0.113.13', '10.99.1.13', 'd-fhr', 't1', 702, '["grp-rate-gap"]', '[]'),
+			('u-sub-gap',    now(), now(), generateUUIDv4(), 0, 5, 'u-sub-gap',    'o', 'activated', 'multicast', '203.0.113.14', '10.99.1.14', 'd-lhr', 't1', 803, '[]', '["grp-rate-gap"]'),
+			-- grp-rate-idle: publisher has counter row with 0 bps.
+			('u-pub-idle',   now(), now(), generateUUIDv4(), 0, 6, 'u-pub-idle',   'o', 'activated', 'multicast', '203.0.113.15', '10.99.1.15', 'd-fhr', 't1', 703, '["grp-rate-idle"]', '[]'),
+			('u-sub-idle',   now(), now(), generateUUIDv4(), 0, 7, 'u-sub-idle',   'o', 'activated', 'multicast', '203.0.113.16', '10.99.1.16', 'd-lhr', 't1', 804, '[]', '["grp-rate-idle"]')`))
+
+	// Mroute entries — control plane is healthy for every (user, group) pair below.
+	// FHR mroutes — publisher tunnel as RPF interface.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-fhr-clean', now(), now(), generateUUIDv4(), 0, 1, 'd-fhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SBNP', 0, 'Tunnel701', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-fhr-gap',   now(), now(), generateUUIDv4(), 0, 2, 'd-fhr', 'default', 'sparse', '233.99.1.2', '10.99.1.13', 'SBNP', 0, 'Tunnel702', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-fhr-idle',  now(), now(), generateUUIDv4(), 0, 3, 'd-fhr', 'default', 'sparse', '233.99.1.3', '10.99.1.15', 'SBNP', 0, 'Tunnel703', '', '', 0, 0, '', 0, 0, '', 0, now())`))
+
+	// LHR mroutes — subscriber tunnel in OIF list.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-lhr-recon', now(), now(), generateUUIDv4(), 0, 1, 'd-lhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel801"]', 1, now()),
+			('mr-lhr-mis',   now(), now(), generateUUIDv4(), 0, 2, 'd-lhr', 'default', 'sparse', '233.99.1.1', '10.99.1.10', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel802"]', 1, now()),
+			('mr-lhr-gap',   now(), now(), generateUUIDv4(), 0, 3, 'd-lhr', 'default', 'sparse', '233.99.1.2', '10.99.1.13', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel803"]', 1, now()),
+			('mr-lhr-idle',  now(), now(), generateUUIDv4(), 0, 4, 'd-lhr', 'default', 'sparse', '233.99.1.3', '10.99.1.15', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel804"]', 1, now())`))
+
+	// Counter rollup rows. NOTE: u-pub-nodata / Tunnel702 deliberately omitted.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			-- grp-rate-clean: publisher RX = 10 Mbps; matched subscriber TX = 10 Mbps; mismatched subscriber TX = 50 Mbps.
+			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel701', 701, 'u-pub-active', 10000000, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel801', 801, 'u-sub-recon',  0, 10000000, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel802', 802, 'u-sub-mis',    0, 50000000, now()),
+			-- grp-rate-gap: subscriber has data; publisher does not.
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel803', 803, 'u-sub-gap',    0, 5000000,  now()),
+			-- grp-rate-idle: publisher and subscriber both report 0 bps.
+			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel703', 703, 'u-pub-idle',   0, 0, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel804', 804, 'u-sub-idle',   0, 0, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	rows, err := conn.Query(ctx, `
+		SELECT
+			user_pk, mode, multicast_group_pk,
+			control_plane_status,
+			rate_status, rate_status_reason,
+			observed_bps_5m, expected_bps_5m,
+			health_status
+		FROM health_multicast_user_rate
+		WHERE multicast_group_pk LIKE 'grp-rate-%'
+		ORDER BY multicast_group_pk, user_pk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		userPK, mode, group              string
+		cp, rate, reason, combined       string
+		observedBps, expectedBps         *float64
+	}
+	got := []row{}
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(
+			&r.userPK, &r.mode, &r.group,
+			&r.cp, &r.rate, &r.reason,
+			&r.observedBps, &r.expectedBps,
+			&r.combined,
+		))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+
+	byKey := map[string]row{}
+	for _, r := range got {
+		byKey[r.userPK] = r
+	}
+
+	// grp-rate-clean: u-pub-active is transmitting → active → reconciled.
+	pub := byKey["u-pub-active"]
+	assert.Equal(t, "healthy", pub.cp, "publisher CP healthy")
+	assert.Equal(t, "active", pub.reason)
+	assert.Equal(t, "reconciled", pub.rate)
+	require.NotNil(t, pub.observedBps)
+	assert.InDelta(t, 10000000, *pub.observedBps, 1)
+	assert.Equal(t, "healthy", pub.combined)
+
+	// u-sub-recon: 10 Mbps matches sum-of-publishers = 10 Mbps → reconciled.
+	subR := byKey["u-sub-recon"]
+	assert.Equal(t, "reconciled", subR.rate)
+	assert.Equal(t, "reconciled", subR.reason)
+	require.NotNil(t, subR.observedBps)
+	require.NotNil(t, subR.expectedBps)
+	assert.InDelta(t, 10000000, *subR.observedBps, 1)
+	assert.InDelta(t, 10000000, *subR.expectedBps, 1)
+	assert.Equal(t, "healthy", subR.combined)
+
+	// u-sub-mis: 50 Mbps vs expected 10 Mbps → mismatch.
+	subM := byKey["u-sub-mis"]
+	assert.Equal(t, "mismatch", subM.rate)
+	assert.Equal(t, "mismatch", subM.reason)
+	require.NotNil(t, subM.observedBps)
+	assert.InDelta(t, 50000000, *subM.observedBps, 1)
+	// CP healthy + rate mismatch → combined degraded.
+	assert.Equal(t, "degraded", subM.combined)
+
+	// grp-rate-gap: publisher has no rate row.
+	pubNoData := byKey["u-pub-nodata"]
+	assert.Equal(t, "no_data", pubNoData.reason)
+	assert.Equal(t, "unknown", pubNoData.rate)
+	assert.Nil(t, pubNoData.observedBps, "no observed rate when no counter row")
+	assert.Equal(t, "unknown", pubNoData.combined)
+
+	// u-sub-gap: subscriber has data but expected is NULL (one+ publisher no_data) → monitoring_gap.
+	subGap := byKey["u-sub-gap"]
+	assert.Equal(t, "monitoring_gap", subGap.reason)
+	assert.Equal(t, "unknown", subGap.rate)
+	assert.Nil(t, subGap.expectedBps, "expected NULL when group has no_data publishers")
+	assert.Equal(t, "unknown", subGap.combined)
+
+	// grp-rate-idle: publisher RX = 0 → idle.
+	pubIdle := byKey["u-pub-idle"]
+	assert.Equal(t, "idle", pubIdle.reason)
+	assert.Equal(t, "unknown", pubIdle.rate)
+	require.NotNil(t, pubIdle.observedBps)
+	assert.InDelta(t, 0, *pubIdle.observedBps, 1)
+	assert.Equal(t, "unknown", pubIdle.combined)
+
+	// u-sub-idle: expected = 0 (publisher present but transmitting 0) → group_idle.
+	subIdle := byKey["u-sub-idle"]
+	assert.Equal(t, "group_idle", subIdle.reason)
+	assert.Equal(t, "unknown", subIdle.rate)
+	require.NotNil(t, subIdle.expectedBps)
+	assert.InDelta(t, 0, *subIdle.expectedBps, 1)
+	assert.Equal(t, "unknown", subIdle.combined)
+}

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -1848,35 +1848,40 @@ export function MulticastGroupDetailPage() {
           </div>
         </div>
 
-        {/* Members filter + tabs */}
-        <div className="flex items-center gap-2 mb-3">
-          <InlineFilter
-            fieldPrefixes={memberFieldPrefixes}
-            entity="multicast-members"
-            autocompleteFields={memberAutocompleteFields}
-            placeholder="Filter members..."
-            onLiveFilterChange={setLiveFilter}
-            filterParams={pk ? { group: pk } : undefined}
-          />
-          {searchFilters.map((filter, idx) => (
-            <button
-              key={`${filter}-${idx}`}
-              onClick={() => removeFilter(filter)}
-              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
-            >
-              {filter}
-              <X className="h-3 w-3" />
-            </button>
-          ))}
-          {searchFilters.length > 1 && (
-            <button
-              onClick={clearAllFilters}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Clear all
-            </button>
-          )}
-        </div>
+        {/* Members filter + tabs. The Health tab is a reconciliation view
+            that always reports across the full group, so the member filter
+            bar would only mislead operators into thinking it scopes the
+            health queries (it doesn't). Hide it while Health is active. */}
+        {activeTab !== 'health' && (
+          <div className="flex items-center gap-2 mb-3">
+            <InlineFilter
+              fieldPrefixes={memberFieldPrefixes}
+              entity="multicast-members"
+              autocompleteFields={memberAutocompleteFields}
+              placeholder="Filter members..."
+              onLiveFilterChange={setLiveFilter}
+              filterParams={pk ? { group: pk } : undefined}
+            />
+            {searchFilters.map((filter, idx) => (
+              <button
+                key={`${filter}-${idx}`}
+                onClick={() => removeFilter(filter)}
+                className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
+              >
+                {filter}
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+            {searchFilters.length > 1 && (
+              <button
+                onClick={clearAllFilters}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Members table */}
         <div className="border border-border rounded-lg bg-card mb-6">

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -31,6 +31,7 @@ import { useChartLegend } from '@/hooks/use-chart-legend'
 import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import { InlineFilter } from '@/components/inline-filter'
 import { Pagination } from '@/components/pagination'
+import { MulticastGroupHealthTab } from '@/components/multicast-group-health-tab'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -1481,9 +1482,14 @@ export function MulticastGroupDetailPage() {
   const navigate = useNavigate()
   const back = useBackLink({ to: '/dz/multicast-groups', label: 'multicast groups' })
   const [searchParams, setSearchParams] = useSearchParams()
-  const activeTab = (searchParams.get('tab') === 'subscribers' ? 'subscribers' : 'publishers') as
-    | 'publishers'
-    | 'subscribers'
+  const tabParam = searchParams.get('tab')
+  const activeTab = (
+    tabParam === 'subscribers'
+      ? 'subscribers'
+      : tabParam === 'health'
+        ? 'health'
+        : 'publishers'
+  ) as 'publishers' | 'subscribers' | 'health'
   const sortField = (searchParams.get('sort') || 'stake_sol') as MemberSortField
   const sortDirection = (searchParams.get('dir') || 'desc') as SortDirection
   const page = parseInt(searchParams.get('page') || '1')
@@ -1495,7 +1501,7 @@ export function MulticastGroupDetailPage() {
   const [selectedSeriesKeys, setSelectedSeriesKeys] = useState<Set<string>>(new Set())
 
   const setActiveTab = useCallback(
-    (tab: 'publishers' | 'subscribers') => {
+    (tab: 'publishers' | 'subscribers' | 'health') => {
       setSearchParams((prev) => {
         const p = new URLSearchParams(prev)
         if (tab === 'publishers') {
@@ -1895,12 +1901,27 @@ export function MulticastGroupDetailPage() {
             >
               Subscribers ({subscriberCount})
             </button>
-            {membersFetching && (
+            <button
+              onClick={() => setActiveTab('health')}
+              className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                activeTab === 'health'
+                  ? 'border-purple-500 text-purple-500'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Health
+            </button>
+            {membersFetching && activeTab !== 'health' && (
               <div className="flex items-center ml-2">
                 <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
               </div>
             )}
           </div>
+          {activeTab === 'health' && pk && (
+            <MulticastGroupHealthTab groupPkOrCode={pk} />
+          )}
+          {activeTab !== 'health' && (
+          <>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
@@ -2045,8 +2066,11 @@ export function MulticastGroupDetailPage() {
               onPageSizeChange={setPageSize}
             />
           )}
+          </>
+          )}
         </div>
 
+        {activeTab !== 'health' && (
         <div className="space-y-6">
           {/* Shred stats chart — only for groups with shred stats */}
           {pk &&
@@ -2067,7 +2091,7 @@ export function MulticastGroupDetailPage() {
             <MulticastTrafficChart
               groupCode={pk}
               members={group.members}
-              activeTab={activeTab}
+              activeTab={activeTab === 'subscribers' ? 'subscribers' : 'publishers'}
               onHoverMember={setHoveredSeriesKey}
               onSelectMember={setSelectedSeriesKeys}
             />
@@ -2076,6 +2100,7 @@ export function MulticastGroupDetailPage() {
           {/* Member count chart */}
           {pk && <MemberCountChart groupCode={pk} />}
         </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -501,7 +501,33 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     )}
                   </td>
                   <td className="px-4 py-3 text-sm">
-                    <HealthBadge status={p.health_status} />
+                    {p.missing_endpoint_reasons && p.missing_endpoint_reasons.length > 0 ? (
+                      <Tooltip
+                        content={
+                          <div className="space-y-1 min-w-[220px]">
+                            <div className="text-xs font-medium">Missing endpoints</div>
+                            <ul className="space-y-0.5 text-xs">
+                              {p.missing_endpoint_reasons.map((r) => (
+                                <li key={r} className="text-muted-foreground">
+                                  • {r}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        }
+                        delayDuration={120}
+                      >
+                        <span
+                          tabIndex={0}
+                          aria-label={`Status ${p.health_status}: ${p.missing_endpoint_reasons.join(', ')}`}
+                          className="inline-flex items-center cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
+                        >
+                          <HealthBadge status={p.health_status} />
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      <HealthBadge status={p.health_status} />
+                    )}
                   </td>
                   <td className="px-4 py-3 text-xs text-muted-foreground">
                     {p.verification_method === 'endpoints_only' ? 'endpoints only' : p.verification_method}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -36,6 +36,7 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
   mismatch: 'TX deviates from sum of publishers',
   monitoring_gap: 'a publisher in this group has no counter data',
   group_idle: 'all publishers transmitting 0 — nothing to verify against',
+  multi_group_ambiguity: "tunnel shared across multiple multicast groups — per-group rate can't be attributed",
 }
 
 const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
@@ -66,7 +67,8 @@ const SECTION_HELP = {
     'Each row pairs one onchain user with the mroute and 5-min rate observed at their device. ' +
     'Publishers expect their Tunnel<N> as the IIF of (S,G) and to be transmitting; ' +
     'subscribers expect their Tunnel<N> in the OIF list and to receive at the same rate publishers send. ' +
-    'A user in P+S mode contributes two rows.',
+    'A user in P+S mode contributes one row (mode = "P+S") that reconciles subscriber-side ' +
+    'against (sum of publishers − self).',
   paths:
     'Each row is a (publisher, subscriber) pair belonging to the group. ' +
     'Endpoints-only verification: both endpoints must be reconciled. ' +
@@ -102,7 +104,6 @@ function RateCell({ item }: { item: MulticastHealthUserItem }) {
     <Tooltip content={tooltip}>
       <span
         tabIndex={0}
-        role="button"
         aria-label={`Rate ${item.rate_status}: ${item.rate_status_reason}`}
         className="inline-flex items-center gap-1.5 cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
       >
@@ -136,6 +137,7 @@ const DIM_BADGE_CLASS: Record<string, string> = {
   no_data: 'bg-muted text-muted-foreground',
   monitoring_gap: 'bg-muted text-muted-foreground',
   group_idle: 'bg-muted text-muted-foreground',
+  multi_group_ambiguity: 'bg-muted text-muted-foreground',
 }
 
 function DimBadge({ value }: { value: string }) {
@@ -175,7 +177,6 @@ function UserCombinedHealthBadge({ item }: { item: MulticastHealthUserItem }) {
     <Tooltip content={tooltip} delayDuration={120}>
       <span
         tabIndex={0}
-        role="button"
         aria-label={`Combined health ${item.health_status}: CP ${item.control_plane_status}, Rate ${item.rate_status}`}
         className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${cls}`}
       >
@@ -291,21 +292,21 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
     queryKey: ['multicast-group-health-summary', groupPkOrCode],
     queryFn: () => fetchMulticastGroupHealth(groupPkOrCode),
     enabled: !!groupPkOrCode,
-    refetchInterval: 30_000,
+    refetchInterval: 60_000,
   })
 
   const usersQuery = useQuery({
     queryKey: ['multicast-group-health-users', groupPkOrCode],
     queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode),
     enabled: !!groupPkOrCode,
-    refetchInterval: 30_000,
+    refetchInterval: 60_000,
   })
 
   const pathsQuery = useQuery({
     queryKey: ['multicast-group-health-paths', groupPkOrCode],
     queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode),
     enabled: !!groupPkOrCode,
-    refetchInterval: 30_000,
+    refetchInterval: 60_000,
   })
 
   if (summaryQuery.isLoading) {

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -8,7 +8,35 @@ import {
   fetchMulticastGroupHealthPaths,
   type MulticastHealthStatus,
   type MulticastHealthStatusCounts,
+  type MulticastHealthUserItem,
+  type MulticastRateStatus,
+  type MulticastRateStatusReason,
 } from '@/lib/api'
+
+function formatBps(bps?: number): string {
+  if (bps === undefined || bps === null) return '—'
+  if (bps === 0) return '0'
+  if (bps >= 1e9) return `${(bps / 1e9).toFixed(2)} Gbps`
+  if (bps >= 1e6) return `${(bps / 1e6).toFixed(2)} Mbps`
+  if (bps >= 1e3) return `${(bps / 1e3).toFixed(2)} Kbps`
+  return `${bps.toFixed(0)} bps`
+}
+
+const RATE_STATUS_BADGE: Record<MulticastRateStatus, string> = {
+  reconciled: 'bg-emerald-500/15 text-emerald-500',
+  mismatch: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+}
+
+const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
+  active: 'transmitting',
+  idle: 'idle (registered, transmitting 0)',
+  no_data: 'no counter data in 15 min',
+  reconciled: 'TX matches sum of publishers',
+  mismatch: 'TX deviates from sum of publishers',
+  monitoring_gap: 'a publisher in this group has no counter data',
+  group_idle: 'all publishers transmitting 0 — nothing to verify against',
+}
 
 const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',
@@ -25,18 +53,19 @@ const STATUS_DOT: Record<MulticastHealthStatus, string> = {
 }
 
 const STATUS_DEFINITIONS: Array<{ status: MulticastHealthStatus; short: string }> = [
-  { status: 'healthy', short: '(S,G) present, SPT bit set, expected tunnel in IIF/OIF' },
-  { status: 'degraded', short: '(S,G) present but flags or tunnel position wrong' },
-  { status: 'unhealthy', short: 'no (S,G) — only (*,G), or expected tunnel missing' },
-  { status: 'unknown', short: 'state-collect has not reported for this device yet' },
+  { status: 'healthy', short: 'control plane reconciles AND subscriber TX matches sum of publishers (±5% / 1 Mbps)' },
+  { status: 'degraded', short: 'control plane reconciles but rates diverge, or partial control plane reconciliation' },
+  { status: 'unhealthy', short: 'no (S,G) mroute, or rates diverge under a degraded control plane' },
+  { status: 'unknown', short: 'no counter data, or no traffic flowing in the 5-min window' },
 ]
 
 const SECTION_HELP = {
   summary:
-    'Per-status totals across three view granularities. A row is rolled up into "healthy" only if reconciliation passes on every dimension.',
+    'Per-status totals across three view granularities. The combined verdict requires control-plane reconciliation (mroute matches onchain) AND data-plane reconciliation (subscriber TX matches sum of publishers within tolerance).',
   users:
-    'Each row pairs one onchain user with the mroute observed at their device. ' +
-    'Publishers expect their Tunnel<N> as the IIF of (S,G); subscribers expect their Tunnel<N> in the OIF list. ' +
+    'Each row pairs one onchain user with the mroute and 5-min rate observed at their device. ' +
+    'Publishers expect their Tunnel<N> as the IIF of (S,G) and to be transmitting; ' +
+    'subscribers expect their Tunnel<N> in the OIF list and to receive at the same rate publishers send. ' +
     'A user in P+S mode contributes two rows.',
   paths:
     'Each row is a (publisher, subscriber) pair belonging to the group. ' +
@@ -51,6 +80,41 @@ function HealthBadge({ status }: { status: MulticastHealthStatus }) {
       {status}
     </span>
   )
+}
+
+function RateCell({ item }: { item: MulticastHealthUserItem }) {
+  const cls = RATE_STATUS_BADGE[item.rate_status] ?? RATE_STATUS_BADGE.unknown
+  const tooltip = (
+    <div className="space-y-1">
+      <div>
+        <span className="font-medium">{item.rate_status_reason}</span> — {RATE_REASON_HUMAN[item.rate_status_reason] ?? ''}
+      </div>
+      <div className="text-muted-foreground">Observed: {formatBps(item.observed_bps_5m)}</div>
+      {item.expected_bps_5m !== undefined && item.expected_bps_5m !== null && (
+        <div className="text-muted-foreground">Expected: {formatBps(item.expected_bps_5m)} (sum of publishers' RX)</div>
+      )}
+      {item.rate_bucket_ts && (
+        <div className="text-muted-foreground">5-min bucket: {new Date(item.rate_bucket_ts).toLocaleTimeString()}</div>
+      )}
+    </div>
+  )
+  return (
+    <Tooltip content={tooltip}>
+      <span className="inline-flex items-center gap-1.5 cursor-help">
+        <span className="tabular-nums font-mono text-xs">{formatBps(item.observed_bps_5m)}</span>
+        <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
+          {item.rate_status}
+        </span>
+      </span>
+    </Tooltip>
+  )
+}
+
+function rowReason(item: MulticastHealthUserItem): string {
+  if (item.mismatch_reason) return item.mismatch_reason
+  // No CP reason → surface the rate reason (or nothing if rate is healthy/active/reconciled).
+  if (['active', 'reconciled'].includes(item.rate_status_reason)) return '—'
+  return RATE_REASON_HUMAN[item.rate_status_reason] ?? '—'
 }
 
 function HelpIcon({ content }: { content: string }) {
@@ -184,19 +248,20 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                 <th className="px-4 py-3 font-medium">Mode</th>
                 <th className="px-4 py-3 font-medium">Device</th>
                 <th className="px-4 py-3 font-medium text-right">Tunnel</th>
+                <th className="px-4 py-3 font-medium">Rate (5m)</th>
                 <th className="px-4 py-3 font-medium">Status</th>
                 <th className="px-4 py-3 font-medium">Reason</th>
               </tr>
             </thead>
             <tbody>
-              {usersQuery.data?.items.length === 0 && (
+              {(usersQuery.data?.items ?? []).length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                  <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
                     No multicast users
                   </td>
                 </tr>
               )}
-              {usersQuery.data?.items.map((u) => (
+              {(usersQuery.data?.items ?? []).map((u) => (
                 <tr key={`${u.user_pk}-${u.mode}`} className="border-b border-border last:border-b-0 hover:bg-muted">
                   <td className="px-4 py-3 text-sm">
                     <Link
@@ -227,9 +292,12 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     {u.user_tunnel_id > 0 ? u.user_tunnel_id : '—'}
                   </td>
                   <td className="px-4 py-3 text-sm">
+                    <RateCell item={u} />
+                  </td>
+                  <td className="px-4 py-3 text-sm">
                     <HealthBadge status={u.health_status} />
                   </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">{u.mismatch_reason || '—'}</td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{rowReason(u)}</td>
                 </tr>
               ))}
             </tbody>
@@ -259,14 +327,14 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
               </tr>
             </thead>
             <tbody>
-              {pathsQuery.data?.items.length === 0 && (
+              {(pathsQuery.data?.items ?? []).length === 0 && (
                 <tr>
                   <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
                     No (publisher, subscriber) pairs
                   </td>
                 </tr>
               )}
-              {pathsQuery.data?.items.map((p) => (
+              {(pathsQuery.data?.items ?? []).map((p) => (
                 <tr
                   key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}
                   className="border-b border-border last:border-b-0 hover:bg-muted"

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -100,7 +100,12 @@ function RateCell({ item }: { item: MulticastHealthUserItem }) {
   )
   return (
     <Tooltip content={tooltip}>
-      <span className="inline-flex items-center gap-1.5 cursor-help">
+      <span
+        tabIndex={0}
+        role="button"
+        aria-label={`Rate ${item.rate_status}: ${item.rate_status_reason}`}
+        className="inline-flex items-center gap-1.5 cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
+      >
         <span className="tabular-nums font-mono text-xs">{formatBps(item.observed_bps_5m)}</span>
         <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
           {item.rate_status}
@@ -169,7 +174,10 @@ function UserCombinedHealthBadge({ item }: { item: MulticastHealthUserItem }) {
   return (
     <Tooltip content={tooltip} delayDuration={120}>
       <span
-        className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium cursor-help ${cls}`}
+        tabIndex={0}
+        role="button"
+        aria-label={`Combined health ${item.health_status}: CP ${item.control_plane_status}, Rate ${item.rate_status}`}
+        className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${cls}`}
       >
         {item.health_status}
       </span>
@@ -220,6 +228,7 @@ function CountsRow({
         <span className="text-emerald-500">{counts.healthy} healthy</span>
         <span className="text-amber-500">{counts.degraded} degraded</span>
         <span className="text-red-500">{counts.unhealthy} unhealthy</span>
+        <span className="text-muted-foreground">{counts.unknown} unknown</span>
         <span className="text-muted-foreground">/ {counts.total}</span>
       </div>
     </div>
@@ -228,6 +237,53 @@ function CountsRow({
 
 function NavLinkArrow() {
   return <ChevronRight className="inline h-3 w-3 ml-0.5 opacity-60 group-hover:opacity-100 transition-opacity" />
+}
+
+// TableStateRow renders a single placeholder row covering loading / error /
+// empty states so the surrounding table doesn't fall into a misleading
+// "empty" state while the query is still in flight or has failed.
+function TableStateRow({
+  isLoading,
+  error,
+  isEmpty,
+  emptyText,
+  colSpan,
+}: {
+  isLoading: boolean
+  error: unknown
+  isEmpty: boolean
+  emptyText: string
+  colSpan: number
+}) {
+  if (isLoading) {
+    return (
+      <tr>
+        <td colSpan={colSpan} className="px-4 py-8 text-center text-muted-foreground">
+          <Loader2 className="inline h-3 w-3 animate-spin mr-2" />
+          Loading…
+        </td>
+      </tr>
+    )
+  }
+  if (error) {
+    return (
+      <tr>
+        <td colSpan={colSpan} className="px-4 py-8 text-center text-red-500">
+          Failed to load: {(error as Error).message}
+        </td>
+      </tr>
+    )
+  }
+  if (isEmpty) {
+    return (
+      <tr>
+        <td colSpan={colSpan} className="px-4 py-8 text-center text-muted-foreground">
+          {emptyText}
+        </td>
+      </tr>
+    )
+  }
+  return null
 }
 
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
@@ -314,13 +370,13 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
               </tr>
             </thead>
             <tbody>
-              {(usersQuery.data?.items ?? []).length === 0 && (
-                <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
-                    No multicast users
-                  </td>
-                </tr>
-              )}
+              <TableStateRow
+                isLoading={usersQuery.isLoading}
+                error={usersQuery.error}
+                isEmpty={(usersQuery.data?.items ?? []).length === 0}
+                emptyText="No multicast users"
+                colSpan={7}
+              />
               {(usersQuery.data?.items ?? []).map((u) => (
                 <tr key={`${u.user_pk}-${u.mode}`} className="border-b border-border last:border-b-0 hover:bg-muted">
                   <td className="px-4 py-3 text-sm">
@@ -387,13 +443,13 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
               </tr>
             </thead>
             <tbody>
-              {(pathsQuery.data?.items ?? []).length === 0 && (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
-                    No (publisher, subscriber) pairs
-                  </td>
-                </tr>
-              )}
+              <TableStateRow
+                isLoading={pathsQuery.isLoading}
+                error={pathsQuery.error}
+                isEmpty={(pathsQuery.data?.items ?? []).length === 0}
+                emptyText="No (publisher, subscriber) pairs"
+                colSpan={6}
+              />
               {(pathsQuery.data?.items ?? []).map((p) => (
                 <tr
                   key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { Loader2, AlertCircle } from 'lucide-react'
+import { Loader2, AlertCircle, Info, ChevronRight } from 'lucide-react'
+import { Tooltip } from '@/components/ui/tooltip'
 import {
   fetchMulticastGroupHealth,
   fetchMulticastGroupHealthUsers,
@@ -16,12 +17,68 @@ const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
   unknown: 'bg-muted text-muted-foreground',
 }
 
+const STATUS_DOT: Record<MulticastHealthStatus, string> = {
+  healthy: 'bg-emerald-500',
+  degraded: 'bg-amber-500',
+  unhealthy: 'bg-red-500',
+  unknown: 'bg-muted-foreground',
+}
+
+const STATUS_DEFINITIONS: Array<{ status: MulticastHealthStatus; short: string }> = [
+  { status: 'healthy', short: '(S,G) present, SPT bit set, expected tunnel in IIF/OIF' },
+  { status: 'degraded', short: '(S,G) present but flags or tunnel position wrong' },
+  { status: 'unhealthy', short: 'no (S,G) — only (*,G), or expected tunnel missing' },
+  { status: 'unknown', short: 'state-collect has not reported for this device yet' },
+]
+
+const SECTION_HELP = {
+  summary:
+    'Per-status totals across three view granularities. A row is rolled up into "healthy" only if reconciliation passes on every dimension.',
+  users:
+    'Each row pairs one onchain user with the mroute observed at their device. ' +
+    'Publishers expect their Tunnel<N> as the IIF of (S,G); subscribers expect their Tunnel<N> in the OIF list. ' +
+    'A user in P+S mode contributes two rows.',
+  paths:
+    'Each row is a (publisher, subscriber) pair belonging to the group. ' +
+    'Endpoints-only verification: both endpoints must be reconciled. ' +
+    'A recursive OIF chain walk (full-path) is a follow-up that will replace "endpoints only" with "full path".',
+}
+
 function HealthBadge({ status }: { status: MulticastHealthStatus }) {
   const cls = STATUS_BADGE[status] ?? STATUS_BADGE.unknown
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
       {status}
     </span>
+  )
+}
+
+function HelpIcon({ content }: { content: string }) {
+  return (
+    <Tooltip content={content}>
+      <button
+        type="button"
+        className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="What does this mean?"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+    </Tooltip>
+  )
+}
+
+function StatusLegend() {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground border-t border-border pt-3 mt-1">
+      <span className="font-medium text-foreground">Status:</span>
+      {STATUS_DEFINITIONS.map(({ status, short }) => (
+        <span key={status} className="inline-flex items-center gap-1.5">
+          <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[status]}`} />
+          <span className="font-medium text-foreground">{status}</span>
+          <span>— {short}</span>
+        </span>
+      ))}
+    </div>
   )
 }
 
@@ -43,6 +100,10 @@ function CountsRow({
       </div>
     </div>
   )
+}
+
+function NavLinkArrow() {
+  return <ChevronRight className="inline h-3 w-3 ml-0.5 opacity-60 group-hover:opacity-100 transition-opacity" />
 }
 
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
@@ -92,7 +153,10 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
       {/* Summary counts */}
       <div className="border border-border rounded-lg bg-card p-4">
         <div className="flex items-baseline justify-between mb-2">
-          <h3 className="text-sm font-medium">Reconciliation summary</h3>
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-medium">Reconciliation summary</h3>
+            <HelpIcon content={SECTION_HELP.summary} />
+          </div>
           {!summary.source_available && (
             <span className="text-xs text-muted-foreground">no state-collect data yet</span>
           )}
@@ -100,12 +164,16 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
         <CountsRow label="Users (onchain ↔ mroute IIF/OIF)" counts={summary.counts.users} />
         <CountsRow label="Paths (publisher → subscriber endpoints)" counts={summary.counts.paths} />
         <CountsRow label="Mroutes (per-row dataplane state)" counts={summary.counts.mroutes} />
+        <StatusLegend />
       </div>
 
       {/* Per-user reconciliation */}
       <div className="border border-border rounded-lg bg-card">
         <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-          <h3 className="text-sm font-medium">Per-user reconciliation</h3>
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-medium">Per-user reconciliation</h3>
+            <HelpIcon content={SECTION_HELP.users} />
+          </div>
           {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
         </div>
         <div className="overflow-x-auto">
@@ -133,9 +201,10 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                   <td className="px-4 py-3 text-sm">
                     <Link
                       to={`/dz/users/${u.user_pk}`}
-                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      className="group text-blue-600 dark:text-blue-400 hover:underline font-mono inline-flex items-center"
                     >
                       {u.user_owner_pubkey ? u.user_owner_pubkey.slice(0, 8) : u.user_pk.slice(0, 8)}
+                      <NavLinkArrow />
                     </Link>
                   </td>
                   <td className="px-4 py-3 text-sm">
@@ -145,9 +214,10 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     {u.user_device_pk ? (
                       <Link
                         to={`/dz/devices/${u.user_device_pk}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                        className="group text-blue-600 dark:text-blue-400 hover:underline font-mono inline-flex items-center"
                       >
                         {u.user_device_code || u.user_device_pk.slice(0, 8)}
+                        <NavLinkArrow />
                       </Link>
                     ) : (
                       '—'
@@ -170,7 +240,10 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
       {/* Per-path reconciliation */}
       <div className="border border-border rounded-lg bg-card">
         <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-          <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
+            <HelpIcon content={SECTION_HELP.paths} />
+          </div>
           {pathsQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
         </div>
         <div className="overflow-x-auto">
@@ -201,18 +274,20 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                   <td className="px-4 py-3 text-sm font-mono">
                     <Link
                       to={`/dz/users/${p.publisher_user_pk}`}
-                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                      className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
                     >
                       {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
+                      <NavLinkArrow />
                     </Link>
                   </td>
                   <td className="px-4 py-3 text-sm font-mono">
                     {p.publisher_device_pk ? (
                       <Link
                         to={`/dz/devices/${p.publisher_device_pk}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                        className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
                       >
                         {p.publisher_device_code || p.publisher_device_pk.slice(0, 8)}
+                        <NavLinkArrow />
                       </Link>
                     ) : (
                       '—'
@@ -221,18 +296,20 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                   <td className="px-4 py-3 text-sm font-mono">
                     <Link
                       to={`/dz/users/${p.subscriber_user_pk}`}
-                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                      className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
                     >
                       {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
+                      <NavLinkArrow />
                     </Link>
                   </td>
                   <td className="px-4 py-3 text-sm font-mono">
                     {p.subscriber_device_pk ? (
                       <Link
                         to={`/dz/devices/${p.subscriber_device_pk}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                        className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
                       >
                         {p.subscriber_device_code || p.subscriber_device_pk.slice(0, 8)}
+                        <NavLinkArrow />
                       </Link>
                     ) : (
                       '—'

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -117,6 +117,66 @@ function rowReason(item: MulticastHealthUserItem): string {
   return RATE_REASON_HUMAN[item.rate_status_reason] ?? '—'
 }
 
+// DIM_BADGE_CLASS covers both health-status and rate-status values used in
+// the combined-verdict hover-card on the Status column.
+const DIM_BADGE_CLASS: Record<string, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  reconciled: 'bg-emerald-500/15 text-emerald-500',
+  active: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  mismatch: 'bg-red-500/15 text-red-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+  idle: 'bg-muted text-muted-foreground',
+  no_data: 'bg-muted text-muted-foreground',
+  monitoring_gap: 'bg-muted text-muted-foreground',
+  group_idle: 'bg-muted text-muted-foreground',
+}
+
+function DimBadge({ value }: { value: string }) {
+  const cls = DIM_BADGE_CLASS[value] ?? DIM_BADGE_CLASS.unknown
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
+      {value}
+    </span>
+  )
+}
+
+function UserCombinedHealthBadge({ item }: { item: MulticastHealthUserItem }) {
+  const cls = STATUS_BADGE[item.health_status] ?? STATUS_BADGE.unknown
+  const tooltip = (
+    <div className="space-y-2 min-w-[260px]">
+      <div className="text-xs font-medium">
+        {item.mode === 'P' ? 'Publisher' : item.mode === 'S' ? 'Subscriber' : 'Publisher + Subscriber'} —{' '}
+        <span className="capitalize">{item.health_status}</span>
+      </div>
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-xs">
+        <span className="text-muted-foreground">Control plane</span>
+        <span className="flex items-center gap-2">
+          <DimBadge value={item.control_plane_status} />
+          {item.mismatch_reason && (
+            <span className="text-muted-foreground text-[11px]">{item.mismatch_reason}</span>
+          )}
+        </span>
+        <span className="text-muted-foreground">Rate</span>
+        <span className="flex items-center gap-2">
+          <DimBadge value={item.rate_status} />
+          <span className="text-muted-foreground text-[11px]">{item.rate_status_reason}</span>
+        </span>
+      </div>
+    </div>
+  )
+  return (
+    <Tooltip content={tooltip} delayDuration={120}>
+      <span
+        className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium cursor-help ${cls}`}
+      >
+        {item.health_status}
+      </span>
+    </Tooltip>
+  )
+}
+
 function HelpIcon({ content }: { content: string }) {
   return (
     <Tooltip content={content}>
@@ -295,7 +355,7 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     <RateCell item={u} />
                   </td>
                   <td className="px-4 py-3 text-sm">
-                    <HealthBadge status={u.health_status} />
+                    <UserCombinedHealthBadge item={u} />
                   </td>
                   <td className="px-4 py-3 text-sm text-muted-foreground">{rowReason(u)}</td>
                 </tr>

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -1,0 +1,255 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { Loader2, AlertCircle } from 'lucide-react'
+import {
+  fetchMulticastGroupHealth,
+  fetchMulticastGroupHealthUsers,
+  fetchMulticastGroupHealthPaths,
+  type MulticastHealthStatus,
+  type MulticastHealthStatusCounts,
+} from '@/lib/api'
+
+const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+}
+
+function HealthBadge({ status }: { status: MulticastHealthStatus }) {
+  const cls = STATUS_BADGE[status] ?? STATUS_BADGE.unknown
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
+      {status}
+    </span>
+  )
+}
+
+function CountsRow({
+  label,
+  counts,
+}: {
+  label: string
+  counts: MulticastHealthStatusCounts
+}) {
+  return (
+    <div className="flex items-center justify-between py-2 text-sm">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="flex items-center gap-3 tabular-nums">
+        <span className="text-emerald-500">{counts.healthy} healthy</span>
+        <span className="text-amber-500">{counts.degraded} degraded</span>
+        <span className="text-red-500">{counts.unhealthy} unhealthy</span>
+        <span className="text-muted-foreground">/ {counts.total}</span>
+      </div>
+    </div>
+  )
+}
+
+export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
+  const summaryQuery = useQuery({
+    queryKey: ['multicast-group-health-summary', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealth(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  const usersQuery = useQuery({
+    queryKey: ['multicast-group-health-users', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  const pathsQuery = useQuery({
+    queryKey: ['multicast-group-health-paths', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode),
+    enabled: !!groupPkOrCode,
+    refetchInterval: 30_000,
+  })
+
+  if (summaryQuery.isLoading) {
+    return (
+      <div className="px-4 py-8 text-center text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+      </div>
+    )
+  }
+
+  if (summaryQuery.error) {
+    return (
+      <div className="px-4 py-6 text-sm text-red-500 flex items-center gap-2">
+        <AlertCircle className="h-4 w-4" />
+        Failed to load health data: {(summaryQuery.error as Error).message}
+      </div>
+    )
+  }
+
+  const summary = summaryQuery.data
+  if (!summary) return null
+
+  return (
+    <div className="p-4 space-y-6">
+      {/* Summary counts */}
+      <div className="border border-border rounded-lg bg-card p-4">
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="text-sm font-medium">Reconciliation summary</h3>
+          {!summary.source_available && (
+            <span className="text-xs text-muted-foreground">no state-collect data yet</span>
+          )}
+        </div>
+        <CountsRow label="Users (onchain ↔ mroute IIF/OIF)" counts={summary.counts.users} />
+        <CountsRow label="Paths (publisher → subscriber endpoints)" counts={summary.counts.paths} />
+        <CountsRow label="Mroutes (per-row dataplane state)" counts={summary.counts.mroutes} />
+      </div>
+
+      {/* Per-user reconciliation */}
+      <div className="border border-border rounded-lg bg-card">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+          <h3 className="text-sm font-medium">Per-user reconciliation</h3>
+          {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="text-sm text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">User</th>
+                <th className="px-4 py-3 font-medium">Mode</th>
+                <th className="px-4 py-3 font-medium">Device</th>
+                <th className="px-4 py-3 font-medium text-right">Tunnel</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {usersQuery.data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                    No multicast users
+                  </td>
+                </tr>
+              )}
+              {usersQuery.data?.items.map((u) => (
+                <tr key={`${u.user_pk}-${u.mode}`} className="border-b border-border last:border-b-0 hover:bg-muted">
+                  <td className="px-4 py-3 text-sm">
+                    <Link
+                      to={`/dz/users/${u.user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                    >
+                      {u.user_owner_pubkey ? u.user_owner_pubkey.slice(0, 8) : u.user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <span className="text-xs text-muted-foreground">{u.mode}</span>
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    {u.user_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${u.user_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
+                      >
+                        {u.user_device_code || u.user_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm tabular-nums text-right font-mono text-muted-foreground">
+                    {u.user_tunnel_id > 0 ? u.user_tunnel_id : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <HealthBadge status={u.health_status} />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{u.mismatch_reason || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Per-path reconciliation */}
+      <div className="border border-border rounded-lg bg-card">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+          <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
+          {pathsQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="text-sm text-left text-muted-foreground border-b border-border">
+                <th className="px-4 py-3 font-medium">Publisher</th>
+                <th className="px-4 py-3 font-medium">FHR device</th>
+                <th className="px-4 py-3 font-medium">Subscriber</th>
+                <th className="px-4 py-3 font-medium">LHR device</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Verified</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pathsQuery.data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                    No (publisher, subscriber) pairs
+                  </td>
+                </tr>
+              )}
+              {pathsQuery.data?.items.map((p) => (
+                <tr
+                  key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}
+                  className="border-b border-border last:border-b-0 hover:bg-muted"
+                >
+                  <td className="px-4 py-3 text-sm font-mono">
+                    <Link
+                      to={`/dz/users/${p.publisher_user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    {p.publisher_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${p.publisher_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {p.publisher_device_code || p.publisher_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    <Link
+                      to={`/dz/users/${p.subscriber_user_pk}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm font-mono">
+                    {p.subscriber_device_pk ? (
+                      <Link
+                        to={`/dz/devices/${p.subscriber_device_pk}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {p.subscriber_device_code || p.subscriber_device_pk.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <HealthBadge status={p.health_status} />
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {p.verification_method === 'endpoints_only' ? 'endpoints only' : p.verification_method}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -77,7 +77,10 @@ function UserHealthBadge({ item }: { item: MulticastHealthUserItem }) {
   return (
     <Tooltip content={tooltipContent} delayDuration={120}>
       <span
-        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium cursor-help ${cls}`}
+        tabIndex={0}
+        role="button"
+        aria-label={`Health ${item.health_status}: CP ${item.control_plane_status}, Rate ${item.rate_status}`}
+        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${cls}`}
       >
         {item.health_status}
       </span>
@@ -524,7 +527,11 @@ export function UserDetailPage() {
   })
 
   const hasMulticast = !!multicastGroups && multicastGroups.length > 0
-  const { data: userHealth } = useQuery({
+  const {
+    data: userHealth,
+    isLoading: userHealthLoading,
+    error: userHealthError,
+  } = useQuery({
     queryKey: ['user-health', pk],
     queryFn: () => fetchUserHealth(pk!),
     enabled: !!pk && hasMulticast,
@@ -815,6 +822,19 @@ export function UserDetailPage() {
                           item={it}
                         />
                       ))}
+                      {healthItems.length === 0 && userHealthLoading && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-muted text-muted-foreground">
+                          loading…
+                        </span>
+                      )}
+                      {healthItems.length === 0 && !!userHealthError && (
+                        <span
+                          className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-red-500/15 text-red-500"
+                          title={(userHealthError as Error).message}
+                        >
+                          health unavailable
+                        </span>
+                      )}
                     </div>
                     <span className="text-xs text-muted-foreground font-mono">
                       {g.multicast_ip}

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Loader2, Users, AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react'
 import { CopyableText } from '@/components/copyable-text'
+import { Tooltip } from '@/components/ui/tooltip'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import {
@@ -26,23 +27,61 @@ const HEALTH_BADGE_CLASS: Record<MulticastHealthStatus, string> = {
   unknown: 'bg-muted text-muted-foreground',
 }
 
+const DIM_BADGE_CLASS: Record<string, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  reconciled: 'bg-emerald-500/15 text-emerald-500',
+  active: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  mismatch: 'bg-red-500/15 text-red-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+  idle: 'bg-muted text-muted-foreground',
+  no_data: 'bg-muted text-muted-foreground',
+  monitoring_gap: 'bg-muted text-muted-foreground',
+  group_idle: 'bg-muted text-muted-foreground',
+}
+
+function DimBadge({ value }: { value: string }) {
+  const cls = DIM_BADGE_CLASS[value] ?? DIM_BADGE_CLASS.unknown
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${cls}`}>
+      {value}
+    </span>
+  )
+}
+
 function UserHealthBadge({ item }: { item: MulticastHealthUserItem }) {
   const cls = HEALTH_BADGE_CLASS[item.health_status] ?? HEALTH_BADGE_CLASS.unknown
-  const parts: string[] = [`${item.mode}: ${item.health_status}`]
-  if (item.mismatch_reason) {
-    parts.push(`CP — ${item.mismatch_reason}`)
-  }
-  if (item.rate_status_reason && item.rate_status_reason !== 'active' && item.rate_status_reason !== 'reconciled') {
-    parts.push(`rate — ${item.rate_status_reason}`)
-  }
-  const title = parts.join('\n')
+  const tooltipContent = (
+    <div className="space-y-2 min-w-[260px]">
+      <div className="text-xs font-medium">
+        {item.mode === 'P' ? 'Publisher' : item.mode === 'S' ? 'Subscriber' : 'Publisher + Subscriber'} —{' '}
+        <span className="capitalize">{item.health_status}</span>
+      </div>
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-xs">
+        <span className="text-muted-foreground">Control plane</span>
+        <span className="flex items-center gap-2">
+          <DimBadge value={item.control_plane_status} />
+          {item.mismatch_reason && (
+            <span className="text-muted-foreground text-[11px]">{item.mismatch_reason}</span>
+          )}
+        </span>
+        <span className="text-muted-foreground">Rate</span>
+        <span className="flex items-center gap-2">
+          <DimBadge value={item.rate_status} />
+          <span className="text-muted-foreground text-[11px]">{item.rate_status_reason}</span>
+        </span>
+      </div>
+    </div>
+  )
   return (
-    <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${cls}`}
-      title={title}
-    >
-      {item.health_status}
-    </span>
+    <Tooltip content={tooltipContent} delayDuration={120}>
+      <span
+        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium cursor-help ${cls}`}
+      >
+        {item.health_status}
+      </span>
+    </Tooltip>
   )
 }
 

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -12,6 +12,7 @@ import {
   fetchPeeringDBFacility,
   fetchUserHealth,
   type MulticastHealthStatus,
+  type MulticastHealthUserItem,
 } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
@@ -25,23 +26,22 @@ const HEALTH_BADGE_CLASS: Record<MulticastHealthStatus, string> = {
   unknown: 'bg-muted text-muted-foreground',
 }
 
-function UserHealthBadge({
-  status,
-  mode,
-  reason,
-}: {
-  status: MulticastHealthStatus
-  mode: string
-  reason?: string
-}) {
-  const cls = HEALTH_BADGE_CLASS[status] ?? HEALTH_BADGE_CLASS.unknown
-  const title = reason ? `${mode}: ${status} — ${reason}` : `${mode}: ${status}`
+function UserHealthBadge({ item }: { item: MulticastHealthUserItem }) {
+  const cls = HEALTH_BADGE_CLASS[item.health_status] ?? HEALTH_BADGE_CLASS.unknown
+  const parts: string[] = [`${item.mode}: ${item.health_status}`]
+  if (item.mismatch_reason) {
+    parts.push(`CP — ${item.mismatch_reason}`)
+  }
+  if (item.rate_status_reason && item.rate_status_reason !== 'active' && item.rate_status_reason !== 'reconciled') {
+    parts.push(`rate — ${item.rate_status_reason}`)
+  }
+  const title = parts.join('\n')
   return (
     <span
       className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${cls}`}
       title={title}
     >
-      {status}
+      {item.health_status}
     </span>
   )
 }
@@ -773,9 +773,7 @@ export function UserDetailPage() {
                       {healthItems.map((it) => (
                         <UserHealthBadge
                           key={`${it.multicast_group_pk}-${it.mode}`}
-                          status={it.health_status}
-                          mode={it.mode}
-                          reason={it.mismatch_reason}
+                          item={it}
                         />
                       ))}
                     </div>

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -78,7 +78,6 @@ function UserHealthBadge({ item }: { item: MulticastHealthUserItem }) {
     <Tooltip content={tooltipContent} delayDuration={120}>
       <span
         tabIndex={0}
-        role="button"
         aria-label={`Health ${item.health_status}: CP ${item.control_plane_status}, Rate ${item.rate_status}`}
         className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${cls}`}
       >

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -5,11 +5,46 @@ import { Loader2, Users, AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react'
 import { CopyableText } from '@/components/copyable-text'
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
-import { fetchUser, fetchUserTraffic, fetchUserMulticastGroups, fetchPeeringDBFacility } from '@/lib/api'
+import {
+  fetchUser,
+  fetchUserTraffic,
+  fetchUserMulticastGroups,
+  fetchPeeringDBFacility,
+  fetchUserHealth,
+  type MulticastHealthStatus,
+} from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 import { useBackLink } from '@/hooks/use-back-link'
 import { useTheme } from '@/hooks/use-theme'
 import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
+
+const HEALTH_BADGE_CLASS: Record<MulticastHealthStatus, string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-500',
+  degraded: 'bg-amber-500/15 text-amber-500',
+  unhealthy: 'bg-red-500/15 text-red-500',
+  unknown: 'bg-muted text-muted-foreground',
+}
+
+function UserHealthBadge({
+  status,
+  mode,
+  reason,
+}: {
+  status: MulticastHealthStatus
+  mode: string
+  reason?: string
+}) {
+  const cls = HEALTH_BADGE_CLASS[status] ?? HEALTH_BADGE_CLASS.unknown
+  const title = reason ? `${mode}: ${status} — ${reason}` : `${mode}: ${status}`
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${cls}`}
+      title={title}
+    >
+      {status}
+    </span>
+  )
+}
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -449,6 +484,14 @@ export function UserDetailPage() {
     enabled: !!pk,
   })
 
+  const hasMulticast = !!multicastGroups && multicastGroups.length > 0
+  const { data: userHealth } = useQuery({
+    queryKey: ['user-health', pk],
+    queryFn: () => fetchUserHealth(pk!),
+    enabled: !!pk && hasMulticast,
+    refetchInterval: 30_000,
+  })
+
   const { data: peeringdb } = useQuery({
     queryKey: ['peeringdb', user?.facility_loc_id],
     queryFn: () => fetchPeeringDBFacility(user!.facility_loc_id),
@@ -703,11 +746,15 @@ export function UserDetailPage() {
             <div className="border border-border rounded-lg p-4 bg-card">
               <h3 className="text-sm font-medium text-muted-foreground mb-3">Multicast Groups</h3>
               <div className="space-y-2">
-                {multicastGroups.map((g) => (
+                {multicastGroups.map((g) => {
+                  const healthItems = (userHealth?.items ?? []).filter(
+                    (it) => it.multicast_group_pk === g.group_pk,
+                  )
+                  return (
                   <div key={g.group_pk} className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">
                       <Link
-                        to={`/dz/multicast-groups/${g.group_pk}`}
+                        to={`/dz/multicast-groups/${g.group_pk}?tab=health`}
                         className="text-blue-600 dark:text-blue-400 hover:underline font-mono"
                       >
                         {g.group_code}
@@ -723,12 +770,21 @@ export function UserDetailPage() {
                       >
                         {g.mode === 'P' ? 'Publisher' : g.mode === 'S' ? 'Subscriber' : 'Pub + Sub'}
                       </span>
+                      {healthItems.map((it) => (
+                        <UserHealthBadge
+                          key={`${it.multicast_group_pk}-${it.mode}`}
+                          status={it.health_status}
+                          mode={it.mode}
+                          reason={it.mismatch_reason}
+                        />
+                      ))}
                     </div>
                     <span className="text-xs text-muted-foreground font-mono">
                       {g.multicast_ip}
                     </span>
                   </div>
-                ))}
+                  )
+                })}
               </div>
             </div>
           )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2170,6 +2170,156 @@ export async function fetchMulticastGroupShredStats(pkOrCode: string, timeRange?
   return res.json()
 }
 
+// Multicast health (onchain ↔ dataplane reconciliation) types
+
+export type MulticastHealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+
+export interface MulticastHealthStatusCounts {
+  healthy: number
+  degraded: number
+  unhealthy: number
+  total: number
+}
+
+export interface MulticastHealthCounts {
+  mroutes: MulticastHealthStatusCounts
+  users: MulticastHealthStatusCounts
+  paths: MulticastHealthStatusCounts
+}
+
+export interface MulticastHealthGroupRef {
+  pk: string
+  code: string
+  multicast_ip: string
+  status: string
+  publisher_count: number
+  subscriber_count: number
+}
+
+export interface MulticastHealthGroupSummary {
+  group: MulticastHealthGroupRef
+  source_available: boolean
+  generated_at: string
+  counts: MulticastHealthCounts
+}
+
+export interface MulticastHealthUserItem {
+  user_pk: string
+  user_owner_pubkey: string
+  user_dz_ip: string
+  user_tunnel_id: number
+  user_device_pk: string
+  user_device_code: string
+  multicast_group_pk: string
+  multicast_group_code: string
+  group_address: string
+  mode: 'P' | 'S' | 'P+S' | string
+  expected_tunnel_position: string
+  publisher_iif_observed: boolean
+  subscriber_oif_observed: boolean
+  reconciled: boolean
+  health_status: MulticastHealthStatus
+  mismatch_reason?: string
+}
+
+export interface MulticastHealthGroupUsersResponse {
+  group: MulticastHealthGroupRef
+  generated_at: string
+  items: MulticastHealthUserItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface MulticastHealthUserResponse {
+  user_pk: string
+  user_owner_pubkey: string
+  user_dz_ip: string
+  user_tunnel_id: number
+  user_device_pk: string
+  user_device_code: string
+  generated_at: string
+  items: MulticastHealthUserItem[]
+}
+
+export interface MulticastHealthPathItem {
+  publisher_user_pk: string
+  publisher_owner_pubkey: string
+  publisher_dz_ip: string
+  publisher_tunnel_id: number
+  publisher_device_pk: string
+  publisher_device_code: string
+  subscriber_user_pk: string
+  subscriber_owner_pubkey: string
+  subscriber_dz_ip: string
+  subscriber_tunnel_id: number
+  subscriber_device_pk: string
+  subscriber_device_code: string
+  publisher_endpoint_observed: boolean
+  subscriber_endpoint_observed: boolean
+  endpoints_reconciled: boolean
+  health_status: MulticastHealthStatus
+  verification_method: 'endpoints_only' | 'full_path' | string
+  missing_endpoint_reasons?: string[]
+}
+
+export interface MulticastHealthGroupPathsResponse {
+  group: MulticastHealthGroupRef
+  generated_at: string
+  items: MulticastHealthPathItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export async function fetchMulticastGroupHealth(pkOrCode: string): Promise<MulticastHealthGroupSummary> {
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health')
+  }
+  return res.json()
+}
+
+export async function fetchMulticastGroupHealthUsers(
+  pkOrCode: string,
+  limit?: number,
+  offset?: number,
+): Promise<MulticastHealthGroupUsersResponse> {
+  const params = new URLSearchParams()
+  if (limit !== undefined) params.set('limit', String(limit))
+  if (offset !== undefined) params.set('offset', String(offset))
+  const qs = params.toString()
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/users${qs ? `?${qs}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health users')
+  }
+  return res.json()
+}
+
+export async function fetchMulticastGroupHealthPaths(
+  pkOrCode: string,
+  limit?: number,
+  offset?: number,
+): Promise<MulticastHealthGroupPathsResponse> {
+  const params = new URLSearchParams()
+  if (limit !== undefined) params.set('limit', String(limit))
+  if (offset !== undefined) params.set('offset', String(offset))
+  const qs = params.toString()
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/paths${qs ? `?${qs}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group health paths')
+  }
+  return res.json()
+}
+
+export async function fetchUserHealth(pk: string): Promise<MulticastHealthUserResponse> {
+  const res = await apiFetch(`/api/dz/users/${encodeURIComponent(pk)}/health`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch user health')
+  }
+  return res.json()
+}
+
 // Critical links types
 export interface CriticalLink {
   sourcePK: string

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2214,6 +2214,7 @@ export type MulticastRateStatusReason =
   | 'mismatch'
   | 'monitoring_gap'
   | 'group_idle'
+  | 'multi_group_ambiguity'
 
 export interface MulticastHealthUserItem {
   user_pk: string

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2178,6 +2178,7 @@ export interface MulticastHealthStatusCounts {
   healthy: number
   degraded: number
   unhealthy: number
+  unknown: number
   total: number
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2203,6 +2203,17 @@ export interface MulticastHealthGroupSummary {
   counts: MulticastHealthCounts
 }
 
+export type MulticastRateStatus = 'reconciled' | 'mismatch' | 'unknown'
+
+export type MulticastRateStatusReason =
+  | 'active'
+  | 'idle'
+  | 'no_data'
+  | 'reconciled'
+  | 'mismatch'
+  | 'monitoring_gap'
+  | 'group_idle'
+
 export interface MulticastHealthUserItem {
   user_pk: string
   user_owner_pubkey: string
@@ -2218,7 +2229,15 @@ export interface MulticastHealthUserItem {
   publisher_iif_observed: boolean
   subscriber_oif_observed: boolean
   reconciled: boolean
+  // Combined (CP × rate) verdict. The CP-only verdict lives on
+  // control_plane_status, the rate-only verdict on rate_status.
   health_status: MulticastHealthStatus
+  control_plane_status: MulticastHealthStatus
+  rate_status: MulticastRateStatus
+  rate_status_reason: MulticastRateStatusReason
+  rate_bucket_ts?: string
+  observed_bps_5m?: number
+  expected_bps_5m?: number
   mismatch_reason?: string
 }
 


### PR DESCRIPTION
## Summary

Multicast health visibility — UI + rate reconciliation. Consolidates the remaining slice of infra#1501 into a single branch (supersedes #629, #630, #631, #632).

Reviewable by commit (in order):

1. `8cb8075` **web**: multicast group Health tab + per-user health card (consumes the `/health` endpoints landed in #628).
2. `fa21d87` **web**: Health tab polish — legend, tooltips, nav arrows.
3. `c1eb701` **indexer**: `health_multicast_user_rate` view (per-user rate reconciliation: sum-of-publishers-RX vs. subscriber-TX from `device_interface_rollup_5m`, with ±5% / 1 Mbps tolerance and 15-min freshness window).
4. `1995140` **api**: read rate dimension from the new view and merge it into `/health/users` and `/users/:pk/health` responses.
5. `9230703` **web**: surface the rate dimension in the per-user health card and group Health tab.
6. `efddd9e` **web**: Radix tooltip (120 ms) replaces native `title=` (1 s) on the user health badge.
7. `9590d5f` **web**: hover-card on the per-user "Status" badge showing CP + Rate dimension verdicts side-by-side.
8. `42e50fa` **indexer** (vihu review): rate view joins on `user_pk`; P+S users reconciled subscriber-side with self's contribution subtracted (PIM-SM RPF).
9. `1c384b9` **api + web** (vihu review): `MulticastHealthStatusCounts.Unknown` explicit; per-user/path tables distinguish loading/error/empty; tooltip triggers keyboard-focusable.
10. `aef3288` **indexer**: gofmt fixup on the rate view test.
11. `76c44a4` **indexer** (codex review): rate view emits `multi_group_ambiguity` for tuples participating in more than one multicast group.
12. `3bf0a01` **web** (codex review): polling 30s → 60s; hide member filter on Health tab; drop `role="button"` from tooltip triggers; rewrite P+S help copy.
13. `48cf20f` **indexer** (vihu re-review): propagate publisher-side ambiguity to subscribers. `gpt_total_publisher_rx_bps` was contaminated by multi-group publishers' RX; now every subscriber/P+S row in such groups falls through to `multi_group_ambiguity` with `expected_bps_5m=NULL`. New test: `TestHealthMulticastUserRate_AmbiguousPublisherPropagates`.
14. `65381f1` **web** (vihu re-review): surface `missing_endpoint_reasons` on the per-path health badge via Radix tooltip when non-empty.

## Testing Verification

- Indexer view: rate tests cover healthy/degraded/freshness-expired/idle and four ambiguity scenarios — tunnel reuse via `user_pk`, P+S subscriber-side reconciliation with self subtracted, multi-group subscriber, and multi-group publisher contaminating a single-group subscriber's expected.
- API: `/health/users` and `/users/:pk/health` responses include `rate_*` fields end-to-end; `counts.unknown` surfaced.
- Web: verified per-user card and Health tab on staging — combined status badge resolves CP + Rate correctly; per-path missing-endpoint tooltip renders; hover-card renders both dimensions; tooltip latency is the expected 120 ms; keyboard nav reaches badges with focus ring; Health tab hides the inline member filter; multi-group rows display "unknown / multi_group_ambiguity" with an explanatory tooltip.
