### PR TITLE
indexer: fix Teraswitch contributor name spelling

### DIFF
--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -38,7 +38,7 @@ var (
 		"rox":      "RockawayX",
 		"s3v":      "S3V",
 		"stakefac": "Staking Facilities",
-		"tsw":      "Terraswitch",
+		"tsw":      "Teraswitch",
 		"velia":    "Velia",
 	}
 )


### PR DESCRIPTION
## Summary of Changes
* Fix a spelling error in the contributor page
