### PR TITLE
indexer: realign AccessPassTypeTag mapping with doublezero SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/lmittmann/tint v1.1.3
-	github.com/malbeclabs/doublezero v0.8.1-0.20260512203329-8b8e8c296088
+	github.com/malbeclabs/doublezero v0.8.1-0.20260610023603-b4c5e59f80b8
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/malbeclabs/doublezero v0.8.1-0.20260512203329-8b8e8c296088 h1:1oWZ6aPdmhqIXcTyNtOLr8d2nndH6BXwoZcXpHRTPu4=
 github.com/malbeclabs/doublezero v0.8.1-0.20260512203329-8b8e8c296088/go.mod h1:46JgwlskRbJx9kD0g3PTmojYcGBhdGEUmouaSzAJcIw=
+github.com/malbeclabs/doublezero v0.8.1-0.20260610023603-b4c5e59f80b8 h1:MGdQy9feO4zM8WOCFuxRQUiRTnmG3ZCfg5/cRi9d4rE=
+github.com/malbeclabs/doublezero v0.8.1-0.20260610023603-b4c5e59f80b8/go.mod h1:JXRIJXQA6lfO8hyI5pIJ0THaDlNNwiYFxpkR2sEXGCw=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -739,12 +739,10 @@ func accessPassTypeTagString(t serviceability.AccessPassTypeTag) string {
 		return "solana_validator"
 	case serviceability.AccessPassTypeSolanaRPC:
 		return "solana_rpc"
-	case serviceability.AccessPassTypeSolanaMulticastPub:
-		return "solana_multicast_pub"
-	case serviceability.AccessPassTypeSolanaMulticastSub:
-		return "solana_multicast_sub"
 	case serviceability.AccessPassTypeOthers:
 		return "others"
+	case serviceability.AccessPassTypeEdgeSeat:
+		return "edge_seat"
 	default:
 		return "unknown"
 	}
