### PR TITLE
multicast: display account user_pk instead of owner pubkey in Health tables

### DIFF
--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -273,7 +273,18 @@ func tokenizeHealthSearch(search string) []healthSearchToken {
 // Returns ("", nil) when search is empty so callers can unconditionally
 // append. Tokens whose field prefix isn't in fieldMap silently fall back to
 // the bare-token path so a typo doesn't break the whole query.
-func buildHealthSearchClause(search string, fieldMap map[string][]string, fallbackCols []string) (string, []any) {
+// healthSearchFieldSpec describes how a field:value token is matched.
+// exact=true does case-insensitive equality (right for enum-like columns
+// like health_status / mode where substring would match too much, e.g.
+// `status:healthy` accidentally hitting `unhealthy`). exact=false is
+// case-insensitive substring via positionCaseInsensitive (right for
+// free-form columns like user_pk / device_code / dz_ip).
+type healthSearchFieldSpec struct {
+	cols  []string
+	exact bool
+}
+
+func buildHealthSearchClause(search string, fieldMap map[string]healthSearchFieldSpec, fallbackCols []string) (string, []any) {
 	if search == "" {
 		return "", nil
 	}
@@ -287,16 +298,28 @@ func buildHealthSearchClause(search string, fieldMap map[string][]string, fallba
 		if tok.value == "" {
 			continue
 		}
-		cols := fallbackCols
+		// Resolve the columns + match mode. Unknown prefix → fallback
+		// substring across the table's default columns.
+		var cols []string
+		exact := false
 		if tok.field != "" {
-			if mapped, ok := fieldMap[tok.field]; ok && len(mapped) > 0 {
-				cols = mapped
+			if spec, ok := fieldMap[tok.field]; ok && len(spec.cols) > 0 {
+				cols = spec.cols
+				exact = spec.exact
 			}
+		}
+		if cols == nil {
+			cols = fallbackCols
 		}
 		parts := make([]string, 0, len(cols))
 		for _, c := range cols {
-			// positionCaseInsensitive avoids LIKE '%' escaping headaches.
-			parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
+			if exact {
+				// Equality on lower(col) gives case-insensitive exact match.
+				// toString() handles non-string columns (tunnel id).
+				parts = append(parts, "lower(toString("+c+")) = lower(?)")
+			} else {
+				parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
+			}
 			args = append(args, tok.value)
 		}
 		if len(parts) == 0 {

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -221,24 +221,80 @@ func parseHealthSearch(r *http.Request) string {
 	return strings.TrimSpace(r.URL.Query().Get("search"))
 }
 
-// buildHealthSearchClause builds a parameterized WHERE-LIKE OR across the
-// passed columns. Returns the SQL fragment (starting with " AND (...)" so
-// it appends cleanly) and the args to extend the query's argument slice.
-// Empty `search` returns ("", nil) so callers can unconditionally append.
-func buildHealthSearchClause(search string, cols []string) (string, []any) {
-	if search == "" || len(cols) == 0 {
+// healthSearchTokens splits a search string into whitespace-separated tokens.
+// Each token is either `field:value` (case-insensitive field, free-form
+// value) or a bare term (matched as substring across the table's default
+// columns). Multiple tokens AND together.
+//
+// Examples:
+//
+//	"device:nyc001 status:unhealthy"      → two field-scoped filters
+//	"3b2Ze7VY"                            → one bare term (any column)
+//	"device:nyc001 unhealthy"             → field-scoped + bare term
+type healthSearchToken struct {
+	field string // empty for bare terms
+	value string
+}
+
+func tokenizeHealthSearch(search string) []healthSearchToken {
+	out := []healthSearchToken{}
+	for _, raw := range strings.Fields(search) {
+		if idx := strings.IndexByte(raw, ':'); idx > 0 && idx < len(raw)-1 {
+			out = append(out, healthSearchToken{
+				field: strings.ToLower(raw[:idx]),
+				value: raw[idx+1:],
+			})
+			continue
+		}
+		// Bare term or malformed field prefix → substring fallback.
+		out = append(out, healthSearchToken{value: strings.TrimSuffix(raw, ":")})
+	}
+	return out
+}
+
+// buildHealthSearchClause builds a parameterized WHERE clause from a search
+// string. Tokens of the form `field:value` are matched against the column
+// listed under that field in fieldMap (substring, case-insensitive). Bare
+// tokens are OR'd across fallbackCols. Multiple tokens AND together.
+//
+// Returns ("", nil) when search is empty so callers can unconditionally
+// append. Tokens whose field prefix isn't in fieldMap silently fall back to
+// the bare-token path so a typo doesn't break the whole query.
+func buildHealthSearchClause(search string, fieldMap map[string][]string, fallbackCols []string) (string, []any) {
+	if search == "" {
 		return "", nil
 	}
-	// Case-insensitive substring match via positionCaseInsensitive() > 0.
-	// Beats LIKE '%foo%' because we don't have to escape % and _ in the
-	// user input, and lets ClickHouse use a single function per column.
-	parts := make([]string, 0, len(cols))
-	args := make([]any, 0, len(cols))
-	for _, c := range cols {
-		parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
-		args = append(args, search)
+	tokens := tokenizeHealthSearch(search)
+	if len(tokens) == 0 {
+		return "", nil
 	}
-	return " AND (" + strings.Join(parts, " OR ") + ")", args
+	clauses := make([]string, 0, len(tokens))
+	args := make([]any, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.value == "" {
+			continue
+		}
+		cols := fallbackCols
+		if tok.field != "" {
+			if mapped, ok := fieldMap[tok.field]; ok && len(mapped) > 0 {
+				cols = mapped
+			}
+		}
+		parts := make([]string, 0, len(cols))
+		for _, c := range cols {
+			// positionCaseInsensitive avoids LIKE '%' escaping headaches.
+			parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
+			args = append(args, tok.value)
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		clauses = append(clauses, "("+strings.Join(parts, " OR ")+")")
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " AND " + strings.Join(clauses, " AND "), args
 }
 
 // parseLimitOffset extracts optional pagination params. Both default to 0,

--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -236,14 +236,27 @@ type healthSearchToken struct {
 	value string
 }
 
+// tokenizeHealthSearch accepts tokens separated by EITHER commas or
+// whitespace. The web UI's InlineFilter convention writes
+// `?search=device:foo,status:bar` (comma-delimited chips); operators
+// poking the API by hand tend to use spaces. We accept both. A leading
+// `all:` prefix (InlineFilter's marker for a bare term) is unwrapped so
+// the server sees just the value.
 func tokenizeHealthSearch(search string) []healthSearchToken {
 	out := []healthSearchToken{}
-	for _, raw := range strings.Fields(search) {
+	for _, raw := range strings.FieldsFunc(search, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
 		if idx := strings.IndexByte(raw, ':'); idx > 0 && idx < len(raw)-1 {
-			out = append(out, healthSearchToken{
-				field: strings.ToLower(raw[:idx]),
-				value: raw[idx+1:],
-			})
+			field := strings.ToLower(raw[:idx])
+			value := raw[idx+1:]
+			if field == "all" {
+				// InlineFilter writes `all:value` for unprefixed text;
+				// treat it as a bare term.
+				out = append(out, healthSearchToken{value: value})
+				continue
+			}
+			out = append(out, healthSearchToken{field: field, value: value})
 			continue
 		}
 		// Bare term or malformed field prefix → substring fallback.

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -14,19 +14,19 @@ import (
 )
 
 // multicastHealthPathSearchFields maps `field:value` prefixes accepted in
-// the path-table search to underlying columns. Both `publisher:` /
-// `subscriber:` and the generic `user:` / `device:` are supported.
-var multicastHealthPathSearchFields = map[string][]string{
-	"publisher":  {"publisher_user_pk", "publisher_owner_pubkey", "publisher_dz_ip", "publisher_device_code"},
-	"subscriber": {"subscriber_user_pk", "subscriber_owner_pubkey", "subscriber_dz_ip", "subscriber_device_code"},
-	"user":       {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
-	"owner":      {"publisher_owner_pubkey", "subscriber_owner_pubkey"},
-	"pubkey":     {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
-	"ip":         {"publisher_dz_ip", "subscriber_dz_ip"},
-	"dz_ip":      {"publisher_dz_ip", "subscriber_dz_ip"},
-	"device":     {"publisher_device_code", "subscriber_device_code", "publisher_device_pk", "subscriber_device_pk"},
-	"status":     {"health_status"},
-	"health":     {"health_status"},
+// the path-table search to underlying columns + match mode. status is
+// enum-like and uses exact match; everything else is substring.
+var multicastHealthPathSearchFields = map[string]healthSearchFieldSpec{
+	"publisher":  {cols: []string{"publisher_user_pk", "publisher_owner_pubkey", "publisher_dz_ip", "publisher_device_code"}},
+	"subscriber": {cols: []string{"subscriber_user_pk", "subscriber_owner_pubkey", "subscriber_dz_ip", "subscriber_device_code"}},
+	"user":       {cols: []string{"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"}},
+	"owner":      {cols: []string{"publisher_owner_pubkey", "subscriber_owner_pubkey"}},
+	"pubkey":     {cols: []string{"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"}},
+	"ip":         {cols: []string{"publisher_dz_ip", "subscriber_dz_ip"}},
+	"dz_ip":      {cols: []string{"publisher_dz_ip", "subscriber_dz_ip"}},
+	"device":     {cols: []string{"publisher_device_code", "subscriber_device_code", "publisher_device_pk", "subscriber_device_pk"}},
+	"status":     {cols: []string{"health_status"}, exact: true},
+	"health":     {cols: []string{"health_status"}, exact: true},
 }
 
 // multicastHealthPathSearchFallback is OR-matched when the token has no

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -13,9 +13,25 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
-// multicastHealthPathSearchCols are the columns the `?search=` filter
-// substring-matches across (case-insensitive).
-var multicastHealthPathSearchCols = []string{
+// multicastHealthPathSearchFields maps `field:value` prefixes accepted in
+// the path-table search to underlying columns. Both `publisher:` /
+// `subscriber:` and the generic `user:` / `device:` are supported.
+var multicastHealthPathSearchFields = map[string][]string{
+	"publisher":  {"publisher_user_pk", "publisher_owner_pubkey", "publisher_dz_ip", "publisher_device_code"},
+	"subscriber": {"subscriber_user_pk", "subscriber_owner_pubkey", "subscriber_dz_ip", "subscriber_device_code"},
+	"user":       {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
+	"owner":      {"publisher_owner_pubkey", "subscriber_owner_pubkey"},
+	"pubkey":     {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
+	"ip":         {"publisher_dz_ip", "subscriber_dz_ip"},
+	"dz_ip":      {"publisher_dz_ip", "subscriber_dz_ip"},
+	"device":     {"publisher_device_code", "subscriber_device_code", "publisher_device_pk", "subscriber_device_pk"},
+	"status":     {"health_status"},
+	"health":     {"health_status"},
+}
+
+// multicastHealthPathSearchFallback is OR-matched when the token has no
+// field prefix.
+var multicastHealthPathSearchFallback = []string{
 	"publisher_owner_pubkey",
 	"publisher_user_pk",
 	"publisher_dz_ip",
@@ -123,7 +139,7 @@ func (a *API) FetchMulticastHealthPathsPageData(ctx context.Context, pkOrCode st
 func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK, search string, limit, offset int) ([]MulticastHealthPathItem, int, error) {
 	whereClause := "multicast_group_pk = ?"
 	args := []any{groupPK}
-	if clause, extra := buildHealthSearchClause(search, multicastHealthPathSearchCols); clause != "" {
+	if clause, extra := buildHealthSearchClause(search, multicastHealthPathSearchFields, multicastHealthPathSearchFallback); clause != "" {
 		whereClause += clause
 		args = append(args, extra...)
 	}

--- a/api/handlers/multicast_health_search_test.go
+++ b/api/handlers/multicast_health_search_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenizeHealthSearch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []healthSearchToken
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: []healthSearchToken{},
+		},
+		{
+			name: "single bare term",
+			in:   "3b2Ze7VY",
+			want: []healthSearchToken{{value: "3b2Ze7VY"}},
+		},
+		{
+			name: "single field token",
+			in:   "device:nyc001",
+			want: []healthSearchToken{{field: "device", value: "nyc001"}},
+		},
+		{
+			name: "mixed bare + field",
+			in:   "unhealthy device:nyc001",
+			want: []healthSearchToken{
+				{value: "unhealthy"},
+				{field: "device", value: "nyc001"},
+			},
+		},
+		{
+			name: "field prefix is lowercased",
+			in:   "DEVICE:NYC001",
+			want: []healthSearchToken{{field: "device", value: "NYC001"}},
+		},
+		{
+			name: "trailing colon with no value falls back to bare",
+			in:   "device:",
+			want: []healthSearchToken{{value: "device"}},
+		},
+		{
+			name: "leading colon is not a field token",
+			in:   ":foo",
+			want: []healthSearchToken{{value: ":foo"}},
+		},
+		{
+			name: "multiple field tokens AND together",
+			in:   "device:nyc001 status:unhealthy mode:P",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+				{field: "mode", value: "P"},
+			},
+		},
+		{
+			name: "extra whitespace ignored",
+			in:   "  device:nyc001     status:unhealthy  ",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tokenizeHealthSearch(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildHealthSearchClause(t *testing.T) {
+	fieldMap := map[string][]string{
+		"device": {"user_device_code", "user_device_pk"},
+		"status": {"health_status"},
+	}
+	fallback := []string{"user_pk", "user_owner_pubkey"}
+
+	t.Run("empty search → no clause", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("", fieldMap, fallback)
+		assert.Equal(t, "", clause)
+		assert.Nil(t, args)
+	})
+
+	t.Run("bare term → fallback columns OR'd", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("3b2Ze7VY", fieldMap, fallback)
+		// Expect: AND (pos(user_pk, ?)>0 OR pos(user_owner_pubkey, ?)>0)
+		assert.Contains(t, clause, "user_pk")
+		assert.Contains(t, clause, "user_owner_pubkey")
+		assert.Equal(t, strings.Count(clause, " OR "), 1)
+		require.Len(t, args, 2)
+		assert.Equal(t, "3b2Ze7VY", args[0])
+		assert.Equal(t, "3b2Ze7VY", args[1])
+	})
+
+	t.Run("known field → mapped columns OR'd", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("device:nyc001", fieldMap, fallback)
+		assert.Contains(t, clause, "user_device_code")
+		assert.Contains(t, clause, "user_device_pk")
+		assert.NotContains(t, clause, "user_pk,")
+		require.Len(t, args, 2)
+		assert.Equal(t, "nyc001", args[0])
+	})
+
+	t.Run("unknown field falls back to bare", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("nonsense:foo", fieldMap, fallback)
+		// "nonsense" not in fieldMap → treated as substring match against fallback
+		assert.Contains(t, clause, "user_pk")
+		assert.Contains(t, clause, "user_owner_pubkey")
+		require.Len(t, args, 2)
+		assert.Equal(t, "foo", args[0])
+	})
+
+	t.Run("multiple tokens AND together", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("device:nyc001 status:unhealthy", fieldMap, fallback)
+		// Two ANDs: the leading " AND " that attaches to caller's WHERE, plus
+		// one between the two token groups.
+		assert.Equal(t, 2, strings.Count(clause, " AND "))
+		assert.Contains(t, clause, "user_device_code")
+		assert.Contains(t, clause, "health_status")
+		require.Len(t, args, 3) // 2 device cols + 1 status col
+	})
+
+	t.Run("placeholders survive into args in token order", func(t *testing.T) {
+		_, args := buildHealthSearchClause("device:nyc status:unhealthy", fieldMap, fallback)
+		// device token first (2 cols, 2 args), status token second (1 col, 1 arg)
+		require.Len(t, args, 3)
+		assert.Equal(t, "nyc", args[0])
+		assert.Equal(t, "nyc", args[1])
+		assert.Equal(t, "unhealthy", args[2])
+	})
+}

--- a/api/handlers/multicast_health_search_test.go
+++ b/api/handlers/multicast_health_search_test.go
@@ -69,6 +69,29 @@ func TestTokenizeHealthSearch(t *testing.T) {
 				{field: "status", value: "unhealthy"},
 			},
 		},
+		{
+			name: "comma-separated tokens (InlineFilter URL form)",
+			in:   "device:nyc001,status:unhealthy,mode:P",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+				{field: "mode", value: "P"},
+			},
+		},
+		{
+			name: "mixed comma + whitespace delimiters",
+			in:   "device:nyc001, status:unhealthy mode:P",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+				{field: "mode", value: "P"},
+			},
+		},
+		{
+			name: "all: prefix is unwrapped to bare term",
+			in:   "all:3b2Ze7VY",
+			want: []healthSearchToken{{value: "3b2Ze7VY"}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/handlers/multicast_health_search_test.go
+++ b/api/handlers/multicast_health_search_test.go
@@ -102,9 +102,9 @@ func TestTokenizeHealthSearch(t *testing.T) {
 }
 
 func TestBuildHealthSearchClause(t *testing.T) {
-	fieldMap := map[string][]string{
-		"device": {"user_device_code", "user_device_pk"},
-		"status": {"health_status"},
+	fieldMap := map[string]healthSearchFieldSpec{
+		"device": {cols: []string{"user_device_code", "user_device_pk"}},
+		"status": {cols: []string{"health_status"}, exact: true},
 	}
 	fallback := []string{"user_pk", "user_owner_pubkey"}
 
@@ -160,5 +160,22 @@ func TestBuildHealthSearchClause(t *testing.T) {
 		assert.Equal(t, "nyc", args[0])
 		assert.Equal(t, "nyc", args[1])
 		assert.Equal(t, "unhealthy", args[2])
+	})
+
+	t.Run("exact-match field uses lower() equality, not positionCaseInsensitive", func(t *testing.T) {
+		// status is declared exact=true; SQL must equality-match (otherwise
+		// status:healthy would substring-match unhealthy, which is the bug
+		// that motivated the exact-match support).
+		clause, args := buildHealthSearchClause("status:healthy", fieldMap, fallback)
+		assert.Contains(t, clause, "lower(toString(health_status)) = lower(?)")
+		assert.NotContains(t, clause, "positionCaseInsensitive(toString(health_status)")
+		require.Len(t, args, 1)
+		assert.Equal(t, "healthy", args[0])
+	})
+
+	t.Run("substring-match field still uses positionCaseInsensitive", func(t *testing.T) {
+		clause, _ := buildHealthSearchClause("device:nyc", fieldMap, fallback)
+		assert.Contains(t, clause, "positionCaseInsensitive(toString(user_device_code), ?) > 0")
+		assert.NotContains(t, clause, "lower(toString(user_device_code)) =")
 	})
 }

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -13,13 +13,29 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
-// multicastHealthUserSearchCols are the columns the `?search=` filter
-// substring-matches across (case-insensitive). Order doesn't matter for
-// correctness, but listing the most likely-matched columns first lets
-// ClickHouse short-circuit OR evaluation in the common case.
-var multicastHealthUserSearchCols = []string{
-	"user_owner_pubkey",
+// multicastHealthUserSearchFields maps the prefixes accepted in a
+// `field:value` search token to the underlying columns to substring-match
+// against. Aliases are flattened (e.g. `user:` matches account or owner;
+// `pubkey:` is an alias for `user:`).
+var multicastHealthUserSearchFields = map[string][]string{
+	"user":    {"user_pk", "user_owner_pubkey"},
+	"account": {"user_pk"},
+	"owner":   {"user_owner_pubkey"},
+	"pubkey":  {"user_pk", "user_owner_pubkey"},
+	"ip":      {"user_dz_ip"},
+	"dz_ip":   {"user_dz_ip"},
+	"device":  {"user_device_code", "user_device_pk"},
+	"tunnel":  {"user_tunnel_id"},
+	"mode":    {"mode"},
+	"status":  {"health_status"},
+	"health":  {"health_status"},
+}
+
+// multicastHealthUserSearchFallback is OR-matched when the token has no
+// field prefix.
+var multicastHealthUserSearchFallback = []string{
 	"user_pk",
+	"user_owner_pubkey",
 	"user_dz_ip",
 	"user_device_code",
 	"user_device_pk",
@@ -67,7 +83,7 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 
 	where := "multicast_group_pk = ?"
 	args := []any{group.PK}
-	if clause, extra := buildHealthSearchClause(search, multicastHealthUserSearchCols); clause != "" {
+	if clause, extra := buildHealthSearchClause(search, multicastHealthUserSearchFields, multicastHealthUserSearchFallback); clause != "" {
 		where += clause
 		args = append(args, extra...)
 	}

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -14,21 +14,22 @@ import (
 )
 
 // multicastHealthUserSearchFields maps the prefixes accepted in a
-// `field:value` search token to the underlying columns to substring-match
-// against. Aliases are flattened (e.g. `user:` matches account or owner;
-// `pubkey:` is an alias for `user:`).
-var multicastHealthUserSearchFields = map[string][]string{
-	"user":    {"user_pk", "user_owner_pubkey"},
-	"account": {"user_pk"},
-	"owner":   {"user_owner_pubkey"},
-	"pubkey":  {"user_pk", "user_owner_pubkey"},
-	"ip":      {"user_dz_ip"},
-	"dz_ip":   {"user_dz_ip"},
-	"device":  {"user_device_code", "user_device_pk"},
-	"tunnel":  {"user_tunnel_id"},
-	"mode":    {"mode"},
-	"status":  {"health_status"},
-	"health":  {"health_status"},
+// `field:value` search token to the underlying columns + match mode.
+// Enum-like fields (status / mode / tunnel) need exact match because
+// their values share substrings — e.g. `status:healthy` would otherwise
+// match `unhealthy`. Free-form columns stay substring.
+var multicastHealthUserSearchFields = map[string]healthSearchFieldSpec{
+	"user":    {cols: []string{"user_pk", "user_owner_pubkey"}},
+	"account": {cols: []string{"user_pk"}},
+	"owner":   {cols: []string{"user_owner_pubkey"}},
+	"pubkey":  {cols: []string{"user_pk", "user_owner_pubkey"}},
+	"ip":      {cols: []string{"user_dz_ip"}},
+	"dz_ip":   {cols: []string{"user_dz_ip"}},
+	"device":  {cols: []string{"user_device_code", "user_device_pk"}},
+	"tunnel":  {cols: []string{"user_tunnel_id"}, exact: true},
+	"mode":    {cols: []string{"mode"}, exact: true},
+	"status":  {cols: []string{"health_status"}, exact: true},
+	"health":  {cols: []string{"health_status"}, exact: true},
 }
 
 // multicastHealthUserSearchFallback is OR-matched when the token has no

--- a/web/src/components/inline-filter.tsx
+++ b/web/src/components/inline-filter.tsx
@@ -20,6 +20,11 @@ interface InlineFilterProps {
   placeholder?: string
   onLiveFilterChange?: (filter: string) => void
   filterParams?: Record<string, string>
+  // URL query-string key to persist committed chips under. Defaults to
+  // 'search' so existing callers keep working; the Health tab uses a
+  // dedicated slot ('hsearch') so its filters don't collide with the
+  // members filter on the same page.
+  paramName?: string
 }
 
 export function InlineFilter({
@@ -29,6 +34,7 @@ export function InlineFilter({
   placeholder = 'Filter...',
   onLiveFilterChange,
   filterParams,
+  paramName = 'search',
 }: InlineFilterProps) {
   const [, setSearchParams] = useSearchParams()
   const [query, setQuery] = useState('')
@@ -114,11 +120,11 @@ export function InlineFilter({
   // Show all field prefixes when query is empty
   const showAllPrefixes = query.length === 0 && isFocused
 
-  // Helper to commit a filter (persist to URL)
+  // Helper to commit a filter (persist to URL under paramName)
   const commitFilter = useCallback((filterValue: string) => {
     setSearchParams(prev => {
       const newParams = new URLSearchParams(prev)
-      const currentSearch = newParams.get('search') || ''
+      const currentSearch = newParams.get(paramName) || ''
       const currentFilters = currentSearch ? currentSearch.split(',').map(f => f.trim()).filter(Boolean) : []
 
       // Add the committed filter if not already present
@@ -126,14 +132,14 @@ export function InlineFilter({
         currentFilters.push(filterValue)
       }
 
-      newParams.set('search', currentFilters.join(','))
+      newParams.set(paramName, currentFilters.join(','))
       newParams.delete('offset')
       newParams.delete('page')
       return newParams
     })
     setQuery('')
     inputRef.current?.focus()
-  }, [setSearchParams])
+  }, [setSearchParams, paramName])
 
   // Helper to clear the live filter without committing
   const clearLiveFilter = useCallback(() => {

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -63,10 +63,12 @@ function SearchInput({
   value,
   onChange,
   placeholder,
+  hint,
 }: {
   value: string
   onChange: (v: string) => void
   placeholder: string
+  hint?: string
 }) {
   return (
     <div className="relative">
@@ -75,7 +77,10 @@ function SearchInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="h-7 w-72 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+        // title attribute renders a native hover hint; sufficient for a
+        // syntax cheat sheet without spawning a Radix tooltip per input.
+        title={hint}
+        className="h-7 w-80 rounded-md border border-border bg-background px-2 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-ring"
       />
     </div>
   )
@@ -401,6 +406,19 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
   return (
     <div className="p-4 space-y-6">
+      {/* Under-development notice. The reconciliation logic and rate dimension
+          here surface real data, but the verdicts assume state-collect covers
+          every device — today only jump devices are collected, so non-jump
+          publishers/subscribers can falsely render as unhealthy. Wording is
+          deliberately concrete so operators read it as caveat, not "do not
+          trust this page". */}
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+        <div className="font-medium">This view is under development.</div>
+        <div className="mt-1 text-amber-200/90">
+          Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
+        </div>
+      </div>
+
       {/* Summary counts */}
       <div className="border border-border rounded-lg bg-card p-4">
         <div className="flex items-baseline justify-between mb-2">
@@ -429,7 +447,8 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <SearchInput
               value={usersSearchInput}
               onChange={setUsersSearchInput}
-              placeholder="Filter user, mode, device, tunnel, status…"
+              placeholder="device:NAME  status:unhealthy  tunnel:520  …"
+              hint="Use field:value (device, status, tunnel, mode, user, owner, ip). Bare text matches any column."
             />
             {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
           </div>
@@ -530,7 +549,8 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
               <SearchInput
                 value={pathsSearchInput}
                 onChange={setPathsSearchInput}
-                placeholder="Filter publisher, subscriber, device, status…"
+                placeholder="publisher:Df  subscriber:Hk  device:nyc001  …"
+                hint="Use field:value (publisher, subscriber, device, status, user, owner, ip). Bare text matches any column."
               />
             )}
             {showPathDetails && pathsQuery.isFetching && (

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -16,26 +16,33 @@ import {
   type MulticastRateStatusReason,
 } from '@/lib/api'
 
-// URL query-string slot for committed Health-tab filter chips. Distinct
-// from the parent page's '?search=' so members-tab and Health-tab filters
-// don't trample each other when switching tabs.
-const HEALTH_SEARCH_PARAM = 'hsearch'
+// URL query-string slots for committed Health-tab filter chips. Distinct
+// from the parent page's '?search=' (members filter) so they don't
+// trample each other when switching tabs. Per-user and per-path each
+// have their own slot so the two tables filter independently.
+const HEALTH_USERS_SEARCH_PARAM = 'husers'
+const HEALTH_PATHS_SEARCH_PARAM = 'hpaths'
 
-// Field prefixes shown in the InlineFilter dropdown on the Health tab.
-// Spans both per-user (mode, tunnel) and per-path (publisher, subscriber)
-// columns since one search bar feeds both tables; server ignores tokens
-// whose field doesn't apply to a given query (unknown field falls through
-// to the bare-token path).
-const healthFieldPrefixes = [
+// Field prefixes for the per-user table filter.
+const healthUserFieldPrefixes = [
   { prefix: 'device:', description: 'Filter by device code (e.g. nyc001)' },
   { prefix: 'status:', description: 'Filter by health status (healthy, degraded, unhealthy, unknown)' },
-  { prefix: 'mode:', description: 'Per-user mode: P, S, or P+S' },
-  { prefix: 'tunnel:', description: 'Per-user tunnel id' },
-  { prefix: 'user:', description: 'Match user account or owner pubkey' },
+  { prefix: 'mode:', description: 'Mode: P, S, or P+S' },
+  { prefix: 'tunnel:', description: 'Tunnel id (exact match)' },
+  { prefix: 'user:', description: "Match user account or owner pubkey" },
   { prefix: 'owner:', description: 'Match owner pubkey' },
-  { prefix: 'publisher:', description: 'Per-path: match the publisher side' },
-  { prefix: 'subscriber:', description: 'Per-path: match the subscriber side' },
-  { prefix: 'ip:', description: "Match a user's dz_ip" },
+  { prefix: 'ip:', description: "Match user's dz_ip" },
+]
+
+// Field prefixes for the per-path table filter.
+const healthPathFieldPrefixes = [
+  { prefix: 'publisher:', description: 'Match the publisher side (pk/owner/ip/device)' },
+  { prefix: 'subscriber:', description: 'Match the subscriber side (pk/owner/ip/device)' },
+  { prefix: 'device:', description: 'Match either publisher or subscriber device' },
+  { prefix: 'status:', description: 'Filter by health status (healthy, degraded, unhealthy, unknown)' },
+  { prefix: 'user:', description: 'Match either side\'s account or owner pubkey' },
+  { prefix: 'owner:', description: 'Match either side\'s owner pubkey' },
+  { prefix: 'ip:', description: "Match either side's dz_ip" },
 ]
 
 function parseHealthSearchFilters(searchParam: string): string[] {
@@ -76,40 +83,54 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
 const HEALTH_PAGE_SIZE = 25
 
 // HealthFilterBar renders the InlineFilter chip UX seen elsewhere on the
-// site (Devices, Facilities, etc.). Committed filters live in
-// `?hsearch=foo,bar` so reloads / shareable URLs preserve them. The
-// search prop combines committed chips with the in-progress text so the
-// table updates as the user types but before they hit Enter.
-function HealthFilterBar({ liveFilter, setLiveFilter }: { liveFilter: string; setLiveFilter: (v: string) => void }) {
+// site (Devices, Facilities, etc.). Committed filters live in the URL
+// slot named by `paramName` so reloads / shareable URLs preserve them.
+// The bar tracks its own live (in-progress) filter via a callback so the
+// parent can pass it through to the underlying API call.
+function HealthFilterBar({
+  paramName,
+  entity,
+  placeholder,
+  fieldPrefixes,
+  liveFilter,
+  setLiveFilter,
+}: {
+  paramName: string
+  entity: string
+  placeholder: string
+  fieldPrefixes: { prefix: string; description: string }[]
+  liveFilter: string
+  setLiveFilter: (v: string) => void
+}) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const committed = parseHealthSearchFilters(searchParams.get(HEALTH_SEARCH_PARAM) || '')
+  const committed = parseHealthSearchFilters(searchParams.get(paramName) || '')
 
   const removeFilter = useCallback((toRemove: string) => {
     const next = committed.filter(f => f !== toRemove)
     setSearchParams(prev => {
       const p = new URLSearchParams(prev)
-      if (next.length === 0) p.delete(HEALTH_SEARCH_PARAM)
-      else p.set(HEALTH_SEARCH_PARAM, next.join(','))
+      if (next.length === 0) p.delete(paramName)
+      else p.set(paramName, next.join(','))
       return p
     })
-  }, [committed, setSearchParams])
+  }, [committed, setSearchParams, paramName])
 
   const clearAll = useCallback(() => {
     setSearchParams(prev => {
       const p = new URLSearchParams(prev)
-      p.delete(HEALTH_SEARCH_PARAM)
+      p.delete(paramName)
       return p
     })
-  }, [setSearchParams])
+  }, [setSearchParams, paramName])
 
   return (
     <div className="flex flex-wrap items-center gap-2">
       <InlineFilter
-        fieldPrefixes={healthFieldPrefixes}
-        entity="multicast-health"
+        fieldPrefixes={fieldPrefixes}
+        entity={entity}
         autocompleteFields={[]}
-        placeholder="Filter health…"
-        paramName={HEALTH_SEARCH_PARAM}
+        placeholder={placeholder}
+        paramName={paramName}
         onLiveFilterChange={setLiveFilter}
       />
       {committed.map((filter, idx) => (
@@ -391,19 +412,28 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   const [usersOffset, setUsersOffset] = useState(0)
   const [pathsOffset, setPathsOffset] = useState(0)
   const [showPathDetails, setShowPathDetails] = useState(false)
-  // Live filter — what's currently typed in the InlineFilter input but not
-  // yet committed as a chip. Combined with the URL-persisted chips on
-  // every query so the table updates as the user types.
-  const [liveFilter, setLiveFilter] = useState('')
+  // Live (in-progress, not yet committed) filter for each table. Combined
+  // with that table's URL-persisted chips before being sent to the API so
+  // the table updates as the user types.
+  const [usersLiveFilter, setUsersLiveFilter] = useState('')
+  const [pathsLiveFilter, setPathsLiveFilter] = useState('')
 
-  const committedFilters = useMemo(
-    () => parseHealthSearchFilters(searchParams.get(HEALTH_SEARCH_PARAM) || ''),
+  const usersCommitted = useMemo(
+    () => parseHealthSearchFilters(searchParams.get(HEALTH_USERS_SEARCH_PARAM) || ''),
     [searchParams],
   )
-  const effectiveSearch = useMemo(() => {
-    const all = liveFilter ? [...committedFilters, liveFilter] : committedFilters
+  const pathsCommitted = useMemo(
+    () => parseHealthSearchFilters(searchParams.get(HEALTH_PATHS_SEARCH_PARAM) || ''),
+    [searchParams],
+  )
+  const usersSearch = useMemo(() => {
+    const all = usersLiveFilter ? [...usersCommitted, usersLiveFilter] : usersCommitted
     return all.join(',')
-  }, [committedFilters, liveFilter])
+  }, [usersCommitted, usersLiveFilter])
+  const pathsSearch = useMemo(() => {
+    const all = pathsLiveFilter ? [...pathsCommitted, pathsLiveFilter] : pathsCommitted
+    return all.join(',')
+  }, [pathsCommitted, pathsLiveFilter])
 
   useEffect(() => {
     setUsersOffset(0)
@@ -411,12 +441,14 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
     setShowPathDetails(false)
   }, [groupPkOrCode])
 
-  // Reset to page 1 whenever the filter set changes so the user sees the
-  // first page of matches rather than an empty page-N.
+  // Reset to page 1 whenever that table's filter set changes so the user
+  // sees the first page of matches rather than an empty page-N.
   useEffect(() => {
     setUsersOffset(0)
+  }, [usersSearch])
+  useEffect(() => {
     setPathsOffset(0)
-  }, [effectiveSearch])
+  }, [pathsSearch])
 
   const summaryQuery = useQuery({
     queryKey: ['multicast-group-health-summary', groupPkOrCode],
@@ -426,16 +458,16 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   })
 
   const usersQuery = useQuery({
-    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, effectiveSearch],
-    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, effectiveSearch || undefined),
+    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch || undefined),
     enabled: !!groupPkOrCode,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
   })
 
   const pathsQuery = useQuery({
-    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, effectiveSearch],
-    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, effectiveSearch || undefined),
+    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch || undefined),
     enabled: !!groupPkOrCode && showPathDetails,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
@@ -478,11 +510,6 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
         </div>
       </div>
 
-      {/* Filter bar — single InlineFilter scopes both per-user and per-path
-          tables. URL slot is dedicated to the Health tab so it doesn't
-          collide with the members filter on the parent page. */}
-      <HealthFilterBar liveFilter={liveFilter} setLiveFilter={setLiveFilter} />
-
       {/* Summary counts */}
       <div className="border border-border rounded-lg bg-card p-4">
         <div className="flex items-baseline justify-between mb-2">
@@ -502,12 +529,22 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
       {/* Per-user reconciliation */}
       <div className="border border-border rounded-lg bg-card">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
-          <div className="flex items-center gap-1.5">
-            <h3 className="text-sm font-medium">Per-user reconciliation</h3>
-            <HelpIcon content={SECTION_HELP.users} />
+        <div className="px-4 py-3 border-b border-border flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-sm font-medium">Per-user reconciliation</h3>
+              <HelpIcon content={SECTION_HELP.users} />
+            </div>
+            {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
           </div>
-          {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+          <HealthFilterBar
+            paramName={HEALTH_USERS_SEARCH_PARAM}
+            entity="multicast-health-users"
+            placeholder="Filter users…"
+            fieldPrefixes={healthUserFieldPrefixes}
+            liveFilter={usersLiveFilter}
+            setLiveFilter={setUsersLiveFilter}
+          />
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -595,23 +632,35 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
       {/* Per-path reconciliation */}
       <div className="border border-border rounded-lg bg-card">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
-            <HelpIcon content={SECTION_HELP.paths} />
+        <div className="px-4 py-3 border-b border-border flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-sm font-medium">Per-path reconciliation (publisher → subscriber)</h3>
+              <HelpIcon content={SECTION_HELP.paths} />
+            </div>
+            <div className="flex items-center gap-2">
+              {showPathDetails && pathsQuery.isFetching && (
+                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+              )}
+              <button
+                type="button"
+                onClick={() => setShowPathDetails((v) => !v)}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                {showPathDetails ? 'Hide details' : 'Show details'}
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            {showPathDetails && pathsQuery.isFetching && (
-              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-            )}
-            <button
-              type="button"
-              onClick={() => setShowPathDetails((v) => !v)}
-              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-            >
-              {showPathDetails ? 'Hide details' : 'Show details'}
-            </button>
-          </div>
+          {showPathDetails && (
+            <HealthFilterBar
+              paramName={HEALTH_PATHS_SEARCH_PARAM}
+              entity="multicast-health-paths"
+              placeholder="Filter paths…"
+              fieldPrefixes={healthPathFieldPrefixes}
+              liveFilter={pathsLiveFilter}
+              setLiveFilter={setPathsLiveFilter}
+            />
+          )}
         </div>
         {!showPathDetails ? (
           <div className="px-4 py-6 text-sm text-muted-foreground flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -503,9 +503,9 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
           publishers/subscribers can falsely render as unhealthy. Wording is
           deliberately concrete so operators read it as caveat, not "do not
           trust this page". */}
-      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-100">
         <div className="font-medium">This view is under development.</div>
-        <div className="mt-1 text-amber-200/90">
+        <div className="mt-1 text-amber-700 dark:text-amber-200/90">
           Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
         </div>
       </div>

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -461,8 +461,9 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                     <Link
                       to={`/dz/users/${u.user_pk}`}
                       className="group text-blue-600 dark:text-blue-400 hover:underline font-mono inline-flex items-center"
+                      title={u.user_owner_pubkey ? `account ${u.user_pk}\nowner ${u.user_owner_pubkey}` : u.user_pk}
                     >
-                      {u.user_owner_pubkey ? u.user_owner_pubkey.slice(0, 8) : u.user_pk.slice(0, 8)}
+                      {u.user_pk.slice(0, 8)}
                       <NavLinkArrow />
                     </Link>
                   </td>
@@ -592,8 +593,14 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                         <Link
                           to={`/dz/users/${p.publisher_user_pk}`}
                           className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                          // Show the account (user_pk) — owner_pubkey collides
+                          // across an operator's many accounts. Owner is in title.
+                          title={p.publisher_owner_pubkey ? `account ${p.publisher_user_pk}\nowner ${p.publisher_owner_pubkey}` : p.publisher_user_pk}
                         >
-                          {p.publisher_owner_pubkey?.slice(0, 8) || p.publisher_user_pk.slice(0, 8)}
+                          {p.publisher_user_pk.slice(0, 8)}
+                          {p.publisher_tunnel_id > 0 && (
+                            <span className="ml-1 text-muted-foreground">·T{p.publisher_tunnel_id}</span>
+                          )}
                           <NavLinkArrow />
                         </Link>
                       </td>
@@ -614,8 +621,12 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
                         <Link
                           to={`/dz/users/${p.subscriber_user_pk}`}
                           className="group text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                          title={p.subscriber_owner_pubkey ? `account ${p.subscriber_user_pk}\nowner ${p.subscriber_owner_pubkey}` : p.subscriber_user_pk}
                         >
-                          {p.subscriber_owner_pubkey?.slice(0, 8) || p.subscriber_user_pk.slice(0, 8)}
+                          {p.subscriber_user_pk.slice(0, 8)}
+                          {p.subscriber_tunnel_id > 0 && (
+                            <span className="ml-1 text-muted-foreground">·T{p.subscriber_tunnel_id}</span>
+                          )}
                           <NavLinkArrow />
                         </Link>
                       </td>

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
-import { Loader2, AlertCircle, Info, ChevronRight } from 'lucide-react'
+import { Loader2, AlertCircle, Info, ChevronRight, X } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
 import { Pagination } from '@/components/pagination'
+import { InlineFilter } from '@/components/inline-filter'
 import {
   fetchMulticastGroupHealth,
   fetchMulticastGroupHealthUsers,
@@ -14,6 +15,33 @@ import {
   type MulticastRateStatus,
   type MulticastRateStatusReason,
 } from '@/lib/api'
+
+// URL query-string slot for committed Health-tab filter chips. Distinct
+// from the parent page's '?search=' so members-tab and Health-tab filters
+// don't trample each other when switching tabs.
+const HEALTH_SEARCH_PARAM = 'hsearch'
+
+// Field prefixes shown in the InlineFilter dropdown on the Health tab.
+// Spans both per-user (mode, tunnel) and per-path (publisher, subscriber)
+// columns since one search bar feeds both tables; server ignores tokens
+// whose field doesn't apply to a given query (unknown field falls through
+// to the bare-token path).
+const healthFieldPrefixes = [
+  { prefix: 'device:', description: 'Filter by device code (e.g. nyc001)' },
+  { prefix: 'status:', description: 'Filter by health status (healthy, degraded, unhealthy, unknown)' },
+  { prefix: 'mode:', description: 'Per-user mode: P, S, or P+S' },
+  { prefix: 'tunnel:', description: 'Per-user tunnel id' },
+  { prefix: 'user:', description: 'Match user account or owner pubkey' },
+  { prefix: 'owner:', description: 'Match owner pubkey' },
+  { prefix: 'publisher:', description: 'Per-path: match the publisher side' },
+  { prefix: 'subscriber:', description: 'Per-path: match the subscriber side' },
+  { prefix: 'ip:', description: "Match a user's dz_ip" },
+]
+
+function parseHealthSearchFilters(searchParam: string): string[] {
+  if (!searchParam) return []
+  return searchParam.split(',').map(f => f.trim()).filter(Boolean)
+}
 
 function formatBps(bps?: number): string {
   if (bps === undefined || bps === null) return '—'
@@ -47,41 +75,66 @@ const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
 // group so the first paint hits the worker cache.
 const HEALTH_PAGE_SIZE = 25
 
-// useDebouncedValue returns `value` delayed by `delayMs`, so a rapidly
-// changing input (typing in the search box) only triggers a new query
-// after the user pauses.
-function useDebouncedValue<T>(value: T, delayMs: number): T {
-  const [debounced, setDebounced] = useState(value)
-  useEffect(() => {
-    const id = setTimeout(() => setDebounced(value), delayMs)
-    return () => clearTimeout(id)
-  }, [value, delayMs])
-  return debounced
-}
+// HealthFilterBar renders the InlineFilter chip UX seen elsewhere on the
+// site (Devices, Facilities, etc.). Committed filters live in
+// `?hsearch=foo,bar` so reloads / shareable URLs preserve them. The
+// search prop combines committed chips with the in-progress text so the
+// table updates as the user types but before they hit Enter.
+function HealthFilterBar({ liveFilter, setLiveFilter }: { liveFilter: string; setLiveFilter: (v: string) => void }) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const committed = parseHealthSearchFilters(searchParams.get(HEALTH_SEARCH_PARAM) || '')
 
-function SearchInput({
-  value,
-  onChange,
-  placeholder,
-  hint,
-}: {
-  value: string
-  onChange: (v: string) => void
-  placeholder: string
-  hint?: string
-}) {
+  const removeFilter = useCallback((toRemove: string) => {
+    const next = committed.filter(f => f !== toRemove)
+    setSearchParams(prev => {
+      const p = new URLSearchParams(prev)
+      if (next.length === 0) p.delete(HEALTH_SEARCH_PARAM)
+      else p.set(HEALTH_SEARCH_PARAM, next.join(','))
+      return p
+    })
+  }, [committed, setSearchParams])
+
+  const clearAll = useCallback(() => {
+    setSearchParams(prev => {
+      const p = new URLSearchParams(prev)
+      p.delete(HEALTH_SEARCH_PARAM)
+      return p
+    })
+  }, [setSearchParams])
+
   return (
-    <div className="relative">
-      <input
-        type="search"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        // title attribute renders a native hover hint; sufficient for a
-        // syntax cheat sheet without spawning a Radix tooltip per input.
-        title={hint}
-        className="h-7 w-80 rounded-md border border-border bg-background px-2 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+    <div className="flex flex-wrap items-center gap-2">
+      <InlineFilter
+        fieldPrefixes={healthFieldPrefixes}
+        entity="multicast-health"
+        autocompleteFields={[]}
+        placeholder="Filter health…"
+        paramName={HEALTH_SEARCH_PARAM}
+        onLiveFilterChange={setLiveFilter}
       />
+      {committed.map((filter, idx) => (
+        <button
+          key={`${filter}-${idx}`}
+          onClick={() => removeFilter(filter)}
+          className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
+        >
+          {filter}
+          <X className="h-3 w-3" />
+        </button>
+      ))}
+      {committed.length > 1 && (
+        <button
+          onClick={clearAll}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Clear all
+        </button>
+      )}
+      {liveFilter && (
+        <span className="text-xs text-muted-foreground italic">
+          previewing: {liveFilter}
+        </span>
+      )}
     </div>
   )
 }
@@ -334,30 +387,36 @@ function TableStateRow({
 }
 
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
+  const [searchParams] = useSearchParams()
   const [usersOffset, setUsersOffset] = useState(0)
   const [pathsOffset, setPathsOffset] = useState(0)
   const [showPathDetails, setShowPathDetails] = useState(false)
-  const [usersSearchInput, setUsersSearchInput] = useState('')
-  const [pathsSearchInput, setPathsSearchInput] = useState('')
-  const usersSearch = useDebouncedValue(usersSearchInput, 200)
-  const pathsSearch = useDebouncedValue(pathsSearchInput, 200)
+  // Live filter — what's currently typed in the InlineFilter input but not
+  // yet committed as a chip. Combined with the URL-persisted chips on
+  // every query so the table updates as the user types.
+  const [liveFilter, setLiveFilter] = useState('')
+
+  const committedFilters = useMemo(
+    () => parseHealthSearchFilters(searchParams.get(HEALTH_SEARCH_PARAM) || ''),
+    [searchParams],
+  )
+  const effectiveSearch = useMemo(() => {
+    const all = liveFilter ? [...committedFilters, liveFilter] : committedFilters
+    return all.join(',')
+  }, [committedFilters, liveFilter])
 
   useEffect(() => {
     setUsersOffset(0)
     setPathsOffset(0)
     setShowPathDetails(false)
-    setUsersSearchInput('')
-    setPathsSearchInput('')
   }, [groupPkOrCode])
 
-  // Reset to page 1 whenever the search text changes so the user sees the
+  // Reset to page 1 whenever the filter set changes so the user sees the
   // first page of matches rather than an empty page-N.
   useEffect(() => {
     setUsersOffset(0)
-  }, [usersSearch])
-  useEffect(() => {
     setPathsOffset(0)
-  }, [pathsSearch])
+  }, [effectiveSearch])
 
   const summaryQuery = useQuery({
     queryKey: ['multicast-group-health-summary', groupPkOrCode],
@@ -367,16 +426,16 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   })
 
   const usersQuery = useQuery({
-    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch],
-    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, usersSearch || undefined),
+    queryKey: ['multicast-group-health-users', groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, effectiveSearch],
+    queryFn: () => fetchMulticastGroupHealthUsers(groupPkOrCode, HEALTH_PAGE_SIZE, usersOffset, effectiveSearch || undefined),
     enabled: !!groupPkOrCode,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
   })
 
   const pathsQuery = useQuery({
-    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch],
-    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch || undefined),
+    queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, effectiveSearch],
+    queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, effectiveSearch || undefined),
     enabled: !!groupPkOrCode && showPathDetails,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
@@ -419,6 +478,11 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
         </div>
       </div>
 
+      {/* Filter bar — single InlineFilter scopes both per-user and per-path
+          tables. URL slot is dedicated to the Health tab so it doesn't
+          collide with the members filter on the parent page. */}
+      <HealthFilterBar liveFilter={liveFilter} setLiveFilter={setLiveFilter} />
+
       {/* Summary counts */}
       <div className="border border-border rounded-lg bg-card p-4">
         <div className="flex items-baseline justify-between mb-2">
@@ -443,15 +507,7 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <h3 className="text-sm font-medium">Per-user reconciliation</h3>
             <HelpIcon content={SECTION_HELP.users} />
           </div>
-          <div className="flex items-center gap-2">
-            <SearchInput
-              value={usersSearchInput}
-              onChange={setUsersSearchInput}
-              placeholder="device:NAME  status:unhealthy  tunnel:520  …"
-              hint="Use field:value (device, status, tunnel, mode, user, owner, ip). Bare text matches any column."
-            />
-            {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
-          </div>
+          {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -545,14 +601,6 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <HelpIcon content={SECTION_HELP.paths} />
           </div>
           <div className="flex items-center gap-2">
-            {showPathDetails && (
-              <SearchInput
-                value={pathsSearchInput}
-                onChange={setPathsSearchInput}
-                placeholder="publisher:Df  subscriber:Hk  device:nyc001  …"
-                hint="Use field:value (publisher, subscriber, device, status, user, owner, ip). Bare text matches any column."
-              />
-            )}
             {showPathDetails && pathsQuery.isFetching && (
               <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
             )}


### PR DESCRIPTION
## Summary

Follow-up to #642. The per-user and per-path tables on the multicast group Health tab rendered `owner_pubkey.slice(0, 8)` in the User / Publisher / Subscriber columns. An operator can own dozens of user accounts (e.g. `3b2Ze7VY` has 90+ subscriber accounts on edge-solana-shreds), so every row from that operator displayed the same 8-char prefix — visually identical even though each row is a distinct account.

Switches the displayed identifier to `user_pk.slice(0, 8)` (the unique account) and adds a hover `title` showing both the full account and the owner pubkey. Per-path rows also append `·T<tunnel_id>` so the account + tunnel pair is visible inline. The link target was already `user_pk` — only the rendered text was using the wrong column.

## Testing Verification

- Filtered the per-path table by `3b2Ze7VY` (owner pubkey, matches 90+ subscriber accounts): each row now renders the distinct subscriber `user_pk` (e.g. `HXQn54bj`, `62LuyHgY`, `3sfBNMTb` …) plus `·T<id>`, instead of `3b2Ze7VY` everywhere.
- Hover on the link surfaces both `account <full user_pk>` and `owner <full owner_pubkey>` for context.
- Per-user table receives the same treatment so the User column is row-distinct.
