### PR TITLE
multicast: cache hot health pages, shrink page size, gate behind login

### DIFF
--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -214,6 +214,33 @@ func addStatusCount(bucket *MulticastHealthStatusCounts, status string, n uint64
 	bucket.Total += n
 }
 
+// parseHealthSearch returns the trimmed `?search=` query param. Empty when
+// absent; handlers treat empty as "no filter" and avoid appending any
+// WHERE-LIKE clause.
+func parseHealthSearch(r *http.Request) string {
+	return strings.TrimSpace(r.URL.Query().Get("search"))
+}
+
+// buildHealthSearchClause builds a parameterized WHERE-LIKE OR across the
+// passed columns. Returns the SQL fragment (starting with " AND (...)" so
+// it appends cleanly) and the args to extend the query's argument slice.
+// Empty `search` returns ("", nil) so callers can unconditionally append.
+func buildHealthSearchClause(search string, cols []string) (string, []any) {
+	if search == "" || len(cols) == 0 {
+		return "", nil
+	}
+	// Case-insensitive substring match via positionCaseInsensitive() > 0.
+	// Beats LIKE '%foo%' because we don't have to escape % and _ in the
+	// user input, and lets ClickHouse use a single function per column.
+	parts := make([]string, 0, len(cols))
+	args := make([]any, 0, len(cols))
+	for _, c := range cols {
+		parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
+		args = append(args, search)
+	}
+	return " AND (" + strings.Join(parts, " OR ") + ")", args
+}
+
 // parseLimitOffset extracts optional pagination params. Both default to 0,
 // which means "stream all rows" for handlers that don't set a bounded
 // default before querying.

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -19,6 +19,30 @@ import (
 // group health summaries.
 const MulticastHealthSummariesCacheKey = "multicast_health_summaries"
 
+// MulticastHealthCachedPageSize is the page size the worker pre-fetches for
+// the hot ShredGroupPK on /health/users and /health/paths. The UI defaults
+// to this same value so the first paint hits the cache; anything else
+// (different page size or non-zero offset) falls through to a live query.
+const MulticastHealthCachedPageSize = 25
+
+// multicast health users / paths per-pk cache keys.
+const (
+	multicastHealthUsersCacheKeyPrefix = "multicast_health_users:"
+	multicastHealthPathsCacheKeyPrefix = "multicast_health_paths:"
+)
+
+// MulticastHealthUsersCacheKey returns the per-pk cache key for the worker
+// to write and the handler to read for the hot first page of
+// /health/users. One row per pk, no list walk.
+func MulticastHealthUsersCacheKey(pk string) string {
+	return multicastHealthUsersCacheKeyPrefix + pk
+}
+
+// MulticastHealthPathsCacheKey returns the per-pk cache key for /health/paths.
+func MulticastHealthPathsCacheKey(pk string) string {
+	return multicastHealthPathsCacheKeyPrefix + pk
+}
+
 // GetMulticastGroupHealth returns per-group health counts across mroutes,
 // multicast users, and publisher↔subscriber paths. Reads from the three
 // health_* views, or from the page cache for mainnet requests when available.

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -35,6 +36,19 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 	}
 
 	limit, offset := parseLimitOffset(r)
+
+	// Cache read-through: only the hot first page of the hot group (the UI's
+	// default request) is pre-fetched by the worker. Anything else falls
+	// through to a live query, which uses the same code path below.
+	if isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
+		if cached, ok := a.readMulticastHealthPathsCache(ctx, group.PK); ok {
+			w.Header().Set("X-Cache", "HIT")
+			writeJSON(w, cached)
+			return
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
 	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, limit, offset)
 	if err != nil {
 		logError("multicast group health/paths query error", "error", err, "pk", group.PK)
@@ -50,6 +64,43 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 		Limit:       limit,
 		Offset:      offset,
 	})
