### PR TITLE
multicast: under-dev banner + field:value
  search on Health tab

### DIFF
--- a/api/handlers/multicast_health.go
+++ b/api/handlers/multicast_health.go
@@ -221,24 +221,80 @@ func parseHealthSearch(r *http.Request) string {
 	return strings.TrimSpace(r.URL.Query().Get("search"))
 }
 
-// buildHealthSearchClause builds a parameterized WHERE-LIKE OR across the
-// passed columns. Returns the SQL fragment (starting with " AND (...)" so
-// it appends cleanly) and the args to extend the query's argument slice.
-// Empty `search` returns ("", nil) so callers can unconditionally append.
-func buildHealthSearchClause(search string, cols []string) (string, []any) {
-	if search == "" || len(cols) == 0 {
+// healthSearchTokens splits a search string into whitespace-separated tokens.
+// Each token is either `field:value` (case-insensitive field, free-form
+// value) or a bare term (matched as substring across the table's default
+// columns). Multiple tokens AND together.
+//
+// Examples:
+//
+//	"device:nyc001 status:unhealthy"      → two field-scoped filters
+//	"3b2Ze7VY"                            → one bare term (any column)
+//	"device:nyc001 unhealthy"             → field-scoped + bare term
+type healthSearchToken struct {
+	field string // empty for bare terms
+	value string
+}
+
+func tokenizeHealthSearch(search string) []healthSearchToken {
+	out := []healthSearchToken{}
+	for _, raw := range strings.Fields(search) {
+		if idx := strings.IndexByte(raw, ':'); idx > 0 && idx < len(raw)-1 {
+			out = append(out, healthSearchToken{
+				field: strings.ToLower(raw[:idx]),
+				value: raw[idx+1:],
+			})
+			continue
+		}
+		// Bare term or malformed field prefix → substring fallback.
+		out = append(out, healthSearchToken{value: strings.TrimSuffix(raw, ":")})
+	}
+	return out
+}
+
+// buildHealthSearchClause builds a parameterized WHERE clause from a search
+// string. Tokens of the form `field:value` are matched against the column
+// listed under that field in fieldMap (substring, case-insensitive). Bare
+// tokens are OR'd across fallbackCols. Multiple tokens AND together.
+//
+// Returns ("", nil) when search is empty so callers can unconditionally
+// append. Tokens whose field prefix isn't in fieldMap silently fall back to
+// the bare-token path so a typo doesn't break the whole query.
+func buildHealthSearchClause(search string, fieldMap map[string][]string, fallbackCols []string) (string, []any) {
+	if search == "" {
 		return "", nil
 	}
-	// Case-insensitive substring match via positionCaseInsensitive() > 0.
-	// Beats LIKE '%foo%' because we don't have to escape % and _ in the
-	// user input, and lets ClickHouse use a single function per column.
-	parts := make([]string, 0, len(cols))
-	args := make([]any, 0, len(cols))
-	for _, c := range cols {
-		parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
-		args = append(args, search)
+	tokens := tokenizeHealthSearch(search)
+	if len(tokens) == 0 {
+		return "", nil
 	}
-	return " AND (" + strings.Join(parts, " OR ") + ")", args
+	clauses := make([]string, 0, len(tokens))
+	args := make([]any, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.value == "" {
+			continue
+		}
+		cols := fallbackCols
+		if tok.field != "" {
+			if mapped, ok := fieldMap[tok.field]; ok && len(mapped) > 0 {
+				cols = mapped
+			}
+		}
+		parts := make([]string, 0, len(cols))
+		for _, c := range cols {
+			// positionCaseInsensitive avoids LIKE '%' escaping headaches.
+			parts = append(parts, "positionCaseInsensitive(toString("+c+"), ?) > 0")
+			args = append(args, tok.value)
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		clauses = append(clauses, "("+strings.Join(parts, " OR ")+")")
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " AND " + strings.Join(clauses, " AND "), args
 }
 
 // parseLimitOffset extracts optional pagination params. Both default to 0,

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -13,9 +13,25 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
-// multicastHealthPathSearchCols are the columns the `?search=` filter
-// substring-matches across (case-insensitive).
-var multicastHealthPathSearchCols = []string{
+// multicastHealthPathSearchFields maps `field:value` prefixes accepted in
+// the path-table search to underlying columns. Both `publisher:` /
+// `subscriber:` and the generic `user:` / `device:` are supported.
+var multicastHealthPathSearchFields = map[string][]string{
+	"publisher": {"publisher_user_pk", "publisher_owner_pubkey", "publisher_dz_ip", "publisher_device_code"},
+	"subscriber": {"subscriber_user_pk", "subscriber_owner_pubkey", "subscriber_dz_ip", "subscriber_device_code"},
+	"user":   {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
+	"owner":  {"publisher_owner_pubkey", "subscriber_owner_pubkey"},
+	"pubkey": {"publisher_user_pk", "publisher_owner_pubkey", "subscriber_user_pk", "subscriber_owner_pubkey"},
+	"ip":     {"publisher_dz_ip", "subscriber_dz_ip"},
+	"dz_ip":  {"publisher_dz_ip", "subscriber_dz_ip"},
+	"device": {"publisher_device_code", "subscriber_device_code", "publisher_device_pk", "subscriber_device_pk"},
+	"status": {"health_status"},
+	"health": {"health_status"},
+}
+
+// multicastHealthPathSearchFallback is OR-matched when the token has no
+// field prefix.
+var multicastHealthPathSearchFallback = []string{
 	"publisher_owner_pubkey",
 	"publisher_user_pk",
 	"publisher_dz_ip",
@@ -123,7 +139,7 @@ func (a *API) FetchMulticastHealthPathsPageData(ctx context.Context, pkOrCode st
 func (a *API) queryMulticastHealthPaths(ctx context.Context, groupPK, search string, limit, offset int) ([]MulticastHealthPathItem, int, error) {
 	whereClause := "multicast_group_pk = ?"
 	args := []any{groupPK}
-	if clause, extra := buildHealthSearchClause(search, multicastHealthPathSearchCols); clause != "" {
+	if clause, extra := buildHealthSearchClause(search, multicastHealthPathSearchFields, multicastHealthPathSearchFallback); clause != "" {
 		whereClause += clause
 		args = append(args, extra...)
 	}

--- a/api/handlers/multicast_health_search_test.go
+++ b/api/handlers/multicast_health_search_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenizeHealthSearch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []healthSearchToken
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: []healthSearchToken{},
+		},
+		{
+			name: "single bare term",
+			in:   "3b2Ze7VY",
+			want: []healthSearchToken{{value: "3b2Ze7VY"}},
+		},
+		{
+			name: "single field token",
+			in:   "device:nyc001",
+			want: []healthSearchToken{{field: "device", value: "nyc001"}},
+		},
+		{
+			name: "mixed bare + field",
+			in:   "unhealthy device:nyc001",
+			want: []healthSearchToken{
+				{value: "unhealthy"},
+				{field: "device", value: "nyc001"},
+			},
+		},
+		{
+			name: "field prefix is lowercased",
+			in:   "DEVICE:NYC001",
+			want: []healthSearchToken{{field: "device", value: "NYC001"}},
+		},
+		{
+			name: "trailing colon with no value falls back to bare",
+			in:   "device:",
+			want: []healthSearchToken{{value: "device"}},
+		},
+		{
+			name: "leading colon is not a field token",
+			in:   ":foo",
+			want: []healthSearchToken{{value: ":foo"}},
+		},
+		{
+			name: "multiple field tokens AND together",
+			in:   "device:nyc001 status:unhealthy mode:P",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+				{field: "mode", value: "P"},
+			},
+		},
+		{
+			name: "extra whitespace ignored",
+			in:   "  device:nyc001     status:unhealthy  ",
+			want: []healthSearchToken{
+				{field: "device", value: "nyc001"},
+				{field: "status", value: "unhealthy"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tokenizeHealthSearch(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildHealthSearchClause(t *testing.T) {
+	fieldMap := map[string][]string{
+		"device": {"user_device_code", "user_device_pk"},
+		"status": {"health_status"},
+	}
+	fallback := []string{"user_pk", "user_owner_pubkey"}
+
+	t.Run("empty search → no clause", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("", fieldMap, fallback)
+		assert.Equal(t, "", clause)
+		assert.Nil(t, args)
+	})
+
+	t.Run("bare term → fallback columns OR'd", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("3b2Ze7VY", fieldMap, fallback)
+		// Expect: AND (pos(user_pk, ?)>0 OR pos(user_owner_pubkey, ?)>0)
+		assert.Contains(t, clause, "user_pk")
+		assert.Contains(t, clause, "user_owner_pubkey")
+		assert.Equal(t, strings.Count(clause, " OR "), 1)
+		require.Len(t, args, 2)
+		assert.Equal(t, "3b2Ze7VY", args[0])
+		assert.Equal(t, "3b2Ze7VY", args[1])
+	})
+
+	t.Run("known field → mapped columns OR'd", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("device:nyc001", fieldMap, fallback)
+		assert.Contains(t, clause, "user_device_code")
+		assert.Contains(t, clause, "user_device_pk")
+		assert.NotContains(t, clause, "user_pk,")
+		require.Len(t, args, 2)
+		assert.Equal(t, "nyc001", args[0])
+	})
+
+	t.Run("unknown field falls back to bare", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("nonsense:foo", fieldMap, fallback)
+		// "nonsense" not in fieldMap → treated as substring match against fallback
+		assert.Contains(t, clause, "user_pk")
+		assert.Contains(t, clause, "user_owner_pubkey")
+		require.Len(t, args, 2)
+		assert.Equal(t, "foo", args[0])
+	})
+
+	t.Run("multiple tokens AND together", func(t *testing.T) {
+		clause, args := buildHealthSearchClause("device:nyc001 status:unhealthy", fieldMap, fallback)
+		// Two ANDs: the leading " AND " that attaches to caller's WHERE, plus
+		// one between the two token groups.
+		assert.Equal(t, 2, strings.Count(clause, " AND "))
+		assert.Contains(t, clause, "user_device_code")
+		assert.Contains(t, clause, "health_status")
+		require.Len(t, args, 3) // 2 device cols + 1 status col
+	})
+
+	t.Run("placeholders survive into args in token order", func(t *testing.T) {
+		_, args := buildHealthSearchClause("device:nyc status:unhealthy", fieldMap, fallback)
+		// device token first (2 cols, 2 args), status token second (1 col, 1 arg)
+		require.Len(t, args, 3)
+		assert.Equal(t, "nyc", args[0])
+		assert.Equal(t, "nyc", args[1])
+		assert.Equal(t, "unhealthy", args[2])
+	})
+}

--- a/api/handlers/multicast_health_users.go
+++ b/api/handlers/multicast_health_users.go
@@ -13,13 +13,29 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
-// multicastHealthUserSearchCols are the columns the `?search=` filter
-// substring-matches across (case-insensitive). Order doesn't matter for
-// correctness, but listing the most likely-matched columns first lets
-// ClickHouse short-circuit OR evaluation in the common case.
-var multicastHealthUserSearchCols = []string{
-	"user_owner_pubkey",
+// multicastHealthUserSearchFields maps the prefixes accepted in a
+// `field:value` search token to the underlying columns to substring-match
+// against. Aliases are flattened (e.g. `user:` matches account or owner;
+// `pubkey:` is an alias for `user:`).
+var multicastHealthUserSearchFields = map[string][]string{
+	"user":    {"user_pk", "user_owner_pubkey"},
+	"account": {"user_pk"},
+	"owner":   {"user_owner_pubkey"},
+	"pubkey":  {"user_pk", "user_owner_pubkey"},
+	"ip":      {"user_dz_ip"},
+	"dz_ip":   {"user_dz_ip"},
+	"device":  {"user_device_code", "user_device_pk"},
+	"tunnel":  {"user_tunnel_id"},
+	"mode":    {"mode"},
+	"status":  {"health_status"},
+	"health":  {"health_status"},
+}
+
+// multicastHealthUserSearchFallback is OR-matched when the token has no
+// field prefix.
+var multicastHealthUserSearchFallback = []string{
 	"user_pk",
+	"user_owner_pubkey",
 	"user_dz_ip",
 	"user_device_code",
 	"user_device_pk",
@@ -67,7 +83,7 @@ func (a *API) GetMulticastGroupHealthUsers(w http.ResponseWriter, r *http.Reques
 
 	where := "multicast_group_pk = ?"
 	args := []any{group.PK}
-	if clause, extra := buildHealthSearchClause(search, multicastHealthUserSearchCols); clause != "" {
+	if clause, extra := buildHealthSearchClause(search, multicastHealthUserSearchFields, multicastHealthUserSearchFallback); clause != "" {
 		where += clause
 		args = append(args, extra...)
 	}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -63,10 +63,12 @@ function SearchInput({
   value,
   onChange,
   placeholder,
+  hint,
 }: {
   value: string
   onChange: (v: string) => void
   placeholder: string
+  hint?: string
 }) {
   return (
     <div className="relative">
@@ -75,7 +77,10 @@ function SearchInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="h-7 w-72 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+        // title attribute renders a native hover hint; sufficient for a
+        // syntax cheat sheet without spawning a Radix tooltip per input.
+        title={hint}
+        className="h-7 w-80 rounded-md border border-border bg-background px-2 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-ring"
       />
     </div>
   )
@@ -401,6 +406,19 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
   return (
     <div className="p-4 space-y-6">
+      {/* Under-development notice. The reconciliation logic and rate dimension
+          here surface real data, but the verdicts assume state-collect covers
+          every device — today only jump devices are collected, so non-jump
+          publishers/subscribers can falsely render as unhealthy. Wording is
+          deliberately concrete so operators read it as caveat, not "do not
+          trust this page". */}
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+        <div className="font-medium">This view is under development.</div>
+        <div className="mt-1 text-amber-200/90">
+          Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
+        </div>
+      </div>
+
       {/* Summary counts */}
       <div className="border border-border rounded-lg bg-card p-4">
         <div className="flex items-baseline justify-between mb-2">
@@ -429,7 +447,8 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             <SearchInput
               value={usersSearchInput}
               onChange={setUsersSearchInput}
-              placeholder="Filter user, mode, device, tunnel, status…"
+              placeholder="device:NAME  status:unhealthy  tunnel:520  …"
+              hint="Use field:value (device, status, tunnel, mode, user, owner, ip). Bare text matches any column."
             />
             {usersQuery.isFetching && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
           </div>
@@ -529,7 +548,8 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
               <SearchInput
                 value={pathsSearchInput}
                 onChange={setPathsSearchInput}
-                placeholder="Filter publisher, subscriber, device, status…"
+                placeholder="publisher:Df  subscriber:Hk  device:nyc001  …"
+                hint="Use field:value (publisher, subscriber, device, status, user, owner, ip). Bare text matches any column."
               />
             )}
             {showPathDetails && pathsQuery.isFetching && (


### PR DESCRIPTION
## Summary

Two adjustments to the Multicast Group Health tab, both follow-ups to #642 driven by today's live review:

1. **Under-development banner.** A yellow info banner now renders at the top of the Health tab calling out that the verdicts are work-in-progress and state-collect only covers jump devices today, so any user / publisher / subscriber on a non-jump device renders as `unhealthy` even when functioning normally. Operators have been reading those false-positives as real outages; the banner sets expectations until the view learns to distinguish "uncollected" from "missing".

2. **Field:value search syntax.** `?search=` on `/health/users` and `/health/paths` is now whitespace-tokenized. Each token is either `field:value` (case-insensitive field, free-form value) or a bare term (broad substring fallback, same as before). Multiple tokens AND together.

    Supported fields on per-user: `device`, `status`, `tunnel`, `mode`, `user`, `account`, `owner`, `pubkey`, `ip`, `health`.
    Supported fields on per-path: `publisher`, `subscriber`, `device`, `status`, `user`, `owner`, `pubkey`, `ip`, `health`.
    Unknown prefixes fall back to substring so a typo doesn't break the whole query.

    The search input placeholders advertise the new syntax (`device:NAME  status:unhealthy  tunnel:520  …`) and a native `title` hint lists all the field prefixes.

## Testing Verification

- New unit tests cover the tokenizer (`tokenizeHealthSearch`) and the clause builder (`buildHealthSearchClause`): bare terms, field-scoped tokens, multi-token AND, lowercased field prefixes, trailing-colon fallback, unknown-field fallback, argument ordering. All green.
- Existing integration tests on the handlers still pass.
- Manual: `?search=device:nyc001 status:unhealthy` on `/health/users` narrows to rows whose device matches `nyc001` AND whose `health_status` matches `unhealthy`. Bare-token syntax (`?search=3b2Ze7VY`) still works.
