### PR TITLE
multicast: fix rate view fan-out + rework
  ambiguity + UI polish

### DIFF
--- a/indexer/db/clickhouse/migrations/20260604000002_health_multicast_user_rate_view_dedupe.sql
+++ b/indexer/db/clickhouse/migrations/20260604000002_health_multicast_user_rate_view_dedupe.sql
@@ -1,0 +1,292 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_multicast_user_rate: rewrite to fix two bugs in the original definition.
+--
+-- 1. ReplacingMergeTree fan-out
+--    device_interface_rollup_5m is SharedReplacingMergeTree. Between merges,
+--    the same logical (bucket_ts, device_pk, intf) row can sit on disk as
+--    multiple part copies. The original view's user_rates CTE joined the
+--    raw table back to itself via recent_bucket, so every part copy became
+--    its own row in the view output. Symptoms:
+--      a. Duplicate rows per (user_pk, multicast_group_pk, mode).
+--      b. gpt_total_publisher_rx_bps inflated by the duplicate factor,
+--         which made subscriber reconciliation flag false 'mismatch'.
+--    The rewrite collapses recent_bucket + user_rates into one aggregating
+--    CTE that picks the latest bucket via max(bucket_ts) and dedupes within
+--    that bucket via argMax. Part copies share identical values by RMT
+--    contract, so argMax's tie-break is safe.
+--
+-- 2. multi_group_ambiguity is gone
+--    The original view bailed to rate_status='unknown'/'multi_group_ambiguity'
+--    when a user's tunnel was shared across multicast groups (per-row) or
+--    when a publisher in the group was multi-group (per-group). Per product
+--    direction: when the subscriber TX doesn't match expected within tolerance,
+--    flag it as a mismatch (combined verdict: degraded) even when we cannot
+--    cleanly attribute per-group. Operators read this as "user tunnel
+--    deviates, investigate." The standard tolerance check runs over whatever
+--    observed/expected we have; cross-group contamination shows up as a
+--    real-looking mismatch because the math doesn't add up. We accept the
+--    occasional false-positive in exchange for not silently suppressing real
+--    divergence.
+--
+-- Behavior carried over unchanged from the original view:
+--   - Join key still includes user_pk so tunnel reuse is handled correctly.
+--   - rate_bucket_ts / observed_bps_5m / expected_bps_5m semantics by mode.
+--   - Idle / monitoring_gap / group_idle reasons still distinguish "publisher
+--     transmitting 0" from "publisher missing counters" from "all idle".
+--   - control_plane_status preserved alongside combined health_status.
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+WITH
+-- Aggregating + argMax collapses two sources of duplication into one CTE:
+--   1. Multiple buckets per (device, tunnel, user) → keep max(bucket_ts).
+--   2. ReplacingMergeTree part-row duplicates within that bucket → argMax
+--      picks one (values are identical by RMT contract, so tie-break safe).
+-- ur_present = 1 lets the outer LEFT JOIN distinguish "no row" (default
+-- 0) from "row exists with rate 0" (sentinel 1).
+user_rates AS (
+    SELECT
+        device_pk AS ur_device_pk,
+        user_tunnel_id AS ur_user_tunnel_id,
+        user_pk AS ur_user_pk,
+        max(bucket_ts) AS ur_bucket_ts,
+        argMax(max_in_bps, bucket_ts) AS ur_max_in_bps,
+        argMax(max_out_bps, bucket_ts) AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+      AND user_pk != ''
+    GROUP BY ur_device_pk, ur_user_tunnel_id, ur_user_pk
+),
+-- Per-group publisher RX total + missing-publisher count so subscribers
+-- (and P+S users on the subscriber side) can reconcile their TX against
+-- expected sum-of-publishers. gpt_missing_publisher_count > 0 means at
+-- least one publisher in the group has no counter row, which forces
+-- subscribers to 'monitoring_gap' (we refuse to reconcile against a
+-- deflated expected).
+group_publisher_total AS (
+    SELECT
+        h.multicast_group_pk AS gpt_multicast_group_pk,
+        sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
+        countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        count() AS gpt_publisher_count
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    WHERE h.mode IN ('P', 'P+S')
+    GROUP BY gpt_multicast_group_pk
+),
+-- Inner layer: compute rate_status_reason / observed_bps_5m / expected_bps_5m
+-- / control_plane_status. The outer SELECT rolls these into the three-value
+-- rate_status and the combined health_status.
+with_rate AS (
+    SELECT
+        h.* EXCEPT (health_status),
+        h.health_status AS control_plane_status,
+        if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+        multiIf(
+            ur.ur_present = 0, NULL,
+            h.mode = 'P',   toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',   toNullable(ur.ur_max_out_bps),
+            h.mode = 'P+S', toNullable(ur.ur_max_out_bps),
+            NULL
+        ) AS observed_bps_5m,
+        multiIf(
+            -- S: expected is the full group_total (only set when no missing publishers).
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps),
+            -- P+S: expected excludes self's contribution (PIM-SM RPF: source does
+            -- not receive its own multicast back via the tree).
+            h.mode = 'P+S' AND ur.ur_present = 1 AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps),
+            NULL
+        ) AS expected_bps_5m,
+        multiIf(
+            ur.ur_present = 0, 'no_data',
+
+            -- Pure publisher: just observe activity.
+            h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',
+            h.mode = 'P', 'idle',
+
+            -- Subscriber-side reconciliation (S and P+S).
+            h.mode IN ('S', 'P+S') AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+            h.mode = 'P+S' AND (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps) = 0, 'group_idle',
+            h.mode = 'S'   AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+
+            h.mode = 'P+S' AND abs(ur.ur_max_out_bps - (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps))
+                                <= greatest(0.05 * (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps), 1000000.0),
+                'reconciled',
+            h.mode = 'S'   AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                                <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode IN ('S', 'P+S'), 'mismatch',
+            'no_data'
+        ) AS rate_status_reason
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN group_publisher_total gpt
+        ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
+)
+SELECT
+    w.*,
+    -- Roll rate_status_reason up into the three-value rate_status.
+    if(rate_status_reason IN ('active', 'reconciled'), 'reconciled',
+        if(rate_status_reason = 'mismatch', 'mismatch', 'unknown')
+    ) AS rate_status,
+    -- Combined verdict per the matrix.
+    --                | rate=reconciled | rate=mismatch | rate=unknown
+    --  CP=healthy    | healthy         | degraded      | unknown
+    --  CP=degraded   | degraded        | unhealthy     | degraded
+    --  CP=unhealthy  | unhealthy       | unhealthy     | unhealthy
+    multiIf(
+        control_plane_status = 'unhealthy', 'unhealthy',
+        control_plane_status = 'degraded' AND rate_status_reason = 'mismatch', 'unhealthy',
+        control_plane_status = 'degraded', 'degraded',
+        control_plane_status = 'healthy' AND rate_status_reason IN ('active', 'reconciled'), 'healthy',
+        control_plane_status = 'healthy' AND rate_status_reason = 'mismatch', 'degraded',
+        control_plane_status = 'healthy', 'unknown',
+        'unknown'
+    ) AS health_status
+FROM with_rate w;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- Re-apply the previous view definition (with the fan-out bug and the
+-- multi_group_ambiguity branches). Pulled from
+-- 20260604000001_health_multicast_user_rate_view.sql.
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+WITH
+recent_bucket AS (
+    SELECT
+        device_pk AS rb_device_pk,
+        user_tunnel_id AS rb_user_tunnel_id,
+        user_pk AS rb_user_pk,
+        max(bucket_ts) AS rb_bucket_ts
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+      AND user_pk != ''
+    GROUP BY rb_device_pk, rb_user_tunnel_id, rb_user_pk
+),
+user_rates AS (
+    SELECT
+        r.device_pk AS ur_device_pk,
+        r.user_tunnel_id AS ur_user_tunnel_id,
+        r.user_pk AS ur_user_pk,
+        r.bucket_ts AS ur_bucket_ts,
+        r.max_in_bps AS ur_max_in_bps,
+        r.max_out_bps AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m r
+    INNER JOIN recent_bucket rb
+        ON r.device_pk = rb.rb_device_pk
+       AND r.user_tunnel_id = rb.rb_user_tunnel_id
+       AND r.user_pk = rb.rb_user_pk
+       AND r.bucket_ts = rb.rb_bucket_ts
+),
+user_group_counts AS (
+    SELECT
+        h.user_device_pk AS ugc_device_pk,
+        h.user_tunnel_id AS ugc_user_tunnel_id,
+        h.user_pk        AS ugc_user_pk,
+        countDistinct(h.multicast_group_pk) AS ugc_group_count
+    FROM health_multicast_user h
+    GROUP BY ugc_device_pk, ugc_user_tunnel_id, ugc_user_pk
+),
+group_publisher_total AS (
+    SELECT
+        h.multicast_group_pk AS gpt_multicast_group_pk,
+        sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
+        countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        countIf(ur.ur_present = 1 AND ugc.ugc_group_count > 1) AS gpt_ambiguous_publisher_count,
+        count() AS gpt_publisher_count
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN user_group_counts ugc
+        ON ugc.ugc_device_pk = h.user_device_pk
+       AND ugc.ugc_user_tunnel_id = h.user_tunnel_id
+       AND ugc.ugc_user_pk = h.user_pk
+    WHERE h.mode IN ('P', 'P+S')
+    GROUP BY gpt_multicast_group_pk
+),
+with_rate AS (
+    SELECT
+        h.* EXCEPT (health_status),
+        h.health_status AS control_plane_status,
+        if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+        multiIf(
+            ur.ur_present = 0, NULL,
+            h.mode = 'P',   toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',   toNullable(ur.ur_max_out_bps),
+            h.mode = 'P+S', toNullable(ur.ur_max_out_bps),
+            NULL
+        ) AS observed_bps_5m,
+        multiIf(
+            ugc.ugc_group_count > 1, NULL,
+            gpt.gpt_ambiguous_publisher_count > 0, NULL,
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps),
+            h.mode = 'P+S' AND ur.ur_present = 1 AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps),
+            NULL
+        ) AS expected_bps_5m,
+        multiIf(
+            ur.ur_present = 0, 'no_data',
+            ugc.ugc_group_count > 1 AND h.mode = 'P' AND ur.ur_max_in_bps = 0, 'idle',
+            ugc.ugc_group_count > 1, 'multi_group_ambiguity',
+            h.mode IN ('S', 'P+S') AND gpt.gpt_ambiguous_publisher_count > 0, 'multi_group_ambiguity',
+            h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',
+            h.mode = 'P', 'idle',
+            h.mode IN ('S', 'P+S') AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+            h.mode = 'P+S' AND (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps) = 0, 'group_idle',
+            h.mode = 'S'   AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+            h.mode = 'P+S' AND abs(ur.ur_max_out_bps - (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps))
+                                <= greatest(0.05 * (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps), 1000000.0),
+                'reconciled',
+            h.mode = 'S'   AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                                <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode IN ('S', 'P+S'), 'mismatch',
+            'no_data'
+        ) AS rate_status_reason
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN user_group_counts ugc
+        ON ugc.ugc_device_pk = h.user_device_pk
+       AND ugc.ugc_user_tunnel_id = h.user_tunnel_id
+       AND ugc.ugc_user_pk = h.user_pk
+    LEFT JOIN group_publisher_total gpt
+        ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
+)
+SELECT
+    w.*,
+    if(rate_status_reason IN ('active', 'reconciled'), 'reconciled',
+        if(rate_status_reason = 'mismatch', 'mismatch', 'unknown')
+    ) AS rate_status,
+    multiIf(
+        control_plane_status = 'unhealthy', 'unhealthy',
+        control_plane_status = 'degraded' AND rate_status_reason = 'mismatch', 'unhealthy',
+        control_plane_status = 'degraded', 'degraded',
+        control_plane_status = 'healthy' AND rate_status_reason IN ('active', 'reconciled'), 'healthy',
+        control_plane_status = 'healthy' AND rate_status_reason = 'mismatch', 'degraded',
+        control_plane_status = 'healthy', 'unknown',
+        'unknown'
+    ) AS health_status
+FROM with_rate w;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -372,13 +372,15 @@ func TestHealthMulticastUserRate_TunnelReuse(t *testing.T) {
 	assert.InDelta(t, 99000000, observed["u-B"], 1, "u-B keeps its own 99 Mbps")
 }
 