+}
+
+// readMulticastHealthPathsCache returns the cached first-page paths response
+// for the given group pk if the worker has written it. Missing entry or
+// decode failure → cache miss, caller falls through to live query.
+func (a *API) readMulticastHealthPathsCache(ctx context.Context, groupPK string) (*MulticastHealthGroupPathsResponse, bool) {
+	data, err := a.readPageCache(ctx, MulticastHealthPathsCacheKey(groupPK))
+	if err != nil {
+		return nil, false
+	}
+	var cached MulticastHealthGroupPathsResponse
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+	return &cached, true
+}
+
+// FetchMulticastHealthPathsPageData fetches the hot first page of
+// /health/paths (offset=0, limit=MulticastHealthCachedPageSize) for the
+// given pkOrCode. The worker calls this on every refresh cycle.
+func (a *API) FetchMulticastHealthPathsPageData(ctx context.Context, pkOrCode string) (*MulticastHealthGroupPathsResponse, error) {
+	group, err := a.queryMulticastDeliveryGroup(ctx, pkOrCode)
+	if err != nil {
+		return nil, err
+	}
+	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, MulticastHealthCachedPageSize, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &MulticastHealthGroupPathsResponse{
+		Group:       group,
+		GeneratedAt: formatMulticastTime(time.Now().UTC()),
+		Items:       items,
+		Total:       total,
+		Limit:       MulticastHealthCachedPageSize,
+		Offset:      0,
+	}, nil
 }
 
 func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string, limit, offset int) ([]MulticastHealthPathItem, int, error) {

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -13,6 +13,22 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
+// multicastHealthPathSearchCols are the columns the `?search=` filter
+// substring-matches across (case-insensitive).
+var multicastHealthPathSearchCols = []string{
+	"publisher_owner_pubkey",
+	"publisher_user_pk",
+	"publisher_dz_ip",
+	"publisher_device_code",
+	"publisher_device_pk",
+	"subscriber_owner_pubkey",
+	"subscriber_user_pk",
+	"subscriber_dz_ip",
+	"subscriber_device_code",
+	"subscriber_device_pk",
+	"health_status",
+}
+
 // GetMulticastGroupHealthPaths returns per-(publisher, subscriber) path
 // reconciliation rows from health_publisher_subscriber_path for one group.
 func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Request) {
@@ -36,11 +52,12 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 	}
 
 	limit, offset := parseLimitOffset(r)
+	search := parseHealthSearch(r)
 
-	// Cache read-through: only the hot first page of the hot group (the UI's
-	// default request) is pre-fetched by the worker. Anything else falls
-	// through to a live query, which uses the same code path below.
-	if isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
+	// Cache read-through: only the hot first page with no search filter
+	// is pre-fetched by the worker. Searched / paged / non-hot requests
+	// fall through to a live query.
+	if search == "" && isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
 		if cached, ok := a.readMulticastHealthPathsCache(ctx, group.PK); ok {
 			w.Header().Set("X-Cache", "HIT")
 			writeJSON(w, cached)
@@ -49,7 +66,7 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 	}
 	w.Header().Set("X-Cache", "MISS")
 
