### PR TITLE
agent: document multicast device capacity and add capacity eval

### DIFF
--- a/agent/evals/multicast_device_capacity_test.go
+++ b/agent/evals/multicast_device_capacity_test.go
@@ -1,0 +1,182 @@
+//go:build evals
+
+package evals_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+	serviceability "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_Agent_Evals_Anthropic_MulticastDeviceCapacity(t *testing.T) {
+	t.Parallel()
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping eval test")
+	}
+
+	runTest_MulticastDeviceCapacity(t, newAnthropicLLMClient)
+}
+
+func runTest_MulticastDeviceCapacity(t *testing.T, llmFactory LLMClientFactory) {
+	ctx := context.Background()
+
+	debugLevel, debug := getDebugLevel()
+
+	clientInfo := testClientInfo(t)
+
+	conn, err := clientInfo.Client.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	seedMulticastDeviceCapacityData(t, ctx, conn)
+
+	validateMulticastDeviceCapacityQuery(t, ctx, conn)
+
+	if testing.Short() {
+		t.Log("Skipping workflow execution in short mode")
+		return
+	}
+
+	p := setupWorkflow(t, ctx, clientInfo, llmFactory, debug, debugLevel)
+
+	question := "which DZDs have capacity for new multicast subscribers?"
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Query: '%s' ===\n", question)
+		} else {
+			t.Logf("=== Starting workflow query: '%s' ===\n", question)
+		}
+	}
+	result, err := p.Run(ctx, question)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Answer)
+
+	response := result.Answer
+	if debug {
+		if debugLevel == 1 {
+			t.Logf("=== Response ===\n%s\n", response)
+		} else {
+			t.Logf("\n=== Final Workflow Response ===\n%s\n", response)
+		}
+	} else {
+		t.Logf("Workflow response:\n%s", response)
+	}
+
+	expectations := []Expectation{
+		{
+			Description:   "Devices with capacity identified",
+			ExpectedValue: "nyc-dzd-a and nyc-dzd-c are reported as having capacity for new multicast subscribers",
+			Rationale:     "nyc-dzd-a has max 5 with 2 current subscribers (3 available); nyc-dzd-c has max 10 with 0 current subscribers (10 available)",
+		},
+		{
+			Description:   "Full device excluded",
+			ExpectedValue: "nyc-dzd-b is NOT reported as having capacity (it is full)",
+			Rationale:     "nyc-dzd-b has max 3 with 3 current subscribers, so 0 available",
+		},
+		{
+			Description:   "Counts derived from live users, not stale on-chain counts",
+			ExpectedValue: "the current subscriber counts reflect the attached multicast users (a=2, c=0), not the device's on-chain multicast_subscribers_count fields (a=0, c=8)",
+			Rationale:     "the on-chain device counts are stale; current subscribers must come from dz_users_current",
+		},
+	}
+	isCorrect, err := evaluateResponse(t, ctx, question, response, expectations...)
+	require.NoError(t, err, "Evaluation must be available")
+	require.True(t, isCorrect, "Evaluation indicates the response does not correctly identify device multicast subscriber capacity")
+}
+
+// seedMulticastDeviceCapacityData seeds data for the device multicast capacity test.
+// Scenario (1 metro, 3 devices, 1 multicast group):
+//   - nyc-dzd-a: max_multicast_subscribers=5, 2 live subscribers -> 3 available (HAS capacity).
+//     On-chain multicast_subscribers_count is left stale at 0.
+//   - nyc-dzd-b: max_multicast_subscribers=3, 3 live subscribers -> 0 available (FULL).
+//   - nyc-dzd-c: max_multicast_subscribers=10, 0 live subscribers -> 10 available (HAS capacity).
+//     On-chain multicast_subscribers_count is set to a stale, misleadingly-high 8.
+//
+// The stale on-chain counts (a=0, c=8) deliberately disagree with the live user
+// data so the eval fails if the agent reads the device count columns instead of
+// counting attached users.
+func seedMulticastDeviceCapacityData(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	now := testTime()
+	opID := uuid.New()
+
+	metros := []serviceability.Metro{
+		{PK: "metro1", Code: "nyc", Name: "New York"},
+	}
+	seedMetros(t, ctx, conn, metros, now, now)
+
+	devices := []serviceability.Device{
+		{PK: "device-a", Code: "nyc-dzd-a", Status: "activated", MetroPK: "metro1", DeviceType: "DZD", MaxMulticastSubscribers: 5, MulticastSubscribersCount: 0},
+		{PK: "device-b", Code: "nyc-dzd-b", Status: "activated", MetroPK: "metro1", DeviceType: "DZD", MaxMulticastSubscribers: 3, MulticastSubscribersCount: 0},
+		{PK: "device-c", Code: "nyc-dzd-c", Status: "activated", MetroPK: "metro1", DeviceType: "DZD", MaxMulticastSubscribers: 10, MulticastSubscribersCount: 8},
+	}
+	seedDevices(t, ctx, conn, devices, now, now)
+
+	groupPK := "group1"
+	multicastGroups := []serviceability.MulticastGroup{
+		{PK: groupPK, OwnerPubkey: "group-owner1", Code: "solana-shreds", MulticastIP: net.ParseIP("239.1.1.1"), MaxBandwidth: 1000000000, Status: "activated", PublisherCount: 0, SubscriberCount: 5},
+	}
+	seedMulticastGroups(t, ctx, conn, multicastGroups, now, opID)
+
+	users := []serviceability.User{
+		// device-a: 2 subscribers
+		{PK: "ua1", OwnerPubkey: "owner-a1", Status: "activated", DevicePK: "device-a", DZIP: net.ParseIP("10.1.1.1"), ClientIP: net.ParseIP("203.0.113.1"), Kind: "multicast", TunnelID: 101, Subscribers: []string{groupPK}},
+		{PK: "ua2", OwnerPubkey: "owner-a2", Status: "activated", DevicePK: "device-a", DZIP: net.ParseIP("10.1.1.2"), ClientIP: net.ParseIP("203.0.113.2"), Kind: "multicast", TunnelID: 102, Subscribers: []string{groupPK}},
+		// device-b: 3 subscribers
+		{PK: "ub1", OwnerPubkey: "owner-b1", Status: "activated", DevicePK: "device-b", DZIP: net.ParseIP("10.1.2.1"), ClientIP: net.ParseIP("203.0.113.3"), Kind: "multicast", TunnelID: 103, Subscribers: []string{groupPK}},
+		{PK: "ub2", OwnerPubkey: "owner-b2", Status: "activated", DevicePK: "device-b", DZIP: net.ParseIP("10.1.2.2"), ClientIP: net.ParseIP("203.0.113.4"), Kind: "multicast", TunnelID: 104, Subscribers: []string{groupPK}},
+		{PK: "ub3", OwnerPubkey: "owner-b3", Status: "activated", DevicePK: "device-b", DZIP: net.ParseIP("10.1.2.3"), ClientIP: net.ParseIP("203.0.113.5"), Kind: "multicast", TunnelID: 105, Subscribers: []string{groupPK}},
+		// device-c: 0 subscribers (no multicast users attached)
+	}
+	seedUsers(t, ctx, conn, users, now, now, opID)
+}
+
+func validateMulticastDeviceCapacityQuery(t *testing.T, ctx context.Context, conn clickhouse.Connection) {
+	query := `
+WITH subs AS (
+    SELECT device_pk, countIf(JSONLength(subscribers) > 0) AS current_subscribers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+    GROUP BY device_pk
+)
+SELECT
+    d.code AS code,
+    d.max_multicast_subscribers AS max_subscribers,
+    COALESCE(s.current_subscribers, 0) AS current_subscribers,
+    toInt64(d.max_multicast_subscribers) - toInt64(COALESCE(s.current_subscribers, 0)) AS available
+FROM dz_devices_current d
+LEFT JOIN subs s ON s.device_pk = d.pk
+WHERE d.max_multicast_subscribers > 0
+ORDER BY d.code
+`
+	result, err := dataset.Query(ctx, conn, query, nil)
+	require.NoError(t, err, "Failed to execute device multicast capacity query")
+	require.Equal(t, 3, result.Count, "Should have exactly 3 devices with a configured subscriber max")
+
+	want := map[string]struct {
+		current, available int64
+	}{
+		"nyc-dzd-a": {current: 2, available: 3},
+		"nyc-dzd-b": {current: 3, available: 0},
+		"nyc-dzd-c": {current: 0, available: 10},
+	}
+	for _, row := range result.Rows {
+		code := row["code"].(string)
+		current := int64(row["current_subscribers"].(uint64))
+		available := row["available"].(int64)
+		exp, ok := want[code]
+		require.True(t, ok, "unexpected device %s", code)
+		require.Equal(t, exp.current, current, "%s current subscribers", code)
+		require.Equal(t, exp.available, available, "%s available capacity", code)
+	}
+
+	t.Logf("Database validation passed: nyc-dzd-a (3 avail), nyc-dzd-b (0 avail), nyc-dzd-c (10 avail)")
+}

