### PR TITLE
shreds: fix validator rewards page multi-client grain and claim status

### DIFF
--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -279,6 +279,7 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 			LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
 				ON S.subscription_epoch = L.subscription_epoch
 			   AND S.node_id = L.node_id
+			   AND S.client_id = L.client_id
 			LEFT JOIN recent_epochs R
 				ON R.solana_epoch = L.subscription_epoch
 		),
@@ -381,9 +382,42 @@ func (a *API) FetchShredsRewardsData(ctx context.Context) (*ShredsRewardsRespons
 	return a.computeShredsRewards(ctx, "", "", "", shredsRewardsDefaultLimit, 0)
 }
 
+// Claim-state values for ShredsRewardsEpochDetail.State. These let the page
+// distinguish "already paid out" from "not finalized yet" — both of which
+// previously surfaced as a bare null is_claimable.
+const (
+	// ClaimStateClaimable: the leaf is accumulated and not yet distributed —
+	// the validator can claim it now (publisher bit set on its status row).
+	ClaimStateClaimable = "claimable"
+	// ClaimStateDistributed: the reward for this leaf has already been paid
+	// out. This is the ONLY positive proof of payment: a status row exists for
+	// the (epoch, node, client) leaf and its publisher bit has been cleared.
+	// The bit is set when a leaf is accumulated and cleared on distribution,
+	// and the indexer freezes a leaf's final bit when its journal is swept — so
+	// a cleared bit, whether the journal is still live or long swept, means the
+	// reward was distributed.
+	ClaimStateDistributed = "distributed"
+	// ClaimStatePending: not claimable yet — either the distribution isn't
+	// finalized (no funded pool), or the leaf hasn't been accumulated yet while
+	// the epoch's journal is still live.
+	ClaimStatePending = "pending"
+	// ClaimStateUnknown: the epoch's pool is funded but we have no per-validator
+	// status row for the leaf and the journal is no longer live, so we cannot
+	// prove whether it was claimed. This is the unrecoverable history before the
+	// indexer began tracking the publisher bitmap — once a journal was swept
+	// without ever being captured, its per-leaf state is gone for good. Epochs
+	// indexed while their journal was live keep a real claimable/distributed
+	// state after the sweep, so this only ever applies to that backfill gap.
+	ClaimStateUnknown = "unknown"
+)
+
 // ShredsRewardsEpochDetail is a single epoch row in the per-validator drilldown.
-// IsClaimable is nil when no status row exists for the epoch (i.e. the epoch
-// is outside the on-chain tracking window).
+//
+// State is the derived lifecycle of the leaf (see ClaimState* constants) and is
+// always set. IsClaimable is retained for back-compat: it is non-nil only when
+// a live journal row exists for the leaf (true → claimable, false → a live row
+// with the bit cleared); it is nil for the distributed and pending states,
+// where there is no live journal bit to report.
 type ShredsRewardsEpochDetail struct {
 	SolanaEpoch       uint64  `json:"solana_epoch"`
 	SubscriptionEpoch uint64  `json:"subscription_epoch"`
@@ -391,6 +425,7 @@ type ShredsRewardsEpochDetail struct {
 	ClientID          uint16  `json:"client_id"`
 	Earned2Z          float64 `json:"earned_2z"`
 	IsClaimable       *bool   `json:"is_claimable,omitempty"`
+	State             string  `json:"state"`
 }
 
 // ShredsRewardsDetailResponse is the response body for the per-validator
@@ -454,6 +489,15 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			SELECT subscription_epoch, sum(leader_slots) AS total_leader_slots
 			FROM dim_dz_shred_validator_rewards_leaves_current
 			GROUP BY subscription_epoch
+		),
+		-- Epochs whose distribution journal is still live on-chain (i.e. we have
+		-- accumulation-status rows for them). Used to tell "already distributed"
+		-- (funded pool, journal swept → no rows) apart from "not yet accumulated"
+		-- (journal still live).
+		journal_live_epochs AS (
+			SELECT subscription_epoch, 1 AS jl_live
+			FROM dim_dz_shred_validator_leaf_distribution_status_current
+			GROUP BY subscription_epoch
 		)
 		SELECT
 			-- subscription_epoch numerically equals the Solana epoch (the
@@ -473,7 +517,30 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			-- emitting NULL, so we detect "no status row" by checking that the
 			-- joined node_id is the empty string (the String default).
 			if(S.node_id = '' OR S.node_id IS NULL, 0, 1) AS has_status,
-			coalesce(S.is_claimable, 0) AS is_claimable
+			coalesce(S.is_claimable, 0) AS is_claimable,
+			-- Derived claim state. Order matters (first match wins):
+			--   status row, bit set   -> claimable (accumulated, not yet distributed)
+			--   status row, bit clear -> distributed (accumulated then paid; the
+			--                            publisher bit is cleared on distribution
+			--                            and a status row only exists once the leaf
+			--                            has been accumulated, so a cleared bit is
+			--                            positive proof the reward was paid out.
+			--                            The indexer freezes this bit when the
+			--                            journal is swept, so it holds for old
+			--                            epochs too)
+			--   epoch has status rows -> pending (this leaf not yet accumulated
+			--                            while the journal is still live)
+			--   pool not funded       -> pending (distribution not finalized)
+			--   funded, no status row -> unknown (journal swept before we ever
+			--                            tracked it; per-leaf state is gone — we
+			--                            must NOT assume it was paid)
+			multiIf(
+				S.node_id != '' AND S.is_claimable = 1, 'claimable',
+				S.node_id != '', 'distributed',
+				JL.jl_live = 1, 'pending',
+				P.tokens_received_2z = 0, 'pending',
+				'unknown'
+			) AS state
 		FROM dim_dz_shred_validator_rewards_leaves_current L
 		INNER JOIN dim_dz_shred_distribution_2z_pool_current P
 			ON P.subscription_epoch = L.subscription_epoch
@@ -485,6 +552,9 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 		LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
 			ON S.subscription_epoch = L.subscription_epoch
 		   AND S.node_id = L.node_id
+		   AND S.client_id = L.client_id
+		LEFT JOIN journal_live_epochs JL
+			ON JL.subscription_epoch = L.subscription_epoch
 		WHERE L.node_id = ?
 		ORDER BY L.subscription_epoch DESC
 	`
@@ -504,12 +574,14 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 		var isClaimable uint8
 		if err := rows.Scan(
 			&ed.SolanaEpoch, &ed.SubscriptionEpoch, &ed.LeaderSlots, &ed.ClientID,
-			&ed.Earned2Z, &hasStatus, &isClaimable,
+			&ed.Earned2Z, &hasStatus, &isClaimable, &ed.State,
 		); err != nil {
 			logError("shreds rewards detail scan failed", "error", err)
 			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 			return
 		}
+		// IsClaimable stays non-nil only when a live journal row exists, for
+		// back-compat; State carries the full lifecycle (incl. distributed).
 		if hasStatus == 1 {
 			b := isClaimable == 1
 			ed.IsClaimable = &b

--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -272,7 +272,10 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 				  -- share). Treat 0 as "unset" and fall through to
 				  -- default_proportion, then 3500.
 				  * toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))
-				  / nullIf(toFloat64(T.total_leader_slots) * toFloat64(10000), 0)
+				  -- Denominator: the journal's authoritative total_leader_slots
+				  -- when we have it, else fall back to the summed indexed leaves
+				  -- (older/swept epochs not yet re-projected with the field).
+				  / nullIf(toFloat64(if(P.total_leader_slots > 0, P.total_leader_slots, T.total_leader_slots)) * toFloat64(10000), 0)
 				  AS earned_2z,
 				coalesce(S.is_claimable, 0) AS is_claimable,
 				if(R.solana_epoch IS NULL, 0, 1) AS is_recent
@@ -520,7 +523,10 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			toFloat64(P.tokens_received_2z)
 			  * toFloat64(L.leader_slots)
 			  * toFloat64(10000 - coalesce(C.proportion, C.default_proportion, 3500))
-			  / nullIf(toFloat64(T.total_leader_slots) * toFloat64(10000), 0) AS earned_2z,
+			  -- Denominator: the journal's authoritative total_leader_slots when
+			  -- we have it, else fall back to the summed indexed leaves (older/
+			  -- swept epochs not yet re-projected with the field).
+			  / nullIf(toFloat64(if(P.total_leader_slots > 0, P.total_leader_slots, T.total_leader_slots)) * toFloat64(10000), 0) AS earned_2z,
 			-- has_status: ClickHouse LEFT JOINs default missing values rather than
 			-- emitting NULL, so we detect "no status row" by checking that the
 			-- joined node_id is the empty string (the String default).

--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -16,6 +16,61 @@ import (
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
+// Supported reward-token mints. From epoch 968 validators may be rewarded in
+// one of these tokens; each has its own per-epoch ShredDistributionJournal and
+// reward pool. Kept in sync with indexer/pkg/dz/shreds/validatorrewards/token.go.
+const (
+	rewardMint2Z   = "J6pQQ3FAcJQeWPPGppWRb4nM8jU3wLyYbRrLh7feMfvd"
+	rewardMintUSDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	rewardMintWSOL = "So11111111111111111111111111111111111111112"
+)
+
+// tokenSymbolSQL maps a leaf-mint column expression to its display symbol.
+func tokenSymbolSQL(col string) string {
+	return fmt.Sprintf(`if(%[1]s = '%[2]s', 'USDC', if(%[1]s = '%[3]s', 'wSOL', '2Z'))`,
+		col, rewardMintUSDC, rewardMintWSOL)
+}
+
+// tokenScaleSQL maps a leaf-mint column expression to its base-units-per-whole-
+// token divisor (2Z=10^8, USDC=10^6, wSOL=10^9).
+func tokenScaleSQL(col string) string {
+	return fmt.Sprintf(`if(%[1]s = '%[2]s', 1000000.0, if(%[1]s = '%[3]s', 1000000000.0, 100000000.0))`,
+		col, rewardMintUSDC, rewardMintWSOL)
+}
+
+// earnedWholeAndTokenSQL builds two parallel expressions: the per-leaf reward in
+// whole tokens, and its display symbol — with a 2Z-equivalent fallback.
+//
+// USDC/wSOL journals don't pre-hold a swapped balance, so before a reward is
+// actually distributed their pool (distributed_amount) is still 0 and the leaf's
+// own-token reward would compute to 0 ("—" in the UI). In that no-pool case we
+// instead value the leaf against the epoch's 2Z pool and label it 2Z, so a
+// claimable non-2Z validator shows a meaningful 2Z-equivalent figure rather than
+// a dash. Once the token is distributed (distributed_amount > 0) the own-token
+// path is used and the real USDC/wSOL amount is shown.
+//
+// Requires both pool rows joined: P = the leaf's own token pool (on its mint),
+// P2Z = the epoch's 2Z pool. slotsCol is the leader_slots column; leafMintExpr
+// resolves the leaf's reward mint. T.total_leader_slots is the legacy fallback
+// denominator.
+func earnedWholeAndTokenSQL(slotsCol, leafMintExpr string) (earnedWhole, tokenSymbol string) {
+	propFactor := `toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))`
+	tokenPool := fmt.Sprintf(`if(P.reward_mint = '' OR P.reward_mint = '%s', toFloat64(P.tokens_received_2z) * 0.9, toFloat64(P.distributed_amount))`, rewardMint2Z)
+	twoZPool := `toFloat64(P2Z.tokens_received_2z) * 0.9`
+	denomP := `nullIf(if(P.accumulated_slots_scaled > 0, toFloat64(P.accumulated_slots_scaled), toFloat64(if(P.total_leader_slots > 0, P.total_leader_slots, T.total_leader_slots)) * 10000.0), 0)`
+	denomP2Z := `nullIf(if(P2Z.accumulated_slots_scaled > 0, toFloat64(P2Z.accumulated_slots_scaled), toFloat64(if(P2Z.total_leader_slots > 0, P2Z.total_leader_slots, T.total_leader_slots)) * 10000.0), 0)`
+
+	hasPool := fmt.Sprintf(`(%s) > 0`, tokenPool)
+	earnedToken := fmt.Sprintf(`(%s) * toFloat64(%s) * %s / %s`, tokenPool, slotsCol, propFactor, denomP)
+	earned2Z := fmt.Sprintf(`(%s) * toFloat64(%s) * %s / %s`, twoZPool, slotsCol, propFactor, denomP2Z)
+
+	earnedBaseUnits := fmt.Sprintf(`if(%s, %s, %s)`, hasPool, earnedToken, earned2Z)
+	scale := fmt.Sprintf(`if(%s, %s, 100000000.0)`, hasPool, tokenScaleSQL(leafMintExpr))
+	earnedWhole = fmt.Sprintf(`(%s) / %s`, earnedBaseUnits, scale)
+	tokenSymbol = fmt.Sprintf(`if(%s, %s, '2Z')`, hasPool, tokenSymbolSQL(leafMintExpr))
+	return earnedWhole, tokenSymbol
+}
+
 // ShredsRewardsRow is a single row of the validator rewards list.
 type ShredsRewardsRow struct {
 	NodeID                 string             `json:"node_id"`
@@ -26,6 +81,10 @@ type ShredsRewardsRow struct {
 	TotalEarned2Z          float64            `json:"total_earned_2z"`
 	ImmediatelyClaimable2Z float64            `json:"immediately_claimable_2z"`
 	EpochEarnings          map[uint64]float64 `json:"epoch_earnings"`
+	// EpochTokens is the reward-token symbol earned in each recent epoch,
+	// parallel to EpochEarnings (a validator picks one token per epoch). The
+	// per-epoch amount in EpochEarnings is in whole units of that token.
+	EpochTokens map[uint64]string `json:"epoch_tokens"`
 }
 
 // ShredsRewardsResponse is the full response for GET /api/dz/shreds/rewards.
@@ -34,6 +93,9 @@ type ShredsRewardsResponse struct {
 	LatestFinalizedEpoch uint64             `json:"latest_finalized_epoch"`
 	EpochColumns         []uint64           `json:"epoch_columns"`
 	Validators           []ShredsRewardsRow `json:"validators"`
+	// Total is the count of distinct validators matching the (search) filter,
+	// before limit/offset — used by the client to render the page count.
+	Total int `json:"total"`
 }
 
 // buildShredsRewardsSearch parses a comma-separated search expression into a
@@ -205,6 +267,7 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 		SELECT subscription_epoch
 		FROM dim_dz_shred_distribution_2z_pool_current
 		WHERE tokens_received_2z > 0
+		GROUP BY subscription_epoch
 		ORDER BY subscription_epoch DESC
 		LIMIT 10
 	`)
@@ -240,6 +303,15 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 		latestFinalized = epochColumns[0]
 	}
 
+	// Per-leaf reward token: the journal that accumulated the leaf, recorded on
+	// its status row's journal_mint_key; legacy/unknown leaves (no status row)
+	// default to 2Z. The pool and per-token denominator are then joined per
+	// (epoch, token), so each token's pool is split only over the validators who
+	// picked it — not the epoch-wide total.
+	leafMintExpr := fmt.Sprintf(`if(S.node_id != '' AND S.journal_mint_key != '', S.journal_mint_key, '%s')`, rewardMint2Z)
+	poolMintExpr := fmt.Sprintf(`if(P.reward_mint != '', P.reward_mint, '%s')`, rewardMint2Z)
+	earnedWholeList, tokenSymList := earnedWholeAndTokenSQL("lt.leader_slots", "lt.leaf_mint")
+
 	// We compute the is_recent flag as a JOIN to the recent_epochs CTE rather
 	// than via `IN (SELECT ...)` inside a sumIf/groupArrayIf: the ClickHouse
 	// analyzer's CTE-column scoping breaks when a CTE is referenced from
@@ -254,53 +326,65 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 			SELECT subscription_epoch AS solana_epoch
 			FROM dim_dz_shred_distribution_2z_pool_current
 			WHERE tokens_received_2z > 0
+			GROUP BY subscription_epoch
 			ORDER BY subscription_epoch DESC
 			LIMIT 10
 		),
-		earnings AS (
+		leaves_tok AS (
 			SELECT
 				L.node_id AS node_id,
 				L.subscription_epoch AS subscription_epoch,
-				toFloat64(P.tokens_received_2z)
-				  * toFloat64(L.leader_slots)
-				  -- Client reward proportion (basis points the client keeps; the
-				  -- validator gets the remainder). proportion is stored as 0 when
-				  -- the per-client value is unset, with the real fallback in
-				  -- default_proportion. A ClickHouse LEFT JOIN also fills a missing
-				  -- row with 0 (not NULL), so coalesce(proportion, default, 3500)
-				  -- would wrongly return 0 (the validator keeping the whole pool
-				  -- share). Treat 0 as "unset" and fall through to
-				  -- default_proportion, then 3500.
-				  * toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))
-				  -- Denominator: the journal's authoritative total_leader_slots
-				  -- when we have it, else fall back to the summed indexed leaves
-				  -- (older/swept epochs not yet re-projected with the field).
-				  / nullIf(toFloat64(if(P.total_leader_slots > 0, P.total_leader_slots, T.total_leader_slots)) * toFloat64(10000), 0)
-				  AS earned_2z,
-				coalesce(S.is_claimable, 0) AS is_claimable,
-				if(R.solana_epoch IS NULL, 0, 1) AS is_recent
+				L.leader_slots AS leader_slots,
+				L.client_id AS client_id,
+				%[1]s AS leaf_mint,
+				coalesce(S.is_claimable, 0) AS is_claimable
 			FROM dim_dz_shred_validator_rewards_leaves_current L
-			INNER JOIN dim_dz_shred_distribution_2z_pool_current P
-				ON P.subscription_epoch = L.subscription_epoch
-			INNER JOIN epoch_totals T
-				ON T.subscription_epoch = L.subscription_epoch
-			LEFT JOIN dim_dz_shred_distribution_client_proportions_current C
-				ON C.subscription_epoch = L.subscription_epoch
-			   AND C.client_id = L.client_id
 			LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
 				ON S.subscription_epoch = L.subscription_epoch
 			   AND S.node_id = L.node_id
 			   AND S.client_id = L.client_id
+		),
+		earnings AS (
+			SELECT
+				lt.node_id AS node_id,
+				lt.subscription_epoch AS subscription_epoch,
+				lt.leaf_mint AS leaf_mint,
+				-- token_symbol and earned carry a 2Z-equivalent fallback for
+				-- claimable non-2Z leaves with no own-token pool yet; see
+				-- earnedWholeAndTokenSQL.
+				%[4]s AS token_symbol,
+				%[2]s AS earned,
+				lt.is_claimable AS is_claimable,
+				if(R.solana_epoch IS NULL, 0, 1) AS is_recent
+			FROM leaves_tok lt
+			INNER JOIN dim_dz_shred_distribution_2z_pool_current P
+				ON P.subscription_epoch = lt.subscription_epoch
+			   AND %[3]s = lt.leaf_mint
+			-- The epoch's 2Z pool, for the 2Z-equivalent fallback.
+			LEFT JOIN dim_dz_shred_distribution_2z_pool_current P2Z
+				ON P2Z.subscription_epoch = lt.subscription_epoch
+			   AND P2Z.reward_mint = '%[5]s'
+			INNER JOIN epoch_totals T
+				ON T.subscription_epoch = lt.subscription_epoch
+			LEFT JOIN dim_dz_shred_distribution_client_proportions_current C
+				ON C.subscription_epoch = lt.subscription_epoch
+			   AND C.client_id = lt.client_id
 			LEFT JOIN recent_epochs R
-				ON R.solana_epoch = L.subscription_epoch
+				ON R.solana_epoch = lt.subscription_epoch
 		),
 		per_validator AS (
 			SELECT
 				node_id AS pv_node_id,
-				sum(coalesce(earned_2z, 0)) AS total_earned_2z,
-				sumIf(coalesce(earned_2z, 0), is_claimable = 1 AND is_recent = 1) AS immediately_claimable_2z,
+				-- Headline columns are 2Z-denominated. Sum by the DISPLAYED token
+				-- (token_symbol = '2Z'), not leaf_mint, so a claimable non-2Z leaf
+				-- valued via the 2Z-equivalent fallback (no own-token pool yet) is
+				-- counted here too — otherwise its claimable amount shows as "—".
+				-- Paid non-2Z leaves keep their own token and stay out of these.
+				sumIf(coalesce(earned, 0), token_symbol = '2Z') AS total_earned_2z,
+				sumIf(coalesce(earned, 0), is_claimable = 1 AND is_recent = 1 AND token_symbol = '2Z') AS immediately_claimable_2z,
 				groupArrayIf(subscription_epoch, is_recent = 1) AS recent_dz_epochs,
-				groupArrayIf(coalesce(earned_2z, 0), is_recent = 1) AS recent_dz_earnings
+				groupArrayIf(coalesce(earned, 0), is_recent = 1) AS recent_dz_earnings,
+				groupArrayIf(token_symbol, is_recent = 1) AS recent_dz_tokens
 			FROM earnings
 			GROUP BY node_id
 		)
@@ -313,7 +397,8 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 			pv.total_earned_2z AS total_earned_2z,
 			pv.immediately_claimable_2z AS immediately_claimable_2z,
 			pv.recent_dz_epochs AS recent_dz_epochs,
-			pv.recent_dz_earnings AS recent_dz_earnings
+			pv.recent_dz_earnings AS recent_dz_earnings,
+			pv.recent_dz_tokens AS recent_dz_tokens
 		FROM per_validator pv
 		LEFT JOIN solana_vote_accounts_current v
 			ON v.node_pubkey = pv.pv_node_id AND v.epoch_vote_account = 'true'
@@ -323,14 +408,16 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 			ON g.pubkey = pv.pv_node_id
 		LEFT JOIN dz_users_current u
 			ON u.client_ip = g.gossip_ip AND u.status = 'activated'
-		%s
-		ORDER BY %s
+		%[7]s
+		ORDER BY %[8]s
 		-- Collapse to one row per validator: the gossip/dz_users joins can
 		-- fan out (e.g. multiple activated DZ users sharing a gossip IP),
 		-- which would otherwise duplicate a validator in the list.
 		LIMIT 1 BY node_id
-		LIMIT %d OFFSET %d
-	`, whereClause, sortSQL, limit, offset)
+		LIMIT %[9]d OFFSET %[10]d
+	`, leafMintExpr, earnedWholeList, poolMintExpr,
+		tokenSymList, rewardMint2Z, rewardMint2Z,
+		whereClause, sortSQL, limit, offset)
 
 	start = time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, query, args...)
@@ -345,6 +432,7 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 		var row ShredsRewardsRow
 		var recentEpochs []uint64
 		var recentEarnings []float64
+		var recentTokens []string
 		if err := rows.Scan(
 			&row.NodeID,
 			&row.VotePubkey,
@@ -355,17 +443,24 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 			&row.ImmediatelyClaimable2Z,
 			&recentEpochs,
 			&recentEarnings,
+			&recentTokens,
 		); err != nil {
 			return nil, fmt.Errorf("shreds rewards scan: %w", err)
 		}
 		row.EpochEarnings = make(map[uint64]float64, len(recentEpochs))
+		row.EpochTokens = make(map[uint64]string, len(recentEpochs))
 		for i, e := range recentEpochs {
 			if i >= len(recentEarnings) {
 				break
 			}
 			// If a node appears multiple times in an epoch (shouldn't happen
 			// in practice — but if data is duplicated across rebuilds, sum).
+			// A validator picks one token per epoch, so the symbol is consistent
+			// across its leaves; record it alongside the summed amount.
 			row.EpochEarnings[e] += recentEarnings[i]
+			if i < len(recentTokens) {
+				row.EpochTokens[e] = recentTokens[i]
+			}
 		}
 		validators = append(validators, row)
 	}
@@ -376,11 +471,55 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 	if epochColumns == nil {
 		epochColumns = []uint64{}
 	}
