### PR TITLE
fix(multicast): prevent health tab overload

### DIFF
--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -14,9 +15,13 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
+// MulticastHealthSummariesCacheKey is the page-cache key for hot multicast
+// group health summaries.
+const MulticastHealthSummariesCacheKey = "multicast_health_summaries"
+
 // GetMulticastGroupHealth returns per-group health counts across mroutes,
 // multicast users, and publisher↔subscriber paths. Reads from the three
-// health_* views.
+// health_* views, or from the page cache for mainnet requests when available.
 func (a *API) GetMulticastGroupHealth(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
@@ -27,7 +32,16 @@ func (a *API) GetMulticastGroupHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	group, err := a.queryMulticastDeliveryGroup(ctx, pkOrCode)
+	if isMainnet(r.Context()) {
+		if cached, ok := a.readMulticastHealthSummaryCache(ctx, pkOrCode); ok {
+			w.Header().Set("X-Cache", "HIT")
+			writeJSON(w, cached)
+			return
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
+	resp, err := a.FetchMulticastGroupHealthData(ctx, pkOrCode)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			http.Error(w, "multicast group not found", http.StatusNotFound)
@@ -38,19 +52,80 @@ func (a *API) GetMulticastGroupHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	counts, err := a.queryMulticastHealthCounts(ctx, group.PK)
+	writeJSON(w, resp)
+}
+
+func (a *API) readMulticastHealthSummaryCache(ctx context.Context, pkOrCode string) (*MulticastHealthGroupSummaryResponse, bool) {
+	data, err := a.readPageCache(ctx, MulticastHealthSummariesCacheKey)
 	if err != nil {
-		logError("multicast health counts error", "error", err, "pk", group.PK)
-		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
-		return
+		return nil, false
 	}
 
-	writeJSON(w, MulticastHealthGroupSummaryResponse{
+	var cached MulticastHealthSummariesCache
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+
+	for i := range cached.Summaries {
+		summary := cached.Summaries[i]
+		if summary.Group.PK == pkOrCode || summary.Group.Code == pkOrCode {
+			return &summary, true
+		}
+	}
+	return nil, false
+}
+
+// FetchMulticastGroupHealthData performs the live per-group summary query.
+func (a *API) FetchMulticastGroupHealthData(ctx context.Context, pkOrCode string) (*MulticastHealthGroupSummaryResponse, error) {
+	group, err := a.queryMulticastDeliveryGroup(ctx, pkOrCode)
+	if err != nil {
+		return nil, err
+	}
+
+	counts, err := a.queryMulticastHealthCounts(ctx, group.PK)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MulticastHealthGroupSummaryResponse{
 		Group:           group,
 		SourceAvailable: true,
 		GeneratedAt:     formatMulticastTime(time.Now().UTC()),
 		Counts:          counts,
-	})
+	}, nil
+}
+
+// FetchMulticastHealthSummariesData builds the page-cache payload for hot
+// multicast group health summaries. With no explicit groups it caches the
+// large edge-solana-shreds group, which is the high-cardinality Health tab.
+func (a *API) FetchMulticastHealthSummariesData(ctx context.Context, pkOrCodes ...string) (*MulticastHealthSummariesCache, error) {
+	if len(pkOrCodes) == 0 {
+		pkOrCodes = []string{ShredGroupPK}
+	}
+
+	generatedAt := formatMulticastTime(time.Now().UTC())
+	cache := &MulticastHealthSummariesCache{
+		GeneratedAt: generatedAt,
+		Summaries:   []MulticastHealthGroupSummaryResponse{},
+	}
+	seen := map[string]bool{}
+	for _, pkOrCode := range pkOrCodes {
+		if pkOrCode == "" || seen[pkOrCode] {
+			continue
+		}
+		seen[pkOrCode] = true
+
+		summary, err := a.FetchMulticastGroupHealthData(ctx, pkOrCode)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+		summary.GeneratedAt = generatedAt
+		cache.Summaries = append(cache.Summaries, *summary)
+	}
+	return cache, nil
 }
 
 // queryMulticastHealthCounts rolls up per-status totals across the three

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -116,7 +116,8 @@ func addStatusCount(bucket *MulticastHealthStatusCounts, status string, n uint64
 }
 
 // parseLimitOffset extracts optional pagination params. Both default to 0,
-// which means "stream all rows" (no slicing in the handler).
+// which means "stream all rows" for handlers that don't set a bounded
+// default before querying.
 func parseLimitOffset(r *http.Request) (limit, offset int) {
 	if v := r.URL.Query().Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -131,22 +132,21 @@ func parseLimitOffset(r *http.Request) (limit, offset int) {
 	return
 }
 
-// applyPagination slices items per requested limit/offset. limit=0 means
-// return all rows; offset is applied before limit. Returns the original
-// total before pagination so callers can include it in the response.
-func applyPagination[T any](items []T, limit, offset int) (page []T, total int) {
-	total = len(items)
-	if offset < 0 {
-		offset = 0
+func (a *API) queryMulticastHealthTotal(ctx context.Context, table, whereClause string, args []any, metricName string) (int, error) {
+	query := `
+		SELECT count()
+		FROM ` + table + `
+		WHERE ` + whereClause + `
+		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
+	`
+	var total uint64
+	start := time.Now()
+	err := a.envDB(ctx).QueryRow(ctx, query, args...).Scan(&total)
+	metrics.RecordClickHouseQuery(metricName, time.Since(start), err)
+	if err != nil {
+		return 0, err
 	}
-	if offset > total {
-		offset = total
-	}
-	items = items[offset:]
-	if limit > 0 && limit < len(items) {
-		items = items[:limit]
-	}
-	return items, total
+	return int(total), nil
 }
 
 // Lower-cased helper for the per-(pk-or-code) pattern, mirroring the existing

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -34,27 +34,43 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	items, err := a.queryMulticastHealthPaths(ctx, group.PK)
+	limit, offset := parseLimitOffset(r)
+	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, limit, offset)
 	if err != nil {
 		logError("multicast group health/paths query error", "error", err, "pk", group.PK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 		return
 	}
 
-	limit, offset := parseLimitOffset(r)
-	page, total := applyPagination(items, limit, offset)
-
 	writeJSON(w, MulticastHealthGroupPathsResponse{
 		Group:       group,
 		GeneratedAt: formatMulticastTime(time.Now().UTC()),
-		Items:       page,
+		Items:       items,
 		Total:       total,
 		Limit:       limit,
 		Offset:      offset,
 	})
 }
 
-func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string) ([]MulticastHealthPathItem, error) {
+func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string, limit, offset int) ([]MulticastHealthPathItem, int, error) {
+	whereClause := "multicast_group_pk = ?"
+	args := []any{groupPK}
+	total := 0
+	if limit > 0 {
+		var err error
+		total, err = a.queryMulticastHealthTotal(ctx, "health_publisher_subscriber_path", whereClause, args, "multicast_health_paths_count")
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	limitClause := ""
+	queryArgs := append([]any{}, args...)
+	if limit > 0 {
+		limitClause = "\n\t\tLIMIT ? OFFSET ?"
+		queryArgs = append(queryArgs, limit, offset)
+	}
+
 	query := `
 		SELECT
 			multicast_group_pk,
@@ -79,23 +95,22 @@ func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string) ([]
 			verification_method,
 			missing_endpoint_reasons
 		FROM health_publisher_subscriber_path
-		WHERE multicast_group_pk = ?
-		-- Stream every (publisher, subscriber) pair; sort actionable rows
-		-- first so any consumer truncating lands on the unhealthy/degraded
-		-- pairs first.
+		WHERE ` + whereClause + `
+		-- Sort actionable rows first so paginated consumers land on the
+		-- unhealthy/degraded pairs first.
 		ORDER BY
 			multiIf(health_status = 'unhealthy', 0,
 			        health_status = 'degraded',  1,
 			        health_status = 'unknown',   2,
 			                                     3),
-			publisher_dz_ip, subscriber_device_code, subscriber_user_pk
+			publisher_dz_ip, subscriber_device_code, subscriber_user_pk` + limitClause + `
 		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
 	`
 	start := time.Now()
-	rows, err := a.envDB(ctx).Query(ctx, query, groupPK)
+	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	metrics.RecordClickHouseQuery("multicast_health_paths", time.Since(start), err)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
@@ -125,9 +140,15 @@ func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string) ([]
 			&it.VerificationMethod,
 			&it.MissingEndpointReasons,
 		); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		items = append(items, it)
 	}
-	return items, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	if limit == 0 {
+		total = len(items)
+	}
+	return items, total, nil
 }

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -91,6 +91,7 @@ func TestGetMulticastGroupHealth_Summary(t *testing.T) {
 
 	rr, body := makeGroupHealthRequest(api, "test-group", "/health")
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+	assert.Equal(t, "MISS", rr.Header().Get("X-Cache"))
 
 	var resp handlers.MulticastHealthGroupSummaryResponse
 	require.NoError(t, json.Unmarshal(body, &resp))
@@ -109,6 +110,60 @@ func TestGetMulticastGroupHealth_Summary(t *testing.T) {
 	// 2 mroute rows (FHR + LHR), both healthy.
 	assert.EqualValues(t, 2, resp.Counts.Mroutes.Total)
 	assert.EqualValues(t, 2, resp.Counts.Mroutes.Healthy)
+}
+
+func TestFetchMulticastHealthSummariesData(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertMulticastTestData(t, api)
+	insertMulticastHealthFixtures(t, api)
+
+	cache, err := api.FetchMulticastHealthSummariesData(t.Context(), "test-group")
+	require.NoError(t, err)
+
+	var summary *handlers.MulticastHealthGroupSummaryResponse
+	for i := range cache.Summaries {
+		if cache.Summaries[i].Group.Code == "test-group" {
+			summary = &cache.Summaries[i]
+			break
+		}
+	}
+	require.NotNil(t, summary)
+	assert.True(t, summary.SourceAvailable)
+	assert.EqualValues(t, 2, summary.Counts.Users.Total)
+	assert.EqualValues(t, 1, summary.Counts.Paths.Total)
+	assert.EqualValues(t, 2, summary.Counts.Mroutes.Total)
+}
+
+func TestGetMulticastGroupHealth_UsesPageCache(t *testing.T) {
+	api := apitesting.NewTestAPIPg(t, testPgDB)
+	cached := handlers.MulticastHealthGroupSummaryResponse{
+		Group: handlers.MulticastDeliveryGroup{
+			PK:              "cached-group-pk",
+			Code:            "cached-group-code",
+			MulticastIP:     "233.0.0.42",
+			PublisherCount:  4,
+			SubscriberCount: 5,
+		},
+		SourceAvailable: true,
+		GeneratedAt:     "2026-06-05T00:00:00Z",
+		Counts: handlers.MulticastHealthCounts{
+			Paths: handlers.MulticastHealthStatusCounts{Healthy: 40, Unhealthy: 2, Total: 42},
+		},
+	}
+	require.NoError(t, api.WritePageCache(t.Context(), handlers.MulticastHealthSummariesCacheKey, handlers.MulticastHealthSummariesCache{
+		GeneratedAt: cached.GeneratedAt,
+		Summaries:   []handlers.MulticastHealthGroupSummaryResponse{cached},
+	}))
+
+	rr, body := makeGroupHealthRequest(api, "cached-group-code", "/health")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+	assert.Equal(t, "HIT", rr.Header().Get("X-Cache"))
+
+	var resp handlers.MulticastHealthGroupSummaryResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	assert.Equal(t, "cached-group-pk", resp.Group.PK)
+	assert.EqualValues(t, 42, resp.Counts.Paths.Total)
 }
 
 func TestGetMulticastGroupHealth_NotFound(t *testing.T) {

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -70,12 +70,12 @@ func makeGroupHealthRequest(api *handlers.API, group string, path string) (*http
 
 func executeRequest(api *handlers.API, req *http.Request, path string) (*httptest.ResponseRecorder, []byte) {
 	rr := httptest.NewRecorder()
-	switch path {
-	case "/health":
+	switch req.URL.Path {
+	case "/api/dz/multicast-groups/" + chi.URLParam(req, "pk") + "/health":
 		api.GetMulticastGroupHealth(rr, req)
-	case "/health/users":
+	case "/api/dz/multicast-groups/" + chi.URLParam(req, "pk") + "/health/users":
 		api.GetMulticastGroupHealthUsers(rr, req)
-	case "/health/paths":
+	case "/api/dz/multicast-groups/" + chi.URLParam(req, "pk") + "/health/paths":
 		api.GetMulticastGroupHealthPaths(rr, req)
 	case "/user-health":
 		api.GetUserHealth(rr, req)
@@ -162,18 +162,38 @@ func TestGetMulticastGroupHealth_Users(t *testing.T) {
 	assert.InDelta(t, 10_000_000, *sub.ObservedBps5m, 1)
 }
 
+func TestGetMulticastGroupHealth_UsersPagination(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertMulticastTestData(t, api)
+	insertMulticastHealthFixtures(t, api)
+
+	rr, body := makeGroupHealthRequest(api, "test-group", "/health/users?limit=1&offset=1")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+
+	var resp handlers.MulticastHealthGroupUsersResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	assert.EqualValues(t, 2, resp.Total)
+	assert.EqualValues(t, 1, resp.Limit)
+	assert.EqualValues(t, 1, resp.Offset)
+	require.Len(t, resp.Items, 1)
+}
+
 func TestGetMulticastGroupHealth_Paths(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
 	insertMulticastTestData(t, api)
 	insertMulticastHealthFixtures(t, api)
 
-	rr, body := makeGroupHealthRequest(api, "test-group", "/health/paths")
+	rr, body := makeGroupHealthRequest(api, "test-group", "/health/paths?limit=1&offset=0")
 	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
 
 	var resp handlers.MulticastHealthGroupPathsResponse
 	require.NoError(t, json.Unmarshal(body, &resp))
 	assert.Equal(t, "test-group", resp.Group.Code)
+	assert.EqualValues(t, 1, resp.Total)
+	assert.EqualValues(t, 1, resp.Limit)
+	assert.EqualValues(t, 0, resp.Offset)
 	require.Len(t, resp.Items, 1)
 	assert.Equal(t, "user-pub", resp.Items[0].PublisherUserPK)
 	assert.Equal(t, "user-sub", resp.Items[0].SubscriberUserPK)

--- a/api/handlers/multicast_health_types.go
+++ b/api/handlers/multicast_health_types.go
@@ -12,6 +12,11 @@ type MulticastHealthGroupSummaryResponse struct {
 	Counts          MulticastHealthCounts  `json:"counts"`
 }
 
+type MulticastHealthSummariesCache struct {
+	GeneratedAt string                                `json:"generated_at"`
+	Summaries   []MulticastHealthGroupSummaryResponse `json:"summaries"`
+}
+
 // MulticastHealthCounts breaks the per-status totals down across the three
 // view granularities for a group. A consumer can read this to render a
 // per-group health dashboard summary without fetching the full row sets.

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -34,20 +34,18 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	items, err := a.queryMulticastHealthUsers(ctx, "multicast_group_pk = ?", group.PK)
+	limit, offset := parseLimitOffset(r)
+	items, total, err := a.queryMulticastHealthUsers(ctx, "multicast_group_pk = ?", []any{group.PK}, limit, offset)
 	if err != nil {
 		logError("multicast group health/users query error", "error", err, "pk", group.PK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 		return
 	}
 
-	limit, offset := parseLimitOffset(r)
-	page, total := applyPagination(items, limit, offset)
-
 	writeJSON(w, MulticastHealthGroupUsersResponse{
 		Group:       group,
 		GeneratedAt: formatMulticastTime(time.Now().UTC()),
-		Items:       page,
+		Items:       items,
 		Total:       total,
 		Limit:       limit,
 		Offset:      offset,
@@ -65,7 +63,7 @@ func (a *API) GetUserHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items, err := a.queryMulticastHealthUsers(ctx, "user_pk = ?", userPK)
+	items, _, err := a.queryMulticastHealthUsers(ctx, "user_pk = ?", []any{userPK}, 0, 0)
 	if err != nil {
 		logError("user health query error", "error", err, "user_pk", userPK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -101,7 +99,23 @@ func (a *API) GetUserHealth(w http.ResponseWriter, r *http.Request) {
 // "user_pk = ?"). The view exposes both the CP-only verdict
 // (control_plane_status) and the combined verdict (health_status); we
 // surface both so consumers can drill in.
-func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string, arg any) ([]MulticastHealthUserItem, error) {
+func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string, args []any, limit, offset int) ([]MulticastHealthUserItem, int, error) {
+	total := 0
+	if limit > 0 {
+		var err error
+		total, err = a.queryMulticastHealthTotal(ctx, "health_multicast_user_rate", whereClause, args, "multicast_health_users_count")
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	limitClause := ""
+	queryArgs := append([]any{}, args...)
+	if limit > 0 {
+		limitClause = "\n\t\tLIMIT ? OFFSET ?"
+		queryArgs = append(queryArgs, limit, offset)
+	}
+
 	query := `
 		SELECT
 			user_pk,
@@ -128,22 +142,21 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			health_status
 		FROM health_multicast_user_rate
 		WHERE ` + whereClause + `
-		-- Stream every row in this group/user; sort actionable rows first
-		-- (unhealthy → degraded → unknown → healthy) so any consumer that
-		-- truncates lands on the rows operators most need to see.
+		-- Sort actionable rows first (unhealthy → degraded → unknown → healthy)
+		-- so paginated consumers land on the rows operators most need to see.
 		ORDER BY
 			multiIf(health_status = 'unhealthy', 0,
 			        health_status = 'degraded',  1,
 			        health_status = 'unknown',   2,
 			                                     3),
-			multicast_group_code, user_pk
+			multicast_group_code, user_pk` + limitClause + `
 		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
 	`
 	start := time.Now()
-	rows, err := a.envDB(ctx).Query(ctx, query, arg)
+	rows, err := a.envDB(ctx).Query(ctx, query, queryArgs...)
 	metrics.RecordClickHouseQuery("multicast_health_users", time.Since(start), err)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
@@ -174,9 +187,15 @@ func (a *API) queryMulticastHealthUsers(ctx context.Context, whereClause string,
 			&it.RateStatusReason,
 			&it.HealthStatus,
 		); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		items = append(items, it)
 	}
-	return items, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	if limit == 0 {
+		total = len(items)
+	}
+	return items, total, nil
 }

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -126,6 +126,9 @@ func (a *Activities) entries() []cacheEntry {
 		{"geo validators", "geo_validators", func(ctx context.Context) (any, error) {
 			return api.FetchGeoValidatorsData(ctx, "", "")
 		}},
+		{"multicast health summaries", handlers.MulticastHealthSummariesCacheKey, func(ctx context.Context) (any, error) {
+			return api.FetchMulticastHealthSummariesData(ctx, handlers.ShredGroupPK)
+		}},
 	}
 }
 

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -1675,15 +1675,15 @@ export function MulticastGroupDetailPage() {
         activeTab,
         filterParams.length > 0 ? filterParams : undefined,
       ),
-    enabled: !!pk,
+    enabled: !!pk && activeTab !== 'health',
     refetchInterval: 30000,
     placeholderData: keepPreviousData,
   })
 
   useDocumentTitle(group?.code || 'Multicast Group')
 
-  const publisherCount = membersResponse?.publisher_count ?? 0
-  const subscriberCount = membersResponse?.subscriber_count ?? 0
+  const publisherCount = membersResponse?.publisher_count ?? group?.publisher_count ?? 0
+  const subscriberCount = membersResponse?.subscriber_count ?? group?.subscriber_count ?? 0
 
   const activeMembers = membersResponse?.items ?? []
 

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -18,8 +18,9 @@ import { useUPlotChart } from '@/hooks/use-uplot-chart'
 import { useUPlotLegendSync } from '@/hooks/use-uplot-legend-sync'
 import { formatChartAxisRate, formatChartAxisPps } from '@/components/topology/utils'
 import {
-  fetchMulticastGroup,
+  fetchMulticastGroupMemberSnapshot,
   fetchMulticastGroupMembers,
+  fetchMulticastGroupMetadata,
   fetchMulticastGroupTraffic,
   fetchMulticastGroupMemberCounts,
   fetchMulticastGroupShredStats,
@@ -1637,15 +1638,25 @@ export function MulticastGroupDetailPage() {
     })
   }, [filterKey, setSearchParams])
 
-  // Group metadata query
+  // Group metadata query. Keep this metadata-only so the Health tab does
+  // not preload large publisher/subscriber member snapshots it never renders.
   const {
     data: group,
     isLoading: groupLoading,
     error: groupError,
   } = useQuery({
     queryKey: ['multicast-group', pk],
-    queryFn: () => fetchMulticastGroup(pk!),
+    queryFn: () => fetchMulticastGroupMetadata(pk!),
     enabled: !!pk,
+    refetchInterval: 30000,
+  })
+
+  // Full member snapshot for chart labels and selected-series surfacing.
+  // This intentionally stays disabled on Health, where charts are hidden.
+  const { data: chartMembers = [] } = useQuery({
+    queryKey: ['multicast-group-member-snapshot', pk],
+    queryFn: () => fetchMulticastGroupMemberSnapshot(pk!),
+    enabled: !!pk && activeTab !== 'health',
     refetchInterval: 30000,
   })
 
@@ -1689,17 +1700,17 @@ export function MulticastGroupDetailPage() {
 
   // Selected members not on current page — surfaced at top of table
   const surfacedMembers = useMemo(() => {
-    if (selectedSeriesKeys.size === 0 || !group) return []
+    if (selectedSeriesKeys.size === 0) return []
     const activeKeys = new Set(activeMembers.map((m) => `${m.device_pk}_${m.tunnel_id}`))
     const modeFilter = activeTab === 'publishers' ? 'P' : 'S'
-    return group.members.filter((m) => {
+    return chartMembers.filter((m) => {
       const key = `${m.device_pk}_${m.tunnel_id}`
       if (!selectedSeriesKeys.has(key)) return false
       if (activeKeys.has(key)) return false
       // Only surface members matching the active tab
       return m.mode === modeFilter || m.mode === 'P+S'
     })
-  }, [selectedSeriesKeys, group, activeMembers, activeTab])
+  }, [selectedSeriesKeys, chartMembers, activeMembers, activeTab])
 
   // Scroll to first selected row when selection changes
   const selectedRowRef = useRef<HTMLTableRowElement>(null)
@@ -2082,20 +2093,20 @@ export function MulticastGroupDetailPage() {
             group &&
             group.has_shred_stats &&
             activeTab === 'publishers' &&
-            group.members.length > 0 && (
+            chartMembers.length > 0 && (
               <ShredStatsChart
                 groupCode={pk}
-                members={group.members}
+                members={chartMembers}
                 onHoverMember={setHoveredSeriesKey}
                 onSelectMember={setSelectedSeriesKeys}
               />
             )}
 
           {/* Traffic chart — uses all members (not just current page) for series labels */}
-          {pk && group && group.members.length > 0 && (
+          {pk && chartMembers.length > 0 && (
             <MulticastTrafficChart
               groupCode={pk}
-              members={group.members}
+              members={chartMembers}
               activeTab={activeTab === 'subscribers' ? 'subscribers' : 'publishers'}
               onHoverMember={setHoveredSeriesKey}
               onSelectMember={setSelectedSeriesKeys}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -294,10 +294,12 @@ function TableStateRow({
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
   const [usersOffset, setUsersOffset] = useState(0)
   const [pathsOffset, setPathsOffset] = useState(0)
+  const [showPathDetails, setShowPathDetails] = useState(false)
 
   useEffect(() => {
     setUsersOffset(0)
     setPathsOffset(0)
+    setShowPathDetails(false)
   }, [groupPkOrCode])
 
   const summaryQuery = useQuery({
@@ -318,7 +320,7 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   const pathsQuery = useQuery({
     queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset],
     queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset),
-    enabled: !!groupPkOrCode,
+    enabled: !!groupPkOrCode && showPathDetails,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
   })
@@ -342,6 +344,8 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
   const summary = summaryQuery.data
   if (!summary) return null
+
+  const pathCount = summary.counts.paths.total
 
   return (
     <div className="p-4 space-y-6">
@@ -451,121 +455,153 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
             <HelpIcon content={SECTION_HELP.paths} />
           </div>
-          {pathsQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+          <div className="flex items-center gap-2">
+            {showPathDetails && pathsQuery.isFetching && (
+              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+            )}
+            <button
+              type="button"
+              onClick={() => setShowPathDetails((v) => !v)}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {showPathDetails ? 'Hide details' : 'Show details'}
+            </button>
+          </div>
         </div>
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="text-sm text-left text-muted-foreground border-b border-border">
-                <th className="px-4 py-3 font-medium">Publisher</th>
-                <th className="px-4 py-3 font-medium">FHR device</th>
-                <th className="px-4 py-3 font-medium">Subscriber</th>
-                <th className="px-4 py-3 font-medium">LHR device</th>
-                <th className="px-4 py-3 font-medium">Status</th>
-                <th className="px-4 py-3 font-medium">Verified</th>
-              </tr>
-            </thead>
-            <tbody>
-              <TableStateRow
-                isLoading={pathsQuery.isLoading}
-                error={pathsQuery.error}
-                isEmpty={(pathsQuery.data?.items ?? []).length === 0}
-                emptyText="No (publisher, subscriber) pairs"
-                colSpan={6}
-              />
-              {(pathsQuery.data?.items ?? []).map((p) => (
-                <tr
-                  key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}
-                  className="border-b border-border last:border-b-0 hover:bg-muted"
-                >
-                  <td className="px-4 py-3 text-sm font-mono">
-                    <Link
-                      to={`/dz/users/${p.publisher_user_pk}`}
-                      className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+        {!showPathDetails ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <div className="text-foreground font-medium">Path details are collapsed by default.</div>
+              <div>
+                This group has {pathCount.toLocaleString()} publisher → subscriber pairs. Load details only when
+                you need row-level endpoint reconciliation.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowPathDetails(true)}
+              className="self-start sm:self-auto px-3 py-1.5 rounded-md border border-border text-xs text-foreground hover:bg-muted transition-colors"
+            >
+              Load path details
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="text-sm text-left text-muted-foreground border-b border-border">
+                    <th className="px-4 py-3 font-medium">Publisher</th>
+                    <th className="px-4 py-3 font-medium">FHR device</th>
+                    <th className="px-4 py-3 font-medium">Subscriber</th>
+                    <th className="px-4 py-3 font-medium">LHR device</th>
+                    <th className="px-4 py-3 font-medium">Status</th>
+                    <th className="px-4 py-3 font-medium">Verified</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <TableStateRow
+                    isLoading={pathsQuery.isLoading}
+                    error={pathsQuery.error}
+                    isEmpty={(pathsQuery.data?.items ?? []).length === 0}
+                    emptyText="No (publisher, subscriber) pairs"
+                    colSpan={6}
+                  />
+                  {(pathsQuery.data?.items ?? []).map((p) => (
+                    <tr
+                      key={`${p.publisher_user_pk}-${p.subscriber_user_pk}`}
+                      className="border-b border-border last:border-b-0 hover:bg-muted"
                     >
-                      {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
-                      <NavLinkArrow />
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-sm font-mono">
-                    {p.publisher_device_pk ? (
-                      <Link
-                        to={`/dz/devices/${p.publisher_device_pk}`}
-                        className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
-                      >
-                        {p.publisher_device_code || p.publisher_device_pk.slice(0, 8)}
-                        <NavLinkArrow />
-                      </Link>
-                    ) : (
-                      '—'
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-sm font-mono">
-                    <Link
-                      to={`/dz/users/${p.subscriber_user_pk}`}
-                      className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
-                    >
-                      {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
-                      <NavLinkArrow />
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-sm font-mono">
-                    {p.subscriber_device_pk ? (
-                      <Link
-                        to={`/dz/devices/${p.subscriber_device_pk}`}
-                        className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
-                      >
-                        {p.subscriber_device_code || p.subscriber_device_pk.slice(0, 8)}
-                        <NavLinkArrow />
-                      </Link>
-                    ) : (
-                      '—'
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    {p.missing_endpoint_reasons && p.missing_endpoint_reasons.length > 0 ? (
-                      <Tooltip
-                        content={
-                          <div className="space-y-1 min-w-[220px]">
-                            <div className="text-xs font-medium">Missing endpoints</div>
-                            <ul className="space-y-0.5 text-xs">
-                              {p.missing_endpoint_reasons.map((r) => (
-                                <li key={r} className="text-muted-foreground">
-                                  • {r}
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        }
-                        delayDuration={120}
-                      >
-                        <span
-                          tabIndex={0}
-                          aria-label={`Status ${p.health_status}: ${p.missing_endpoint_reasons.join(', ')}`}
-                          className="inline-flex items-center cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
+                      <td className="px-4 py-3 text-sm font-mono">
+                        <Link
+                          to={`/dz/users/${p.publisher_user_pk}`}
+                          className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
                         >
+                          {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
+                          <NavLinkArrow />
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-sm font-mono">
+                        {p.publisher_device_pk ? (
+                          <Link
+                            to={`/dz/devices/${p.publisher_device_pk}`}
+                            className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                          >
+                            {p.publisher_device_code || p.publisher_device_pk.slice(0, 8)}
+                            <NavLinkArrow />
+                          </Link>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-mono">
+                        <Link
+                          to={`/dz/users/${p.subscriber_user_pk}`}
+                          className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                        >
+                          {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
+                          <NavLinkArrow />
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-sm font-mono">
+                        {p.subscriber_device_pk ? (
+                          <Link
+                            to={`/dz/devices/${p.subscriber_device_pk}`}
+                            className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                          >
+                            {p.subscriber_device_code || p.subscriber_device_pk.slice(0, 8)}
+                            <NavLinkArrow />
+                          </Link>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {p.missing_endpoint_reasons && p.missing_endpoint_reasons.length > 0 ? (
+                          <Tooltip
+                            content={
+                              <div className="space-y-1 min-w-[220px]">
+                                <div className="text-xs font-medium">Missing endpoints</div>
+                                <ul className="space-y-0.5 text-xs">
+                                  {p.missing_endpoint_reasons.map((r) => (
+                                    <li key={r} className="text-muted-foreground">
+                                      • {r}
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            }
+                            delayDuration={120}
+                          >
+                            <span
+                              tabIndex={0}
+                              aria-label={`Status ${p.health_status}: ${p.missing_endpoint_reasons.join(', ')}`}
+                              className="inline-flex items-center cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
+                            >
+                              <HealthBadge status={p.health_status} />
+                            </span>
+                          </Tooltip>
+                        ) : (
                           <HealthBadge status={p.health_status} />
-                        </span>
-                      </Tooltip>
-                    ) : (
-                      <HealthBadge status={p.health_status} />
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-xs text-muted-foreground">
-                    {p.verification_method === 'endpoints_only' ? 'endpoints only' : p.verification_method}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        {pathsQuery.data && (
-          <Pagination
-            total={pathsQuery.data.total}
-            limit={HEALTH_PAGE_SIZE}
-            offset={pathsOffset}
-            onOffsetChange={setPathsOffset}
-          />
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                        {p.verification_method === 'endpoints_only' ? 'endpoints only' : p.verification_method}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {pathsQuery.data && (
+              <Pagination
+                total={pathsQuery.data.total}
+                limit={HEALTH_PAGE_SIZE}
+                offset={pathsOffset}
+                onOffsetChange={setPathsOffset}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { Loader2, AlertCircle, Info, ChevronRight } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
+import { Pagination } from '@/components/pagination'
 import {
   fetchMulticastGroupHealth,
   fetchMulticastGroupHealthUsers,
@@ -38,6 +40,8 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
   group_idle: 'all publishers transmitting 0 — nothing to verify against',
   multi_group_ambiguity: "tunnel shared across multiple multicast groups — per-group rate can't be attributed",
 }
+
+const HEALTH_PAGE_SIZE = 100
 
 const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',
@@ -288,6 +292,14 @@ function TableStateRow({
 }
 
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
+  const [usersOffset, setUsersOffset] = useState(0)
+  const [pathsOffset, setPathsOffset] = useState(0)
+
+  useEffect(() => {
+    setUsersOffset(0)
+    setPathsOffset(0)
+  }, [groupPkOrCode])
+
   const summaryQuery = useQuery({
     queryKey: ['multicast-group-health-summary', groupPkOrCode],
     queryFn: () => fetchMulticastGroupHealth(groupPkOrCode),
@@ -296,17 +308,19 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   })
 
   const usersQuery = useQuery({
-    queryKey: ['multicast-group-health-users', groupPkOrCode],
-    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode),
+    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset),
     enabled: !!groupPkOrCode,
     refetchInterval: 60_000,
+    placeholderData: keepPreviousData,
   })
 
   const pathsQuery = useQuery({
-    queryKey: ['multicast-group-health-paths', groupPkOrCode],
-    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode),
+    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset),
     enabled: !!groupPkOrCode,
     refetchInterval: 60_000,
+    placeholderData: keepPreviousData,
   })
 
   if (summaryQuery.isLoading) {
@@ -420,6 +434,14 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             </tbody>
           </table>
         </div>
+        {usersQuery.data && (
+          <Pagination
+            total={usersQuery.data.total}
+            limit={HEALTH_PAGE_SIZE}
+            offset={usersOffset}
+            onOffsetChange={setUsersOffset}
+          />
+        )}
       </div>
 
       {/* Per-path reconciliation */}
@@ -537,6 +559,14 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             </tbody>
           </table>
         </div>
+        {pathsQuery.data && (
+          <Pagination
+            total={pathsQuery.data.total}
+            limit={HEALTH_PAGE_SIZE}
+            offset={pathsOffset}
+            onOffsetChange={setPathsOffset}
+          />
+        )}
       </div>
     </div>
   )

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1953,9 +1953,12 @@ export interface MulticastMember {
   current_slot: number
 }
 
-export interface MulticastGroupDetail extends MulticastGroupListItem {
-  members: MulticastMember[]
+export interface MulticastGroupMetadata extends MulticastGroupListItem {
   has_shred_stats: boolean
+}
+
+export interface MulticastGroupDetail extends MulticastGroupMetadata {
+  members: MulticastMember[]
 }
 
 export interface MulticastMembersResponse extends PaginatedResponse<MulticastMember> {
@@ -1983,17 +1986,24 @@ export async function fetchMulticastGroups(
   return res.json()
 }
 
-export async function fetchMulticastGroup(pkOrCode: string): Promise<MulticastGroupDetail> {
-  const encoded = encodeURIComponent(pkOrCode)
-  const [groupRes, pubRes, subRes] = await Promise.all([
-    apiFetch(`/api/dz/multicast-groups/${encoded}`),
-    apiFetch(`/api/dz/multicast-groups/${encoded}/members?tab=publishers&limit=1000`),
-    apiFetch(`/api/dz/multicast-groups/${encoded}/members?tab=subscribers&limit=1000`),
-  ])
-  if (!groupRes.ok) {
+export async function fetchMulticastGroupMetadata(pkOrCode: string): Promise<MulticastGroupMetadata> {
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}`)
+  if (!res.ok) {
     throw new Error('Failed to fetch multicast group')
   }
-  const group = await groupRes.json() as MulticastGroupListItem & { has_shred_stats?: boolean }
+  const group = await res.json() as MulticastGroupListItem & { has_shred_stats?: boolean }
+  return { ...group, has_shred_stats: group.has_shred_stats ?? false }
+}
+
+export async function fetchMulticastGroupMemberSnapshot(
+  pkOrCode: string,
+  limit = 1000,
+): Promise<MulticastMember[]> {
+  const encoded = encodeURIComponent(pkOrCode)
+  const [pubRes, subRes] = await Promise.all([
+    apiFetch(`/api/dz/multicast-groups/${encoded}/members?tab=publishers&limit=${limit}`),
+    apiFetch(`/api/dz/multicast-groups/${encoded}/members?tab=subscribers&limit=${limit}`),
+  ])
   let members: MulticastMember[] = []
   if (pubRes.ok) {
     const pubData = await pubRes.json() as MulticastMembersResponse
@@ -2009,7 +2019,15 @@ export async function fetchMulticastGroup(pkOrCode: string): Promise<MulticastGr
       }
     }
   }
-  return { ...group, members, has_shred_stats: group.has_shred_stats ?? false }
+  return members
+}
+
+export async function fetchMulticastGroup(pkOrCode: string): Promise<MulticastGroupDetail> {
+  const [group, members] = await Promise.all([
+    fetchMulticastGroupMetadata(pkOrCode),
+    fetchMulticastGroupMemberSnapshot(pkOrCode),
+  ])
+  return { ...group, members }
 }
 
 export async function fetchMulticastGroupMembers(


### PR DESCRIPTION
# Summary

Prevents the multicast Health tab from overloading the browser on large groups like `edge-solana-shreds` by bounding detail queries, deferring expensive preloads, and caching the hot summary endpoint.

## Changes

- Push `LIMIT/OFFSET` into ClickHouse for `/health/users` and `/health/paths`.
- Add Health tab pagination with a page size of 100.
- Disable multicast member snapshot preloads while the Health tab is active.
- Split group metadata fetching from member snapshot fetching.
- Collapse per-path reconciliation by default and only load `/health/paths` on demand.
- Add page-cache support for the hot multicast health summary using `multicast_health_summaries`.
- Preserve existing response shapes while adding `X-Cache: HIT/MISS` visibility.