--- a/agent/pkg/workflow/prompts/SQL_CONTEXT.md
+++ b/agent/pkg/workflow/prompts/SQL_CONTEXT.md
@@ -519,6 +519,38 @@ JOIN solana_vote_accounts_current va ON gn.pubkey = va.node_pubkey
 WHERE u.status = 'activated' AND u.kind = 'multicast' AND has(JSONExtract(u.publishers, 'Array(String)'), 'group_pk_value')
 ```
 
+### Device multicast capacity ("room for new subscribers/publishers")
+`dz_devices_current` has capacity columns:
+- `max_multicast_subscribers` / `max_multicast_publishers` — the maximum subscriber/publisher slots configured on the device. A value of `0` means the limit is **unknown/unset**, not "zero capacity".
+- `multicast_subscribers_count` / `multicast_publishers_count` — on-chain reported counts. These are frequently **stale or 0 even when users are attached**. Do NOT use them to answer "how many subscribers does this device have" or capacity questions.
+
+**Always derive the current count from live users in `dz_users_current`**, not from the device count columns:
+- current subscribers on a device = activated multicast users on that device with a non-empty `subscribers` array
+- current publishers on a device = activated multicast users on that device with a non-empty `publishers` array
+
+**Available capacity** for new subscribers = `max_multicast_subscribers - current_subscribers`, and is only meaningful when `max_multicast_subscribers > 0`. If `max_multicast_subscribers = 0`, the capacity is unknown — say so rather than reporting a number. A device "has capacity for new subscribers" when `max_multicast_subscribers > 0 AND current_subscribers < max_multicast_subscribers`.
+
+**Canonical "which devices have capacity for new multicast subscribers" query:**
+```sql
+WITH subs AS (
+    SELECT device_pk, countIf(JSONLength(subscribers) > 0) AS current_subscribers
+    FROM dz_users_current
+    WHERE status = 'activated' AND kind = 'multicast'
+    GROUP BY device_pk
+)
+SELECT
+    d.code,
+    d.max_multicast_subscribers AS max_subscribers,
+    COALESCE(s.current_subscribers, 0) AS current_subscribers,
+    toInt64(d.max_multicast_subscribers) - toInt64(COALESCE(s.current_subscribers, 0)) AS available
+FROM dz_devices_current d
+LEFT JOIN subs s ON s.device_pk = d.pk
+WHERE d.max_multicast_subscribers > 0
+  AND COALESCE(s.current_subscribers, 0) < d.max_multicast_subscribers
+ORDER BY available DESC
+```
+Swap `subscribers`→`publishers` and `max_multicast_subscribers`→`max_multicast_publishers` for publisher capacity.
+
 **Traffic gotcha:** On tunnel interfaces, use `in_octets_delta`/`out_octets_delta` for bandwidth. Do NOT use `in_multicast_pkts_delta`/`out_multicast_pkts_delta` — these counters are unreliable on tunnel interfaces.
 
 ### History Tables (CRITICAL)


### PR DESCRIPTION
Resolves: #651

## Summary of Changes
- Add a "Device multicast capacity" section to the agent's `SQL_CONTEXT.md` so it can answer questions like "which DZDs have capacity for new subscribers". Previously the agent had no definition of device capacity and would reason over the stale on-chain `multicast_subscribers_count` / `multicast_publishers_count` columns on `dz_devices_current`, producing nonsensical answers.
- The new guidance: marks the on-chain device count columns as unreliable; defines current subscribers/publishers as activated multicast users on the device with a non-empty `subscribers`/`publishers` array (from `dz_users_current`); defines available capacity as `max_multicast_subscribers - current`, only meaningful when `max_multicast_subscribers > 0` (0 means unknown, not full); and includes a canonical "which devices have capacity" query.
- Add the `MulticastDeviceCapacity` eval. It seeds devices whose stale on-chain counts deliberately disagree with their attached users (a: on-chain 0 vs live 2; c: on-chain 8 vs live 0), so the eval fails if the agent reads the device count columns instead of counting live users.

This is the agent-facing half of the multicast count problem. The data/display half is #650 (PR #653).

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Docs (prompt)|     1 | +~35 / -1   | +~34 |
| Tests (eval) |     1 | +~185 / -0  | +~185|

Prompt guidance plus a new eval; no production code paths change.

## Testing Verification
- `MulticastDeviceCapacity` eval passes against the live agent (`claude-haiku-4-5`): the agent generated a query counting live subscribers via `countIf(JSONLength(subscribers) > 0)` and computing `max - current`, reported `nyc-dzd-c` (10 available) and `nyc-dzd-a` (3 available), correctly excluded the full `nyc-dzd-b`, and used live counts (a=2, c=0) rather than the stale on-chain values (a=0, c=8). The eval's LLM judge passed all three expectations.
- The eval's ground-truth ClickHouse query is independently asserted (a=3, b=0, c=10 available) so the scenario is verified even in short mode.