+
+	// Total distinct validators matching the filter (before limit/offset), for
+	// the client's page count. Mirrors the page query's population — validators
+	// with at least one leaf in a funded (pooled) epoch, after the same search
+	// joins/filter — and countDistinct collapses the gossip/dz_users fan-out the
+	// way LIMIT 1 BY node_id does in the page query.
+	countQuery := fmt.Sprintf(`
+		WITH leaves_tok AS (
+			SELECT L.node_id AS node_id, L.subscription_epoch AS subscription_epoch, %[1]s AS leaf_mint
+			FROM dim_dz_shred_validator_rewards_leaves_current L
+			LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
+				ON S.subscription_epoch = L.subscription_epoch
+			   AND S.node_id = L.node_id
+			   AND S.client_id = L.client_id
+		),
+		per_validator AS (
+			SELECT lt.node_id AS pv_node_id
+			FROM leaves_tok lt
+			INNER JOIN dim_dz_shred_distribution_2z_pool_current P
+				ON P.subscription_epoch = lt.subscription_epoch
+			   AND %[2]s = lt.leaf_mint
+			GROUP BY lt.node_id
+		)
+		SELECT countDistinct(pv.pv_node_id)
+		FROM per_validator pv
+		LEFT JOIN solana_vote_accounts_current v
+			ON v.node_pubkey = pv.pv_node_id AND v.epoch_vote_account = 'true'
+		LEFT JOIN validatorsapp_validators_current va
+			ON v.vote_pubkey = va.vote_account
+		LEFT JOIN solana_gossip_nodes_current g
+			ON g.pubkey = pv.pv_node_id
+		LEFT JOIN dz_users_current u
+			ON u.client_ip = g.gossip_ip AND u.status = 'activated'
+		%[3]s
+	`, leafMintExpr, poolMintExpr, whereClause)
+	var total uint64
+	cstart := time.Now()
+	cerr := a.envDB(ctx).QueryRow(ctx, countQuery, args...).Scan(&total)
+	metrics.RecordClickHouseQuery("shreds_rewards:count", time.Since(cstart), cerr)
+	if cerr != nil {
+		return nil, fmt.Errorf("shreds rewards count query: %w", cerr)
+	}
+
 	return &ShredsRewardsResponse{
 		CurrentSolanaEpoch:   currentSolanaEpoch,
 		LatestFinalizedEpoch: latestFinalized,
 		EpochColumns:         epochColumns,
 		Validators:           validators,
+		Total:                int(total),
 	}, nil
 }
 
@@ -430,13 +569,16 @@ const (
 // with the bit cleared); it is nil for the distributed and pending states,
 // where there is no live journal bit to report.
 type ShredsRewardsEpochDetail struct {
-	SolanaEpoch       uint64  `json:"solana_epoch"`
-	SubscriptionEpoch uint64  `json:"subscription_epoch"`
-	LeaderSlots       uint32  `json:"leader_slots"`
-	ClientID          uint16  `json:"client_id"`
-	Earned2Z          float64 `json:"earned_2z"`
-	IsClaimable       *bool   `json:"is_claimable,omitempty"`
-	State             string  `json:"state"`
+	SolanaEpoch       uint64 `json:"solana_epoch"`
+	SubscriptionEpoch uint64 `json:"subscription_epoch"`
+	LeaderSlots       uint32 `json:"leader_slots"`
+	ClientID          uint16 `json:"client_id"`
+	// Earned is the reward in whole units of TokenSymbol (the token the
+	// validator chose for the epoch: 2Z, USDC, or wSOL).
+	Earned      float64 `json:"earned"`
+	TokenSymbol string  `json:"token_symbol"`
+	IsClaimable *bool   `json:"is_claimable,omitempty"`
+	State       string  `json:"state"`
 }
 
 // ShredsRewardsDetailResponse is the response body for the per-validator
@@ -493,9 +635,15 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 		logError("shreds rewards detail header scan failed", "error", err)
 	}
 
-	// Per-epoch rows. Mirrors the list query's `earnings` CTE but restricted
-	// to a single node_id and returning every epoch (not just the last 10).
-	const detailQuery = `
+	// Per-epoch rows. Mirrors the list query's earnings logic but restricted to
+	// a single node_id and returning every epoch (not just the last 10). The
+	// per-leaf reward token comes from its status row's journal_mint_key
+	// (defaulting to 2Z for legacy/unknown leaves), and the pool/denominator are
+	// joined per (epoch, token); see the list query for the formula.
+	leafMintExpr := fmt.Sprintf(`if(S.node_id != '' AND S.journal_mint_key != '', S.journal_mint_key, '%s')`, rewardMint2Z)
+	poolMintExpr := fmt.Sprintf(`if(P.reward_mint != '', P.reward_mint, '%s')`, rewardMint2Z)
+	earnedWhole, tokenSym := earnedWholeAndTokenSQL("L.leader_slots", leafMintExpr)
+	detailQuery := fmt.Sprintf(`
 		WITH epoch_totals AS (
 			SELECT subscription_epoch, sum(leader_slots) AS total_leader_slots
 			FROM dim_dz_shred_validator_rewards_leaves_current
@@ -520,16 +668,12 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			L.subscription_epoch,
 			L.leader_slots,
 			L.client_id,
-			toFloat64(P.tokens_received_2z)
-			  * toFloat64(L.leader_slots)
-			  -- Client reward proportion: treat a 0/missing value as "unset" and
-			  -- fall through to default_proportion, then 3500 (see the list query
-			  -- for why coalesce alone returns 0 here).
-			  * toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))
-			  -- Denominator: the journal's authoritative total_leader_slots when
-			  -- we have it, else fall back to the summed indexed leaves (older/
-			  -- swept epochs not yet re-projected with the field).
-			  / nullIf(toFloat64(if(P.total_leader_slots > 0, P.total_leader_slots, T.total_leader_slots)) * toFloat64(10000), 0) AS earned_2z,
+			-- token_symbol and earned carry a 2Z-equivalent fallback: a claimable
+			-- USDC/wSOL leaf has no own-token pool yet (distributed_amount = 0), so
+			-- it is valued against the epoch's 2Z pool and labelled 2Z. See
+			-- earnedWholeAndTokenSQL.
+			%[3]s AS token_symbol,
+			%[4]s AS earned,
 			-- has_status: ClickHouse LEFT JOINs default missing values rather than
 			-- emitting NULL, so we detect "no status row" by checking that the
 			-- joined node_id is the empty string (the String default).
@@ -544,7 +688,9 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			--                            positive proof the reward was paid out.
 			--                            The indexer freezes this bit when the
 			--                            journal is swept, so it holds for old
-			--                            epochs too)
+			--                            epochs too. For non-2Z tokens the per-leaf
+			--                            sweep is not yet tracked, so a distributed
+			--                            leaf may linger as claimable.)
 			--   epoch has status rows -> pending (this leaf not yet accumulated
 			--                            while the journal is still live)
 			--   pool not funded       -> pending (distribution not finalized)
@@ -559,22 +705,28 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 				'unknown'
 			) AS state
 		FROM dim_dz_shred_validator_rewards_leaves_current L
+		LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
+			ON S.subscription_epoch = L.subscription_epoch
+		   AND S.node_id = L.node_id
+		   AND S.client_id = L.client_id
 		INNER JOIN dim_dz_shred_distribution_2z_pool_current P
 			ON P.subscription_epoch = L.subscription_epoch
+		   AND %[1]s = %[2]s
+		-- The epoch's 2Z pool, for the 2Z-equivalent fallback when the leaf's own
+		-- token has no pool yet.
+		LEFT JOIN dim_dz_shred_distribution_2z_pool_current P2Z
+			ON P2Z.subscription_epoch = L.subscription_epoch
+		   AND P2Z.reward_mint = '%[5]s'
 		INNER JOIN epoch_totals T
 			ON T.subscription_epoch = L.subscription_epoch
 		LEFT JOIN dim_dz_shred_distribution_client_proportions_current C
 			ON C.subscription_epoch = L.subscription_epoch
 		   AND C.client_id = L.client_id
-		LEFT JOIN dim_dz_shred_validator_leaf_distribution_status_current S
-			ON S.subscription_epoch = L.subscription_epoch
-		   AND S.node_id = L.node_id
-		   AND S.client_id = L.client_id
 		LEFT JOIN journal_live_epochs JL
 			ON JL.subscription_epoch = L.subscription_epoch
 		WHERE L.node_id = ?
 		ORDER BY L.subscription_epoch DESC
-	`
+	`, poolMintExpr, leafMintExpr, tokenSym, earnedWhole, rewardMint2Z)
 	start := time.Now()
 	rows, err := a.envDB(ctx).Query(ctx, detailQuery, nodeID)
 	metrics.RecordClickHouseQuery("shreds_rewards_detail", time.Since(start), err)
@@ -591,7 +743,7 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 		var isClaimable uint8
 		if err := rows.Scan(
 			&ed.SolanaEpoch, &ed.SubscriptionEpoch, &ed.LeaderSlots, &ed.ClientID,
-			&ed.Earned2Z, &hasStatus, &isClaimable, &ed.State,
+			&ed.TokenSymbol, &ed.Earned, &hasStatus, &isClaimable, &ed.State,
 		); err != nil {
 			logError("shreds rewards detail scan failed", "error", err)
 			http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)

--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -263,7 +263,15 @@ func (a *API) computeShredsRewards(ctx context.Context, search, sortField, order
 				L.subscription_epoch AS subscription_epoch,
 				toFloat64(P.tokens_received_2z)
 				  * toFloat64(L.leader_slots)
-				  * toFloat64(10000 - coalesce(C.proportion, C.default_proportion, 3500))
+				  -- Client reward proportion (basis points the client keeps; the
+				  -- validator gets the remainder). proportion is stored as 0 when
+				  -- the per-client value is unset, with the real fallback in
+				  -- default_proportion. A ClickHouse LEFT JOIN also fills a missing
+				  -- row with 0 (not NULL), so coalesce(proportion, default, 3500)
+				  -- would wrongly return 0 (the validator keeping the whole pool
+				  -- share). Treat 0 as "unset" and fall through to
+				  -- default_proportion, then 3500.
+				  * toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))
 				  / nullIf(toFloat64(T.total_leader_slots) * toFloat64(10000), 0)
 				  AS earned_2z,
 				coalesce(S.is_claimable, 0) AS is_claimable,

--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -522,7 +522,10 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 			L.client_id,
 			toFloat64(P.tokens_received_2z)
 			  * toFloat64(L.leader_slots)
-			  * toFloat64(10000 - coalesce(C.proportion, C.default_proportion, 3500))
+			  -- Client reward proportion: treat a 0/missing value as "unset" and
+			  -- fall through to default_proportion, then 3500 (see the list query
+			  -- for why coalesce alone returns 0 here).
+			  * toFloat64(10000 - if(C.proportion > 0, C.proportion, if(C.default_proportion > 0, C.default_proportion, 3500)))
 			  -- Denominator: the journal's authoritative total_leader_slots when
 			  -- we have it, else fall back to the summed indexed leaves (older/
 			  -- swept epochs not yet re-projected with the field).

--- a/api/handlers/shreds_rewards_test.go
+++ b/api/handlers/shreds_rewards_test.go
@@ -98,14 +98,14 @@ func insertShredsRewardsTestData(t *testing.T, api *handlers.API) {
 	err = api.DB.Exec(ctx, `
 		INSERT INTO dim_dz_shred_validator_leaf_distribution_status_history
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
-		 subscription_epoch, node_id, is_claimable, journal_mint_key)
+		 subscription_epoch, node_id, client_id, is_claimable, journal_mint_key)
 		VALUES
-		('s-100-A', now(), now(), generateUUIDv4(), 0, 1, 100, 'node-A', 0, ''),
-		('s-100-B', now(), now(), generateUUIDv4(), 0, 2, 100, 'node-B', 0, ''),
-		('s-101-A', now(), now(), generateUUIDv4(), 0, 3, 101, 'node-A', 0, ''),
-		('s-101-B', now(), now(), generateUUIDv4(), 0, 4, 101, 'node-B', 0, ''),
-		('s-102-A', now(), now(), generateUUIDv4(), 0, 5, 102, 'node-A', 1, 'journal-A'),
-		('s-102-B', now(), now(), generateUUIDv4(), 0, 6, 102, 'node-B', 1, 'journal-B')
+		('s-100-A', now(), now(), generateUUIDv4(), 0, 1, 100, 'node-A', 1, 0, ''),
+		('s-100-B', now(), now(), generateUUIDv4(), 0, 2, 100, 'node-B', 1, 0, ''),
+		('s-101-A', now(), now(), generateUUIDv4(), 0, 3, 101, 'node-A', 1, 0, ''),
+		('s-101-B', now(), now(), generateUUIDv4(), 0, 4, 101, 'node-B', 1, 0, ''),
+		('s-102-A', now(), now(), generateUUIDv4(), 0, 5, 102, 'node-A', 1, 1, 'journal-A'),
+		('s-102-B', now(), now(), generateUUIDv4(), 0, 6, 102, 'node-B', 1, 1, 'journal-B')
 	`)
 	require.NoError(t, err)
 
@@ -347,6 +347,72 @@ func TestGetShredsRewards_DeduplicatesValidators(t *testing.T) {
 	assert.Equal(t, 1, seen["node-B"])
 }
 
+// TestGetShredsRewards_MultiClientValidator is the regression test for the bug
+// where a validator publishing under multiple software clients in a single
+// epoch was collapsed to one leaf row, understating its leader slots and
+// earnings. node-X publishes under client 1 (30 slots) and client 2 (70 slots)
+// in epoch 200; both leaves must be counted.
+//
+//	pool = 10000, total_leader_slots(200) = 30 + 70 = 100, client proportion 3500
+//	(→ 65% to validator). earned(client1) = 10000*30*6500/(100*10000) = 1950,
+//	earned(client2) = 10000*70*6500/(100*10000) = 4550, total = 6500.
+//
+// Only client 1 is claimable, so immediately_claimable = 1950 (not 6500) —
+// proving the per-client claimable grain too.
+func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_rewards_leaves_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, associated_dz_epoch, node_id, leader_slots, client_id, leaf_index)
+		VALUES
+		('200-X-c1', now(), now(), generateUUIDv4(), 0, 1, 200, 20, 'node-X', 30, 1, 0),
+		('200-X-c2', now(), now(), generateUUIDv4(), 0, 2, 200, 20, 'node-X', 70, 2, 1)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_2z_pool_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, tokens_received_2z)
+		VALUES ('epoch-200', now(), now(), generateUUIDv4(), 0, 1, 200, 10000)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_client_proportions_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, client_id, proportion, default_proportion)
+		VALUES
+		('p-200-1', now(), now(), generateUUIDv4(), 0, 1, 200, 1, 3500, 3500),
+		('p-200-2', now(), now(), generateUUIDv4(), 0, 2, 200, 2, 3500, 3500)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_leaf_distribution_status_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, node_id, client_id, is_claimable, journal_mint_key)
+		VALUES
+		('s-200-X-c1', now(), now(), generateUUIDv4(), 0, 1, 200, 'node-X', 1, 1, 'journal-X'),
+		('s-200-X-c2', now(), now(), generateUUIDv4(), 0, 2, 200, 'node-X', 2, 0, 'journal-X')
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredsRewards(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := decodeShredsRewards(t, rr.Body.Bytes())
+
+	require.Len(t, resp.Validators, 1, "node-X must appear exactly once")
+	x := resp.Validators[0]
+	assert.Equal(t, "node-X", x.NodeID)
+	// Both client leaves counted: 1950 + 4550 = 6500.
+	assert.InDelta(t, 6500.0, x.TotalEarned2Z, 1e-6, "earnings must sum across both clients")
+	// Only client 1 is claimable: 1950, not the full 6500.
+	assert.InDelta(t, 1950.0, x.ImmediatelyClaimable2Z, 1e-6, "only client 1's earnings are claimable")
+	// Per-epoch earnings for epoch 200 is the node's full 6500.
+	assert.InDelta(t, 6500.0, x.EpochEarnings[200], 1e-6)
+}
+
 // withChiNodeIDParam installs the {nodeId} URL param onto the request context
 // so the handler can read it via chi.URLParam.
 func withChiNodeIDParam(req *http.Request, nodeID string) *http.Request {
@@ -405,6 +471,12 @@ func TestGetShredsRewardsDetail_FullHistory(t *testing.T) {
 	assert.True(t, *resp.Epochs[0].IsClaimable, "epoch 102 is claimable")
 	assert.False(t, *resp.Epochs[1].IsClaimable, "epoch 101 is not claimable")
 	assert.False(t, *resp.Epochs[2].IsClaimable, "epoch 100 is not claimable")
+
+	// Derived state mirrors the live-journal bits: 102 claimable, 100/101 have
+	// live rows with the bit cleared -> distributed (accumulated then paid).
+	assert.Equal(t, handlers.ClaimStateClaimable, resp.Epochs[0].State, "epoch 102")
+	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[1].State, "epoch 101")
+	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[2].State, "epoch 100")
 
 	// SolanaEpoch equals SubscriptionEpoch by construction.
 	assert.Equal(t, uint64(102), resp.Epochs[0].SubscriptionEpoch)
@@ -507,6 +579,51 @@ func TestGetShredsRewardsDetail_IncludesEpochsOutsideRecentWindow(t *testing.T) 
 	assert.NotNil(t, resp.Epochs[1].IsClaimable, "epoch 101 has a status row")
 	assert.NotNil(t, resp.Epochs[2].IsClaimable, "epoch 100 has a status row")
 
+	// Epoch 99 has a funded pool but no status row at all (its journal was
+	// swept before we ever tracked it), so its per-leaf claim state is
+	// unrecoverable — reported as unknown, NOT assumed paid.
+	assert.Equal(t, handlers.ClaimStateUnknown, resp.Epochs[3].State, "epoch 99 has no recoverable status")
+	// 100/101 are live-journal rows with the bit cleared -> distributed (paid),
+	// 102 is claimable.
+	assert.Equal(t, handlers.ClaimStateClaimable, resp.Epochs[0].State, "epoch 102")
+	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[1].State, "epoch 101")
+	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[2].State, "epoch 100")
+
 	// And the earnings math still works for the older epoch.
 	assert.InDelta(t, 3900.0, resp.Epochs[3].Earned2Z, 1e-6)
+}
+
+// TestGetShredsRewardsDetail_PendingState covers the fourth claim state: an
+// epoch with a pool row but zero tokens (distribution not finalized) and no
+// status row anywhere must report `pending`, not `distributed`.
+func TestGetShredsRewardsDetail_PendingState(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_rewards_leaves_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, associated_dz_epoch, node_id, leader_slots, client_id, leaf_index)
+		VALUES ('200-P', now(), now(), generateUUIDv4(), 0, 1, 200, 20, 'node-P', 50, 1, 0)
+	`))
+	// Pool row exists (so the INNER JOIN keeps the epoch) but tokens=0 →
+	// distribution not finalized. No status rows seeded anywhere.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_2z_pool_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, subscription_epoch, tokens_received_2z)
+		VALUES ('epoch-200', now(), now(), generateUUIDv4(), 0, 1, 200, 0)
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards/node-P", nil)
+	req = withChiNodeIDParam(req, "node-P")
+	rr := httptest.NewRecorder()
+	api.GetShredsRewardsDetail(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := decodeShredsRewardsDetail(t, rr.Body.Bytes())
+
+	require.Len(t, resp.Epochs, 1)
+	assert.Equal(t, handlers.ClaimStatePending, resp.Epochs[0].State, "unfunded epoch is pending, not distributed")
+	assert.Nil(t, resp.Epochs[0].IsClaimable, "no live journal row → is_claimable nil")
 }

--- a/api/handlers/shreds_rewards_test.go
+++ b/api/handlers/shreds_rewards_test.go
@@ -16,21 +16,24 @@ import (
 )
 
 // insertShredsRewardsTestData seeds two validators (node-A, node-B) across
-// three subscription epochs (100, 101, 102) so that the earnings math is exact:
+// three subscription epochs (100, 101, 102) so that the earnings math is exact.
+// Pools are in base units (2Z = 8 decimals); 1e12 base units = 10000 whole 2Z.
+// Earnings are returned in WHOLE tokens (the API divides by the token decimals)
+// and include the 10% burn (×0.9):
 //
-//	tokens_received_2z (the 2Z journal pool) = 10000 per epoch.
-//	leader_slots: A=60, B=40 per epoch → total_leader_slots=100.
-//	client_proportion = 3500 (35% to client), so 65% to validator (10000-3500=6500).
-//	earned_2z(A) per epoch = 10000 * 60 * 6500 / (100 * 10000) = 3900.
-//	earned_2z(B) per epoch = 10000 * 40 * 6500 / (100 * 10000) = 2600.
+//	pool = 1e12 base units (10000 whole 2Z) per epoch.
+//	leader_slots: A=60, B=40 per epoch → summed-leaf denominator = 100.
+//	client_proportion = 3500 (35% to client) → 65% to validator (10000-3500=6500).
+//	earned(A) per epoch = 1e12 * 60 * 6500 * 0.9 / (100 * 10000) / 1e8 = 3510 whole 2Z.
+//	earned(B) per epoch = 1e12 * 40 * 6500 * 0.9 / (100 * 10000) / 1e8 = 2340 whole 2Z.
 //
 // Across three epochs:
 //
-//	total(A) = 3*3900 = 11700, total(B) = 3*2600 = 7800.
+//	total(A) = 3*3510 = 10530, total(B) = 3*2340 = 7020.
 //
 // is_claimable=1 is only set for epoch=102 (newest) for both validators, so
-// the per-epoch claimable amount is 3900 / 2600 respectively (the rest is
-// not claimable).
+// the per-epoch claimable amount is 3510 / 2340 respectively (the rest is
+// not claimable). journal_mint_key is left empty → the leaf resolves to 2Z.
 func insertShredsRewardsTestData(t *testing.T, api *handlers.API) {
 	t.Helper()
 	ctx := t.Context()
@@ -68,17 +71,19 @@ func insertShredsRewardsTestData(t *testing.T, api *handlers.API) {
 	`)
 	require.NoError(t, err)
 
-	// 2Z reward pool per subscription_epoch (the journal's post-swap 2Z). This
-	// is the numerator for the earnings formula: tokens_received_2z=10000 per
-	// epoch keeps the expected earned_2z values identical to the doc comment.
+	// Reward pool per subscription_epoch (the journal's post-swap balance, in
+	// base units). 1e12 base units = 10000 whole 2Z. This is the numerator for
+	// the earnings formula. reward_mint/accumulated_slots_scaled are left at
+	// their defaults (''/0), exercising the legacy fallback: '' → 2Z, 0 → the
+	// summed-leaves denominator.
 	err = api.DB.Exec(ctx, `
 		INSERT INTO dim_dz_shred_distribution_2z_pool_history
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, tokens_received_2z)
 		VALUES
-		('epoch-100', now(), now(), generateUUIDv4(), 0, 1, 100, 10000),
-		('epoch-101', now(), now(), generateUUIDv4(), 0, 2, 101, 10000),
-		('epoch-102', now(), now(), generateUUIDv4(), 0, 3, 102, 10000)
+		('epoch-100', now(), now(), generateUUIDv4(), 0, 1, 100, 1000000000000),
+		('epoch-101', now(), now(), generateUUIDv4(), 0, 2, 101, 1000000000000),
+		('epoch-102', now(), now(), generateUUIDv4(), 0, 3, 102, 1000000000000)
 	`)
 	require.NoError(t, err)
 