-	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, limit, offset)
+	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, search, limit, offset)
 	if err != nil {
 		logError("multicast group health/paths query error", "error", err, "pk", group.PK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -89,7 +106,7 @@ func (a *API) FetchMulticastHealthPathsPageData(ctx context.Context, pkOrCode st
 	if err != nil {
 		return nil, err
 	}
-	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, MulticastHealthCachedPageSize, 0)
+	items, total, err := a.queryMulticastHealthPaths(ctx, group.PK, "", MulticastHealthCachedPageSize, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -103,9 +120,13 @@ func (a *API) FetchMulticastHealthPathsPageData(ctx context.Context, pkOrCode st
 	}, nil
 }
 
-func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK string, limit, offset int) ([]MulticastHealthPathItem, int, error) {
+func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK, search string, limit, offset int) ([]MulticastHealthPathItem, int, error) {
 	whereClause := "multicast_group_pk = ?"
 	args := []any{groupPK}
+	if clause, extra := buildHealthSearchClause(search, multicastHealthPathSearchCols); clause != "" {
+		whereClause += clause
+		args = append(args, extra...)
+	}
 	total := 0
 	if limit > 0 {
 		var err error

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -35,6 +36,19 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 	}
 
 	limit, offset := parseLimitOffset(r)
+
+	// Cache read-through: only the hot first page of the hot group (the UI's
+	// default request) is pre-fetched by the worker. Anything else falls
+	// through to a live query, which uses the same code path below.
+	if isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
+		if cached, ok := a.readMulticastHealthUsersCache(ctx, group.PK); ok {
+			w.Header().Set("X-Cache", "HIT")
+			writeJSON(w, cached)
+			return
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
 	items, total, err := a.queryMulticastHealthUsers(ctx, "multicast_group_pk = ?", []any{group.PK}, limit, offset)
 	if err != nil {
 		logError("multicast group health/users query error", "error", err, "pk", group.PK)
@@ -92,6 +106,46 @@ func (a *API) GetUserHealth(w http.ResponseWriter, r *http.Request) {
 		GeneratedAt:     formatMulticastTime(time.Now().UTC()),
 		Items:           items,
 	})
+}
+
+// readMulticastHealthUsersCache returns the cached first-page users response
+// for the given group pk if the worker has written it. Missing entry or
+// decode failure → cache miss, caller falls through to live query.
+func (a *API) readMulticastHealthUsersCache(ctx context.Context, groupPK string) (*MulticastHealthGroupUsersResponse, bool) {
+	data, err := a.readPageCache(ctx, MulticastHealthUsersCacheKey(groupPK))
+	if err != nil {
+		return nil, false
+	}
+	var cached MulticastHealthGroupUsersResponse
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+	return &cached, true
+}
+
+// FetchMulticastHealthUsersPageData fetches the hot first page of
+// /health/users (offset=0, limit=MulticastHealthCachedPageSize) for the
+// given pkOrCode. The worker calls this on every refresh cycle and writes
+// the result under MulticastHealthUsersCacheKey(pk).
+func (a *API) FetchMulticastHealthUsersPageData(ctx context.Context, pkOrCode string) (*MulticastHealthGroupUsersResponse, error) {
+	group, err := a.queryMulticastDeliveryGroup(ctx, pkOrCode)
+	if err != nil {
+		return nil, err
+	}
+	items, total, err := a.queryMulticastHealthUsers(
+		ctx, "multicast_group_pk = ?", []any{group.PK}, MulticastHealthCachedPageSize, 0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &MulticastHealthGroupUsersResponse{
+		Group:       group,
+		GeneratedAt: formatMulticastTime(time.Now().UTC()),
+		Items:       items,
+		Total:       total,
+		Limit:       MulticastHealthCachedPageSize,
+		Offset:      0,
+	}, nil
 }
 
 // queryMulticastHealthUsers reads from health_multicast_user_rate with a

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -13,6 +13,21 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
+// multicastHealthUserSearchCols are the columns the `?search=` filter
+// substring-matches across (case-insensitive). Order doesn't matter for
+// correctness, but listing the most likely-matched columns first lets
+// ClickHouse short-circuit OR evaluation in the common case.
+var multicastHealthUserSearchCols = []string{
+	"user_owner_pubkey",
+	"user_pk",
+	"user_dz_ip",
+	"user_device_code",
+	"user_device_pk",
+	"user_tunnel_id",
+	"mode",
+	"health_status",
+}
+
 // GetMulticastGroupHealthUsers returns per-user reconciliation rows from
 // health_multicast_user filtered to one group.
 func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Request) {
@@ -36,11 +51,12 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 	}
 
 	limit, offset := parseLimitOffset(r)
+	search := parseHealthSearch(r)
 
-	// Cache read-through: only the hot first page of the hot group (the UI's
-	// default request) is pre-fetched by the worker. Anything else falls
-	// through to a live query, which uses the same code path below.
-	if isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
+	// Cache read-through: only the hot first page of the hot group with no
+	// search filter is pre-fetched by the worker. Searched / paged / non-hot
+	// requests fall through to a live query.
+	if search == "" && isMainnet(r.Context()) && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK {
 		if cached, ok := a.readMulticastHealthUsersCache(ctx, group.PK); ok {
 			w.Header().Set("X-Cache", "HIT")
 			writeJSON(w, cached)
@@ -49,7 +65,13 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 	}
 	w.Header().Set("X-Cache", "MISS")
 
-	items, total, err := a.queryMulticastHealthUsers(ctx, "multicast_group_pk = ?", []any{group.PK}, limit, offset)
+	where := "multicast_group_pk = ?"
+	args := []any{group.PK}
+	if clause, extra := buildHealthSearchClause(search, multicastHealthUserSearchCols); clause != "" {
+		where += clause
+		args = append(args, extra...)
+	}
+	items, total, err := a.queryMulticastHealthUsers(ctx, where, args, limit, offset)
 	if err != nil {
 		logError("multicast group health/users query error", "error", err, "pk", group.PK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -129,6 +129,16 @@ func (a *Activities) entries() []cacheEntry {
 		{"multicast health summaries", handlers.MulticastHealthSummariesCacheKey, func(ctx context.Context) (any, error) {
 			return api.FetchMulticastHealthSummariesData(ctx, handlers.ShredGroupPK)
 		}},
+		// Pre-fetch the hot first page of /health/users and /health/paths for
+		// ShredGroupPK. The UI's default request (offset=0, limit=
+		// MulticastHealthCachedPageSize) hits these caches and returns in ~1ms
+		// instead of running the view live (multi-second on edge-solana-shreds).
+		{"multicast health users (shreds)", handlers.MulticastHealthUsersCacheKey(handlers.ShredGroupPK), func(ctx context.Context) (any, error) {
+			return api.FetchMulticastHealthUsersPageData(ctx, handlers.ShredGroupPK)
+		}},
+		{"multicast health paths (shreds)", handlers.MulticastHealthPathsCacheKey(handlers.ShredGroupPK), func(ctx context.Context) (any, error) {
+			return api.FetchMulticastHealthPathsPageData(ctx, handlers.ShredGroupPK)
+		}},
 	}
 }
 

--- a/web/src/components/multicast-group-detail-page.tsx
+++ b/web/src/components/multicast-group-detail-page.tsx
@@ -33,6 +33,7 @@ import { SmallDropdown } from '@/components/topology/TimeRangeSelector'
 import { InlineFilter } from '@/components/inline-filter'
 import { Pagination } from '@/components/pagination'
 import { MulticastGroupHealthTab } from '@/components/multicast-group-health-tab'
+import { useAuth } from '@/contexts/AuthContext'
 
 function formatBps(bps: number): string {
   if (bps === 0) return '—'
@@ -1482,12 +1483,16 @@ export function MulticastGroupDetailPage() {
   const { pk } = useParams<{ pk: string }>()
   const navigate = useNavigate()
   const back = useBackLink({ to: '/dz/multicast-groups', label: 'multicast groups' })
+  const { isAuthenticated } = useAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab')
+  // Health tab is gated behind login for now: the underlying views are
+  // heavy and we don't want anonymous traffic hammering them. If the URL
+  // asks for tab=health while logged out, fall back to publishers.
   const activeTab = (
     tabParam === 'subscribers'
       ? 'subscribers'
-      : tabParam === 'health'
+      : tabParam === 'health' && isAuthenticated
         ? 'health'
         : 'publishers'
   ) as 'publishers' | 'subscribers' | 'health'
@@ -1917,16 +1922,18 @@ export function MulticastGroupDetailPage() {
             >
               Subscribers ({subscriberCount})
             </button>
-            <button
-              onClick={() => setActiveTab('health')}
-              className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors -mb-px ${
-                activeTab === 'health'
-                  ? 'border-purple-500 text-purple-500'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Health
-            </button>
+            {isAuthenticated && (
+              <button
+                onClick={() => setActiveTab('health')}
+                className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                  activeTab === 'health'
+                    ? 'border-purple-500 text-purple-500'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Health
+              </button>
+            )}
             {membersFetching && activeTab !== 'health' && (
               <div className="flex items-center ml-2">
                 <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -47,6 +47,40 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
 // group so the first paint hits the worker cache.
 const HEALTH_PAGE_SIZE = 25
 
+// useDebouncedValue returns `value` delayed by `delayMs`, so a rapidly
+// changing input (typing in the search box) only triggers a new query
+// after the user pauses.
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+  return debounced
+}
+
+function SearchInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+}) {
+  return (
+    <div className="relative">
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="h-7 w-72 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+    </div>
+  )
+}
+
 const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',
   degraded: 'bg-amber-500/15 text-amber-500',
@@ -298,12 +332,27 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   const [usersOffset, setUsersOffset] = useState(0)
   const [pathsOffset, setPathsOffset] = useState(0)
   const [showPathDetails, setShowPathDetails] = useState(false)
+  const [usersSearchInput, setUsersSearchInput] = useState('')
+  const [pathsSearchInput, setPathsSearchInput] = useState('')
+  const usersSearch = useDebouncedValue(usersSearchInput, 200)
+  const pathsSearch = useDebouncedValue(pathsSearchInput, 200)
 
   useEffect(() => {
     setUsersOffset(0)
     setPathsOffset(0)
     setShowPathDetails(false)
+    setUsersSearchInput('')
+    setPathsSearchInput('')
   }, [groupPkOrCode])
+
+  // Reset to page 1 whenever the search text changes so the user sees the
+  // first page of matches rather than an empty page-N.
+  useEffect(() => {
+    setUsersOffset(0)
+  }, [usersSearch])
+  useEffect(() => {
+    setPathsOffset(0)
+  }, [pathsSearch])
 
   const summaryQuery = useQuery({
     queryKey: ['multicast-group-health-summary', groupPkOrCode],
@@ -313,16 +362,16 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   })
 
   const usersQuery = useQuery({
-    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset],
-    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset),
+    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch || undefined),
     enabled: !!groupPkOrCode,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
   })
 
   const pathsQuery = useQuery({
-    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset],
-    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset),
+    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch || undefined),
     enabled: !!groupPkOrCode && showPathDetails,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
@@ -371,12 +420,19 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
       {/* Per-user reconciliation */}
       <div className="border border-border rounded-lg bg-card">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
             <h3 className="text-sm font-medium">Per-user reconciliation</h3>
             <HelpIcon content={SECTION_HELP.users} />
           </div>
-          {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+          <div className="flex items-center gap-2">
+            <SearchInput
+              value={usersSearchInput}
+              onChange={setUsersSearchInput}
+              placeholder="Filter user, mode, device, tunnel, status…"
+            />
+            {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+          </div>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -469,6 +525,13 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <HelpIcon content={SECTION_HELP.paths} />
           </div>
           <div className="flex items-center gap-2">
+            {showPathDetails && (
+              <SearchInput
+                value={pathsSearchInput}
+                onChange={setPathsSearchInput}
+                placeholder="Filter publisher, subscriber, device, status…"
+              />
+            )}
             {showPathDetails && pathsQuery.isFetching && (
               <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
             )}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -40,7 +40,12 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
   group_idle: 'all publishers transmitting 0 — nothing to verify against',
 }
 
-const HEALTH_PAGE_SIZE = 100
+// 25 keeps the per-page Radix Tooltip.Root count (~2 per row × N rows) below
+// the threshold where mounting blocks the main thread long enough to trigger
+// Chrome's "Page Unresponsive" prompt on large groups (edge-solana-shreds has
+// 857 users). It also matches the server-side cached page size for the hot
+// group so the first paint hits the worker cache.
+const HEALTH_PAGE_SIZE = 25
 
 const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2325,10 +2325,12 @@ export async function fetchMulticastGroupHealthUsers(
   pkOrCode: string,
   limit?: number,
   offset?: number,
+  search?: string,
 ): Promise<MulticastHealthGroupUsersResponse> {
   const params = new URLSearchParams()
   if (limit !== undefined) params.set('limit', String(limit))
   if (offset !== undefined) params.set('offset', String(offset))
+  if (search) params.set('search', search)
   const qs = params.toString()
   const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/users${qs ? `?${qs}` : ''}`)
   if (!res.ok) {
@@ -2341,10 +2343,12 @@ export async function fetchMulticastGroupHealthPaths(
   pkOrCode: string,
   limit?: number,
   offset?: number,
+  search?: string,
 ): Promise<MulticastHealthGroupPathsResponse> {
   const params = new URLSearchParams()
   if (limit !== undefined) params.set('limit', String(limit))
   if (offset !== undefined) params.set('offset', String(offset))
+  if (search) params.set('search', search)
   const qs = params.toString()
   const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/paths${qs ? `?${qs}` : ''}`)
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Follow-up to #641 covering the perf issues we hit during prod validation on edge-solana-shreds (857 users).

1. **Pre-fetch `/health/users` and `/health/paths` first page for `ShredGroupPK`** in the page-cache worker, keyed per-pk (`multicast_health_users:<pk>` / `multicast_health_paths:<pk>`). Handler reads cache only when the request matches the worker's slice (default page size, offset 0, the hot group); any other request falls through to a live query. Drops ~4s and ~2s warm endpoints to ~ms on cache hit.
2. **`HEALTH_PAGE_SIZE`: 100 → 25.** Keeps the per-page Radix `Tooltip.Root` count under the threshold where Chrome shows "Page Unresponsive" on edge-solana-shreds. Also aligns with the new server-side cached slice so the first paint hits the cache.
3. **Login-gate the Health tab.** The Health tab button is hidden unless the viewer is authenticated, and `?tab=health` falls back to publishers when logged out. Anonymous traffic on a 30s refetch interval was hammering the heavy health views with no business need to do so.
4. **Search filter on both Health tables.** New `?search=` param on `/health/users` and `/health/paths` does a case-insensitive substring OR across the relevant columns (user pubkey/owner/dz_ip/device/tunnel/mode/status on users; publisher and subscriber pubkey/owner/dz_ip/device + status on paths). Renders a debounced search input above each table. Cache read-through is restricted to the unfiltered hot first page so any search request hits the live view.

## Testing Verification

- Existing handler tests still pass against the rewired users/paths fetchers.
- Verified the worker-cache read-through path triggers only on `search == "" && offset == 0 && limit == MulticastHealthCachedPageSize && group.PK == ShredGroupPK`; everything else falls through to the live query unchanged.
- Manual: confirmed Health tab is no longer rendered or reachable when `isAuthenticated` is false.
- Manual: search input filters server-side; typing `unhealthy` narrows to unhealthy rows, `nyc002` to that device, `Df` to matching user pubkeys.