-// TestHealthMulticastUserRate_MultiGroupAmbiguity verifies that when one
-// (device, tunnel, user) tuple subscribes to multiple multicast groups —
-// so its per-tunnel rate is a cross-group aggregate that cannot be
-// attributed per-group — every rate row for that user is marked
-// rate_status='unknown' with reason 'multi_group_ambiguity', not
-// silently reconciled or mismatched.
-func TestHealthMulticastUserRate_MultiGroupAmbiguity(t *testing.T) {
+// TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded verifies
+// that when one (device, tunnel, user) tuple subscribes to multiple multicast
+// groups — so its per-tunnel TX is a cross-group aggregate — every rate row
+// for that user gets the standard tolerance check applied. The TX includes
+// other groups' traffic, so observed (10 Mbps) exceeds expected (5 Mbps
+// per-group) beyond tolerance and the view flags mismatch → degraded.
+// Operators read this as "user tunnel deviates, investigate" rather than
+// the previous silent fall-through to unknown.
+func TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
 	require.NoError(t, err)
@@ -439,7 +441,7 @@ func TestHealthMulticastUserRate_MultiGroupAmbiguity(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
 
 	rows, err := conn.Query(ctx, `
-		SELECT multicast_group_pk, rate_status, rate_status_reason, expected_bps_5m
+		SELECT multicast_group_pk, rate_status, rate_status_reason, observed_bps_5m, expected_bps_5m, health_status
 		FROM health_multicast_user_rate
 		WHERE user_pk = 'u-mga-sub'
 		ORDER BY multicast_group_pk`)
@@ -447,32 +449,39 @@ func TestHealthMulticastUserRate_MultiGroupAmbiguity(t *testing.T) {
 	defer rows.Close()
 
 	type r struct {
-		group, rate, reason string
-		expected            *float64
+		group, rate, reason, combined string
+		observed, expected            *float64
 	}
 	got := []r{}
 	for rows.Next() {
 		var x r
-		require.NoError(t, rows.Scan(&x.group, &x.rate, &x.reason, &x.expected))
+		require.NoError(t, rows.Scan(&x.group, &x.rate, &x.reason, &x.observed, &x.expected, &x.combined))
 		got = append(got, x)
 	}
 	require.NoError(t, rows.Err())
 	require.Len(t, got, 2, "subscriber should produce one row per group")
 
 	for _, row := range got {
-		assert.Equal(t, "unknown", row.rate, "multi-group subscriber rate must not reconcile (group=%s)", row.group)
-		assert.Equal(t, "multi_group_ambiguity", row.reason, "group=%s", row.group)
-		assert.Nil(t, row.expected, "no per-group expected when ambiguous (group=%s)", row.group)
+		// Observed = subscriber tunnel TX (10 Mbps, cross-group aggregate).
+		// Expected = single-group publisher RX (5 Mbps). |10M - 5M| = 5M > 1M tolerance.
+		assert.Equal(t, "mismatch", row.rate, "TX/expected divergence must surface as mismatch (group=%s)", row.group)
+		assert.Equal(t, "mismatch", row.reason, "group=%s", row.group)
+		require.NotNil(t, row.observed)
+		require.NotNil(t, row.expected)
+		assert.InDelta(t, 10000000, *row.observed, 1)
+		assert.InDelta(t, 5000000, *row.expected, 1)
+		assert.Equal(t, "degraded", row.combined, "CP healthy + rate mismatch → combined degraded (group=%s)", row.group)
 	}
 }
 
-// TestHealthMulticastUserRate_AmbiguousPublisherPropagates verifies that
-// when a multicast group's publisher is multi-group (its per-tunnel RX is
-// a cross-group aggregate), the contamination propagates to every
-// subscriber in that group — even subscribers whose own tunnels are
-// single-group — since gpt_total_publisher_rx_bps cannot be cleanly
-// derived for that group's expected.
-func TestHealthMulticastUserRate_AmbiguousPublisherPropagates(t *testing.T) {
+// TestHealthMulticastUserRate_AmbiguousPublisherFlaggedDegraded verifies
+// that when a group's publisher is multi-group (its per-tunnel RX is a
+// cross-group aggregate that inflates gpt_total_publisher_rx_bps), every
+// single-group subscriber in that group sees observed (their honest
+// per-group TX) < expected (the inflated total) and the standard
+// tolerance check flags mismatch → degraded. This replaces the previous
+// silent fall-through to unknown.
+func TestHealthMulticastUserRate_AmbiguousPublisherFlaggedDegraded(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
 	require.NoError(t, err)
@@ -531,19 +540,124 @@ func TestHealthMulticastUserRate_AmbiguousPublisherPropagates(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
 
 	rows2, err := conn.Query(ctx, `
-		SELECT rate_status, rate_status_reason, expected_bps_5m
+		SELECT rate_status, rate_status_reason, observed_bps_5m, expected_bps_5m, health_status
 		FROM health_multicast_user_rate
 		WHERE user_pk = 'u-ap-sub' AND multicast_group_pk = 'grp-ap-X'`)
 	require.NoError(t, err)
 	defer rows2.Close()
 	require.True(t, rows2.Next(), "expected one row for u-ap-sub on grp-ap-X")
 
-	var rate, reason string
-	var expected *float64
-	require.NoError(t, rows2.Scan(&rate, &reason, &expected))
+	var rate, reason, combined string
+	var observed, expected *float64
+	require.NoError(t, rows2.Scan(&rate, &reason, &observed, &expected, &combined))
 	require.NoError(t, rows2.Err())
-	assert.Equal(t, "unknown", rate,
-		"single-group subscriber must not reconcile when group's publisher is multi-group")
-	assert.Equal(t, "multi_group_ambiguity", reason)
-	assert.Nil(t, expected, "expected must be NULL — gpt_total is contaminated")
+	// Observed = honest single-group subscriber TX (5 Mbps).
+	// Expected = publisher's contaminated cross-group RX (10 Mbps). |5M - 10M| = 5M > 1M tolerance.
+	assert.Equal(t, "mismatch", rate, "TX/expected divergence must surface as mismatch")
+	assert.Equal(t, "mismatch", reason)
+	require.NotNil(t, observed)
+	require.NotNil(t, expected)
+	assert.InDelta(t, 5000000, *observed, 1)
+	assert.InDelta(t, 10000000, *expected, 1)
+	assert.Equal(t, "degraded", combined, "CP healthy + rate mismatch → combined degraded")
+}
+
+// TestHealthMulticastUserRate_RollupDedup guards against the
+// ReplacingMergeTree fan-out bug: device_interface_rollup_5m can hold
+// multiple part-row copies of the same logical row between merges, and
+// without dedup in the rate view those duplicates fan out into multiple
+// view rows per (user, group, mode) AND inflate gpt_total_publisher_rx_bps,
+// causing false 'mismatch' verdicts on subscribers.
+func TestHealthMulticastUserRate_RollupDedup(t *testing.T) {
+	info := laketesting.NewClientWithInfo(t, sharedDB)
+	conn, err := info.Client.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	ctx := t.Context()
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_devices_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
+		VALUES
+			('d-dd-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-dd-fhr', 'activated', 'edge', 'dd-fhr-dz1', '', '', '', 0, '[]'),
+			('d-dd-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-dd-lhr', 'activated', 'edge', 'dd-lhr-dz1', '', '', '', 0, '[]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('grp-dd', now(), now(), generateUUIDv4(), 0, 1, 'grp-dd', 'o', 'rate-dd', '233.99.6.1', 100000000, 'activated', 1, 1)`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
+		VALUES
+			('u-dd-pub', now(), now(), generateUUIDv4(), 0, 1, 'u-dd-pub', 'o', 'activated', 'multicast', '203.0.118.1', '10.99.6.1', 'd-dd-fhr', 't1', 970, '["grp-dd"]', '[]'),
+			('u-dd-sub', now(), now(), generateUUIDv4(), 0, 2, 'u-dd-sub', 'o', 'activated', 'multicast', '203.0.118.2', '10.99.6.2', 'd-dd-lhr', 't1', 971, '[]', '["grp-dd"]')`))
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO dim_dz_ip_mroute_entries_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 device_pubkey, vrf, mode, group_address, source_address,
+			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
+			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
+			 oif_list, oif_count, creation_time)
+		VALUES
+			('mr-dd-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-dd-fhr', 'default', 'sparse', '233.99.6.1', '10.99.6.1', 'SBNP', 0, 'Tunnel970', '', '', 0, 0, '', 0, 0, '', 0, now()),
+			('mr-dd-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-dd-lhr', 'default', 'sparse', '233.99.6.1', '10.99.6.1', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel971"]', 1, now())`))
+
+	// Insert THREE identical part-row copies for each rollup bucket — emulates
+	// what ReplacingMergeTree leaves on disk before background merges run.
+	// Without dedup in the view, the publisher fan-out would multiply
+	// gpt_total_publisher_rx_bps by 3 (30 Mbps), and the subscriber's
+	// observed (10 Mbps) would be flagged mismatch against the inflated
+	// expected. With dedup, expected == observed == 10 Mbps → reconciled.
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO device_interface_rollup_5m
+			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
+		VALUES
+			(now() - INTERVAL 1 MINUTE, 'd-dd-fhr', 'Tunnel970', 970, 'u-dd-pub', 10000000, 0,        now()),
+			(now() - INTERVAL 1 MINUTE, 'd-dd-fhr', 'Tunnel970', 970, 'u-dd-pub', 10000000, 0,        now()),
+			(now() - INTERVAL 1 MINUTE, 'd-dd-fhr', 'Tunnel970', 970, 'u-dd-pub', 10000000, 0,        now()),
+			(now() - INTERVAL 1 MINUTE, 'd-dd-lhr', 'Tunnel971', 971, 'u-dd-sub', 0,        10000000, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-dd-lhr', 'Tunnel971', 971, 'u-dd-sub', 0,        10000000, now()),
+			(now() - INTERVAL 1 MINUTE, 'd-dd-lhr', 'Tunnel971', 971, 'u-dd-sub', 0,        10000000, now())`))
+
+	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
+	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
+
+	// 1. View must emit exactly one row per (user, group, mode) — no fan-out.
+	countRows, err := conn.Query(ctx,
+		`SELECT count() FROM health_multicast_user_rate WHERE multicast_group_pk = 'grp-dd'`)
+	require.NoError(t, err)
+	require.True(t, countRows.Next())
+	var rowCount uint64
+	require.NoError(t, countRows.Scan(&rowCount))
+	countRows.Close()
+	assert.Equal(t, uint64(2), rowCount,
+		"expected 2 rows (publisher + subscriber); got %d means part-row duplicates fanned out", rowCount)
+
+	// 2. Subscriber's expected_bps_5m must reflect the deduped publisher RX
+	//    (10 Mbps), not the inflated 30 Mbps — so the verdict is healthy,
+	//    not the spurious 'mismatch' the original bug would produce.
+	rows, err := conn.Query(ctx, `
+		SELECT mode, observed_bps_5m, expected_bps_5m, rate_status, health_status
+		FROM health_multicast_user_rate
+		WHERE multicast_group_pk = 'grp-dd' AND user_pk = 'u-dd-sub'`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var mode, rate, combined string
+	var observed, expected *float64
+	require.NoError(t, rows.Scan(&mode, &observed, &expected, &rate, &combined))
+	require.NoError(t, rows.Err())
+	assert.Equal(t, "S", mode)
+	require.NotNil(t, observed)
+	require.NotNil(t, expected)
+	assert.InDelta(t, 10000000, *observed, 1)
+	assert.InDelta(t, 10000000, *expected, 1, "expected must equal deduped publisher RX, not 3× inflated")
+	assert.Equal(t, "reconciled", rate)
+	assert.Equal(t, "healthy", combined)
 }

--- a/web/src/components/multicast-delivery-panel.tsx
+++ b/web/src/components/multicast-delivery-panel.tsx
@@ -48,7 +48,6 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
   mismatch: 'TX deviates from sum of publishers',
   monitoring_gap: 'a publisher in this group has no counter data',
   group_idle: 'all publishers are idle, nothing to verify',
-  multi_group_ambiguity: "tunnel shared across multiple multicast groups — per-group rate can't be attributed",
 }
 
 function compactNumber(value: number): string {

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -38,7 +38,6 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
   mismatch: 'TX deviates from sum of publishers',
   monitoring_gap: 'a publisher in this group has no counter data',
   group_idle: 'all publishers transmitting 0 — nothing to verify against',
-  multi_group_ambiguity: "tunnel shared across multiple multicast groups — per-group rate can't be attributed",
 }
 
 const HEALTH_PAGE_SIZE = 100
@@ -141,7 +140,6 @@ const DIM_BADGE_CLASS: Record<string, string> = {
   no_data: 'bg-muted text-muted-foreground',
   monitoring_gap: 'bg-muted text-muted-foreground',
   group_idle: 'bg-muted text-muted-foreground',
-  multi_group_ambiguity: 'bg-muted text-muted-foreground',
 }
 
 function DimBadge({ value }: { value: string }) {
@@ -430,7 +428,17 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     <RateCell item={u} />
                   </td>
                   <td className="px-4 py-3 text-sm">
-                    <UserCombinedHealthBadge item={u} />
+                    <div className="flex flex-col gap-1">
+                      <UserCombinedHealthBadge item={u} />
+                      {/* Inline dimension breakdown so operators can scan
+                          CP × Rate without needing to hover every row. */}
+                      <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                        <span>CP</span>
+                        <DimBadge value={u.control_plane_status} />
+                        <span className="ml-1">Rate</span>
+                        <DimBadge value={u.rate_status} />
+                      </div>
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-sm text-muted-foreground">{rowReason(u)}</td>
                 </tr>

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -789,12 +789,22 @@ export function UserDetailPage() {
           {/* Multicast Groups */}
           {multicastGroups && multicastGroups.length > 0 && (
             <div className="border border-border rounded-lg p-4 bg-card">
-              <h3 className="text-sm font-medium text-muted-foreground mb-3">Multicast Groups</h3>
+              <h3 className="text-sm font-medium text-muted-foreground mb-1">Multicast Groups</h3>
+              <p className="text-xs text-muted-foreground mb-3">
+                Healthy = control plane reconciled with onchain expectation AND data-plane rate matches expected. Hover a badge for the CP × Rate breakdown.
+              </p>
               <div className="space-y-2">
                 {multicastGroups.map((g) => {
-                  const healthItems = (userHealth?.items ?? []).filter(
-                    (it) => it.multicast_group_pk === g.group_pk,
-                  )
+                  // Filter to this group, then dedupe by mode as a safety net
+                  // against any future duplicate rows from the rate view.
+                  const seenModes = new Set<string>()
+                  const healthItems = (userHealth?.items ?? [])
+                    .filter((it) => it.multicast_group_pk === g.group_pk)
+                    .filter((it) => {
+                      if (seenModes.has(it.mode)) return false
+                      seenModes.add(it.mode)
+                      return true
+                    })
                   return (
                   <div key={g.group_pk} className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2232,7 +2232,6 @@ export type MulticastRateStatusReason =
   | 'mismatch'
   | 'monitoring_gap'
   | 'group_idle'
-  | 'multi_group_ambiguity'
 
 export interface MulticastHealthUserItem {
   user_pk: string


### PR DESCRIPTION
## Summary

Follow-up to #633 covering bugs and UI polish surfaced during live review.

1. **`health_multicast_user_rate` fan-out fix.** `device_interface_rollup_5m` is `SharedReplacingMergeTree`. Between merges, the same logical row sits on disk as multiple part copies. The original view's `recent_bucket` + `user_rates` join brought every part copy back, so each user/group row was emitted N times AND `gpt_total_publisher_rx_bps` was inflated N×, which produced false `mismatch` subscriber verdicts. Rewritten with a single aggregating CTE (`max(bucket_ts)` + `argMax(...)` to dedupe pre-merge duplicates).
2. **`multi_group_ambiguity` removed.** Previously the view bailed to `rate_status='unknown' / 'multi_group_ambiguity'` when a user's tunnel was shared across groups or when a publisher in the group was multi-group. Per product call: when subscriber TX doesn't match expected within tolerance, flag mismatch (combined verdict: degraded) and let operators read it as "user tunnel deviates, investigate" rather than silently suppressing the divergence.
3. **Per-user / per-path tables paginated** on the Multicast Group Health tab (25 rows/page). Drops the on-page Radix Tooltip.Root count from 400+ to ~25, which incidentally fixes the "rollover only works on the first instance" bug that 200+ tooltip instances had triggered.
4. **Status column now stacks the combined badge with inline CP + Rate dim badges** so the dimension breakdown is visible without hovering every row.
5. **One-line healthy explainer + client-side mode dedup** on the user page Multicast Groups card. Explainer answers "what does healthy mean?" without forcing a hover; dedup is defense-in-depth in case the view ever emits duplicates again.

## Testing Verification

- New `TestHealthMulticastUserRate_RollupDedup` inserts 3 identical pre-merge rollup rows for each tunnel and asserts the view emits exactly 2 rows (publisher + subscriber, not 6) AND that the deduped publisher RX (10 Mbps) drives the subscriber to `reconciled` / `healthy` instead of the spurious `mismatch` that the inflated 30 Mbps total would have produced.
- `TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded` (renamed from `_MultiGroupAmbiguity`) asserts that a multi-group subscriber whose tunnel TX (10 Mbps cross-group) exceeds per-group expected (5 Mbps) now reports `mismatch` → `degraded` for both groups instead of `unknown / multi_group_ambiguity`.
- `TestHealthMulticastUserRate_AmbiguousPublisherFlaggedDegraded` (renamed) asserts that a single-group subscriber in a group with a multi-group publisher reports `mismatch` → `degraded` (observed 5 Mbps vs contaminated expected 10 Mbps).
- Existing healthy / idle / no_data / monitoring_gap / P+S / tunnel-reuse cases all still pass under the rewritten view.
- Spot-checked the live Health tab against the deduped view via the staging path: the duplicate-badge rows on rebop / edge-solana-shreds collapse to one row per (user, mode) once the migration applies.