@@ -104,8 +109,8 @@ func insertShredsRewardsTestData(t *testing.T, api *handlers.API) {
 		('s-100-B', now(), now(), generateUUIDv4(), 0, 2, 100, 'node-B', 1, 0, ''),
 		('s-101-A', now(), now(), generateUUIDv4(), 0, 3, 101, 'node-A', 1, 0, ''),
 		('s-101-B', now(), now(), generateUUIDv4(), 0, 4, 101, 'node-B', 1, 0, ''),
-		('s-102-A', now(), now(), generateUUIDv4(), 0, 5, 102, 'node-A', 1, 1, 'journal-A'),
-		('s-102-B', now(), now(), generateUUIDv4(), 0, 6, 102, 'node-B', 1, 1, 'journal-B')
+		('s-102-A', now(), now(), generateUUIDv4(), 0, 5, 102, 'node-A', 1, 1, ''),
+		('s-102-B', now(), now(), generateUUIDv4(), 0, 6, 102, 'node-B', 1, 1, '')
 	`)
 	require.NoError(t, err)
 
@@ -191,7 +196,7 @@ func TestGetShredsRewards_GoldenPath(t *testing.T) {
 	assert.Equal(t, uint64(12), resp.CurrentSolanaEpoch)
 
 	require.Len(t, resp.Validators, 2)
-	// Default sort is total_earned_2z DESC: node-A (11700) before node-B (7800).
+	// Default sort is total_earned_2z DESC: node-A (10530) before node-B (7020).
 	a := resp.Validators[0]
 	b := resp.Validators[1]
 	assert.Equal(t, "node-A", a.NodeID)
@@ -199,21 +204,24 @@ func TestGetShredsRewards_GoldenPath(t *testing.T) {
 	assert.Equal(t, "vote-A", a.VotePubkey)
 	assert.Equal(t, uint64(5000000000), a.ActivatedStake)
 	assert.Equal(t, "203.0.113.10", a.DZUserIP)
-	assert.InDelta(t, 11700.0, a.TotalEarned2Z, 1e-6)
-	assert.InDelta(t, 3900.0, a.ImmediatelyClaimable2Z, 1e-6)
+	assert.InDelta(t, 10530.0, a.TotalEarned2Z, 1e-6)
+	assert.InDelta(t, 3510.0, a.ImmediatelyClaimable2Z, 1e-6)
 	assert.Greater(t, a.TotalEarned2Z, b.TotalEarned2Z)
 
 	assert.Equal(t, "node-B", b.NodeID)
 	assert.Equal(t, "Bravo Validator", b.ValidatorName)
 	assert.Empty(t, b.DZUserIP, "node-B has no dz_users row")
-	assert.InDelta(t, 7800.0, b.TotalEarned2Z, 1e-6)
-	assert.InDelta(t, 2600.0, b.ImmediatelyClaimable2Z, 1e-6)
+	assert.InDelta(t, 7020.0, b.TotalEarned2Z, 1e-6)
+	assert.InDelta(t, 2340.0, b.ImmediatelyClaimable2Z, 1e-6)
 
-	// Per-epoch earnings map covers all 3 Solana epochs (== subscription_epochs).
+	// Per-epoch earnings map covers all 3 Solana epochs (== subscription_epochs),
+	// each tagged with the 2Z token symbol.
 	require.Len(t, a.EpochEarnings, 3)
 	for _, e := range []uint64{100, 101, 102} {
-		assert.InDelta(t, 3900.0, a.EpochEarnings[e], 1e-6, "node-A epoch %d", e)
-		assert.InDelta(t, 2600.0, b.EpochEarnings[e], 1e-6, "node-B epoch %d", e)
+		assert.InDelta(t, 3510.0, a.EpochEarnings[e], 1e-6, "node-A epoch %d", e)
+		assert.InDelta(t, 2340.0, b.EpochEarnings[e], 1e-6, "node-B epoch %d", e)
+		assert.Equal(t, "2Z", a.EpochTokens[e], "node-A epoch %d token", e)
+		assert.Equal(t, "2Z", b.EpochTokens[e], "node-B epoch %d token", e)
 	}
 }
 
@@ -353,11 +361,12 @@ func TestGetShredsRewards_DeduplicatesValidators(t *testing.T) {
 // earnings. node-X publishes under client 1 (30 slots) and client 2 (70 slots)
 // in epoch 200; both leaves must be counted.
 //
-//	pool = 10000, total_leader_slots(200) = 30 + 70 = 100, client proportion 3500
-//	(→ 65% to validator). earned(client1) = 10000*30*6500/(100*10000) = 1950,
-//	earned(client2) = 10000*70*6500/(100*10000) = 4550, total = 6500.
+//	pool = 1e12 base units (10000 whole 2Z), denominator = 30 + 70 = 100, client
+//	proportion 3500 (→ 65% to validator), 10% burn (×0.9). In whole 2Z:
+//	earned(client1) = 10000*30/100*0.65*0.9 = 1755,
+//	earned(client2) = 10000*70/100*0.65*0.9 = 4095, total = 5850.
 //
-// Only client 1 is claimable, so immediately_claimable = 1950 (not 6500) —
+// Only client 1 is claimable, so immediately_claimable = 1755 (not 5850) —
 // proving the per-client claimable grain too.
 func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 	t.Parallel()
@@ -376,7 +385,7 @@ func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 		INSERT INTO dim_dz_shred_distribution_2z_pool_history
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, tokens_received_2z)
-		VALUES ('epoch-200', now(), now(), generateUUIDv4(), 0, 1, 200, 10000)
+		VALUES ('epoch-200', now(), now(), generateUUIDv4(), 0, 1, 200, 1000000000000)
 	`))
 	require.NoError(t, api.DB.Exec(ctx, `
 		INSERT INTO dim_dz_shred_distribution_client_proportions_history
@@ -391,8 +400,8 @@ func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, node_id, client_id, is_claimable, journal_mint_key)
 		VALUES
-		('s-200-X-c1', now(), now(), generateUUIDv4(), 0, 1, 200, 'node-X', 1, 1, 'journal-X'),
-		('s-200-X-c2', now(), now(), generateUUIDv4(), 0, 2, 200, 'node-X', 2, 0, 'journal-X')
+		('s-200-X-c1', now(), now(), generateUUIDv4(), 0, 1, 200, 'node-X', 1, 1, ''),
+		('s-200-X-c2', now(), now(), generateUUIDv4(), 0, 2, 200, 'node-X', 2, 0, '')
 	`))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards", nil)
@@ -405,12 +414,12 @@ func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 	require.Len(t, resp.Validators, 1, "node-X must appear exactly once")
 	x := resp.Validators[0]
 	assert.Equal(t, "node-X", x.NodeID)
-	// Both client leaves counted: 1950 + 4550 = 6500.
-	assert.InDelta(t, 6500.0, x.TotalEarned2Z, 1e-6, "earnings must sum across both clients")
-	// Only client 1 is claimable: 1950, not the full 6500.
-	assert.InDelta(t, 1950.0, x.ImmediatelyClaimable2Z, 1e-6, "only client 1's earnings are claimable")
-	// Per-epoch earnings for epoch 200 is the node's full 6500.
-	assert.InDelta(t, 6500.0, x.EpochEarnings[200], 1e-6)
+	// Both client leaves counted: 1755 + 4095 = 5850.
+	assert.InDelta(t, 5850.0, x.TotalEarned2Z, 1e-6, "earnings must sum across both clients")
+	// Only client 1 is claimable: 1755, not the full 5850.
+	assert.InDelta(t, 1755.0, x.ImmediatelyClaimable2Z, 1e-6, "only client 1's earnings are claimable")
+	// Per-epoch earnings for epoch 200 is the node's full 5850.
+	assert.InDelta(t, 5850.0, x.EpochEarnings[200], 1e-6)
 }
 
 // TestGetShredsRewards_ProportionDefaultsWhenUnset is the regression test for
@@ -420,8 +429,9 @@ func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 // The validator share must use default_proportion (3500 → 65%), NOT treat the
 // 0 as a literal proportion (which gave a 100% share and overstated earnings).
 //
-//	pool = 10000, total_leader_slots = 100, validator share = 10000-3500 = 6500
-//	earned = 10000 * 100 * 6500 / (100 * 10000) = 6500   (NOT 10000)
+//	pool = 1e12 base units (10000 whole 2Z), denominator = 100, validator share
+//	= 10000-3500 = 6500, 10% burn (×0.9). earned = 10000 * 0.65 * 0.9 = 5850 whole
+//	2Z   (NOT 9000, the burn-applied 0-proportion bug, nor 10000)
 func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
@@ -437,7 +447,7 @@ func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
 		INSERT INTO dim_dz_shred_distribution_2z_pool_history
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, tokens_received_2z)
-		VALUES ('epoch-300', now(), now(), generateUUIDv4(), 0, 1, 300, 10000)
+		VALUES ('epoch-300', now(), now(), generateUUIDv4(), 0, 1, 300, 1000000000000)
 	`))
 	// proportion stored as 0 (unset), real fallback in default_proportion.
 	require.NoError(t, api.DB.Exec(ctx, `
@@ -455,8 +465,9 @@ func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
 	resp := decodeShredsRewards(t, rr.Body.Bytes())
 
 	require.Len(t, resp.Validators, 1)
-	// 6500 (65% share via default_proportion), NOT 10000 (the 0-proportion bug).
-	assert.InDelta(t, 6500.0, resp.Validators[0].TotalEarned2Z, 1e-6,
+	// 5850 (65% share via default_proportion, ×0.9 burn), NOT 9000 (the
+	// 0-proportion bug giving a 100% share, then burned).
+	assert.InDelta(t, 5850.0, resp.Validators[0].TotalEarned2Z, 1e-6,
 		"unset proportion must fall through to default_proportion, not a 100% share")
 }
 
@@ -466,9 +477,11 @@ func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
 // summed-leaves denominator is too small and over-credits everyone; the stored
 // value is the true denominator.
 //
-//	pool = 10000, node-D leader_slots = 100, but the journal's total = 200
-//	(another 100 slots belong to a validator whose leaf isn't indexed).
-//	earned = 10000 * 100 * 6500 / (200 * 10000) = 3250   (NOT 6500)
+//	pool = 1e12 base units (10000 whole 2Z), node-D leader_slots = 100, but the
+//	journal's total_leader_slots = 200 (another 100 slots belong to a validator
+//	whose leaf isn't indexed), with the 10% burn (×0.9). accumulated_slots_scaled
+//	is unset (0) so the denominator falls back to total_leader_slots × 10000.
+//	earned = 10000 * 100/200 * 0.65 * 0.9 = 2925 whole 2Z   (NOT 5850)
 func TestGetShredsRewards_UsesJournalTotalLeaderSlots(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)
@@ -486,7 +499,7 @@ func TestGetShredsRewards_UsesJournalTotalLeaderSlots(t *testing.T) {
 		INSERT INTO dim_dz_shred_distribution_2z_pool_history
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, tokens_received_2z, total_leader_slots)
-		VALUES ('epoch-400', now(), now(), generateUUIDv4(), 0, 1, 400, 10000, 200)
+		VALUES ('epoch-400', now(), now(), generateUUIDv4(), 0, 1, 400, 1000000000000, 200)
 	`))
 	require.NoError(t, api.DB.Exec(ctx, `
 		INSERT INTO dim_dz_shred_distribution_client_proportions_history
@@ -503,9 +516,82 @@ func TestGetShredsRewards_UsesJournalTotalLeaderSlots(t *testing.T) {
 	resp := decodeShredsRewards(t, rr.Body.Bytes())
 
 	require.Len(t, resp.Validators, 1)
-	// 3250 (denominator 200), NOT 6500 (summed-leaves denominator 100).
-	assert.InDelta(t, 3250.0, resp.Validators[0].TotalEarned2Z, 1e-6,
+	// 2925 (denominator 200), NOT 5850 (summed-leaves denominator 100).
+	assert.InDelta(t, 2925.0, resp.Validators[0].TotalEarned2Z, 1e-6,
 		"must divide by the journal's total_leader_slots, not the summed indexed leaves")
+}
+
+// TestGetShredsRewards_MultiTokenUSDC covers the multi-token era: a validator
+// rewarded in USDC. Its leaf is attributed to the USDC mint via the status row's
+// journal_mint_key, joined to the USDC pool, and split over the USDC journal's
+// accumulated_slots_scaled denominator (not the epoch total), with the 10% burn
+// and USDC's 6 decimals.
+//
+//	USDC is not burned and its journal holds no swapped balance
+//	(tokens_received_2z = 0); the pool comes from distributed_amount = 9e8 base
+//	units (900 whole USDC). accumulated_slots_scaled = 50 × 10000 = 500000 (so the
+//	journal owns 50 slots), node-U has all 50 slots, client proportion defaults to
+//	3500 (→ 65%), NO burn.
+//	earned = 9e8 * 50 * 6500 / 500000 / 1e6 = 585 whole USDC.
+//
+// The 2Z headline total stays 0 (cross-token sums are not meaningful), but the
+// per-epoch cell carries the USDC amount and symbol.
+func TestGetShredsRewards_MultiTokenUSDC(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_rewards_leaves_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, associated_dz_epoch, node_id, leader_slots, client_id, leaf_index)
+		VALUES ('500-U', now(), now(), generateUUIDv4(), 0, 1, 500, 50, 'node-U', 50, 1, 0)
+	`))
+	// USDC pool: tokens_received_2z=0 (no swapped balance), reward drawn from
+	// distributed_amount, with the per-token scaled-slot denominator.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_2z_pool_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, tokens_received_2z, total_leader_slots, reward_mint, accumulated_slots_scaled, distributed_amount)
+		VALUES ('epoch-500:usdc', now(), now(), generateUUIDv4(), 0, 1, 500, 0, 0, '`+usdcMint+`', 500000, 900000000)
+	`))
+	// Status row attributes node-U's leaf to the USDC journal.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_leaf_distribution_status_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, node_id, client_id, is_claimable, journal_mint_key)
+		VALUES ('s-500-U', now(), now(), generateUUIDv4(), 0, 1, 500, 'node-U', 1, 1, '`+usdcMint+`')
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredsRewards(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := decodeShredsRewards(t, rr.Body.Bytes())
+
+	require.Len(t, resp.Validators, 1)
+	u := resp.Validators[0]
+	assert.Equal(t, "node-U", u.NodeID)
+	// USDC-only validator: no 2Z, so the 2Z headline total is 0.
+	assert.InDelta(t, 0.0, u.TotalEarned2Z, 1e-6, "USDC earnings must not count toward the 2Z total")
+	// The per-epoch cell carries the USDC amount and symbol.
+	assert.InDelta(t, 585.0, u.EpochEarnings[500], 1e-6, "USDC reward split over the journal's slots, with burn")
+	assert.Equal(t, "USDC", u.EpochTokens[500])
+
+	// Detail endpoint surfaces the same per-token amount and symbol.
+	dreq := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards/node-U", nil)
+	dreq = withChiNodeIDParam(dreq, "node-U")
+	drr := httptest.NewRecorder()
+	api.GetShredsRewardsDetail(drr, dreq)
+	assert.Equal(t, http.StatusOK, drr.Code, "body=%s", drr.Body.String())
+	dresp := decodeShredsRewardsDetail(t, drr.Body.Bytes())
+	require.Len(t, dresp.Epochs, 1)
+	assert.Equal(t, "USDC", dresp.Epochs[0].TokenSymbol)
+	assert.InDelta(t, 585.0, dresp.Epochs[0].Earned, 1e-6)
+	assert.Equal(t, handlers.ClaimStateClaimable, dresp.Epochs[0].State)
 }
 
 // withChiNodeIDParam installs the {nodeId} URL param onto the request context
@@ -551,11 +637,13 @@ func TestGetShredsRewardsDetail_FullHistory(t *testing.T) {
 	assert.Equal(t, uint64(101), resp.Epochs[1].SolanaEpoch)
 	assert.Equal(t, uint64(100), resp.Epochs[2].SolanaEpoch)
 
-	// Per-row fields use the shared earnings formula: 3900 per epoch for node-A.
+	// Per-row fields use the shared earnings formula: 3510 whole 2Z per epoch
+	// for node-A (3900 × 0.9 burn), tagged with the 2Z symbol.
 	for i, e := range resp.Epochs {
 		assert.Equal(t, uint32(60), e.LeaderSlots, "epoch index %d", i)
 		assert.Equal(t, uint16(1), e.ClientID, "epoch index %d", i)
-		assert.InDelta(t, 3900.0, e.Earned2Z, 1e-6, "epoch index %d", i)
+		assert.InDelta(t, 3510.0, e.Earned, 1e-6, "epoch index %d", i)
+		assert.Equal(t, "2Z", e.TokenSymbol, "epoch index %d", i)
 	}
 
 	// All three epochs have status rows in the fixture, so IsClaimable is non-nil.
@@ -639,7 +727,7 @@ func TestGetShredsRewardsDetail_IncludesEpochsOutsideRecentWindow(t *testing.T) 
 		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 		 subscription_epoch, tokens_received_2z)
 		VALUES
-		('epoch-99', now(), now(), generateUUIDv4(), 0, 4, 99, 10000)
+		('epoch-99', now(), now(), generateUUIDv4(), 0, 4, 99, 1000000000000)
 	`)
 	require.NoError(t, err)
 
@@ -684,8 +772,9 @@ func TestGetShredsRewardsDetail_IncludesEpochsOutsideRecentWindow(t *testing.T) 
 	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[1].State, "epoch 101")
 	assert.Equal(t, handlers.ClaimStateDistributed, resp.Epochs[2].State, "epoch 100")
 
-	// And the earnings math still works for the older epoch.
-	assert.InDelta(t, 3900.0, resp.Epochs[3].Earned2Z, 1e-6)
+	// And the earnings math still works for the older epoch (3900 × 0.9 burn).
+	assert.InDelta(t, 3510.0, resp.Epochs[3].Earned, 1e-6)
+	assert.Equal(t, "2Z", resp.Epochs[3].TokenSymbol)
 }
 
 // TestGetShredsRewardsDetail_PendingState covers the fourth claim state: an

--- a/api/handlers/shreds_rewards_test.go
+++ b/api/handlers/shreds_rewards_test.go
@@ -196,6 +196,7 @@ func TestGetShredsRewards_GoldenPath(t *testing.T) {
 	assert.Equal(t, uint64(12), resp.CurrentSolanaEpoch)
 
 	require.Len(t, resp.Validators, 2)
+	assert.Equal(t, 2, resp.Total, "Total reflects the full count query, not the page size")
 	// Default sort is total_earned_2z DESC: node-A (10530) before node-B (7020).
 	a := resp.Validators[0]
 	b := resp.Validators[1]
@@ -524,8 +525,7 @@ func TestGetShredsRewards_UsesJournalTotalLeaderSlots(t *testing.T) {
 // TestGetShredsRewards_MultiTokenUSDC covers the multi-token era: a validator
 // rewarded in USDC. Its leaf is attributed to the USDC mint via the status row's
 // journal_mint_key, joined to the USDC pool, and split over the USDC journal's
-// accumulated_slots_scaled denominator (not the epoch total), with the 10% burn
-// and USDC's 6 decimals.
+// accumulated_slots_scaled denominator (not the epoch total), with USDC's 6 decimals.
 //
 //	USDC is not burned and its journal holds no swapped balance
 //	(tokens_received_2z = 0); the pool comes from distributed_amount = 9e8 base

--- a/api/handlers/shreds_rewards_test.go
+++ b/api/handlers/shreds_rewards_test.go
@@ -413,6 +413,53 @@ func TestGetShredsRewards_MultiClientValidator(t *testing.T) {
 	assert.InDelta(t, 6500.0, x.EpochEarnings[200], 1e-6)
 }
 
+// TestGetShredsRewards_ProportionDefaultsWhenUnset is the regression test for
+// the earnings overstatement: the per-client proportion is stored as 0 when
+// unset, with the real fallback in default_proportion, and a missing client
+// row also reads as 0 (ClickHouse fills LEFT JOIN columns with 0, not NULL).
+// The validator share must use default_proportion (3500 → 65%), NOT treat the
+// 0 as a literal proportion (which gave a 100% share and overstated earnings).
+//
+//	pool = 10000, total_leader_slots = 100, validator share = 10000-3500 = 6500
+//	earned = 10000 * 100 * 6500 / (100 * 10000) = 6500   (NOT 10000)
+func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_rewards_leaves_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, associated_dz_epoch, node_id, leader_slots, client_id, leaf_index)
+		VALUES ('300-Z', now(), now(), generateUUIDv4(), 0, 1, 300, 30, 'node-Z', 100, 1, 0)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_2z_pool_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, tokens_received_2z)
+		VALUES ('epoch-300', now(), now(), generateUUIDv4(), 0, 1, 300, 10000)
+	`))
+	// proportion stored as 0 (unset), real fallback in default_proportion.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_client_proportions_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, client_id, proportion, default_proportion)
+		VALUES ('p-300-1', now(), now(), generateUUIDv4(), 0, 1, 300, 1, 0, 3500)
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredsRewards(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := decodeShredsRewards(t, rr.Body.Bytes())
+
+	require.Len(t, resp.Validators, 1)
+	// 6500 (65% share via default_proportion), NOT 10000 (the 0-proportion bug).
+	assert.InDelta(t, 6500.0, resp.Validators[0].TotalEarned2Z, 1e-6,
+		"unset proportion must fall through to default_proportion, not a 100% share")
+}
+
 // withChiNodeIDParam installs the {nodeId} URL param onto the request context
 // so the handler can read it via chi.URLParam.
 func withChiNodeIDParam(req *http.Request, nodeID string) *http.Request {

--- a/api/handlers/shreds_rewards_test.go
+++ b/api/handlers/shreds_rewards_test.go
@@ -460,6 +460,54 @@ func TestGetShredsRewards_ProportionDefaultsWhenUnset(t *testing.T) {
 		"unset proportion must fall through to default_proportion, not a 100% share")
 }
 
