### PR TITLE
feat: set MCP server display Title to "DoubleZero Data"

### DIFF
--- a/api/handlers/mcp.go
+++ b/api/handlers/mcp.go
@@ -33,6 +33,7 @@ func (a *API) InitMCP() http.Handler {
 func (a *API) createMCPServer(r *http.Request) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "doublezero",
+		Title:   "DoubleZero Data",
 		Version: "1.0.0",
 	}, &mcp.ServerOptions{
 		Instructions: "IMPORTANT: Always call get_schema before writing SQL or Cypher queries to understand the available tables, columns, and their types. Do not assume table or column names. All tools are read-only and can be called concurrently.",

--- a/api/handlers/mcp_test.go
+++ b/api/handlers/mcp_test.go
@@ -95,6 +95,7 @@ func TestMCPHandler_Initialize(t *testing.T) {
 	serverInfo, ok := result["serverInfo"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "doublezero", serverInfo["name"])
+	assert.Equal(t, "DoubleZero Data", serverInfo["title"])
 	assert.Equal(t, "1.0.0", serverInfo["version"])
 }
 


### PR DESCRIPTION
## What

Adds a `Title` to the MCP server's `Implementation` so clients display "DoubleZero Data" instead of the programmatic name "doublezero".

```go
server := mcp.NewServer(&mcp.Implementation{
    Name:    "doublezero",      // unchanged — programmatic identifier
    Title:   "DoubleZero Data", // new — human-readable display name
    Version: "1.0.0",
}, ...)
```

## Why

Per the MCP spec / go-sdk docs, `Title` is "intended for UI and end-user contexts" while `Name` is "for programmatic or logical use." This disambiguates the connector from other connectors.

`Name` is deliberately left as `doublezero` — it's the stable identifier and isn't user-facing.

## Caveat

This only affects clients that render `serverInfo.title`. Claude's connector UI is known to ignore some `serverInfo` fields (e.g. it ignores `icons` and uses the favicon instead), so the rename may not surface in Claude until/unless its UI reads `title`. Landing this makes the server spec-correct either way.

## Test

Extends `TestMCPHandler_Initialize` to assert `serverInfo["title"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)