### PR TITLE
admin: skip materialized-view inner tables in remote proxy setup

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -123,19 +123,13 @@ func Setup(log *slog.Logger, cfg Config) error {
 	defer remoteConn.Close()
 
 	// Discover all tables in the remote database
-	rows, err := remoteConn.Query(ctx, "SELECT name FROM system.tables WHERE database = ? ORDER BY name", cfg.RemoteDatabase)
+	tableNames, err := discoverProxyableTables(ctx, remoteConn, cfg.RemoteDatabase)
 	if err != nil {
-		return fmt.Errorf("failed to query remote tables: %w", err)
+		return err
 	}
-	defer rows.Close()
 
 	created, skipped := 0, 0
-	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			return fmt.Errorf("failed to scan table name: %w", err)
-		}
-
+	for _, tableName := range tableNames {
 		result, err := checkTable(ctx, localConn, cfg.RemoteDatabase, tableName, log)
 		if err != nil {
 			return err
@@ -221,18 +215,12 @@ func mirrorRemoteDatabase(ctx context.Context, log *slog.Logger, localConn, remo
 		return 0, 0, fmt.Errorf("failed to create database %s: %w", database, err)
 	}
 
-	rows, err := remoteConn.Query(ctx, "SELECT name FROM system.tables WHERE database = ? ORDER BY name", database)
+	tableNames, err := discoverProxyableTables(ctx, remoteConn, database)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to query remote tables for %s: %w", database, err)
+		return 0, 0, err
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			return 0, 0, fmt.Errorf("failed to scan table name: %w", err)
-		}
-
+	for _, tableName := range tableNames {
 		if skippedExternalTables[tableName] {
 			log.Info("skipping excluded table", "table", fmt.Sprintf("%s.%s", database, tableName))
 			skipped++
@@ -261,6 +249,35 @@ func mirrorRemoteDatabase(ctx context.Context, log *slog.Logger, localConn, remo
 		created++
 	}
 	return created, skipped, nil
+}
+
+// discoverProxyableTables returns the names of tables in the given remote
+// database to proxy, excluding ClickHouse internal materialized-view inner
+// tables (".inner.<name>" and ".inner_id.<uuid>"). Those inner tables cannot be
+// proxied: their leading-dot names are not valid qualified names, so
+// remoteSecure('db.<name>') is rejected with "Invalid qualified name" (code 62).
+func discoverProxyableTables(ctx context.Context, remoteConn clickhouse.Connection, database string) ([]string, error) {
+	rows, err := remoteConn.Query(ctx,
+		"SELECT name FROM system.tables WHERE database = ? AND name NOT LIKE '.inner%' ORDER BY name",
+		database,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query remote tables for %s: %w", database, err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("failed to scan table name for %s: %w", database, err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating remote tables for %s: %w", database, err)
+	}
+	return names, nil
 }
 
 type tableCheckResult int

--- a/admin/remotetables/setup_test.go
+++ b/admin/remotetables/setup_test.go
@@ -1,0 +1,58 @@
+package remotetables
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscoverProxyableTablesSkipsMaterializedViewInnerTables verifies that the
+// table discovery used to build remote proxies excludes ClickHouse's internal
+// materialized-view inner tables (".inner_id.<uuid>"). Those cannot be proxied
+// via remoteSecure() and previously crashed setup with "Invalid qualified name".
+func TestDiscoverProxyableTablesSkipsMaterializedViewInnerTables(t *testing.T) {
+	ctx := context.Background()
+	log := slog.Default()
+
+	chdb, err := apitesting.NewClickHouseDB(ctx, log, nil)
+	require.NoError(t, err)
+	t.Cleanup(chdb.Close)
+
+	conn, dbName := apitesting.SetupClickHouseForTest(t, chdb)
+
+	// A materialized view (without an explicit TO table) creates a hidden inner
+	// storage table named ".inner_id.<uuid>" in the same database.
+	require.NoError(t, conn.Exec(ctx, "CREATE TABLE src (id UInt64) ENGINE = MergeTree ORDER BY id"))
+	require.NoError(t, conn.Exec(ctx, "CREATE MATERIALIZED VIEW mv ENGINE = MergeTree ORDER BY id AS SELECT id FROM src"))
+
+	// Sanity: the MV really did create an internal inner table, so the filter
+	// is exercising the case it is meant to handle.
+	var innerCount uint64
+	require.NoError(t, conn.QueryRow(ctx,
+		"SELECT count() FROM system.tables WHERE database = ? AND name LIKE '.inner%'", dbName,
+	).Scan(&innerCount))
+	require.Positive(t, innerCount, "expected the materialized view to create an internal .inner table")
+
+	// Exercise discovery through the same client type setup.go uses.
+	client, err := clickhouse.NewClient(ctx, log, chdb.Addr(), dbName, chdb.Username(), chdb.Password(), false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	remoteConn, err := client.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = remoteConn.Close() })
+
+	names, err := discoverProxyableTables(ctx, remoteConn, dbName)
+	require.NoError(t, err)
+
+	require.Contains(t, names, "src", "base table should be proxied")
+	require.Contains(t, names, "mv", "materialized view itself should be proxied")
+	for _, n := range names {
+		require.False(t, strings.HasPrefix(n, ".inner"), "internal MV inner table must be excluded: %s", n)
+	}
+}


### PR DESCRIPTION
## Summary of Changes

- When discovering tables to proxy, exclude ClickHouse internal materialized-view inner tables (`.inner_id.<uuid>` and `.inner.<name>`). These cannot be proxied via `remoteSecure()` because their leading-dot names are not valid qualified names, so proxy setup fails with `code: 62 Invalid qualified name` whenever a materialized view exists in a proxied database.
- Centralize table discovery into a single `discoverProxyableTables` helper so all discovery paths share the same filtering.

## Testing Verification

- Added `TestDiscoverProxyableTablesSkipsMaterializedViewInnerTables`: creates a materialized view (which produces a hidden `.inner_id` inner table), confirms it exists, then asserts discovery returns the base table and the view but excludes the inner table. Verified against a real ClickHouse via testcontainers.