+// TestGetShredsRewards_UsesJournalTotalLeaderSlots verifies earnings divide by
+// the journal's authoritative total_leader_slots (stored on the pool row), not
+// the sum of indexed leaves. When some validators' leaves are missing, the
+// summed-leaves denominator is too small and over-credits everyone; the stored
+// value is the true denominator.
+//
+//	pool = 10000, node-D leader_slots = 100, but the journal's total = 200
+//	(another 100 slots belong to a validator whose leaf isn't indexed).
+//	earned = 10000 * 100 * 6500 / (200 * 10000) = 3250   (NOT 6500)
+func TestGetShredsRewards_UsesJournalTotalLeaderSlots(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	ctx := t.Context()
+
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_validator_rewards_leaves_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, associated_dz_epoch, node_id, leader_slots, client_id, leaf_index)
+		VALUES ('400-D', now(), now(), generateUUIDv4(), 0, 1, 400, 40, 'node-D', 100, 1, 0)
+	`))
+	// Pool carries the authoritative denominator (200) — larger than the lone
+	// indexed leaf's 100 slots, simulating a missing validator's leaves.
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_2z_pool_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, tokens_received_2z, total_leader_slots)
+		VALUES ('epoch-400', now(), now(), generateUUIDv4(), 0, 1, 400, 10000, 200)
+	`))
+	require.NoError(t, api.DB.Exec(ctx, `
+		INSERT INTO dim_dz_shred_distribution_client_proportions_history
+		(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+		 subscription_epoch, client_id, proportion, default_proportion)
+		VALUES ('p-400-1', now(), now(), generateUUIDv4(), 0, 1, 400, 1, 3500, 3500)
+	`))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/shreds/rewards", nil)
+	rr := httptest.NewRecorder()
+	api.GetShredsRewards(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := decodeShredsRewards(t, rr.Body.Bytes())
+
+	require.Len(t, resp.Validators, 1)
+	// 3250 (denominator 200), NOT 6500 (summed-leaves denominator 100).
+	assert.InDelta(t, 3250.0, resp.Validators[0].TotalEarned2Z, 1e-6,
+		"must divide by the journal's total_leader_slots, not the summed indexed leaves")
+}
+
 // withChiNodeIDParam installs the {nodeId} URL param onto the request context
 // so the handler can read it via chi.URLParam.
 func withChiNodeIDParam(req *http.Request, nodeID string) *http.Request {

--- a/indexer/db/clickhouse/migrations/20260611000001_shred_rewards_client_grain.sql
+++ b/indexer/db/clickhouse/migrations/20260611000001_shred_rewards_client_grain.sql
@@ -21,7 +21,7 @@ TRUNCATE TABLE IF EXISTS stg_dim_dz_shred_validator_rewards_leaves_snapshot;
 -- overwrite another's. Extend the grain to include client_id. We drop and
 -- recreate (rather than ALTER ... ADD COLUMN) so client_id lands in the correct
 -- column position for the dim-type-2 positional batch insert. The table is
--- window-bounded (~12 most-recent epochs) and repopulated every refresh, so the
+-- window-bounded and repopulated every refresh, so the
 -- rebuild is cheap.
 DROP VIEW IF EXISTS dim_dz_shred_validator_leaf_distribution_status_current;
 DROP TABLE IF EXISTS dim_dz_shred_validator_leaf_distribution_status_history;

--- a/indexer/db/clickhouse/migrations/20260611000001_shred_rewards_client_grain.sql
+++ b/indexer/db/clickhouse/migrations/20260611000001_shred_rewards_client_grain.sql
@@ -1,0 +1,140 @@
+-- +goose Up
+
+-- Fix: validator rewards collapsed multiple software clients in a single epoch.
+--
+-- The leaf grain is (subscription_epoch, node_id, client_id) — a validator that
+-- publishes under more than one client (e.g. Agave + Firedancer) produces one
+-- merkle leaf per client. The dim-type-2 entity_id is hash(pk), and pk omitted
+-- client_id, so those leaves collapsed to a single row: the node's leader slots
+-- (and therefore its earnings) were understated.
+--
+-- The leaves table columns are unchanged — only the pk/entity_id values now
+-- include client_id — so we truncate the history + staging tables and let the
+-- indexer rebuild from the public S3 export (which retains past epochs). The
+-- refresh loop re-fetches every epoch once LeavesStatusForEpoch reports empty.
+TRUNCATE TABLE IF EXISTS dim_dz_shred_validator_rewards_leaves_history;
+TRUNCATE TABLE IF EXISTS stg_dim_dz_shred_validator_rewards_leaves_snapshot;
+
+-- The leaf distribution status (claimable bit) shares the same defect: the
+-- publisher-accumulation bitmap is per leaf (i.e. per node+client), but the
+-- table keyed per (subscription_epoch, node_id), so one client's bit could
+-- overwrite another's. Extend the grain to include client_id. We drop and
+-- recreate (rather than ALTER ... ADD COLUMN) so client_id lands in the correct
+-- column position for the dim-type-2 positional batch insert. The table is
+-- window-bounded (~12 most-recent epochs) and repopulated every refresh, so the
+-- rebuild is cheap.
+DROP VIEW IF EXISTS dim_dz_shred_validator_leaf_distribution_status_current;
+DROP TABLE IF EXISTS dim_dz_shred_validator_leaf_distribution_status_history;
+DROP TABLE IF EXISTS stg_dim_dz_shred_validator_leaf_distribution_status_snapshot;
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_shred_validator_leaf_distribution_status_snapshot (
+    entity_id            String,
+    snapshot_ts          DateTime64(3),
+    ingested_at          DateTime64(3),
+    op_id                UUID,
+    is_deleted           UInt8 DEFAULT 0,
+    attrs_hash           UInt64,
+    pk                   String,
+    subscription_epoch   UInt64,
+    node_id              String,
+    client_id            UInt16,
+    is_claimable         UInt8,
+    journal_mint_key     String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dim_dz_shred_validator_leaf_distribution_status_history (
+    entity_id            String,
+    snapshot_ts          DateTime64(3),
+    ingested_at          DateTime64(3),
+    op_id                UUID,
+    is_deleted           UInt8 DEFAULT 0,
+    attrs_hash           UInt64,
+    pk                   String,
+    subscription_epoch   UInt64,
+    node_id              String,
+    client_id            UInt16,
+    is_claimable         UInt8,
+    journal_mint_key     String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_validator_leaf_distribution_status_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_validator_leaf_distribution_status_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, node_id, client_id, is_claimable, journal_mint_key
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- Revert the status table to the per-(subscription_epoch, node_id) grain.
+DROP VIEW IF EXISTS dim_dz_shred_validator_leaf_distribution_status_current;
+DROP TABLE IF EXISTS dim_dz_shred_validator_leaf_distribution_status_history;
+DROP TABLE IF EXISTS stg_dim_dz_shred_validator_leaf_distribution_status_snapshot;
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS stg_dim_dz_shred_validator_leaf_distribution_status_snapshot (
+    entity_id            String,
+    snapshot_ts          DateTime64(3),
+    ingested_at          DateTime64(3),
+    op_id                UUID,
+    is_deleted           UInt8 DEFAULT 0,
+    attrs_hash           UInt64,
+    pk                   String,
+    subscription_epoch   UInt64,
+    node_id              String,
+    is_claimable         UInt8,
+    journal_mint_key     String
+) ENGINE = MergeTree
+PARTITION BY toDate(snapshot_ts)
+ORDER BY (op_id, entity_id)
+TTL ingested_at + INTERVAL 7 DAY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dim_dz_shred_validator_leaf_distribution_status_history (
+    entity_id            String,
+    snapshot_ts          DateTime64(3),
+    ingested_at          DateTime64(3),
+    op_id                UUID,
+    is_deleted           UInt8 DEFAULT 0,
+    attrs_hash           UInt64,
+    pk                   String,
+    subscription_epoch   UInt64,
+    node_id              String,
+    is_claimable         UInt8,
+    journal_mint_key     String
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_ts)
+ORDER BY (entity_id, snapshot_ts, ingested_at, op_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_validator_leaf_distribution_status_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_validator_leaf_distribution_status_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, node_id, is_claimable, journal_mint_key
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+TRUNCATE TABLE IF EXISTS dim_dz_shred_validator_rewards_leaves_history;
+TRUNCATE TABLE IF EXISTS stg_dim_dz_shred_validator_rewards_leaves_snapshot;

--- a/indexer/db/clickhouse/migrations/20260612000001_shred_pool_total_leader_slots.sql
+++ b/indexer/db/clickhouse/migrations/20260612000001_shred_pool_total_leader_slots.sql
@@ -1,0 +1,55 @@
+-- +goose Up
+
+-- Add the journal's authoritative leader-slot denominator to the 2Z pool table.
+--
+-- Validator earnings split the epoch's 2Z pool by leader_slots / total_leader_slots.
+-- The query previously derived the denominator as sum(leader_slots) over the
+-- indexed leaves, but those leaves are incomplete for older epochs (the S3 export
+-- / verification lags), so the denominator was too small and every present
+-- validator's share was over-credited by a per-epoch constant factor. The
+-- ShredDistributionJournal carries the true total_leader_slots; record it here so
+-- the API can divide by the authoritative value.
+--
+-- Appended as the last column (matching the dim-type-2 positional batch insert,
+-- whose payload order now ends with total_leader_slots) via ADD COLUMN, so the
+-- existing pool history — which must survive journal sweeps for all-time
+-- earnings — is preserved rather than rebuilt. Existing rows default to 0; the
+-- indexer backfills the real value on its next refresh for every still-readable
+-- journal, and the API falls back to the summed-leaves denominator when it is 0.
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    ADD COLUMN IF NOT EXISTS total_leader_slots UInt64;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    ADD COLUMN IF NOT EXISTS total_leader_slots UInt64;
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_distribution_2z_pool_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_distribution_2z_pool_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, tokens_received_2z, total_leader_slots
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_distribution_2z_pool_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_distribution_2z_pool_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, tokens_received_2z
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    DROP COLUMN IF EXISTS total_leader_slots;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    DROP COLUMN IF EXISTS total_leader_slots;

--- a/indexer/db/clickhouse/migrations/20260616000001_shred_pool_reward_token.sql
+++ b/indexer/db/clickhouse/migrations/20260616000001_shred_pool_reward_token.sql
@@ -1,0 +1,96 @@
+-- +goose Up
+
+-- Clear the leaf distribution status history so the per-leaf reward-token
+-- attribution rebuilds cleanly. The pre-multi-token projection marked any
+-- cleared 2Z-journal bit in the accumulation prefix as a distributed 2Z leaf;
+-- for epochs ≥ 968 that mistagged USDC/wSOL leaves as 2Z. The new projection
+-- only marks a leaf distributed for the token it was previously attributed to,
+-- so the stale 2Z rows must be cleared or they would perpetuate. The table is
+-- window-bounded (~12 recent epochs) and repopulated every indexer refresh, so
+-- this is cheap; older epochs whose journals are already swept cannot be
+-- re-attributed regardless.
+TRUNCATE TABLE IF EXISTS dim_dz_shred_validator_leaf_distribution_status_history;
+TRUNCATE TABLE IF EXISTS stg_dim_dz_shred_validator_leaf_distribution_status_snapshot;
+
+-- Multi-token reward pools.
+--
+-- From epoch 968 the shred-subscription program supports multiple reward tokens
+-- (2Z, USDC, wSOL). Each token gets its own ShredDistributionJournal per epoch,
+-- owning only the leaves of validators who picked that token. Two new columns
+-- carry what the rewards page needs to split each token's pool correctly:
+--
+--   reward_mint               base58 of the token this journal pays out in. The
+--                             API joins each leaf (tagged via the leaf
+--                             distribution status' journal_mint_key) to the pool
+--                             for its token. Empty on legacy rows → treated as 2Z.
+--   accumulated_slots_scaled  the journal's authoritative per-token denominator,
+--                             accumulated_publisher_slots_scaled +
+--                             accumulated_client_slots_scaled (= this token's
+--                             leader slots × 10000). The API divides by this
+--                             rather than the epoch-wide total_leader_slots so a
+--                             validator's reward is split over its journal's
+--                             slots. Zero on legacy rows → API falls back to
+--                             total_leader_slots × 10000, then summed leaves.
+--
+-- Appended as the last columns (matching the dim-type-2 positional batch insert,
+-- whose payload order now ends with reward_mint, accumulated_slots_scaled) via
+-- ADD COLUMN, so the existing pool history — which must survive journal sweeps
+-- for all-time earnings — is preserved rather than rebuilt. Existing rows default
+-- to empty/0; the indexer backfills the real values on its next refresh for every
+-- still-readable journal. The 2Z journal keeps its bare epoch-{e} pk so its
+-- historical series stays one entity per epoch; other tokens are keyed
+-- epoch-{e}:mint-{mint}.
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    ADD COLUMN IF NOT EXISTS reward_mint String;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    ADD COLUMN IF NOT EXISTS accumulated_slots_scaled UInt64;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    ADD COLUMN IF NOT EXISTS distributed_amount UInt64;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    ADD COLUMN IF NOT EXISTS reward_mint String;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    ADD COLUMN IF NOT EXISTS accumulated_slots_scaled UInt64;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    ADD COLUMN IF NOT EXISTS distributed_amount UInt64;
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_distribution_2z_pool_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_distribution_2z_pool_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, tokens_received_2z, total_leader_slots,
+    reward_mint, accumulated_slots_scaled, distributed_amount
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW dim_dz_shred_distribution_2z_pool_current AS
+WITH ranked AS (
+    SELECT *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_shred_distribution_2z_pool_history
+)
+SELECT entity_id, snapshot_ts, ingested_at, op_id, attrs_hash, pk,
+    subscription_epoch, tokens_received_2z, total_leader_slots
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    DROP COLUMN IF EXISTS distributed_amount;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    DROP COLUMN IF EXISTS accumulated_slots_scaled;
+ALTER TABLE dim_dz_shred_distribution_2z_pool_history
+    DROP COLUMN IF EXISTS reward_mint;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    DROP COLUMN IF EXISTS distributed_amount;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    DROP COLUMN IF EXISTS accumulated_slots_scaled;
+ALTER TABLE stg_dim_dz_shred_distribution_2z_pool_snapshot
+    DROP COLUMN IF EXISTS reward_mint;

--- a/indexer/db/clickhouse/migrations/20260616000001_shred_pool_reward_token.sql
+++ b/indexer/db/clickhouse/migrations/20260616000001_shred_pool_reward_token.sql
@@ -6,7 +6,7 @@
 -- for epochs ≥ 968 that mistagged USDC/wSOL leaves as 2Z. The new projection
 -- only marks a leaf distributed for the token it was previously attributed to,
 -- so the stale 2Z rows must be cleared or they would perpetuate. The table is
--- window-bounded (~12 recent epochs) and repopulated every indexer refresh, so
+-- window-bounded and repopulated every indexer refresh, so
 -- this is cheap; older epochs whose journals are already swept cannot be
 -- re-attributed regardless.
 TRUNCATE TABLE IF EXISTS dim_dz_shred_validator_leaf_distribution_status_history;

--- a/indexer/pkg/dz/shreds/validatorrewards/journal.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal.go
@@ -86,8 +86,11 @@ const (
 	offClientAccumulationBitmapStartIndex    = 112
 	offClientAccumulationBitmapEndIndex      = 116
 	offTotalLeaderSlots                      = 128
+	offAccumulatedPublisherSlotsScaled       = 136
+	offAccumulatedClientSlotsScaled          = 144
 	offAccumulatedPublisherLeafCount         = 152
 	offDistributedPublisherLeafCount         = 156
+	offDistributedAmount                     = 160
 )
 
 // JournalView captures the subset of ShredDistributionJournal state we
@@ -97,11 +100,18 @@ const (
 // documents where they live in the account.
 type JournalView struct {
 	SubscriptionEpoch uint64
-	MintKey           solana.PublicKey
+	// MintKey is the journal's seed mint — the token validators selected to be
+	// rewarded in. Each (subscription_epoch, mint_key) has its own journal, and
+	// a journal owns only the leaves of validators who picked that token.
+	MintKey solana.PublicKey
+	// RewardMintKey is the mint of the tokens actually held and paid out by this
+	// journal (TokensReceivedAmount is denominated in it). For the supported
+	// reward tokens (2Z, USDC, wSOL) it equals MintKey.
+	RewardMintKey solana.PublicKey
 	// TokensReceivedAmount is the journal's post-Jupiter-swap balance of
 	// reward_mint_key tokens (`rewards_amount()` upstream for a non-bypassed
-	// journal). For the 2Z journal this is the validator-reward pool that
-	// per-leaf publisher shares are drawn from.
+	// journal). This is the validator-reward pool that per-leaf publisher shares
+	// are drawn from, in base units of RewardMintKey.
 	TokensReceivedAmount                  uint64
 	PublisherAccumulationBitmapStartIndex uint32
 	PublisherAccumulationBitmapEndIndex   uint32
@@ -110,9 +120,24 @@ type JournalView struct {
 	// split the pool by leader slots — NOT the sum of the leaves we happen to
 	// have indexed (which can be incomplete and would over-credit each present
 	// validator).
-	TotalLeaderSlots              uint32
-	AccumulatedPublisherLeafCount uint32
-	DistributedPublisherLeafCount uint32
+	TotalLeaderSlots uint32
+	// AccumulatedPublisherSlotsScaled and AccumulatedClientSlotsScaled are the
+	// running sums of leader_slots × proportion (in basis points) over the
+	// leaves accumulated into THIS journal — i.e. only the validators who picked
+	// this journal's token. Their sum equals (this journal's leader slots) ×
+	// 10000 and is the authoritative per-token reward denominator: in the
+	// multi-token era a validator's share is split over its journal's slots, not
+	// the epoch-wide total.
+	AccumulatedPublisherSlotsScaled uint64
+	AccumulatedClientSlotsScaled    uint64
+	AccumulatedPublisherLeafCount   uint32
+	DistributedPublisherLeafCount   uint32
+	// DistributedAmount is the running total of reward-token base units already
+	// paid out by this journal. For non-2Z tokens (USDC, wSOL) the journal does
+	// not pre-hold a swapped balance (TokensReceivedAmount is 0), so this is the
+	// reward pool the page splits; for a finalized epoch it is the full pool.
+	// (The 2Z journal instead splits TokensReceivedAmount, less the 10% burn.)
+	DistributedAmount uint64
 	// RemainingData is `account_data[journalFixedHeader:]`. Bitmaps are
 	// referenced into it via the start/end indices above.
 	RemainingData []byte
@@ -140,13 +165,29 @@ func DecodeJournalAccount(data []byte) (*JournalView, error) {
 		PublisherAccumulationBitmapStartIndex: binary.LittleEndian.Uint32(data[offPublisherAccumulationBitmapStartIndex : offPublisherAccumulationBitmapStartIndex+4]),
 		PublisherAccumulationBitmapEndIndex:   binary.LittleEndian.Uint32(data[offPublisherAccumulationBitmapEndIndex : offPublisherAccumulationBitmapEndIndex+4]),
 		TotalLeaderSlots:                      binary.LittleEndian.Uint32(data[offTotalLeaderSlots : offTotalLeaderSlots+4]),
+		AccumulatedPublisherSlotsScaled:       binary.LittleEndian.Uint64(data[offAccumulatedPublisherSlotsScaled : offAccumulatedPublisherSlotsScaled+8]),
+		AccumulatedClientSlotsScaled:          binary.LittleEndian.Uint64(data[offAccumulatedClientSlotsScaled : offAccumulatedClientSlotsScaled+8]),
 		AccumulatedPublisherLeafCount:         binary.LittleEndian.Uint32(data[offAccumulatedPublisherLeafCount : offAccumulatedPublisherLeafCount+4]),
 		DistributedPublisherLeafCount:         binary.LittleEndian.Uint32(data[offDistributedPublisherLeafCount : offDistributedPublisherLeafCount+4]),
+		DistributedAmount:                     binary.LittleEndian.Uint64(data[offDistributedAmount : offDistributedAmount+8]),
 		RemainingData:                         data[journalFixedHeader:],
 	}
 	copy(view.MintKey[:], data[offMintKey:offMintKey+32])
+	copy(view.RewardMintKey[:], data[offRewardMintKey:offRewardMintKey+32])
 
 	return view, nil
+}
+
+// AccumulatedSlotsScaledDenominator returns the per-token reward denominator:
+// accumulated_publisher_slots_scaled + accumulated_client_slots_scaled. This
+// equals (the journal's leader slots) × 10000, so dividing
+// tokens_received × leader_slots × (10000 − client_proportion) by it yields the
+// validator's share of this journal's pool.
+func (j *JournalView) AccumulatedSlotsScaledDenominator() uint64 {
+	if j == nil {
+		return 0
+	}
+	return j.AccumulatedPublisherSlotsScaled + j.AccumulatedClientSlotsScaled
 }
 
 // publisherBitmap returns the slice of RemainingData that holds the
@@ -191,34 +232,50 @@ func (j *JournalView) IsClaimableForLeafIndex(leafIndex uint32) (bool, bool) {
 	return set, true
 }
 
-// ProjectStatuses emits one LeafDistributionStatusRow per leaf in
-// `[0, AccumulatedPublisherLeafCount)`. Leaves with no (node_id, client_id)
-// mapping in `leafIndexToIdentity` are silently skipped. The journal's mint
-// key is recorded on every row as the source of the bitmap. Rows are keyed
-// per (node, client) so a validator running multiple clients keeps an
-// independent claimable bit per client.
-func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIdentity map[uint32]LeafIdentity) []LeafDistributionStatusRow {
+// ProjectStatuses emits per-leaf status rows attributing each leaf to this
+// journal's reward token and recording its claimable bit. Leaves with no
+// (node_id, client_id) mapping in `leafIndexToIdentity` are silently skipped.
+// Rows are keyed per (node, client) so a validator running multiple clients
+// keeps an independent bit per client.
+//
+// In the multi-token era each journal owns only the leaves of validators who
+// picked its token, scattered across the epoch's global leaf indices. A SET
+// publisher bit is the authoritative ownership signal: it means this journal
+// accumulated the leaf and has not yet distributed it (immediately claimable),
+// and the row's JournalMintKey then identifies the validator's reward token.
+//
+// Detecting an already-distributed leaf (accumulated, then paid → bit cleared)
+// cannot be done from a cleared bit alone, because a cleared bit is
+// indistinguishable from "not this journal's leaf" — especially in the
+// multi-token era, where each journal owns only a sparse subset of the epoch's
+// global leaf indices (so the leaf index is NOT a contiguous accumulation
+// prefix). We resolve it with prior attribution: `existingMint` maps each leaf
+// index to the reward mint already recorded for it (from the persisted status
+// table). A leaf whose bit is now clear is marked distributed for THIS journal
+// only if it was previously attributed to this journal's token. A leaf never
+// captured while its bit was set (e.g. distributed before we first observed it)
+// has no prior attribution and is left out — its token is unrecoverable.
+func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIdentity map[uint32]LeafIdentity, existingMint map[uint32]string) []LeafDistributionStatusRow {
 	if view == nil {
 		return nil
 	}
-	count := view.AccumulatedPublisherLeafCount
-	if count == 0 {
-		return nil
-	}
-	rows := make([]LeafDistributionStatusRow, 0, count)
-	mintB58 := view.MintKey.String()
-	for leafIndex := uint32(0); leafIndex < count; leafIndex++ {
-		id, ok := leafIndexToIdentity[leafIndex]
-		if !ok {
-			continue
-		}
-		claimable, ok := view.IsClaimableForLeafIndex(leafIndex)
-		if !ok {
-			continue
-		}
+	rewardMint := view.RewardMintKey.String()
+
+	rows := make([]LeafDistributionStatusRow, 0, len(leafIndexToIdentity))
+	for leafIndex, id := range leafIndexToIdentity {
+		set, _ := view.IsClaimableForLeafIndex(leafIndex)
 		var bit uint8
-		if claimable {
+		switch {
+		case set:
+			// Bit set ⇒ this journal owns the leaf and it is claimable.
 			bit = 1
+		case rewardMint != "" && existingMint[leafIndex] == rewardMint:
+			// Previously attributed to this token, bit now clear ⇒ distributed.
+		default:
+			// Not owned by this journal (bit unset, no prior attribution to this
+			// token) ⇒ skip so we never mistag another token's (or an
+			// unrecoverable) leaf.
+			continue
 		}
 		rows = append(rows, LeafDistributionStatusRow{
 			PK:                LeafDistributionStatusPK(subscriptionEpoch, id.NodeID, id.ClientID),
@@ -226,7 +283,7 @@ func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIde
 			NodeID:            id.NodeID,
 			ClientID:          id.ClientID,
 			IsClaimable:       bit,
-			JournalMintKey:    mintB58,
+			JournalMintKey:    rewardMint,
 		})
 	}
 	return rows

--- a/indexer/pkg/dz/shreds/validatorrewards/journal.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal.go
@@ -184,10 +184,12 @@ func (j *JournalView) IsClaimableForLeafIndex(leafIndex uint32) (bool, bool) {
 }
 
 // ProjectStatuses emits one LeafDistributionStatusRow per leaf in
-// `[0, AccumulatedPublisherLeafCount)`. Leaves with no node-id mapping in
-// `leafIndexToNodeID` are silently skipped. The journal's mint key is
-// recorded on every row as the source of the bitmap.
-func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToNodeID map[uint32]string) []LeafDistributionStatusRow {
+// `[0, AccumulatedPublisherLeafCount)`. Leaves with no (node_id, client_id)
+// mapping in `leafIndexToIdentity` are silently skipped. The journal's mint
+// key is recorded on every row as the source of the bitmap. Rows are keyed
+// per (node, client) so a validator running multiple clients keeps an
+// independent claimable bit per client.
+func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIdentity map[uint32]LeafIdentity) []LeafDistributionStatusRow {
 	if view == nil {
 		return nil
 	}
@@ -198,7 +200,7 @@ func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToNod
 	rows := make([]LeafDistributionStatusRow, 0, count)
 	mintB58 := view.MintKey.String()
 	for leafIndex := uint32(0); leafIndex < count; leafIndex++ {
-		nodeID, ok := leafIndexToNodeID[leafIndex]
+		id, ok := leafIndexToIdentity[leafIndex]
 		if !ok {
 			continue
 		}
@@ -211,9 +213,10 @@ func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToNod
 			bit = 1
 		}
 		rows = append(rows, LeafDistributionStatusRow{
-			PK:                LeafDistributionStatusPK(subscriptionEpoch, nodeID),
+			PK:                LeafDistributionStatusPK(subscriptionEpoch, id.NodeID, id.ClientID),
 			SubscriptionEpoch: subscriptionEpoch,
-			NodeID:            nodeID,
+			NodeID:            id.NodeID,
+			ClientID:          id.ClientID,
 			IsClaimable:       bit,
 			JournalMintKey:    mintB58,
 		})

--- a/indexer/pkg/dz/shreds/validatorrewards/journal.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal.go
@@ -85,6 +85,7 @@ const (
 	offPublisherAccumulationBitmapEndIndex   = 108
 	offClientAccumulationBitmapStartIndex    = 112
 	offClientAccumulationBitmapEndIndex      = 116
+	offTotalLeaderSlots                      = 128
 	offAccumulatedPublisherLeafCount         = 152
 	offDistributedPublisherLeafCount         = 156
 )
@@ -104,8 +105,14 @@ type JournalView struct {
 	TokensReceivedAmount                  uint64
 	PublisherAccumulationBitmapStartIndex uint32
 	PublisherAccumulationBitmapEndIndex   uint32
-	AccumulatedPublisherLeafCount         uint32
-	DistributedPublisherLeafCount         uint32
+	// TotalLeaderSlots is the journal's authoritative count of all leader slots
+	// in the epoch. It is the denominator the on-chain distribution uses to
+	// split the pool by leader slots — NOT the sum of the leaves we happen to
+	// have indexed (which can be incomplete and would over-credit each present
+	// validator).
+	TotalLeaderSlots              uint32
+	AccumulatedPublisherLeafCount uint32
+	DistributedPublisherLeafCount uint32
 	// RemainingData is `account_data[journalFixedHeader:]`. Bitmaps are
 	// referenced into it via the start/end indices above.
 	RemainingData []byte
@@ -132,6 +139,7 @@ func DecodeJournalAccount(data []byte) (*JournalView, error) {
 		TokensReceivedAmount:                  binary.LittleEndian.Uint64(data[offTokensReceivedAmount : offTokensReceivedAmount+8]),
 		PublisherAccumulationBitmapStartIndex: binary.LittleEndian.Uint32(data[offPublisherAccumulationBitmapStartIndex : offPublisherAccumulationBitmapStartIndex+4]),
 		PublisherAccumulationBitmapEndIndex:   binary.LittleEndian.Uint32(data[offPublisherAccumulationBitmapEndIndex : offPublisherAccumulationBitmapEndIndex+4]),
+		TotalLeaderSlots:                      binary.LittleEndian.Uint32(data[offTotalLeaderSlots : offTotalLeaderSlots+4]),
 		AccumulatedPublisherLeafCount:         binary.LittleEndian.Uint32(data[offAccumulatedPublisherLeafCount : offAccumulatedPublisherLeafCount+4]),
 		DistributedPublisherLeafCount:         binary.LittleEndian.Uint32(data[offDistributedPublisherLeafCount : offDistributedPublisherLeafCount+4]),
 		RemainingData:                         data[journalFixedHeader:],

--- a/indexer/pkg/dz/shreds/validatorrewards/journal.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal.go
@@ -232,50 +232,102 @@ func (j *JournalView) IsClaimableForLeafIndex(leafIndex uint32) (bool, bool) {
 	return set, true
 }
 
-// ProjectStatuses emits per-leaf status rows attributing each leaf to this
-// journal's reward token and recording its claimable bit. Leaves with no
-// (node_id, client_id) mapping in `leafIndexToIdentity` are silently skipped.
-// Rows are keyed per (node, client) so a validator running multiple clients
-// keeps an independent bit per client.
+// CollectClaimableTokens records, for every leaf currently claimable (its
+// publisher bit is SET in one of the epoch's journals), the reward mint of the
+// owning journal into dst, keyed by (node, client). A set bit is the
+// authoritative ownership signal, so this is the source of truth for which token
+// each validator picked. Accumulated across all epochs, dst lets a leaf that is
+// now distributed (cleared everywhere) still be attributed to the token the
+// validator was last seen claimable in.
+func CollectClaimableTokens(views []*JournalView, leafIndexToIdentity map[uint32]LeafIdentity, dst map[LeafIdentity]string) {
+	for leafIndex, id := range leafIndexToIdentity {
+		for _, v := range views {
+			if v == nil {
+				continue
+			}
+			if set, ok := v.IsClaimableForLeafIndex(leafIndex); ok && set {
+				dst[id] = v.RewardMintKey.String()
+				break
+			}
+		}
+	}
+}
+
+// ProjectEpochStatuses emits per-leaf status rows for one subscription epoch by
+// reading ALL of the epoch's still-live token journals together. Rows are keyed
+// per (node, client) so a validator running multiple clients keeps an
+// independent bit per client; leaves with no identity mapping are skipped.
 //
-// In the multi-token era each journal owns only the leaves of validators who
-// picked its token, scattered across the epoch's global leaf indices. A SET
-// publisher bit is the authoritative ownership signal: it means this journal
-// accumulated the leaf and has not yet distributed it (immediately claimable),
-// and the row's JournalMintKey then identifies the validator's reward token.
+// Unlike a per-journal projection this needs no observation history. Every leaf
+// accumulates into exactly one token journal, so Σ accumulated_publisher_leaf_count
+// across the epoch's journals equals the leaf count once accumulation is
+// complete. Given that:
 //
-// Detecting an already-distributed leaf (accumulated, then paid → bit cleared)
-// cannot be done from a cleared bit alone, because a cleared bit is
-// indistinguishable from "not this journal's leaf" — especially in the
-// multi-token era, where each journal owns only a sparse subset of the epoch's
-// global leaf indices (so the leaf index is NOT a contiguous accumulation
-// prefix). We resolve it with prior attribution: `existingMint` maps each leaf
-// index to the reward mint already recorded for it (from the persisted status
-// table). A leaf whose bit is now clear is marked distributed for THIS journal
-// only if it was previously attributed to this journal's token. A leaf never
-// captured while its bit was set (e.g. distributed before we first observed it)
-// has no prior attribution and is left out — its token is unrecoverable.
-func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIdentity map[uint32]LeafIdentity, existingMint map[uint32]string) []LeafDistributionStatusRow {
-	if view == nil {
+//   - A SET publisher bit in some journal ⇒ that journal owns the leaf and it is
+//     claimable; the journal's reward mint is the validator's token.
+//   - A bit CLEAR in EVERY journal, in a fully-accumulated epoch ⇒ the leaf was
+//     accumulated then distributed (paid). Its token can't be read from a cleared
+//     bitmap. When the epoch has a single journal the token is unambiguous (every
+//     leaf belongs to it); otherwise it is taken from tokenByIdentity (the
+//     validator's claimable observations elsewhere), defaulting to 2Z.
+//   - A bit clear everywhere while the epoch is NOT yet fully accumulated ⇒ the
+//     leaf simply hasn't been accumulated yet; it is left out (pending).
+//
+// Because it derives distribution from the live on-chain bitmaps every refresh,
+// it is stateless-correct: an already-distributed leaf is reconstructed without
+// ever having been observed while claimable, as long as its journals are live.
+func ProjectEpochStatuses(
+	subscriptionEpoch uint64,
+	views []*JournalView,
+	leafIndexToIdentity map[uint32]LeafIdentity,
+	tokenByIdentity map[LeafIdentity]string,
+) []LeafDistributionStatusRow {
+	if len(views) == 0 {
 		return nil
 	}
-	rewardMint := view.RewardMintKey.String()
+	var sumAccumulated uint64
+	for _, v := range views {
+		if v != nil {
+			sumAccumulated += uint64(v.AccumulatedPublisherLeafCount)
+		}
+	}
+	fullyAccumulated := sumAccumulated >= uint64(len(leafIndexToIdentity))
 
 	rows := make([]LeafDistributionStatusRow, 0, len(leafIndexToIdentity))
 	for leafIndex, id := range leafIndexToIdentity {
-		set, _ := view.IsClaimableForLeafIndex(leafIndex)
+		var mint string
+		var claimable, owned bool
+		for _, v := range views {
+			if v == nil {
+				continue
+			}
+			if set, ok := v.IsClaimableForLeafIndex(leafIndex); ok && set {
+				mint, claimable, owned = v.RewardMintKey.String(), true, true
+				break
+			}
+		}
+		if !owned {
+			if !fullyAccumulated {
+				// Not yet accumulated into any journal — pending. Skip.
+				continue
+			}
+			// Distributed. The reward token is unrecoverable from a cleared
+			// bitmap. If the epoch has a single journal the token is unambiguous
+			// (every leaf belongs to it — this covers all pre-multi-token epochs,
+			// which always had one 2Z journal). Otherwise borrow the token from
+			// the validator's claimable observations elsewhere, defaulting to 2Z.
+			switch {
+			case len(views) == 1:
+				mint = views[0].RewardMintKey.String()
+			case tokenByIdentity[id] != "":
+				mint = tokenByIdentity[id]
+			default:
+				mint = DoubleZeroMintKey
+			}
+		}
 		var bit uint8
-		switch {
-		case set:
-			// Bit set ⇒ this journal owns the leaf and it is claimable.
+		if claimable {
 			bit = 1
-		case rewardMint != "" && existingMint[leafIndex] == rewardMint:
-			// Previously attributed to this token, bit now clear ⇒ distributed.
-		default:
-			// Not owned by this journal (bit unset, no prior attribution to this
-			// token) ⇒ skip so we never mistag another token's (or an
-			// unrecoverable) leaf.
-			continue
 		}
 		rows = append(rows, LeafDistributionStatusRow{
 			PK:                LeafDistributionStatusPK(subscriptionEpoch, id.NodeID, id.ClientID),
@@ -283,7 +335,7 @@ func ProjectStatuses(view *JournalView, subscriptionEpoch uint64, leafIndexToIde
 			NodeID:            id.NodeID,
 			ClientID:          id.ClientID,
 			IsClaimable:       bit,
-			JournalMintKey:    rewardMint,
+			JournalMintKey:    mint,
 		})
 	}
 	return rows

--- a/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
@@ -166,32 +166,36 @@ func TestIsClaimableForLeafIndex_BitmapUnallocated(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
+// indexByNode keys status rows by node_id for convenient assertions.
+func indexByNode(rows []LeafDistributionStatusRow) map[string]LeafDistributionStatusRow {
+	m := make(map[string]LeafDistributionStatusRow, len(rows))
+	for _, r := range rows {
+		m[r.NodeID] = r
+	}
+	return m
+}
+
+func TestProjectEpochStatuses_PartialAccumulationPending(t *testing.T) {
 	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
-	// Bits 0 and 1 set (claimable), bit 2 clear; accumulated count is 2. The
-	// two set bits emit claimable rows; leaf index 2 has a clear bit and lies
-	// beyond the accumulated prefix, so it is neither claimable nor a
-	// distributed leaf — it must be excluded (pending).
+	// Bits 0 and 1 set (claimable), bit 2 clear; accumulated count is 2 but the
+	// map has 3 leaves, so the epoch is NOT fully accumulated. Leaf 2 hasn't been
+	// accumulated yet → pending (no row), not distributed.
 	bitmap := []byte{0b00000011}
 	data := buildJournalAccount(t, 951, mint, mint, 2, 0, bitmap)
 
 	view, err := DecodeJournalAccount(data)
 	require.NoError(t, err)
 
-	leafIndexToNodeID := map[uint32]LeafIdentity{
+	leafMap := map[uint32]LeafIdentity{
 		0: {NodeID: "node-a", ClientID: 1},
 		1: {NodeID: "node-b", ClientID: 2},
 		2: {NodeID: "node-c", ClientID: 1},
 	}
 
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID, nil)
+	rows := ProjectEpochStatuses(951, []*JournalView{view}, leafMap, nil)
 	require.Len(t, rows, 2)
 
-	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
-	for _, r := range rows {
-		byNode[r.NodeID] = r
-	}
-
+	byNode := indexByNode(rows)
 	rowA, ok := byNode["node-a"]
 	require.True(t, ok)
 	assert.Equal(t, uint64(951), rowA.SubscriptionEpoch)
@@ -200,25 +204,45 @@ func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 	assert.Equal(t, uint8(1), rowA.IsClaimable)
 	assert.Equal(t, DoubleZeroMintKey, rowA.JournalMintKey)
 
-	rowB, ok := byNode["node-b"]
-	require.True(t, ok)
-	assert.Equal(t, uint8(1), rowB.IsClaimable)
+	assert.Equal(t, uint8(1), byNode["node-b"].IsClaimable)
 
-	// node-c (leaf index 2) has a clear bit beyond the accumulated prefix — excluded.
 	_, ok = byNode["node-c"]
-	assert.False(t, ok)
+	assert.False(t, ok, "leaf 2 not yet accumulated → pending, no row")
 }
 
-// TestProjectStatuses_NonPublisherTokenAttribution covers the multi-token era:
-// a non-2Z journal (here USDC) owns a sparse, high global leaf index. Its set
-// bit must attribute the leaf to the journal's reward mint (USDC) and mark it
-// claimable, while a clear bit must NOT emit a (distributed) row — only the 2Z
-// journal tracks distribution via its accumulated prefix.
-func TestProjectStatuses_NonPublisherTokenAttribution(t *testing.T) {
+func TestProjectEpochStatuses_FullAccumulationDistributed(t *testing.T) {
+	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	// Bits 0 and 2 set, bit 1 clear; accumulated == leaf count (3), so the epoch
+	// is fully accumulated and leaf 1's cleared bit ⇒ distributed — derived from
+	// the live bitmap with no observation history.
+	bitmap := []byte{0b00000101}
+	data := buildJournalAccount(t, 951, mint, mint, 3, 1, bitmap)
+
+	view, err := DecodeJournalAccount(data)
+	require.NoError(t, err)
+
+	leafMap := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1},
+		1: {NodeID: "node-b", ClientID: 2},
+		2: {NodeID: "node-c", ClientID: 1},
+	}
+
+	rows := ProjectEpochStatuses(951, []*JournalView{view}, leafMap, nil)
+	require.Len(t, rows, 3)
+
+	byNode := indexByNode(rows)
+	assert.Equal(t, uint8(1), byNode["node-a"].IsClaimable)
+	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable, "cleared bit in fully-accumulated epoch ⇒ distributed")
+	assert.Equal(t, DoubleZeroMintKey, byNode["node-b"].JournalMintKey, "pre-968 distributed defaults to 2Z")
+	assert.Equal(t, uint8(1), byNode["node-c"].IsClaimable)
+}
+
+// TestProjectEpochStatuses_NonPublisherTokenClaimable covers the multi-token
+// era: a non-2Z journal (here USDC) owns a sparse, high global leaf index. Its
+// set bit attributes the leaf to USDC and marks it claimable. The other leaf is
+// clear but the epoch is not fully accumulated, so it stays pending.
+func TestProjectEpochStatuses_NonPublisherTokenClaimable(t *testing.T) {
 	usdc := solana.MustPublicKeyFromBase58(USDCMintKey)
-	// Leaf at global index 17 owned by the USDC journal (bit 17 set); leaf at
-	// index 3 is not owned (bit clear). accumulatedCount is irrelevant for a
-	// non-2Z journal — ownership is the set bit alone.
 	bitmap := make([]byte, 3) // covers indices 0..23
 	bitmap[17/8] = 1 << (17 % 8)
 	data := buildJournalAccount(t, 970, usdc, usdc, 1, 0, bitmap)
@@ -227,20 +251,20 @@ func TestProjectStatuses_NonPublisherTokenAttribution(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, usdc, view.RewardMintKey)
 
-	leafIndexToIdentity := map[uint32]LeafIdentity{
+	leafMap := map[uint32]LeafIdentity{
 		3:  {NodeID: "node-x", ClientID: 1},
 		17: {NodeID: "node-y", ClientID: 2},
 	}
 
-	rows := ProjectStatuses(view, 970, leafIndexToIdentity, nil)
-	require.Len(t, rows, 1, "only the set-bit leaf is owned by this token journal")
+	rows := ProjectEpochStatuses(970, []*JournalView{view}, leafMap, nil)
+	require.Len(t, rows, 1, "set-bit leaf claimable; the other isn't accumulated yet (pending)")
 	assert.Equal(t, "node-y", rows[0].NodeID)
 	assert.Equal(t, uint16(2), rows[0].ClientID)
 	assert.Equal(t, uint8(1), rows[0].IsClaimable)
 	assert.Equal(t, USDCMintKey, rows[0].JournalMintKey, "leaf attributed to USDC")
 }
 
-func TestProjectStatuses_MissingLeafInMap(t *testing.T) {
+func TestProjectEpochStatuses_MissingLeafInMap(t *testing.T) {
 	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
 	bitmap := []byte{0b00000101}
 	data := buildJournalAccount(t, 951, mint, mint, 3, 0, bitmap)
@@ -248,87 +272,96 @@ func TestProjectStatuses_MissingLeafInMap(t *testing.T) {
 	view, err := DecodeJournalAccount(data)
 	require.NoError(t, err)
 
-	// Only leaf index 0 and 2 have a node-id mapping. Leaf 1 has no
-	// mapping and must be silently skipped.
-	leafIndexToNodeID := map[uint32]LeafIdentity{
+	// Only leaf index 0 and 2 have a mapping. Leaf 1 has none → silently skipped.
+	leafMap := map[uint32]LeafIdentity{
 		0: {NodeID: "node-a", ClientID: 1},
 		2: {NodeID: "node-c", ClientID: 1},
 	}
 
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID, nil)
+	rows := ProjectEpochStatuses(951, []*JournalView{view}, leafMap, nil)
 	require.Len(t, rows, 2)
-
-	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
-	for _, r := range rows {
-		byNode[r.NodeID] = r
-	}
-
-	rowA, ok := byNode["node-a"]
-	require.True(t, ok)
-	assert.Equal(t, uint8(1), rowA.IsClaimable)
-
-	rowC, ok := byNode["node-c"]
-	require.True(t, ok)
-	assert.Equal(t, uint8(1), rowC.IsClaimable)
-}
-
-func TestProjectStatuses_ClearedBitEmitsZero(t *testing.T) {
-	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
-	// Bit 0 set, bit 1 clear, bit 2 set.
-	bitmap := []byte{0b00000101}
-	data := buildJournalAccount(t, 951, mint, mint, 3, 1, bitmap)
-
-	view, err := DecodeJournalAccount(data)
-	require.NoError(t, err)
-
-	leafIndexToNodeID := map[uint32]LeafIdentity{
-		0: {NodeID: "node-a", ClientID: 1},
-		1: {NodeID: "node-b", ClientID: 2},
-		2: {NodeID: "node-c", ClientID: 1},
-	}
-	// node-b's leaf was previously attributed to 2Z, so its now-cleared bit marks
-	// it distributed (claimable=0). Without that prior attribution it would be
-	// skipped (an unrecoverable/other-token leaf), not assumed 2Z.
-	existingMint := map[uint32]string{1: DoubleZeroMintKey}
-
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID, existingMint)
-	require.Len(t, rows, 3)
-
-	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
-	for _, r := range rows {
-		byNode[r.NodeID] = r
-	}
-
+	byNode := indexByNode(rows)
 	assert.Equal(t, uint8(1), byNode["node-a"].IsClaimable)
-	// bit 1 clear + previously 2Z → distributed.
-	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable)
 	assert.Equal(t, uint8(1), byNode["node-c"].IsClaimable)
 }
 
-// TestProjectStatuses_MultiClientSameNode is the regression test for the bug
-// where a validator publishing under more than one software client in a single
-// epoch was collapsed to one row. The two leaves share a node_id but differ by
-// client_id, so they must produce two distinct rows with distinct PKs and
-// independent claimable bits.
-func TestProjectStatuses_MultiClientSameNode(t *testing.T) {
-	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
-	// Two accumulated leaves: bit 0 set (claimable), bit 1 clear.
-	bitmap := []byte{0b00000001}
-	data := buildJournalAccount(t, 951, mint, mint, 2, 0, bitmap)
+// TestProjectEpochStatuses_MultiToken covers a fully-accumulated multi-token
+// epoch: a 2Z journal and a USDC journal. A set bit identifies the owning token
+// (claimable); a leaf cleared in EVERY journal is distributed, with its token
+// taken from the claimable-observation map.
+func TestProjectEpochStatuses_MultiToken(t *testing.T) {
+	twoZ := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	usdc := solana.MustPublicKeyFromBase58(USDCMintKey)
+	// 2Z journal owns leaf 0 (bit 0 set), accumulated 1.
+	zView, err := DecodeJournalAccount(buildJournalAccount(t, 970, twoZ, twoZ, 1, 0, []byte{0b00000001}))
+	require.NoError(t, err)
+	// USDC journal: leaf 1 set (claimable), leaf 2 clear (distributed). accumulated 2.
+	uView, err := DecodeJournalAccount(buildJournalAccount(t, 970, usdc, usdc, 2, 1, []byte{0b00000010}))
+	require.NoError(t, err)
 
+	views := []*JournalView{zView, uView}
+	leafMap := map[uint32]LeafIdentity{
+		0: {NodeID: "node-z", ClientID: 1},
+		1: {NodeID: "node-u", ClientID: 1},
+		2: {NodeID: "node-w", ClientID: 1},
+	}
+	// Σ accumulated = 3 = leaf count → fully accumulated.
+	tokenByIdentity := map[LeafIdentity]string{}
+	CollectClaimableTokens(views, leafMap, tokenByIdentity)
+	// node-w is distributed (not claimable this epoch); mimic a prior claimable
+	// observation in USDC so its distributed leaf attributes to USDC.
+	tokenByIdentity[LeafIdentity{NodeID: "node-w", ClientID: 1}] = USDCMintKey
+
+	rows := ProjectEpochStatuses(970, views, leafMap, tokenByIdentity)
+	require.Len(t, rows, 3)
+	byNode := indexByNode(rows)
+	assert.Equal(t, uint8(1), byNode["node-z"].IsClaimable)
+	assert.Equal(t, DoubleZeroMintKey, byNode["node-z"].JournalMintKey)
+	assert.Equal(t, uint8(1), byNode["node-u"].IsClaimable)
+	assert.Equal(t, USDCMintKey, byNode["node-u"].JournalMintKey)
+	assert.Equal(t, uint8(0), byNode["node-w"].IsClaimable, "cleared everywhere + fully accumulated ⇒ distributed")
+	assert.Equal(t, USDCMintKey, byNode["node-w"].JournalMintKey, "distributed token from claimable-observation map")
+}
+
+// TestProjectEpochStatuses_SingleJournalDistributedTokenUnambiguous: when an
+// epoch has a single journal, a distributed leaf takes that journal's token and
+// the cross-epoch token map is ignored. This is what keeps pre-multi-token
+// epochs (always one 2Z journal) correctly 2Z even for a validator that later
+// switched to USDC — without any hardcoded launch epoch.
+func TestProjectEpochStatuses_SingleJournalDistributedTokenUnambiguous(t *testing.T) {
+	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	// bit 0 clear, accumulated 1 == leaf count → fully accumulated → distributed.
+	data := buildJournalAccount(t, 960, mint, mint, 1, 1, []byte{0b00000000})
 	view, err := DecodeJournalAccount(data)
 	require.NoError(t, err)
 
-	// Same node_id, two different client_ids — distinct leaves.
-	leafIndexToIdentity := map[uint32]LeafIdentity{
+	leafMap := map[uint32]LeafIdentity{0: {NodeID: "node-a", ClientID: 1}}
+	// Map says USDC, but the single 2Z journal wins (unambiguous).
+	tokenByIdentity := map[LeafIdentity]string{{NodeID: "node-a", ClientID: 1}: USDCMintKey}
+
+	rows := ProjectEpochStatuses(960, []*JournalView{view}, leafMap, tokenByIdentity)
+	require.Len(t, rows, 1)
+	assert.Equal(t, uint8(0), rows[0].IsClaimable)
+	assert.Equal(t, DoubleZeroMintKey, rows[0].JournalMintKey, "single-journal epoch ⇒ that journal's token")
+}
+
+// TestProjectEpochStatuses_MultiClientSameNode is the regression test for the
+// bug where a validator publishing under more than one software client in a
+// single epoch was collapsed to one row. The leaves share a node_id but differ
+// by client_id, so they produce two distinct rows with independent bits.
+func TestProjectEpochStatuses_MultiClientSameNode(t *testing.T) {
+	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	// bit 0 set (claimable), bit 1 clear (distributed); accumulated == leaf count 2.
+	data := buildJournalAccount(t, 951, mint, mint, 2, 1, []byte{0b00000001})
+	view, err := DecodeJournalAccount(data)
+	require.NoError(t, err)
+
+	leafMap := map[uint32]LeafIdentity{
 		0: {NodeID: "node-a", ClientID: 1},
 		1: {NodeID: "node-a", ClientID: 2},
 	}
-	// client 2's leaf was previously attributed to 2Z, so its cleared bit marks
-	// it distributed; client 1's bit is still set (claimable).
-	existingMint := map[uint32]string{1: DoubleZeroMintKey}
 
-	rows := ProjectStatuses(view, 951, leafIndexToIdentity, existingMint)
+	rows := ProjectEpochStatuses(951, []*JournalView{view}, leafMap, nil)
 	require.Len(t, rows, 2, "each (node, client) leaf must produce its own row")
 
 	byClient := make(map[uint16]LeafDistributionStatusRow, len(rows))
@@ -336,53 +369,38 @@ func TestProjectStatuses_MultiClientSameNode(t *testing.T) {
 		assert.Equal(t, "node-a", r.NodeID)
 		byClient[r.ClientID] = r
 	}
-
-	require.Contains(t, byClient, uint16(1))
-	require.Contains(t, byClient, uint16(2))
 	assert.NotEqual(t, byClient[1].PK, byClient[2].PK, "PKs must differ by client_id")
 	assert.Equal(t, LeafDistributionStatusPK(951, "node-a", 1), byClient[1].PK)
 	assert.Equal(t, LeafDistributionStatusPK(951, "node-a", 2), byClient[2].PK)
-	// Independent claimable bits: client 1 claimable, client 2 not.
 	assert.Equal(t, uint8(1), byClient[1].IsClaimable)
 	assert.Equal(t, uint8(0), byClient[2].IsClaimable)
 }
 
-// TestProjectStatuses_SkipsLeafAttributedToOtherToken verifies the prior-
-// attribution guard: when the 2Z journal's bit for a leaf is clear, the leaf is
-// marked distributed-2Z ONLY if it was previously attributed to 2Z. A leaf
-// previously attributed to another token (USDC), or never attributed at all, is
-// skipped — never mistagged as a distributed 2Z leaf.
-func TestProjectStatuses_SkipsLeafAttributedToOtherToken(t *testing.T) {
-	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
-	// bit 0 set, bits 1 and 2 clear.
-	bitmap := []byte{0b00000001}
-	data := buildJournalAccount(t, 951, mint, mint, 3, 0, bitmap)
-	view, err := DecodeJournalAccount(data)
+func TestProjectEpochStatuses_NoViews(t *testing.T) {
+	rows := ProjectEpochStatuses(951, nil, map[uint32]LeafIdentity{0: {NodeID: "n", ClientID: 1}}, nil)
+	assert.Empty(t, rows)
+}
+
+func TestCollectClaimableTokens(t *testing.T) {
+	twoZ := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	usdc := solana.MustPublicKeyFromBase58(USDCMintKey)
+	zView, err := DecodeJournalAccount(buildJournalAccount(t, 970, twoZ, twoZ, 1, 0, []byte{0b00000001}))
+	require.NoError(t, err)
+	uView, err := DecodeJournalAccount(buildJournalAccount(t, 970, usdc, usdc, 1, 0, []byte{0b00000010}))
 	require.NoError(t, err)
 
-	leafIndexToIdentity := map[uint32]LeafIdentity{
-		0: {NodeID: "node-a", ClientID: 1}, // bit set -> claimable
-		1: {NodeID: "node-b", ClientID: 1}, // bit clear, previously 2Z -> distributed
-		2: {NodeID: "node-c", ClientID: 1}, // bit clear, previously USDC -> skip
-		3: {NodeID: "node-d", ClientID: 1}, // bit clear, never attributed -> skip
+	leafMap := map[uint32]LeafIdentity{
+		0: {NodeID: "node-z", ClientID: 1}, // set in 2Z
+		1: {NodeID: "node-u", ClientID: 1}, // set in USDC
+		2: {NodeID: "node-x", ClientID: 1}, // set in neither
 	}
-	existingMint := map[uint32]string{
-		1: DoubleZeroMintKey,
-		2: USDCMintKey,
-	}
+	dst := map[LeafIdentity]string{}
+	CollectClaimableTokens([]*JournalView{zView, uView}, leafMap, dst)
 
-	rows := ProjectStatuses(view, 951, leafIndexToIdentity, existingMint)
-	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
-	for _, r := range rows {
-		byNode[r.NodeID] = r
-	}
-	require.Len(t, rows, 2, "only the set-bit leaf and the previously-2Z leaf emit rows")
-	assert.Equal(t, uint8(1), byNode["node-a"].IsClaimable, "node-a claimable")
-	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable, "node-b distributed (was 2Z)")
-	_, ok := byNode["node-c"]
-	assert.False(t, ok, "node-c was USDC — must not be tagged a distributed 2Z leaf")
-	_, ok = byNode["node-d"]
-	assert.False(t, ok, "node-d never attributed — must be skipped, not assumed 2Z")
+	assert.Equal(t, DoubleZeroMintKey, dst[LeafIdentity{NodeID: "node-z", ClientID: 1}])
+	assert.Equal(t, USDCMintKey, dst[LeafIdentity{NodeID: "node-u", ClientID: 1}])
+	_, ok := dst[LeafIdentity{NodeID: "node-x", ClientID: 1}]
+	assert.False(t, ok, "leaf set in no journal is not recorded")
 }
 
 func TestJournalPDA_IsDeterministic(t *testing.T) {

--- a/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
@@ -60,13 +60,20 @@ func buildJournalAccount(
 
 	// padding (4B) zero
 
-	// accumulated_publisher_slots_scaled (8B), accumulated_client_slots_scaled (8B) zero
+	// accumulated_publisher_slots_scaled (8B) at 136 and
+	// accumulated_client_slots_scaled (8B) at 144 — recognizable sentinels so the
+	// per-token scaled-slot denominator decode is exercised (sum = 1_538_000).
+	binary.LittleEndian.PutUint64(buf[136:144], 1_000_000)
+	binary.LittleEndian.PutUint64(buf[144:152], 538_000)
 
 	// accumulated_publisher_leaf_count
 	binary.LittleEndian.PutUint32(buf[152:156], accumulatedPublisherLeafCount)
 	binary.LittleEndian.PutUint32(buf[156:160], distributedPublisherLeafCount)
 
-	// distributed_amount (8B), accumulated_client_leaf_count (4B),
+	// distributed_amount (8B) at 160 — sentinel so the decode is exercised.
+	binary.LittleEndian.PutUint64(buf[160:168], 4_242_000)
+
+	// accumulated_client_leaf_count (4B),
 	// distributed_client_leaf_count (4B), padding (16B),
 	// first_distribute_timestamp (8B), gap (96B) — all zero.
 
@@ -86,12 +93,17 @@ func TestDecodeJournalAccount_ValidLayout(t *testing.T) {
 
 	assert.Equal(t, uint64(951), view.SubscriptionEpoch)
 	assert.Equal(t, mint, view.MintKey)
+	assert.Equal(t, reward, view.RewardMintKey)
 	assert.Equal(t, uint64(7_000_000), view.TokensReceivedAmount)
 	assert.Equal(t, uint32(0), view.PublisherAccumulationBitmapStartIndex)
 	assert.Equal(t, uint32(len(bitmap)), view.PublisherAccumulationBitmapEndIndex)
 	assert.Equal(t, uint32(4242), view.TotalLeaderSlots)
+	assert.Equal(t, uint64(1_000_000), view.AccumulatedPublisherSlotsScaled)
+	assert.Equal(t, uint64(538_000), view.AccumulatedClientSlotsScaled)
+	assert.Equal(t, uint64(1_538_000), view.AccumulatedSlotsScaledDenominator())
 	assert.Equal(t, uint32(5), view.AccumulatedPublisherLeafCount)
 	assert.Equal(t, uint32(2), view.DistributedPublisherLeafCount)
+	assert.Equal(t, uint64(4_242_000), view.DistributedAmount)
 	assert.Equal(t, bitmap, view.RemainingData)
 }
 
@@ -156,9 +168,11 @@ func TestIsClaimableForLeafIndex_BitmapUnallocated(t *testing.T) {
 
 func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
-	// Bitmap has 3 bits set (indices 0, 1, 2) but accumulated count is 2,
-	// so only the first two leaves should emit rows.
-	bitmap := []byte{0b00000111}
+	// Bits 0 and 1 set (claimable), bit 2 clear; accumulated count is 2. The
+	// two set bits emit claimable rows; leaf index 2 has a clear bit and lies
+	// beyond the accumulated prefix, so it is neither claimable nor a
+	// distributed leaf — it must be excluded (pending).
+	bitmap := []byte{0b00000011}
 	data := buildJournalAccount(t, 951, mint, mint, 2, 0, bitmap)
 
 	view, err := DecodeJournalAccount(data)
@@ -170,7 +184,7 @@ func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 		2: {NodeID: "node-c", ClientID: 1},
 	}
 
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
+	rows := ProjectStatuses(view, 951, leafIndexToNodeID, nil)
 	require.Len(t, rows, 2)
 
 	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
@@ -190,9 +204,40 @@ func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, uint8(1), rowB.IsClaimable)
 
-	// node-c is at leaf index 2 — beyond accumulated count — excluded.
+	// node-c (leaf index 2) has a clear bit beyond the accumulated prefix — excluded.
 	_, ok = byNode["node-c"]
 	assert.False(t, ok)
+}
+
+// TestProjectStatuses_NonPublisherTokenAttribution covers the multi-token era:
+// a non-2Z journal (here USDC) owns a sparse, high global leaf index. Its set
+// bit must attribute the leaf to the journal's reward mint (USDC) and mark it
+// claimable, while a clear bit must NOT emit a (distributed) row — only the 2Z
+// journal tracks distribution via its accumulated prefix.
+func TestProjectStatuses_NonPublisherTokenAttribution(t *testing.T) {
+	usdc := solana.MustPublicKeyFromBase58(USDCMintKey)
+	// Leaf at global index 17 owned by the USDC journal (bit 17 set); leaf at
+	// index 3 is not owned (bit clear). accumulatedCount is irrelevant for a
+	// non-2Z journal — ownership is the set bit alone.
+	bitmap := make([]byte, 3) // covers indices 0..23
+	bitmap[17/8] = 1 << (17 % 8)
+	data := buildJournalAccount(t, 970, usdc, usdc, 1, 0, bitmap)
+
+	view, err := DecodeJournalAccount(data)
+	require.NoError(t, err)
+	require.Equal(t, usdc, view.RewardMintKey)
+
+	leafIndexToIdentity := map[uint32]LeafIdentity{
+		3:  {NodeID: "node-x", ClientID: 1},
+		17: {NodeID: "node-y", ClientID: 2},
+	}
+
+	rows := ProjectStatuses(view, 970, leafIndexToIdentity, nil)
+	require.Len(t, rows, 1, "only the set-bit leaf is owned by this token journal")
+	assert.Equal(t, "node-y", rows[0].NodeID)
+	assert.Equal(t, uint16(2), rows[0].ClientID)
+	assert.Equal(t, uint8(1), rows[0].IsClaimable)
+	assert.Equal(t, USDCMintKey, rows[0].JournalMintKey, "leaf attributed to USDC")
 }
 
 func TestProjectStatuses_MissingLeafInMap(t *testing.T) {
@@ -210,7 +255,7 @@ func TestProjectStatuses_MissingLeafInMap(t *testing.T) {
 		2: {NodeID: "node-c", ClientID: 1},
 	}
 
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
+	rows := ProjectStatuses(view, 951, leafIndexToNodeID, nil)
 	require.Len(t, rows, 2)
 
 	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
@@ -241,8 +286,12 @@ func TestProjectStatuses_ClearedBitEmitsZero(t *testing.T) {
 		1: {NodeID: "node-b", ClientID: 2},
 		2: {NodeID: "node-c", ClientID: 1},
 	}
+	// node-b's leaf was previously attributed to 2Z, so its now-cleared bit marks
+	// it distributed (claimable=0). Without that prior attribution it would be
+	// skipped (an unrecoverable/other-token leaf), not assumed 2Z.
+	existingMint := map[uint32]string{1: DoubleZeroMintKey}
 
-	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
+	rows := ProjectStatuses(view, 951, leafIndexToNodeID, existingMint)
 	require.Len(t, rows, 3)
 
 	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
@@ -251,7 +300,7 @@ func TestProjectStatuses_ClearedBitEmitsZero(t *testing.T) {
 	}
 
 	assert.Equal(t, uint8(1), byNode["node-a"].IsClaimable)
-	// bit 1 is clear → already distributed (or never accumulated).
+	// bit 1 clear + previously 2Z → distributed.
 	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable)
 	assert.Equal(t, uint8(1), byNode["node-c"].IsClaimable)
 }
@@ -275,8 +324,11 @@ func TestProjectStatuses_MultiClientSameNode(t *testing.T) {
 		0: {NodeID: "node-a", ClientID: 1},
 		1: {NodeID: "node-a", ClientID: 2},
 	}
+	// client 2's leaf was previously attributed to 2Z, so its cleared bit marks
+	// it distributed; client 1's bit is still set (claimable).
+	existingMint := map[uint32]string{1: DoubleZeroMintKey}
 
-	rows := ProjectStatuses(view, 951, leafIndexToIdentity)
+	rows := ProjectStatuses(view, 951, leafIndexToIdentity, existingMint)
 	require.Len(t, rows, 2, "each (node, client) leaf must produce its own row")
 
 	byClient := make(map[uint16]LeafDistributionStatusRow, len(rows))
@@ -293,6 +345,44 @@ func TestProjectStatuses_MultiClientSameNode(t *testing.T) {
 	// Independent claimable bits: client 1 claimable, client 2 not.
 	assert.Equal(t, uint8(1), byClient[1].IsClaimable)
 	assert.Equal(t, uint8(0), byClient[2].IsClaimable)
+}
+
+// TestProjectStatuses_SkipsLeafAttributedToOtherToken verifies the prior-
+// attribution guard: when the 2Z journal's bit for a leaf is clear, the leaf is
+// marked distributed-2Z ONLY if it was previously attributed to 2Z. A leaf
+// previously attributed to another token (USDC), or never attributed at all, is
+// skipped — never mistagged as a distributed 2Z leaf.
+func TestProjectStatuses_SkipsLeafAttributedToOtherToken(t *testing.T) {
+	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	// bit 0 set, bits 1 and 2 clear.
+	bitmap := []byte{0b00000001}
+	data := buildJournalAccount(t, 951, mint, mint, 3, 0, bitmap)
+	view, err := DecodeJournalAccount(data)
+	require.NoError(t, err)
+
+	leafIndexToIdentity := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1}, // bit set -> claimable
+		1: {NodeID: "node-b", ClientID: 1}, // bit clear, previously 2Z -> distributed
+		2: {NodeID: "node-c", ClientID: 1}, // bit clear, previously USDC -> skip
+		3: {NodeID: "node-d", ClientID: 1}, // bit clear, never attributed -> skip
+	}
+	existingMint := map[uint32]string{
+		1: DoubleZeroMintKey,
+		2: USDCMintKey,
+	}
+
+	rows := ProjectStatuses(view, 951, leafIndexToIdentity, existingMint)
+	byNode := make(map[string]LeafDistributionStatusRow, len(rows))
+	for _, r := range rows {
+		byNode[r.NodeID] = r
+	}
+	require.Len(t, rows, 2, "only the set-bit leaf and the previously-2Z leaf emit rows")
+	assert.Equal(t, uint8(1), byNode["node-a"].IsClaimable, "node-a claimable")
+	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable, "node-b distributed (was 2Z)")
+	_, ok := byNode["node-c"]
+	assert.False(t, ok, "node-c was USDC — must not be tagged a distributed 2Z leaf")
+	_, ok = byNode["node-d"]
+	assert.False(t, ok, "node-d never attributed — must be skipped, not assumed 2Z")
 }
 
 func TestJournalPDA_IsDeterministic(t *testing.T) {

--- a/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
@@ -54,7 +54,11 @@ func buildJournalAccount(
 
 	// client bitmap left zero (unallocated)
 
-	// validator_pool (8B), total_leader_slots (4B), padding (4B) zero
+	// validator_pool (8B) at 120 left zero; total_leader_slots (u32) at 128 —
+	// a recognizable sentinel so the decode of the denominator is exercised.
+	binary.LittleEndian.PutUint32(buf[128:132], 4242)
+
+	// padding (4B) zero
 
 	// accumulated_publisher_slots_scaled (8B), accumulated_client_slots_scaled (8B) zero
 
@@ -85,6 +89,7 @@ func TestDecodeJournalAccount_ValidLayout(t *testing.T) {
 	assert.Equal(t, uint64(7_000_000), view.TokensReceivedAmount)
 	assert.Equal(t, uint32(0), view.PublisherAccumulationBitmapStartIndex)
 	assert.Equal(t, uint32(len(bitmap)), view.PublisherAccumulationBitmapEndIndex)
+	assert.Equal(t, uint32(4242), view.TotalLeaderSlots)
 	assert.Equal(t, uint32(5), view.AccumulatedPublisherLeafCount)
 	assert.Equal(t, uint32(2), view.DistributedPublisherLeafCount)
 	assert.Equal(t, bitmap, view.RemainingData)

--- a/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/journal_test.go
@@ -159,10 +159,10 @@ func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 	view, err := DecodeJournalAccount(data)
 	require.NoError(t, err)
 
-	leafIndexToNodeID := map[uint32]string{
-		0: "node-a",
-		1: "node-b",
-		2: "node-c",
+	leafIndexToNodeID := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1},
+		1: {NodeID: "node-b", ClientID: 2},
+		2: {NodeID: "node-c", ClientID: 1},
 	}
 
 	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
@@ -176,7 +176,8 @@ func TestProjectStatuses_OnlyAccumulatedLeaves(t *testing.T) {
 	rowA, ok := byNode["node-a"]
 	require.True(t, ok)
 	assert.Equal(t, uint64(951), rowA.SubscriptionEpoch)
-	assert.Equal(t, LeafDistributionStatusPK(951, "node-a"), rowA.PK)
+	assert.Equal(t, uint16(1), rowA.ClientID)
+	assert.Equal(t, LeafDistributionStatusPK(951, "node-a", 1), rowA.PK)
 	assert.Equal(t, uint8(1), rowA.IsClaimable)
 	assert.Equal(t, DoubleZeroMintKey, rowA.JournalMintKey)
 
@@ -199,9 +200,9 @@ func TestProjectStatuses_MissingLeafInMap(t *testing.T) {
 
 	// Only leaf index 0 and 2 have a node-id mapping. Leaf 1 has no
 	// mapping and must be silently skipped.
-	leafIndexToNodeID := map[uint32]string{
-		0: "node-a",
-		2: "node-c",
+	leafIndexToNodeID := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1},
+		2: {NodeID: "node-c", ClientID: 1},
 	}
 
 	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
@@ -230,10 +231,10 @@ func TestProjectStatuses_ClearedBitEmitsZero(t *testing.T) {
 	view, err := DecodeJournalAccount(data)
 	require.NoError(t, err)
 
-	leafIndexToNodeID := map[uint32]string{
-		0: "node-a",
-		1: "node-b",
-		2: "node-c",
+	leafIndexToNodeID := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1},
+		1: {NodeID: "node-b", ClientID: 2},
+		2: {NodeID: "node-c", ClientID: 1},
 	}
 
 	rows := ProjectStatuses(view, 951, leafIndexToNodeID)
@@ -248,6 +249,45 @@ func TestProjectStatuses_ClearedBitEmitsZero(t *testing.T) {
 	// bit 1 is clear → already distributed (or never accumulated).
 	assert.Equal(t, uint8(0), byNode["node-b"].IsClaimable)
 	assert.Equal(t, uint8(1), byNode["node-c"].IsClaimable)
+}
+
+// TestProjectStatuses_MultiClientSameNode is the regression test for the bug
+// where a validator publishing under more than one software client in a single
+// epoch was collapsed to one row. The two leaves share a node_id but differ by
+// client_id, so they must produce two distinct rows with distinct PKs and
+// independent claimable bits.
+func TestProjectStatuses_MultiClientSameNode(t *testing.T) {
+	mint := solana.MustPublicKeyFromBase58(DoubleZeroMintKey)
+	// Two accumulated leaves: bit 0 set (claimable), bit 1 clear.
+	bitmap := []byte{0b00000001}
+	data := buildJournalAccount(t, 951, mint, mint, 2, 0, bitmap)
+
+	view, err := DecodeJournalAccount(data)
+	require.NoError(t, err)
+
+	// Same node_id, two different client_ids — distinct leaves.
+	leafIndexToIdentity := map[uint32]LeafIdentity{
+		0: {NodeID: "node-a", ClientID: 1},
+		1: {NodeID: "node-a", ClientID: 2},
+	}
+
+	rows := ProjectStatuses(view, 951, leafIndexToIdentity)
+	require.Len(t, rows, 2, "each (node, client) leaf must produce its own row")
+
+	byClient := make(map[uint16]LeafDistributionStatusRow, len(rows))
+	for _, r := range rows {
+		assert.Equal(t, "node-a", r.NodeID)
+		byClient[r.ClientID] = r
+	}
+
+	require.Contains(t, byClient, uint16(1))
+	require.Contains(t, byClient, uint16(2))
+	assert.NotEqual(t, byClient[1].PK, byClient[2].PK, "PKs must differ by client_id")
+	assert.Equal(t, LeafDistributionStatusPK(951, "node-a", 1), byClient[1].PK)
+	assert.Equal(t, LeafDistributionStatusPK(951, "node-a", 2), byClient[2].PK)
+	// Independent claimable bits: client 1 claimable, client 2 not.
+	assert.Equal(t, uint8(1), byClient[1].IsClaimable)
+	assert.Equal(t, uint8(0), byClient[2].IsClaimable)
 }
 
 func TestJournalPDA_IsDeterministic(t *testing.T) {

--- a/indexer/pkg/dz/shreds/validatorrewards/schema.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/schema.go
@@ -133,19 +133,41 @@ func LeafDistributionStatusPK(subscriptionEpoch uint64, nodeID string, clientID 
 	return fmt.Sprintf("epoch-%d:node-%s:client-%d", subscriptionEpoch, nodeID, clientID)
 }
 
-// Distribution2ZPoolRow is one row per subscription_epoch recording the 2Z
-// reward pool read from that epoch's 2Z ShredDistributionJournal. This is the
-// validator-pool the per-leaf publisher shares are drawn from, replacing the
-// defunct ShredDistribution.distributed_validator_2z_amount field.
+// Distribution2ZPoolRow is one row per (subscription_epoch, reward token)
+// recording the reward pool read from that epoch's ShredDistributionJournal for
+// the token. Before epoch 968 there was a single 2Z journal per epoch (one row);
+// from 968 on, each supported token (2Z, USDC, wSOL) has its own journal owning
+// the leaves of validators who picked it (one row per token). This is the pool
+// the per-leaf publisher shares are drawn from.
+//
+// The table name and the 2Z row's PK (epoch-{e}) are retained so the historical
+// 2Z pool series — which must survive journal sweeps for all-time earnings — is
+// preserved; non-2Z rows are keyed per (epoch, mint). See DistributionPoolPK.
 type Distribution2ZPoolRow struct {
-	PK                string // epoch-{subscription_epoch}
+	PK                string // epoch-{subscription_epoch}[:mint-{reward_mint}]
 	SubscriptionEpoch uint64
-	TokensReceived2Z  uint64
-	// TotalLeaderSlots is the journal's authoritative leader-slot denominator
-	// for the epoch (see JournalView.TotalLeaderSlots). The rewards page divides
-	// each validator's leader_slots by this rather than by the sum of indexed
-	// leaves, which is incomplete for older epochs and over-credits validators.
+	// TokensReceived2Z is the pool size in base units of RewardMint (the column
+	// name is legacy; it now holds whichever token the journal pays out).
+	TokensReceived2Z uint64
+	// TotalLeaderSlots is the journal's authoritative leader-slot count for the
+	// epoch (see JournalView.TotalLeaderSlots). Legacy fallback denominator used
+	// when AccumulatedSlotsScaled is unavailable (older/swept rows).
 	TotalLeaderSlots uint64
+	// RewardMint is the base58 mint this pool pays out in (JournalView.RewardMintKey).
+	// Empty on legacy rows written before multi-token support; the API treats an
+	// empty mint as 2Z.
+	RewardMint string
+	// AccumulatedSlotsScaled is the journal's per-token reward denominator:
+	// accumulated_publisher_slots_scaled + accumulated_client_slots_scaled, which
+	// equals (this token's leader slots) × 10000. The API divides
+	// tokens × leader_slots × (10000 − client_proportion) by it. Zero on legacy
+	// rows; the API falls back to TotalLeaderSlots × 10000 then summed leaves.
+	AccumulatedSlotsScaled uint64
+	// DistributedAmount is the journal's running total of paid-out reward base
+	// units (JournalView.DistributedAmount). For non-2Z tokens this is the pool
+	// the page splits (their TokensReceived2Z is 0); the 2Z journal instead uses
+	// TokensReceived2Z less the 10% burn. Zero on legacy rows.
+	DistributedAmount uint64
 }
 
 type distribution2ZPoolSchema struct{}
@@ -163,11 +185,14 @@ func (s *distribution2ZPoolSchema) PayloadColumns() []string {
 		"subscription_epoch:BIGINT",
 		"tokens_received_2z:BIGINT",
 		"total_leader_slots:BIGINT",
+		"reward_mint:VARCHAR",
+		"accumulated_slots_scaled:BIGINT",
+		"distributed_amount:BIGINT",
 	}
 }
 
 func (s *distribution2ZPoolSchema) ToRow(r Distribution2ZPoolRow) []any {
-	return []any{r.PK, r.SubscriptionEpoch, r.TokensReceived2Z, r.TotalLeaderSlots}
+	return []any{r.PK, r.SubscriptionEpoch, r.TokensReceived2Z, r.TotalLeaderSlots, r.RewardMint, r.AccumulatedSlotsScaled, r.DistributedAmount}
 }
 
 func (s *distribution2ZPoolSchema) GetPrimaryKey(r Distribution2ZPoolRow) string {
@@ -182,7 +207,21 @@ func NewDistribution2ZPoolDataset(log *slog.Logger) (*dataset.DimensionType2Data
 	return dataset.NewDimensionType2Dataset(log, distribution2ZPoolSchemaSingleton)
 }
 
-// Distribution2ZPoolPK builds the canonical primary key.
+// Distribution2ZPoolPK builds the canonical primary key for the 2Z pool row.
+// The 2Z journal keeps the bare epoch-{e} key so the historical 2Z series
+// (written before multi-token support and before the reward_mint column) stays
+// one continuous entity per epoch rather than forking into a duplicate row.
 func Distribution2ZPoolPK(subscriptionEpoch uint64) string {
 	return fmt.Sprintf("epoch-%d", subscriptionEpoch)
+}
+
+// DistributionPoolPK builds the primary key for a per-(epoch, reward mint) pool
+// row. The 2Z journal uses the legacy bare epoch-{e} key (Distribution2ZPoolPK)
+// to preserve its historical series; every other token journal is keyed
+// epoch-{e}:mint-{mint} so the per-token pools never collide with it.
+func DistributionPoolPK(subscriptionEpoch uint64, rewardMint string) string {
+	if rewardMint == DoubleZeroMintKey {
+		return Distribution2ZPoolPK(subscriptionEpoch)
+	}
+	return fmt.Sprintf("epoch-%d:mint-%s", subscriptionEpoch, rewardMint)
 }

--- a/indexer/pkg/dz/shreds/validatorrewards/schema.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/schema.go
@@ -65,9 +65,14 @@ func NewLeafDataset(log *slog.Logger) (*dataset.DimensionType2Dataset, error) {
 	return dataset.NewDimensionType2Dataset(log, schema)
 }
 
-// LeafPK builds the canonical primary key for a leaf row.
-func LeafPK(subscriptionEpoch uint64, nodeID string) string {
-	return fmt.Sprintf("epoch-%d:node-%s", subscriptionEpoch, nodeID)
+// LeafPK builds the canonical primary key for a leaf row. The grain is
+// (subscription_epoch, node_id, client_id): a validator can publish under
+// multiple software clients in a single epoch, each producing its own merkle
+// leaf. client_id MUST be part of the key, otherwise the multiple leaves for
+// one node collapse to a single row and that node's leader slots (and thus
+// earnings) are understated.
+func LeafPK(subscriptionEpoch uint64, nodeID string, clientID uint16) string {
+	return fmt.Sprintf("epoch-%d:node-%s:client-%d", subscriptionEpoch, nodeID, clientID)
 }
 
 // LeafDistributionStatusRow is one row per (subscription_epoch, node_id)
@@ -75,9 +80,10 @@ func LeafPK(subscriptionEpoch uint64, nodeID string) string {
 // yet distributed (immediately claimable); 0 = either not yet accumulated
 // or already distributed.
 type LeafDistributionStatusRow struct {
-	PK                string // {subscription_epoch}:{node_id}
+	PK                string // {subscription_epoch}:{node_id}:{client_id}
 	SubscriptionEpoch uint64
 	NodeID            string
+	ClientID          uint16
 	IsClaimable       uint8
 	JournalMintKey    string // base58 of the journal mint we read (the 2Z mint for v1)
 }
@@ -96,13 +102,14 @@ func (s *leafDistributionStatusSchema) PayloadColumns() []string {
 	return []string{
 		"subscription_epoch:BIGINT",
 		"node_id:VARCHAR",
+		"client_id:INTEGER",
 		"is_claimable:INTEGER",
 		"journal_mint_key:VARCHAR",
 	}
 }
 
 func (s *leafDistributionStatusSchema) ToRow(r LeafDistributionStatusRow) []any {
-	return []any{r.PK, r.SubscriptionEpoch, r.NodeID, r.IsClaimable, r.JournalMintKey}
+	return []any{r.PK, r.SubscriptionEpoch, r.NodeID, r.ClientID, r.IsClaimable, r.JournalMintKey}
 }
 
 func (s *leafDistributionStatusSchema) GetPrimaryKey(r LeafDistributionStatusRow) string {
@@ -117,9 +124,13 @@ func NewLeafDistributionStatusDataset(log *slog.Logger) (*dataset.DimensionType2
 	return dataset.NewDimensionType2Dataset(log, leafDistributionStatusSchemaSingleton)
 }
 
-// LeafDistributionStatusPK builds the canonical primary key.
-func LeafDistributionStatusPK(subscriptionEpoch uint64, nodeID string) string {
-	return fmt.Sprintf("epoch-%d:node-%s", subscriptionEpoch, nodeID)
+// LeafDistributionStatusPK builds the canonical primary key. The grain matches
+// the leaves table — (subscription_epoch, node_id, client_id) — because the
+// publisher-accumulation bitmap is per leaf, and a leaf is a (node, client)
+// pair. Keying per node alone would let one client's claimable bit overwrite
+// another's for the same validator in an epoch.
+func LeafDistributionStatusPK(subscriptionEpoch uint64, nodeID string, clientID uint16) string {
+	return fmt.Sprintf("epoch-%d:node-%s:client-%d", subscriptionEpoch, nodeID, clientID)
 }
 
 // Distribution2ZPoolRow is one row per subscription_epoch recording the 2Z

--- a/indexer/pkg/dz/shreds/validatorrewards/schema.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/schema.go
@@ -141,6 +141,11 @@ type Distribution2ZPoolRow struct {
 	PK                string // epoch-{subscription_epoch}
 	SubscriptionEpoch uint64
 	TokensReceived2Z  uint64
+	// TotalLeaderSlots is the journal's authoritative leader-slot denominator
+	// for the epoch (see JournalView.TotalLeaderSlots). The rewards page divides
+	// each validator's leader_slots by this rather than by the sum of indexed
+	// leaves, which is incomplete for older epochs and over-credits validators.
+	TotalLeaderSlots uint64
 }
 
 type distribution2ZPoolSchema struct{}
@@ -157,11 +162,12 @@ func (s *distribution2ZPoolSchema) PayloadColumns() []string {
 	return []string{
 		"subscription_epoch:BIGINT",
 		"tokens_received_2z:BIGINT",
+		"total_leader_slots:BIGINT",
 	}
 }
 
 func (s *distribution2ZPoolSchema) ToRow(r Distribution2ZPoolRow) []any {
-	return []any{r.PK, r.SubscriptionEpoch, r.TokensReceived2Z}
+	return []any{r.PK, r.SubscriptionEpoch, r.TokensReceived2Z, r.TotalLeaderSlots}
 }
 
 func (s *distribution2ZPoolSchema) GetPrimaryKey(r Distribution2ZPoolRow) string {

--- a/indexer/pkg/dz/shreds/validatorrewards/store.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/store.go
@@ -171,6 +171,48 @@ func (s *Store) LeafIndexToNodeClient(ctx context.Context, subscriptionEpoch uin
 	return out, nil
 }
 
+// ExistingLeafMints returns the reward mint already recorded for each
+// (node_id, client_id) leaf of an epoch, from the leaf_distribution_status
+// _current view. The status projection uses this to tell an already-distributed
+// leaf (its journal's publisher bit cleared) apart from a leaf that never
+// belonged to the journal: only a leaf previously attributed to a token may be
+// marked distributed in that token. Returns an empty (non-nil) map when no
+// statuses exist yet for the epoch.
+func (s *Store) ExistingLeafMints(ctx context.Context, subscriptionEpoch uint64) (map[LeafIdentity]string, error) {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	defer conn.Close()
+
+	const q = `SELECT node_id, client_id, journal_mint_key
+		FROM dim_dz_shred_validator_leaf_distribution_status_current
+		WHERE subscription_epoch = ?`
+
+	rows, err := conn.Query(ctx, q, subscriptionEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("query existing leaf mints: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[LeafIdentity]string)
+	for rows.Next() {
+		var (
+			nodeID   string
+			clientID uint16
+			mint     string
+		)
+		if err := rows.Scan(&nodeID, &clientID, &mint); err != nil {
+			return nil, fmt.Errorf("scan existing leaf mint row: %w", err)
+		}
+		out[LeafIdentity{NodeID: nodeID, ClientID: clientID}] = mint
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate existing leaf mint rows: %w", err)
+	}
+	return out, nil
+}
+
 // ReplaceLeaves writes the verified leaves as a fresh dim-type-2 snapshot
 // for (subscriptionEpoch, associatedDZEpoch). Each leaf becomes one row
 // with LeafIndex set to its position in the sorted slice.

--- a/indexer/pkg/dz/shreds/validatorrewards/store.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/store.go
@@ -123,40 +123,50 @@ func (s *Store) LeavesStatusForEpoch(ctx context.Context, subscriptionEpoch uint
 	return status, nil
 }
 
-// LeafIndexToNodeID returns the leaf_index → node_id mapping for the given
-// subscription_epoch from the leaves _current view. Returns an empty (non-nil)
-// map when there are no leaves for that epoch (e.g., S3 verifier hasn't run
-// yet).
-func (s *Store) LeafIndexToNodeID(ctx context.Context, subscriptionEpoch uint64) (map[uint32]string, error) {
+// LeafIdentity is the (node_id, client_id) pair a leaf_index resolves to. A
+// validator (node_id) can own several leaves in one epoch — one per software
+// client — so the claimable-bit projection must carry the client_id through
+// to key its output rows at the same grain as the leaves table.
+type LeafIdentity struct {
+	NodeID   string
+	ClientID uint16
+}
+
+// LeafIndexToNodeClient returns the leaf_index → (node_id, client_id) mapping
+// for the given subscription_epoch from the leaves _current view. Returns an
+// empty (non-nil) map when there are no leaves for that epoch (e.g., S3
+// verifier hasn't run yet).
+func (s *Store) LeafIndexToNodeClient(ctx context.Context, subscriptionEpoch uint64) (map[uint32]LeafIdentity, error) {
 	conn, err := s.cfg.ClickHouse.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
 	}
 	defer conn.Close()
 
-	const q = `SELECT leaf_index, node_id
+	const q = `SELECT leaf_index, node_id, client_id
 		FROM dim_dz_shred_validator_rewards_leaves_current
 		WHERE subscription_epoch = ?`
 
 	rows, err := conn.Query(ctx, q, subscriptionEpoch)
 	if err != nil {
-		return nil, fmt.Errorf("query leaf_index → node_id mapping: %w", err)
+		return nil, fmt.Errorf("query leaf_index → (node_id, client_id) mapping: %w", err)
 	}
 	defer rows.Close()
 
-	out := make(map[uint32]string)
+	out := make(map[uint32]LeafIdentity)
 	for rows.Next() {
 		var (
 			leafIndex uint32
 			nodeID    string
+			clientID  uint16
 		)
-		if err := rows.Scan(&leafIndex, &nodeID); err != nil {
-			return nil, fmt.Errorf("scan leaf_index → node_id row: %w", err)
+		if err := rows.Scan(&leafIndex, &nodeID, &clientID); err != nil {
+			return nil, fmt.Errorf("scan leaf_index → (node_id, client_id) row: %w", err)
 		}
-		out[leafIndex] = nodeID
+		out[leafIndex] = LeafIdentity{NodeID: nodeID, ClientID: clientID}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate leaf_index → node_id rows: %w", err)
+		return nil, fmt.Errorf("iterate leaf_index → (node_id, client_id) rows: %w", err)
 	}
 	return out, nil
 }
@@ -209,7 +219,7 @@ func (s *Store) ReplaceLeaves(
 	toRow := func(i int) ([]any, error) {
 		nodeID := v.NodeIDStrings[i]
 		row := LeafRow{
-			PK:                LeafPK(subscriptionEpoch, nodeID),
+			PK:                LeafPK(subscriptionEpoch, nodeID, v.Leaves[i].ClientID),
 			SubscriptionEpoch: subscriptionEpoch,
 			AssociatedDZEpoch: associatedDZEpoch,
 			NodeID:            nodeID,

--- a/indexer/pkg/dz/shreds/validatorrewards/store.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/store.go
@@ -171,48 +171,6 @@ func (s *Store) LeafIndexToNodeClient(ctx context.Context, subscriptionEpoch uin
 	return out, nil
 }
 
-// ExistingLeafMints returns the reward mint already recorded for each
-// (node_id, client_id) leaf of an epoch, from the leaf_distribution_status
-// _current view. The status projection uses this to tell an already-distributed
-// leaf (its journal's publisher bit cleared) apart from a leaf that never
-// belonged to the journal: only a leaf previously attributed to a token may be
-// marked distributed in that token. Returns an empty (non-nil) map when no
-// statuses exist yet for the epoch.
-func (s *Store) ExistingLeafMints(ctx context.Context, subscriptionEpoch uint64) (map[LeafIdentity]string, error) {
-	conn, err := s.cfg.ClickHouse.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
-	}
-	defer conn.Close()
-
-	const q = `SELECT node_id, client_id, journal_mint_key
-		FROM dim_dz_shred_validator_leaf_distribution_status_current
-		WHERE subscription_epoch = ?`
-
-	rows, err := conn.Query(ctx, q, subscriptionEpoch)
-	if err != nil {
-		return nil, fmt.Errorf("query existing leaf mints: %w", err)
-	}
-	defer rows.Close()
-
-	out := make(map[LeafIdentity]string)
-	for rows.Next() {
-		var (
-			nodeID   string
-			clientID uint16
-			mint     string
-		)
-		if err := rows.Scan(&nodeID, &clientID, &mint); err != nil {
-			return nil, fmt.Errorf("scan existing leaf mint row: %w", err)
-		}
-		out[LeafIdentity{NodeID: nodeID, ClientID: clientID}] = mint
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate existing leaf mint rows: %w", err)
-	}
-	return out, nil
-}
-
 // ReplaceLeaves writes the verified leaves as a fresh dim-type-2 snapshot
 // for (subscriptionEpoch, associatedDZEpoch). Each leaf becomes one row
 // with LeafIndex set to its position in the sorted slice.

--- a/indexer/pkg/dz/shreds/validatorrewards/store_write_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/store_write_test.go
@@ -62,8 +62,8 @@ func TestStore_ReplaceLeafDistributionStatuses_RoundTrip(t *testing.T) {
 	ctx := t.Context()
 
 	rows := []LeafDistributionStatusRow{
-		{PK: LeafDistributionStatusPK(975, "node-A"), SubscriptionEpoch: 975, NodeID: "node-A", IsClaimable: 1, JournalMintKey: DoubleZeroMintKey},
-		{PK: LeafDistributionStatusPK(975, "node-B"), SubscriptionEpoch: 975, NodeID: "node-B", IsClaimable: 0, JournalMintKey: DoubleZeroMintKey},
+		{PK: LeafDistributionStatusPK(975, "node-A", 1), SubscriptionEpoch: 975, NodeID: "node-A", ClientID: 1, IsClaimable: 1, JournalMintKey: DoubleZeroMintKey},
+		{PK: LeafDistributionStatusPK(975, "node-B", 1), SubscriptionEpoch: 975, NodeID: "node-B", ClientID: 1, IsClaimable: 0, JournalMintKey: DoubleZeroMintKey},
 	}
 	require.NoError(t, store.ReplaceLeafDistributionStatuses(ctx, rows))
 

--- a/indexer/pkg/dz/shreds/validatorrewards/token.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/token.go
@@ -11,30 +11,3 @@ const (
 	// WSOLMintKey is the canonical wrapped-SOL mint.
 	WSOLMintKey = "So11111111111111111111111111111111111111112"
 )
-
-// TokenInfo describes how to render and scale a reward token's on-chain base
-// units into whole tokens.
-type TokenInfo struct {
-	Symbol   string
-	Decimals uint8
-}
-
-// tokenInfoByMint maps a reward mint (base58) to its display symbol and decimal
-// scale. Amounts in the journals are in base units; whole tokens = base units /
-// 10^Decimals.
-var tokenInfoByMint = map[string]TokenInfo{
-	DoubleZeroMintKey: {Symbol: "2Z", Decimals: 8},
-	USDCMintKey:       {Symbol: "USDC", Decimals: 6},
-	WSOLMintKey:       {Symbol: "wSOL", Decimals: 9},
-}
-
-// TokenInfoForMint returns the (symbol, decimals) for a known reward mint and a
-// bool reporting whether the mint is recognized. Unknown mints fall back to the
-// 2Z scale so a newly-added token never silently produces NaN amounts, but the
-// ok=false return lets callers log/flag it.
-func TokenInfoForMint(mint string) (TokenInfo, bool) {
-	if info, ok := tokenInfoByMint[mint]; ok {
-		return info, true
-	}
-	return TokenInfo{Symbol: "?", Decimals: 8}, false
-}

--- a/indexer/pkg/dz/shreds/validatorrewards/token.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/token.go
@@ -1,0 +1,40 @@
+package validatorrewards
+
+// Supported reward-token mints. From epoch 968 onward validators may choose to
+// be rewarded in one of these tokens; each (subscription_epoch, mint) gets its
+// own ShredDistributionJournal that owns the leaves of validators who picked it.
+//
+// DoubleZeroMintKey (2Z) is defined in journal.go.
+const (
+	// USDCMintKey is the canonical mainnet USDC mint.
+	USDCMintKey = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	// WSOLMintKey is the canonical wrapped-SOL mint.
+	WSOLMintKey = "So11111111111111111111111111111111111111112"
+)
+
+// TokenInfo describes how to render and scale a reward token's on-chain base
+// units into whole tokens.
+type TokenInfo struct {
+	Symbol   string
+	Decimals uint8
+}
+
+// tokenInfoByMint maps a reward mint (base58) to its display symbol and decimal
+// scale. Amounts in the journals are in base units; whole tokens = base units /
+// 10^Decimals.
+var tokenInfoByMint = map[string]TokenInfo{
+	DoubleZeroMintKey: {Symbol: "2Z", Decimals: 8},
+	USDCMintKey:       {Symbol: "USDC", Decimals: 6},
+	WSOLMintKey:       {Symbol: "wSOL", Decimals: 9},
+}
+
+// TokenInfoForMint returns the (symbol, decimals) for a known reward mint and a
+// bool reporting whether the mint is recognized. Unknown mints fall back to the
+// 2Z scale so a newly-added token never silently produces NaN amounts, but the
+// ok=false return lets callers log/flag it.
+func TokenInfoForMint(mint string) (TokenInfo, bool) {
+	if info, ok := tokenInfoByMint[mint]; ok {
+		return info, true
+	}
+	return TokenInfo{Symbol: "?", Decimals: 8}, false
+}

--- a/indexer/pkg/dz/shreds/view.go
+++ b/indexer/pkg/dz/shreds/view.go
@@ -545,6 +545,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			PK:                validatorrewards.Distribution2ZPoolPK(view.SubscriptionEpoch),
 			SubscriptionEpoch: view.SubscriptionEpoch,
 			TokensReceived2Z:  view.TokensReceivedAmount,
+			TotalLeaderSlots:  uint64(view.TotalLeaderSlots),
 		})
 	}
 	if len(poolRows) > 0 {

--- a/indexer/pkg/dz/shreds/view.go
+++ b/indexer/pkg/dz/shreds/view.go
@@ -477,24 +477,25 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 	}
 
 	// Project per-leaf claimable bits from in-flight ShredDistributionJournal
-	// accounts to the leaf_distribution_status table. We restrict to the most
-	// recent subscription epochs so we don't scan the entire history every
-	// refresh.
+	// accounts to the leaf_distribution_status table.
 	//
-	// Only project journal-status rows for the last 12 subscription epochs
-	// (10 visible on the page + 2 in-flight buffer). Older epochs are out of
-	// the "immediately claimable" window per the spec and don't need bitmap
-	// tracking.
-	const recentJournalWindow uint64 = 12
+	// We project EVERY 2Z journal still readable on-chain, not just a recent
+	// window. GetProgramAccounts only returns journals that have not yet been
+	// swept, so this set is inherently bounded by the on-chain journal lifetime
+	// (a handful of epochs). Projecting all of them every refresh — combined
+	// with the additive write (MissingMeansDeleted: false) and the un-TTL'd
+	// history table — guarantees the LAST snapshot we take before a journal is
+	// swept records its true final bitmap. That frozen final bit is what the
+	// rewards page reads for swept epochs: a cleared bit means the leaf was
+	// distributed (paid), a set bit means it was never claimed. Bounding to a
+	// recent window here would instead freeze a stale, pre-distribution bit for
+	// any journal that outlived the window, mislabeling paid epochs.
 	var statusRows []validatorrewards.LeafDistributionStatusRow
 	if len(allAccounts.Journals) > 0 {
-		var minEpoch uint64
-		if ec.CurrentSubscriptionEpoch > recentJournalWindow {
-			minEpoch = ec.CurrentSubscriptionEpoch - recentJournalWindow
-		}
-		// Cache leaf-index → node-id maps per subscription_epoch so we only
-		// hit ClickHouse once per epoch when multiple journals share it.
-		leafMaps := make(map[uint64]map[uint32]string)
+		// Cache leaf-index → (node-id, client-id) maps per subscription_epoch
+		// so we only hit ClickHouse once per epoch when multiple journals
+		// share it.
+		leafMaps := make(map[uint64]map[uint32]validatorrewards.LeafIdentity)
 		for _, kj := range allAccounts.Journals {
 			view := kj.View
 			if view == nil {
@@ -505,14 +506,11 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			if view.MintKey.String() != validatorrewards.DoubleZeroMintKey {
 				continue
 			}
-			if view.SubscriptionEpoch < minEpoch {
-				continue
-			}
 			leafMap, ok := leafMaps[view.SubscriptionEpoch]
 			if !ok {
-				m, err := v.leafStore.LeafIndexToNodeID(ctx, view.SubscriptionEpoch)
+				m, err := v.leafStore.LeafIndexToNodeClient(ctx, view.SubscriptionEpoch)
 				if err != nil {
-					return result, fmt.Errorf("load leaf_index → node_id mapping for epoch %d: %w",
+					return result, fmt.Errorf("load leaf_index → (node_id, client_id) mapping for epoch %d: %w",
 						view.SubscriptionEpoch, err)
 				}
 				leafMaps[view.SubscriptionEpoch] = m

--- a/indexer/pkg/dz/shreds/view.go
+++ b/indexer/pkg/dz/shreds/view.go
@@ -476,84 +476,67 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		}
 	}
 
-	// Project per-leaf claimable bits from in-flight ShredDistributionJournal
+	// Project per-leaf claim status from in-flight ShredDistributionJournal
 	// accounts to the leaf_distribution_status table.
 	//
-	// We project EVERY 2Z journal still readable on-chain, not just a recent
-	// window. GetProgramAccounts only returns journals that have not yet been
-	// swept, so this set is inherently bounded by the on-chain journal lifetime
-	// (a handful of epochs). Projecting all of them every refresh — combined
-	// with the additive write (MissingMeansDeleted: false) and the un-TTL'd
-	// history table — guarantees the LAST snapshot we take before a journal is
-	// swept records its true final bitmap. That frozen final bit is what the
-	// rewards page reads for swept epochs: a cleared bit means the leaf was
-	// distributed (paid), a set bit means it was never claimed. Bounding to a
-	// recent window here would instead freeze a stale, pre-distribution bit for
-	// any journal that outlived the window, mislabeling paid epochs.
+	// We project EVERY journal still readable on-chain, not just a recent window.
+	// GetProgramAccounts only returns journals that have not yet been swept, so
+	// this set is inherently bounded by the on-chain journal lifetime (a handful
+	// of epochs). Projecting all of them every refresh — combined with the
+	// additive write (MissingMeansDeleted: false) and the un-TTL'd history table —
+	// keeps every live epoch's status current and freezes its final state before
+	// the journal is swept.
+	//
+	// The projection is cross-journal and STATELESS: it reads all of an epoch's
+	// token journals together and uses the completeness invariant (every leaf
+	// accumulates into exactly one token) to classify distributed leaves without
+	// any observation history — see ProjectEpochStatuses. This is why no offline
+	// backfill is needed: an already-distributed leaf is reconstructed from the
+	// live bitmaps on every refresh. A (node,client)→token map built from the
+	// claimable (set-bit) observations across all live epochs attributes the
+	// reward token of those distributed leaves.
 	var statusRows []validatorrewards.LeafDistributionStatusRow
 	if len(allAccounts.Journals) > 0 {
-		// Cache leaf-index → (node-id, client-id) maps per subscription_epoch
-		// so we only hit ClickHouse once per epoch when multiple journals
-		// share it.
-		leafMaps := make(map[uint64]map[uint32]validatorrewards.LeafIdentity)
-		loadLeafMap := func(epoch uint64) (map[uint32]validatorrewards.LeafIdentity, error) {
-			if m, ok := leafMaps[epoch]; ok {
-				return m, nil
+		// Group the live journal views by subscription_epoch.
+		viewsByEpoch := make(map[uint64][]*validatorrewards.JournalView)
+		for _, kj := range allAccounts.Journals {
+			if kj.View == nil {
+				continue
 			}
+			viewsByEpoch[kj.View.SubscriptionEpoch] = append(viewsByEpoch[kj.View.SubscriptionEpoch], kj.View)
+		}
+
+		// Load each epoch's leaf_index → (node_id, client_id) map once. Epochs
+		// whose leaves aren't indexed yet (S3 export pending) are skipped.
+		leafMaps := make(map[uint64]map[uint32]validatorrewards.LeafIdentity, len(viewsByEpoch))
+		for epoch := range viewsByEpoch {
 			m, err := v.leafStore.LeafIndexToNodeClient(ctx, epoch)
 			if err != nil {
-				return nil, fmt.Errorf("load leaf_index → (node_id, client_id) mapping for epoch %d: %w", epoch, err)
+				return result, fmt.Errorf("load leaf_index → (node_id, client_id) mapping for epoch %d: %w", epoch, err)
 			}
-			leafMaps[epoch] = m
-			return m, nil
+			if len(m) > 0 {
+				leafMaps[epoch] = m
+			}
 		}
 
-		// Per-epoch leaf_index → previously-recorded reward mint, from the
-		// persisted status table. ProjectStatuses uses it to mark a leaf
-		// distributed (bit cleared) only for the token it was already attributed
-		// to — never mistagging another token's leaf.
-		existingMintByEpoch := make(map[uint64]map[uint32]string)
-		loadExistingMint := func(epoch uint64, leafMap map[uint32]validatorrewards.LeafIdentity) (map[uint32]string, error) {
-			if m, ok := existingMintByEpoch[epoch]; ok {
-				return m, nil
+		// Build the (node,client)→reward-token map from claimable observations
+		// across ALL live epochs, so a leaf distributed in one epoch can be
+		// attributed to the token the validator was last seen claimable in.
+		tokenByIdentity := make(map[validatorrewards.LeafIdentity]string)
+		for epoch, views := range viewsByEpoch {
+			if leafMap, ok := leafMaps[epoch]; ok {
+				validatorrewards.CollectClaimableTokens(views, leafMap, tokenByIdentity)
 			}
-			byIdentity, err := v.leafStore.ExistingLeafMints(ctx, epoch)
-			if err != nil {
-				return nil, fmt.Errorf("load existing leaf mints for epoch %d: %w", epoch, err)
-			}
-			m := make(map[uint32]string, len(byIdentity))
-			for leafIndex, id := range leafMap {
-				if mint, ok := byIdentity[id]; ok {
-					m[leafIndex] = mint
-				}
-			}
-			existingMintByEpoch[epoch] = m
-			return m, nil
 		}
 
-		// Project EVERY token journal, attributing each leaf to its journal's
-		// reward mint. The per-leaf row records that mint, which is how the
-		// rewards page attributes each leaf to its reward token.
-		for _, kj := range allAccounts.Journals {
-			view := kj.View
-			if view == nil {
+		// Project each epoch's status from all its token journals together.
+		for epoch, views := range viewsByEpoch {
+			leafMap, ok := leafMaps[epoch]
+			if !ok {
 				continue
-			}
-			leafMap, err := loadLeafMap(view.SubscriptionEpoch)
-			if err != nil {
-				return result, err
-			}
-			if len(leafMap) == 0 {
-				// Leaves not yet indexed for this epoch (S3 export pending,
-				// or out of the leaf window). Skip — next refresh will retry.
-				continue
-			}
-			existingMint, err := loadExistingMint(view.SubscriptionEpoch, leafMap)
-			if err != nil {
-				return result, err
 			}
 			statusRows = append(statusRows,
-				validatorrewards.ProjectStatuses(view, view.SubscriptionEpoch, leafMap, existingMint)...)
+				validatorrewards.ProjectEpochStatuses(epoch, views, leafMap, tokenByIdentity)...)
 		}
 		if len(statusRows) > 0 {
 			if err := v.leafStore.ReplaceLeafDistributionStatuses(ctx, statusRows); err != nil {

--- a/indexer/pkg/dz/shreds/view.go
+++ b/indexer/pkg/dz/shreds/view.go
@@ -496,33 +496,64 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		// so we only hit ClickHouse once per epoch when multiple journals
 		// share it.
 		leafMaps := make(map[uint64]map[uint32]validatorrewards.LeafIdentity)
+		loadLeafMap := func(epoch uint64) (map[uint32]validatorrewards.LeafIdentity, error) {
+			if m, ok := leafMaps[epoch]; ok {
+				return m, nil
+			}
+			m, err := v.leafStore.LeafIndexToNodeClient(ctx, epoch)
+			if err != nil {
+				return nil, fmt.Errorf("load leaf_index → (node_id, client_id) mapping for epoch %d: %w", epoch, err)
+			}
+			leafMaps[epoch] = m
+			return m, nil
+		}
+
+		// Per-epoch leaf_index → previously-recorded reward mint, from the
+		// persisted status table. ProjectStatuses uses it to mark a leaf
+		// distributed (bit cleared) only for the token it was already attributed
+		// to — never mistagging another token's leaf.
+		existingMintByEpoch := make(map[uint64]map[uint32]string)
+		loadExistingMint := func(epoch uint64, leafMap map[uint32]validatorrewards.LeafIdentity) (map[uint32]string, error) {
+			if m, ok := existingMintByEpoch[epoch]; ok {
+				return m, nil
+			}
+			byIdentity, err := v.leafStore.ExistingLeafMints(ctx, epoch)
+			if err != nil {
+				return nil, fmt.Errorf("load existing leaf mints for epoch %d: %w", epoch, err)
+			}
+			m := make(map[uint32]string, len(byIdentity))
+			for leafIndex, id := range leafMap {
+				if mint, ok := byIdentity[id]; ok {
+					m[leafIndex] = mint
+				}
+			}
+			existingMintByEpoch[epoch] = m
+			return m, nil
+		}
+
+		// Project EVERY token journal, attributing each leaf to its journal's
+		// reward mint. The per-leaf row records that mint, which is how the
+		// rewards page attributes each leaf to its reward token.
 		for _, kj := range allAccounts.Journals {
 			view := kj.View
 			if view == nil {
 				continue
 			}
-			// Only the 2Z (DoubleZero) mint journal carries the publisher
-			// accumulation bitmap relevant to the rewards page.
-			if view.MintKey.String() != validatorrewards.DoubleZeroMintKey {
-				continue
-			}
-			leafMap, ok := leafMaps[view.SubscriptionEpoch]
-			if !ok {
-				m, err := v.leafStore.LeafIndexToNodeClient(ctx, view.SubscriptionEpoch)
-				if err != nil {
-					return result, fmt.Errorf("load leaf_index → (node_id, client_id) mapping for epoch %d: %w",
-						view.SubscriptionEpoch, err)
-				}
-				leafMaps[view.SubscriptionEpoch] = m
-				leafMap = m
+			leafMap, err := loadLeafMap(view.SubscriptionEpoch)
+			if err != nil {
+				return result, err
 			}
 			if len(leafMap) == 0 {
 				// Leaves not yet indexed for this epoch (S3 export pending,
 				// or out of the leaf window). Skip — next refresh will retry.
 				continue
 			}
+			existingMint, err := loadExistingMint(view.SubscriptionEpoch, leafMap)
+			if err != nil {
+				return result, err
+			}
 			statusRows = append(statusRows,
-				validatorrewards.ProjectStatuses(view, view.SubscriptionEpoch, leafMap)...)
+				validatorrewards.ProjectStatuses(view, view.SubscriptionEpoch, leafMap, existingMint)...)
 		}
 		if len(statusRows) > 0 {
 			if err := v.leafStore.ReplaceLeafDistributionStatuses(ctx, statusRows); err != nil {
@@ -531,21 +562,27 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		}
 	}
 
-	// Project the per-epoch 2Z reward pool from the 2Z journals. Unlike the
+	// Project the per-(epoch, token) reward pool from every journal. Unlike the
 	// claimable-bit projection above, this is NOT window-bounded: the pool is
-	// the numerator for all-time earnings, so we record every 2Z journal we
-	// can still read on-chain (the table accumulates and survives sweeps).
+	// the numerator for all-time earnings, so we record every journal we can
+	// still read on-chain (the table accumulates and survives sweeps). Each
+	// journal contributes its token's pool size and the authoritative per-token
+	// denominator (accumulated_publisher_slots_scaled + accumulated_client_slots_scaled).
 	var poolRows []validatorrewards.Distribution2ZPoolRow
 	for _, kj := range allAccounts.Journals {
 		view := kj.View
-		if view == nil || view.MintKey.String() != validatorrewards.DoubleZeroMintKey {
+		if view == nil {
 			continue
 		}
+		rewardMint := view.RewardMintKey.String()
 		poolRows = append(poolRows, validatorrewards.Distribution2ZPoolRow{
-			PK:                validatorrewards.Distribution2ZPoolPK(view.SubscriptionEpoch),
-			SubscriptionEpoch: view.SubscriptionEpoch,
-			TokensReceived2Z:  view.TokensReceivedAmount,
-			TotalLeaderSlots:  uint64(view.TotalLeaderSlots),
+			PK:                     validatorrewards.DistributionPoolPK(view.SubscriptionEpoch, rewardMint),
+			SubscriptionEpoch:      view.SubscriptionEpoch,
+			TokensReceived2Z:       view.TokensReceivedAmount,
+			TotalLeaderSlots:       uint64(view.TotalLeaderSlots),
+			RewardMint:             rewardMint,
+			AccumulatedSlotsScaled: view.AccumulatedSlotsScaledDenominator(),
+			DistributedAmount:      view.DistributedAmount,
 		})
 	}
 	if len(poolRows) > 0 {

--- a/web/src/components/shreds-rewards-detail-page.tsx
+++ b/web/src/components/shreds-rewards-detail-page.tsx
@@ -6,12 +6,22 @@ import { fetchShredsRewardsDetail } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { PageHeader } from './page-header'
 import { CopyableText } from './copyable-text'
-import { format2Z } from './shreds-rewards-format'
+import { formatTokenAmount } from './shreds-rewards-format'
 
 function truncatePK(pk: string): string {
   if (!pk) return ''
   if (pk.length <= 12) return pk
   return `${pk.slice(0, 6)}...${pk.slice(-4)}`
+}
+
+// formatTokenTotals renders a {symbol: whole-token amount} map as a compact
+// per-token list (e.g. "12.34 2Z · 5.00 USDC"). Rewards span multiple tokens
+// from epoch 968, so an all-time total is a per-token breakdown, not one number.
+function formatTokenTotals(totals: Record<string, number>): string {
+  const parts = Object.entries(totals)
+    .filter(([, amt]) => amt > 0)
+    .map(([sym, amt]) => formatTokenAmount(amt, sym))
+  return parts.length > 0 ? parts.join(' · ') : '—'
 }
 
 function formatStake(lamports: number): string {
@@ -50,12 +60,19 @@ export function ShredsRewardsDetailPage() {
   })
 
   const totals = useMemo(() => {
-    if (!data) return { all: 0, claimable: 0 }
-    const all = data.epochs.reduce((acc, e) => acc + (e.earned_2z || 0), 0)
-    const claimable = data.epochs
-      .filter((e) => e.state === 'claimable')
-      .reduce((acc, e) => acc + (e.earned_2z || 0), 0)
-    return { all, claimable }
+    const all: Record<string, number> = {}
+    const claimable: Record<string, number> = {}
+    if (data) {
+      for (const e of data.epochs) {
+        const sym = e.token_symbol || '2Z'
+        all[sym] = (all[sym] || 0) + (e.earned || 0)
+        if (e.state === 'claimable') {
+          claimable[sym] = (claimable[sym] || 0) + (e.earned || 0)
+        }
+      }
+    }
+    const hasClaimable = Object.values(claimable).some((v) => v > 0)
+    return { all, claimable, hasClaimable }
   }, [data])
 
   if (isLoading) {
@@ -132,16 +149,16 @@ export function ShredsRewardsDetailPage() {
               <span className="text-muted-foreground/60">—</span>
             )}
           </FactCard>
-          <FactCard label="All-time Earned">{format2Z(totals.all)}</FactCard>
+          <FactCard label="All-time Earned">{formatTokenTotals(totals.all)}</FactCard>
           <FactCard label="Immediately Claimable">
             <span
               className={cn(
-                totals.claimable > 0
+                totals.hasClaimable
                   ? 'text-amber-500 dark:text-amber-400'
                   : 'text-muted-foreground/60',
               )}
             >
-              {format2Z(totals.claimable)}
+              {formatTokenTotals(totals.claimable)}
             </span>
           </FactCard>
         </div>
@@ -169,7 +186,7 @@ export function ShredsRewardsDetailPage() {
                     Client
                   </th>
                   <th className="px-4 py-3 text-right font-medium uppercase tracking-wider">
-                    Earned 2Z
+                    Earned
                   </th>
                   <th className="px-4 py-3 text-left font-medium uppercase tracking-wider">
                     Status
@@ -235,7 +252,7 @@ export function ShredsRewardsDetailPage() {
                           {epoch.client_id}
                         </td>
                         <td className="px-4 py-3 tabular-nums text-right font-medium">
-                          {format2Z(epoch.earned_2z)}
+                          {formatTokenAmount(epoch.earned, epoch.token_symbol)}
                         </td>
                         <td className="px-4 py-3">
                           <span

--- a/web/src/components/shreds-rewards-detail-page.tsx
+++ b/web/src/components/shreds-rewards-detail-page.tsx
@@ -53,7 +53,7 @@ export function ShredsRewardsDetailPage() {
     if (!data) return { all: 0, claimable: 0 }
     const all = data.epochs.reduce((acc, e) => acc + (e.earned_2z || 0), 0)
     const claimable = data.epochs
-      .filter((e) => e.is_claimable === true)
+      .filter((e) => e.state === 'claimable')
       .reduce((acc, e) => acc + (e.earned_2z || 0), 0)
     return { all, claimable }
   }, [data])
@@ -188,24 +188,35 @@ export function ShredsRewardsDetailPage() {
                   </tr>
                 ) : (
                   data.epochs.map((epoch) => {
-                    const claimStatus =
-                      epoch.is_claimable === true
-                        ? 'claimable'
-                        : epoch.is_claimable === false
-                          ? 'paid'
-                          : 'untracked'
-                    const statusStyle =
-                      claimStatus === 'claimable'
-                        ? 'bg-amber-500/10 text-amber-500 dark:text-amber-400 border-amber-500/30'
-                        : claimStatus === 'paid'
-                          ? 'bg-muted text-muted-foreground border-border'
-                          : 'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/30'
-                    const statusLabel =
-                      claimStatus === 'claimable'
-                        ? 'Claimable'
-                        : claimStatus === 'paid'
-                          ? 'Paid'
-                          : 'Accrued'
+                    // Drive the badge off the derived lifecycle `state`:
+                    //   claimable   -> Claimable (claimable now)
+                    //   distributed -> Paid (rewards already distributed)
+                    //   pending     -> Pending (accruing / not finalized)
+                    //   unknown     -> Unknown (journal swept before we tracked
+                    //                  it; per-leaf claim state is unrecoverable)
+                    const claimStyle: Record<string, string> = {
+                      claimable:
+                        'bg-amber-500/10 text-amber-500 dark:text-amber-400 border-amber-500/30',
+                      distributed: 'bg-muted text-muted-foreground border-border',
+                      pending:
+                        'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/30',
+                      unknown:
+                        'bg-transparent text-muted-foreground/50 border-border/50',
+                    }
+                    const claimLabel: Record<string, string> = {
+                      claimable: 'Claimable',
+                      distributed: 'Paid',
+                      pending: 'Pending',
+                      unknown: 'Unknown',
+                    }
+                    const bucket =
+                      epoch.state === 'claimable' ||
+                      epoch.state === 'distributed' ||
+                      epoch.state === 'unknown'
+                        ? epoch.state
+                        : 'pending'
+                    const statusStyle = claimStyle[bucket]
+                    const statusLabel = claimLabel[bucket]
                     return (
                       <tr
                         key={`${epoch.solana_epoch}-${epoch.subscription_epoch}`}

--- a/web/src/components/shreds-rewards-format.ts
+++ b/web/src/components/shreds-rewards-format.ts
@@ -1,16 +1,21 @@
 // Shared formatting helpers for the Edge Rewards pages.
 
-// The 2Z mint has 8 decimals (DOUBLEZERO_MINT_DECIMALS), so on-chain amounts
-// arrive in base units where 1 whole 2Z = 10^8 base units. Scale to whole 2Z
-// before display.
-const TWO_Z_UNITS_PER_TOKEN = 100_000_000
-
-export function format2Z(baseUnits: number): string {
-  if (!Number.isFinite(baseUnits) || baseUnits <= 0) return '—'
-  const amount = baseUnits / TWO_Z_UNITS_PER_TOKEN
+// formatTokenAmount renders a reward amount already scaled to whole tokens (the
+// API divides on-chain base units by the token's decimals) and appends the
+// token symbol. From epoch 968 validators may be rewarded in 2Z, USDC, or wSOL,
+// so the symbol must travel with the amount rather than being assumed to be 2Z.
+export function formatTokenAmount(amount: number, symbol: string): string {
+  const sym = symbol || '2Z'
+  if (!Number.isFinite(amount) || amount <= 0) return '—'
   if (amount >= 1_000_000)
-    return `${(amount / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 })}M 2Z`
+    return `${(amount / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 })}M ${sym}`
   if (amount >= 10_000)
-    return `${(amount / 1_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}K 2Z`
-  return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} 2Z`
+    return `${(amount / 1_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}K ${sym}`
+  return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${sym}`
+}
+
+// format2Z formats a whole-2Z amount. Thin wrapper for the 2Z-only call sites
+// (e.g. the list page's headline 2Z totals).
+export function format2Z(amount: number): string {
+  return formatTokenAmount(amount, '2Z')
 }

--- a/web/src/components/shreds-rewards-page.tsx
+++ b/web/src/components/shreds-rewards-page.tsx
@@ -185,10 +185,14 @@ export function ShredsRewardsPage() {
   }
 
   const validators = data?.validators ?? []
-  // We don't know total count from the API; derive whether there's another page by
-  // checking whether the response is a full page.
-  const hasMore = validators.length === PAGE_SIZE
-  const fauxTotal = hasMore ? offset + PAGE_SIZE + 1 : offset + validators.length
+  // The API returns the true total of matching validators (before limit/offset),
+  // so the pagination footer can show the real page count. Fall back to the
+  // full-page heuristic only if total is missing (e.g. an older API).
+  const total =
+    data?.total ??
+    (validators.length === PAGE_SIZE
+      ? offset + PAGE_SIZE + 1
+      : offset + validators.length)
 
   const thClass =
     'px-4 py-3 font-medium cursor-pointer select-none hover:text-foreground transition-colors whitespace-nowrap'
@@ -388,9 +392,9 @@ export function ShredsRewardsPage() {
               </tbody>
             </table>
           </div>
-          {(hasMore || offset > 0) && (
+          {(total > PAGE_SIZE || offset > 0) && (
             <Pagination
-              total={fauxTotal}
+              total={total}
               limit={PAGE_SIZE}
               offset={offset}
               onOffsetChange={setOffset}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6773,9 +6773,13 @@ export interface ShredsRewardsRow {
   validator_name: string
   activated_stake: number
   dz_user_ip: string
+  // 2Z-only headline totals (cross-token sums are not meaningful).
   total_earned_2z: number
   immediately_claimable_2z: number
+  // Per recent-epoch reward, in whole units of the token earned that epoch.
   epoch_earnings: Record<string, number>
+  // Per recent-epoch reward-token symbol, parallel to epoch_earnings.
+  epoch_tokens: Record<string, string>
 }
 
 export interface ShredsRewardsResponse {
@@ -6783,6 +6787,8 @@ export interface ShredsRewardsResponse {
   latest_finalized_epoch: number
   epoch_columns: number[]
   validators: ShredsRewardsRow[]
+  // Total distinct validators matching the filter, before limit/offset.
+  total: number
 }
 
 export interface ShredsRewardsParams {
@@ -6819,7 +6825,10 @@ export interface ShredsRewardsEpochDetail {
   subscription_epoch: number
   leader_slots: number
   client_id: number
-  earned_2z: number
+  // Reward in whole units of token_symbol (the token the validator chose for
+  // the epoch: 2Z, USDC, or wSOL).
+  earned: number
+  token_symbol: string
   // Retained for back-compat; `state` carries the full lifecycle.
   is_claimable?: boolean | null
   state: ShredsRewardsClaimState

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6808,13 +6808,21 @@ export async function fetchShredsRewards(
   return res.json()
 }
 
+export type ShredsRewardsClaimState =
+  | 'claimable'
+  | 'distributed'
+  | 'pending'
+  | 'unknown'
+
 export interface ShredsRewardsEpochDetail {
   solana_epoch: number
   subscription_epoch: number
   leader_slots: number
   client_id: number
   earned_2z: number
+  // Retained for back-compat; `state` carries the full lifecycle.
   is_claimable?: boolean | null
+  state: ShredsRewardsClaimState
 }
 
 export interface ShredsRewardsDetail {


### PR DESCRIPTION
## Summary

Fixes the validator rewards detail page across four issues: per-validator earnings were understated for multi-client validators, the per-epoch claim status was unreliable, the validator's share was overstated, and the Earned 2Z amount was inflated by the wrong denominator.

- **Multi-client grain fix.** A validator publishing under more than one software client in a single epoch produces one merkle leaf per client. The leaf and leaf-distribution-status tables keyed on `(subscription_epoch, node_id)` only, so those leaves collapsed into a single row — understating leader slots/earnings and letting one client's claimable bit clobber another's. Both grains now include `client_id`; a migration rebuilds the affected tables.
- **Derived claim lifecycle state.** Each epoch row carries an explicit `state` — `claimable`, `distributed` (Paid), `pending`, or `unknown` — instead of a bare nullable `is_claimable` bit. A funded epoch with no per-validator status row (journal swept before tracking began) is reported as `unknown` rather than assumed Paid.
- **Client-proportion default fix.** The per-client reward proportion is stored as `0` when unset (real fallback in `default_proportion`), and a ClickHouse `LEFT JOIN` fills a missing row with `0`, not `NULL`. So `coalesce(proportion, default_proportion, 3500)` returned `0`, giving the validator the whole pool share instead of ~65%. A `0` now falls through to `default_proportion`, then `3500`.
- **Authoritative leader-slot denominator.** Earnings split the pool by `leader_slots / total_leader_slots`, but the denominator was `sum(leader_slots)` over the *indexed* leaves — incomplete for older epochs, so every present validator was over-credited by a per-epoch constant factor. The `ShredDistributionJournal`'s own `total_leader_slots` (byte offset 128) is now decoded, stored on the 2Z-pool row, and used as the denominator (falling back to summed leaves when not yet populated).

## Validation

Cross-referenced against actual on-chain 2Z distribution amounts. Before the denominator fix, computed earnings were a constant multiple of actual *within* each epoch (e.g. epoch 976: every validator exactly 1.073× actual; 975: 1.146×; 974: 1.242×) — the signature of a shared, too-small denominator. The factor tracked the missing-validator gap (epoch 975 coverage 87.3% ⇒ 1/0.873 ≈ 1.146). Dividing by the journal's `total_leader_slots` removes it.

## Known limitations

- **Old swept epochs**: epochs whose journal was swept before this change keep `total_leader_slots = 0` (can't be re-fetched on-chain), so they fall back to the summed-leaves denominator and remain approximate. Epochs from the deploy forward are exact.
- **Paid status** is derived from the publisher accumulation bitmap; a cleared bit means distributed, but the bitmap doesn't encode *why* it cleared, so a forfeited/expired claim can read as Paid in rare cases. The authoritative source (actual distribution transactions) isn't indexed in this repo — a tracked follow-up.

## Testing Verification

- Earnings sum across multiple client leaves in one epoch; only the claimable client's share counts as immediately-claimable (`TestGetShredsRewards_MultiClientValidator`).
- Unset/zero client proportion falls through to `default_proportion` (65% share), not a 100% share (`TestGetShredsRewards_ProportionDefaultsWhenUnset`).
- Earnings divide by the stored `total_leader_slots`, not the summed leaves, when present (`TestGetShredsRewards_UsesJournalTotalLeaderSlots`).
- `total_leader_slots` decodes from journal byte offset 128 (`TestDecodeJournalAccount_ValidLayout`).
- Claim state resolves across the lifecycle: live claimable bit → `claimable`, cleared bit → `distributed`, funded-but-no-status → `unknown`, unfunded pool → `pending` (`TestGetShredsRewardsDetail_*`).