@@ -753,8 +751,10 @@ func accessPassTypeTagString(t serviceability.AccessPassTypeTag) string {
 func convertAccessPasses(onchain []serviceability.AccessPass) []AccessPass {
 	result := make([]AccessPass, len(onchain))
 	for i, ap := range onchain {
+		// Only SolanaValidator and SolanaRPC passes carry an associated pubkey onchain.
 		var associatedPubkey string
-		if ap.AccessPassTypeTag >= 1 && ap.AccessPassTypeTag <= 4 {
+		if ap.AccessPassTypeTag == serviceability.AccessPassTypeSolanaValidator ||
+			ap.AccessPassTypeTag == serviceability.AccessPassTypeSolanaRPC {
 			associatedPubkey = solana.PublicKeyFromBytes(ap.AssociatedPubkey[:]).String()
 		}
 

--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -440,6 +441,13 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 	return result, nil
 }
 
+// statusString strips the SDK's " (deprecated)" suffix so the strings stored in
+// ClickHouse keep lake's stable status vocabulary (e.g. "pending", "expired")
+// regardless of upstream deprecation annotations.
+func statusString(s fmt.Stringer) string {
+	return strings.TrimSuffix(s.String(), " (deprecated)")
+}
+
 func convertContributors(onchain []serviceability.Contributor) []Contributor {
 	result := make([]Contributor, len(onchain))
 	for i, contributor := range onchain {
@@ -466,13 +474,13 @@ func convertDevices(onchain []serviceability.Device) []Device {
 			interfaces = append(interfaces, Interface{
 				Name:   iface.Name,
 				IP:     ip,
-				Status: iface.Status.String(),
+				Status: statusString(iface.Status),
 			})
 		}
 
 		result[i] = Device{
 			PK:                        solana.PublicKeyFromBytes(device.PubKey[:]).String(),
-			Status:                    device.Status.String(),
+			Status:                    statusString(device.Status),
 			DeviceType:                device.DeviceType.String(),
 			Code:                      device.Code,
 			PublicIP:                  net.IP(device.PublicIp[:]).String(),
@@ -501,7 +509,7 @@ func convertDeviceInterfaces(onchain []serviceability.Device) []DeviceInterface 
 			result = append(result, DeviceInterface{
 				DevicePK:           devicePK,
 				Intf:               iface.Name,
-				Status:             iface.Status.String(),
+				Status:             statusString(iface.Status),
 				InterfaceType:      iface.InterfaceType.String(),
 				CYOAType:           iface.InterfaceCYOA.String(),
 				DIAType:            iface.InterfaceDIA.String(),
@@ -536,7 +544,7 @@ func convertUsers(onchain []serviceability.User) []User {
 		result[i] = User{
 			PK:          solana.PublicKeyFromBytes(user.PubKey[:]).String(),
 			OwnerPubkey: solana.PublicKeyFromBytes(user.Owner[:]).String(),
-			Status:      user.Status.String(),
+			Status:      statusString(user.Status),
 			Kind:        user.UserType.String(),
 			ClientIP:    net.IP(user.ClientIp[:]),
 			DZIP:        net.IP(user.DzIp[:]),
@@ -599,7 +607,7 @@ func convertLinks(onchain []serviceability.Link, devices []serviceability.Device
 
 		result[i] = Link{
 			PK:                  solana.PublicKeyFromBytes(link.PubKey[:]).String(),
-			Status:              link.Status.String(),
+			Status:              statusString(link.Status),
 			Code:                link.Code,
 			SideAPK:             sideAPK,
 			SideZPK:             sideZPK,
@@ -671,7 +679,7 @@ func convertTenants(onchain []serviceability.Tenant, topologies []serviceability
 			PK:                solana.PublicKeyFromBytes(t.PubKey[:]).String(),
 			OwnerPubkey:       solana.PublicKeyFromBytes(t.Owner[:]).String(),
 			Code:              t.Code,
-			PaymentStatus:     t.PaymentStatus.String(),
+			PaymentStatus:     statusString(t.PaymentStatus),
 			VrfID:             t.VrfId,
 			MetroRouting:      t.MetroRouting,
 			RouteLiveness:     t.RouteLiveness,
@@ -691,7 +699,7 @@ func convertLocations(onchain []serviceability.Location) []Location {
 			Lat:            loc.Lat,
 			Lng:            loc.Lng,
 			LocId:          loc.LocId,
-			Status:         loc.Status.String(),
+			Status:         statusString(loc.Status),
 			Code:           loc.Code,
 			Name:           loc.Name,
 			Country:        loc.Country,
@@ -778,7 +786,7 @@ func convertAccessPasses(onchain []serviceability.AccessPass) []AccessPass {
 			UserPayer:          solana.PublicKeyFromBytes(ap.UserPayer[:]).String(),
 			LastAccessEpoch:    ap.LastAccessEpoch,
 			ConnectionCount:    ap.ConnectionCount,
-			Status:             ap.Status.String(),
+			Status:             statusString(ap.Status),
 			MGroupPubAllowlist: pubAllowlist,
 			MGroupSubAllowlist: subAllowlist,
 			Flags:              ap.Flags,

--- a/indexer/pkg/dz/serviceability/view_test.go
+++ b/indexer/pkg/dz/serviceability/view_test.go
@@ -2,6 +2,7 @@ package dzsvc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1241,5 +1242,29 @@ func TestLake_Serviceability_View_ConvertAccessPasses_AssociatedPubkey(t *testin
 		require.Len(t, result, 1)
 		require.Equal(t, tt.want, result[0].AssociatedPubkey,
 			"tag %s should have associated pubkey %q", accessPassTypeTagString(tt.tag), tt.want)
+	}
+}
+
+func TestLake_Serviceability_View_StatusString_StripsDeprecatedSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status fmt.Stringer
+		want   string
+	}{
+		{serviceability.AccessPassStatusExpiredDeprecated, "expired"},
+		{serviceability.AccessPassStatusConnected, "connected"},
+		{serviceability.DeviceStatusPendingDeprecated, "pending"},
+		{serviceability.DeviceStatusRejectedDeprecated, "rejected"},
+		{serviceability.DeviceStatusActivated, "activated"},
+		{serviceability.LinkStatusPendingDeprecated, "pending"},
+		{serviceability.LinkStatusRejectedDeprecated, "rejected"},
+		{serviceability.UserStatusPendingDeprecated, "pending"},
+		{serviceability.UserStatusPendingBanDeprecated, "pending_ban"},
+		{serviceability.UserStatusActivated, "activated"},
+		{serviceability.LocationStatusPendingDeprecated, "pending"},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, statusString(tt.status))
 	}
 }

--- a/indexer/pkg/dz/serviceability/view_test.go
+++ b/indexer/pkg/dz/serviceability/view_test.go
@@ -1197,3 +1197,49 @@ func TestLake_Serviceability_View_Refresh(t *testing.T) {
 		require.Contains(t, err.Error(), "refusing to write snapshot")
 	})
 }
+
+func TestLake_Serviceability_View_AccessPassTypeTagString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tag  serviceability.AccessPassTypeTag
+		want string
+	}{
+		{serviceability.AccessPassTypePrepaid, "prepaid"},
+		{serviceability.AccessPassTypeSolanaValidator, "solana_validator"},
+		{serviceability.AccessPassTypeSolanaRPC, "solana_rpc"},
+		{serviceability.AccessPassTypeOthers, "others"},
+		{serviceability.AccessPassTypeEdgeSeat, "edge_seat"},
+		{serviceability.AccessPassTypeTag(99), "unknown"},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, accessPassTypeTagString(tt.tag))
+	}
+}
+
+func TestLake_Serviceability_View_ConvertAccessPasses_AssociatedPubkey(t *testing.T) {
+	t.Parallel()
+
+	pubkey := [32]byte{1, 2, 3}
+	want := solana.PublicKeyFromBytes(pubkey[:]).String()
+
+	tests := []struct {
+		tag  serviceability.AccessPassTypeTag
+		want string
+	}{
+		{serviceability.AccessPassTypePrepaid, ""},
+		{serviceability.AccessPassTypeSolanaValidator, want},
+		{serviceability.AccessPassTypeSolanaRPC, want},
+		{serviceability.AccessPassTypeOthers, ""},
+		{serviceability.AccessPassTypeEdgeSeat, ""},
+	}
+	for _, tt := range tests {
+		result := convertAccessPasses([]serviceability.AccessPass{{
+			AccessPassTypeTag: tt.tag,
+			AssociatedPubkey:  pubkey,
+		}})
+		require.Len(t, result, 1)
+		require.Equal(t, tt.want, result[0].AssociatedPubkey,
+			"tag %s should have associated pubkey %q", accessPassTypeTagString(tt.tag), tt.want)
+	}
+}

--- a/web/src/components/access-pass-detail-page.tsx
+++ b/web/src/components/access-pass-detail-page.tsx
@@ -19,9 +19,8 @@ const TYPE_TAG_COLORS: Record<string, string> = {
   prepaid: 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400 border-zinc-500/20',
   solana_validator: 'bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20',
   solana_rpc: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
-  solana_multicast_pub: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
-  solana_multicast_sub: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20',
   others: 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20',
+  edge_seat: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -529,7 +528,7 @@ export function AccessPassDetailPage() {
                 </>
               )}
 
-              {(ap.type_tag === 'solana_rpc' || ap.type_tag === 'solana_multicast_pub' || ap.type_tag === 'solana_multicast_sub') && (
+              {ap.type_tag === 'solana_rpc' && (
                 <div className="flex justify-between gap-4">
                   <dt className="text-sm text-muted-foreground shrink-0">Pubkey</dt>
                   <dd className="text-sm font-mono min-w-0">

--- a/web/src/components/access-passes-page.tsx
+++ b/web/src/components/access-passes-page.tsx
@@ -17,9 +17,8 @@ const TYPE_TAG_COLORS: Record<string, string> = {
   prepaid: 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400 border-zinc-500/20',
   solana_validator: 'bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20',
   solana_rpc: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
-  solana_multicast_pub: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
-  solana_multicast_sub: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20',
   others: 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20',
+  edge_seat: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
 }
 
 function TypeTagBadge({ tag }: { tag: string }) {


### PR DESCRIPTION
## Reason for Change
https://github.com/malbeclabs/doublezero/pull/3865 changed the EdgeSeat access pass type. It wasn't used onchain anywhere yet, but Lake needs a matching PR for the SDK changes.

## Summary of Changes

* Bump `github.com/malbeclabs/doublezero` to `b4c5e59f` (includes doublezero#3865) and realign the indexer's `AccessPassTypeTag` mapping with the onchain enum: `Others=3` → `"others"`, `EdgeSeat=4` → `"edge_seat"`, multicast variants removed. Without this, lake fails to compile on the next SDK bump, and an `Others` pass would be indexed as `solana_multicast_pub` with garbage fields.
* Populate `associated_pubkey` only for `SolanaValidator` and `SolanaRPC` passes — the only variants that carry one onchain. Previously tags 1–4 were converted, which would emit the base58-encoded zero pubkey for `Others`/`EdgeSeat`.
* Keep lake's stored status vocabulary stable across the SDK bump: the bump also renamed deprecated status variants across seven enums, appending a `" (deprecated)"` suffix to their `String()` output (e.g. `"expired"` → `"expired (deprecated)"`, `"pending"` → `"pending (deprecated)"`). Lake stored `Status.String()` verbatim, so stale onchain accounts would have spawned spurious SCD2 version rows with drifted strings and broken web `STATUS_COLORS` maps and the agent's documented status values. A new `statusString` helper strips the suffix at the conversion boundary.
* Update web access-pass badge color maps: drop the multicast entries, add `edge_seat`, and narrow the associated-pubkey display condition to `solana_rpc`.
* No backfill needed: verified onchain 2026-06-09 that zero tag-3 (`Others`) and tag-4 (`EdgeSeat`) AccessPass accounts exist on mainnet-beta, testnet, and devnet.
* Fixes #656

## Testing Verification

* New unit tests pin the tag-string mapping (all five variants plus unknown), the associated-pubkey gating (populated only for validator/RPC, empty for prepaid/others/edge_seat), and the `statusString` deprecation-suffix stripping for the renamed variants across `AccessPass`, `Device`, `Link`, `User`, and `Location` statuses — all passing.
* Diffed the SDK between the pinned commit (`8b8e8c29`) and `b4c5e59f` to audit bump side effects: the `AccessPass` struct gained additive fields (no compile impact), and the status `String()` renames are the only behavioral change reaching lake — handled by `statusString`.
* Full `go test -short` across the repo: all packages pass except those requiring a Docker daemon for ClickHouse testcontainers (unavailable in the sandbox; failures are setup-only and identical on a clean tree). `golangci-lint` reports 0 issues; `tsc -b` passes for the web changes.
* Architecture and security reviews posted on #656; the High finding (status-string drift) is fixed here, all remaining findings are Medium/Low.
