### PR TITLE
indexer: chunk telemetry-usage influxdb query to bound heap

### DIFF
--- a/indexer/pkg/dz/telemetry/usage/chunk_test.go
+++ b/indexer/pkg/dz/telemetry/usage/chunk_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +91,40 @@ func TestLake_TelemetryUsage_QueryIntfCountersChunked_PropagatesError(t *testing
 	_, err := queryIntfCountersChunked(context.Background(), mock, start, end, 5*time.Minute)
 	require.ErrorIs(t, err, wantErr)
 	require.Equal(t, 2, calls, "must stop at the first failing chunk")
+}
+
+// Backfill takes arbitrary, potentially multi-day ranges — the case most likely
+// to trigger the InfluxDB heap exhaustion this chunking guards against. It must
+// split its range into bounded sub-queries just like the steady-state refresh.
+func TestLake_TelemetryUsage_BackfillForTimeRange_ChunksQuery(t *testing.T) {
+	t.Parallel()
+
+	var windows [][2]time.Time
+	influx := &mockInfluxDBClient{
+		queryIntfCountersFunc: func(_ context.Context, s, e time.Time) ([]map[string]any, error) {
+			windows = append(windows, [2]time.Time{s, e})
+			return nil, nil
+		},
+	}
+
+	view, err := NewView(ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		ClickHouse:      testClient(t),
+		InfluxDB:        influx,
+		Bucket:          "test-bucket",
+		RefreshInterval: time.Second,
+		QueryWindow:     time.Hour,
+		QueryChunk:      5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	start := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Hour)
+	_, err = view.BackfillForTimeRange(context.Background(), start, end)
+	require.NoError(t, err)
+
+	require.Len(t, windows, 12, "backfill must split its range into bounded chunks")
+	for _, w := range windows {
+		require.LessOrEqualf(t, w[1].Sub(w[0]), 5*time.Minute, "backfill sub-query %v..%v exceeds chunk", w[0], w[1])
+	}
 }

--- a/indexer/pkg/dz/telemetry/usage/chunk_test.go
+++ b/indexer/pkg/dz/telemetry/usage/chunk_test.go
@@ -1,0 +1,93 @@
+package dztelemusage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLake_TelemetryUsage_QueryIntfCountersChunked_SplitsWindow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Hour)
+	chunk := 5 * time.Minute
+
+	var windows [][2]time.Time
+	mock := &mockInfluxDBClient{
+		queryIntfCountersFunc: func(_ context.Context, s, e time.Time) ([]map[string]any, error) {
+			windows = append(windows, [2]time.Time{s, e})
+			return []map[string]any{{"intf": "eth0", "time": s.Format(time.RFC3339Nano)}}, nil
+		},
+	}
+
+	rows, err := queryIntfCountersChunked(context.Background(), mock, start, end, chunk)
+	require.NoError(t, err)
+
+	// 1 hour split into 5-minute chunks => 12 bounded sub-queries.
+	require.Len(t, windows, 12, "expected one sub-query per chunk")
+	// Rows from every chunk are concatenated.
+	require.Len(t, rows, 12)
+
+	// No sub-query exceeds the chunk size — this is what bounds InfluxDB heap.
+	for _, w := range windows {
+		require.LessOrEqualf(t, w[1].Sub(w[0]), chunk, "sub-query window %v..%v exceeds chunk %v", w[0], w[1], chunk)
+	}
+
+	// Sub-windows are contiguous and exactly cover [start, end).
+	require.Equal(t, start, windows[0][0])
+	require.Equal(t, end, windows[len(windows)-1][1])
+	for i := 1; i < len(windows); i++ {
+		require.Equalf(t, windows[i-1][1], windows[i][0], "gap/overlap between chunk %d and %d", i-1, i)
+	}
+}
+
+func TestLake_TelemetryUsage_QueryIntfCountersChunked_RemainderWindow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	end := start.Add(12 * time.Minute)
+	chunk := 5 * time.Minute
+
+	var windows [][2]time.Time
+	mock := &mockInfluxDBClient{
+		queryIntfCountersFunc: func(_ context.Context, s, e time.Time) ([]map[string]any, error) {
+			windows = append(windows, [2]time.Time{s, e})
+			return nil, nil
+		},
+	}
+
+	_, err := queryIntfCountersChunked(context.Background(), mock, start, end, chunk)
+	require.NoError(t, err)
+
+	// 12 minutes => [0,5), [5,10), [10,12): three chunks, last is the 2-minute remainder.
+	require.Len(t, windows, 3)
+	require.Equal(t, end, windows[len(windows)-1][1], "final chunk must clamp to end, never overshoot")
+	require.Equal(t, 2*time.Minute, windows[2][1].Sub(windows[2][0]))
+}
+
+func TestLake_TelemetryUsage_QueryIntfCountersChunked_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Hour)
+	wantErr := errors.New("request too large: Heap exhausted")
+
+	calls := 0
+	mock := &mockInfluxDBClient{
+		queryIntfCountersFunc: func(_ context.Context, _, _ time.Time) ([]map[string]any, error) {
+			calls++
+			if calls == 2 {
+				return nil, wantErr
+			}
+			return nil, nil
+		},
+	}
+
+	_, err := queryIntfCountersChunked(context.Background(), mock, start, end, 5*time.Minute)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 2, calls, "must stop at the first failing chunk")
+}

--- a/indexer/pkg/dz/telemetry/usage/store_backfill.go
+++ b/indexer/pkg/dz/telemetry/usage/store_backfill.go
@@ -51,7 +51,7 @@ func (v *View) BackfillForTimeRange(ctx context.Context, startTime, endTime time
 	v.log.Info("telemetry/usage: querying influxdb for backfill", "from", startTimeUTC, "to", endTimeUTC)
 
 	queryStart := time.Now()
-	rows, err := v.cfg.InfluxDB.QueryIntfCounters(ctx, startTimeUTC, endTimeUTC)
+	rows, err := queryIntfCountersChunked(ctx, v.cfg.InfluxDB, startTimeUTC, endTimeUTC, v.cfg.QueryChunk)
 	queryDuration := time.Since(queryStart)
 	metrics.RecordInfluxQuery(v.cfg.DZEnv, "backfill", queryDuration, len(rows), err)
 	if err != nil {

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -154,6 +154,7 @@ type ViewConfig struct {
 	ClickHouse      clickhouse.Client
 	RefreshInterval time.Duration
 	QueryWindow     time.Duration // How far back to query from InfluxDB
+	QueryChunk      time.Duration // Max time span of a single InfluxDB query; larger windows are split into chunks
 	DZEnv           string        // DZ network environment (e.g. "mainnet-beta", "testnet", "devnet")
 }
 
@@ -175,6 +176,13 @@ func (cfg *ViewConfig) Validate() error {
 	}
 	if cfg.QueryWindow <= 0 {
 		cfg.QueryWindow = 1 * time.Hour // Default to 1 hour window
+	}
+	if cfg.QueryChunk <= 0 {
+		// Bound each InfluxDB query to a small span. In steady state the query
+		// window is only a few minutes (one chunk), but when the high-water mark
+		// falls behind the window grows to QueryWindow; chunking keeps each
+		// server-side pivot small enough to stay under InfluxDB Cloud's heap limit.
+		cfg.QueryChunk = 5 * time.Minute
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
@@ -463,12 +471,39 @@ type CounterBaselines struct {
 	OutErrors   map[string]*int64
 }
 
+// queryIntfCountersChunked fetches interface counters over [start, end) by splitting the
+// range into contiguous half-open sub-windows of at most chunk duration and concatenating
+// the rows. A single unbounded query over a multi-hour window pivots millions of rows
+// server-side and exhausts InfluxDB Cloud's heap ("deduplicate batches: Heap exhausted");
+// chunking bounds each query's memory regardless of how far behind the high-water mark has
+// fallen. The sub-windows exactly partition [start, end), so the concatenated result matches
+// a single query and downstream time-sorting/forward-fill is unaffected.
+func queryIntfCountersChunked(ctx context.Context, client InfluxDBClient, start, end time.Time, chunk time.Duration) ([]map[string]any, error) {
+	if chunk <= 0 || !end.After(start) {
+		return client.QueryIntfCounters(ctx, start, end)
+	}
+
+	var all []map[string]any
+	for s := start; s.Before(end); s = s.Add(chunk) {
+		e := s.Add(chunk)
+		if e.After(end) {
+			e = end
+		}
+		rows, err := client.QueryIntfCounters(ctx, s, e)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, rows...)
+	}
+	return all, nil
+}
+
 func (v *View) queryInfluxDB(ctx context.Context, startTime, endTime time.Time, baselines *CounterBaselines, alreadyWritten MaxTimestampsByKey) ([]InterfaceUsage, *CounterBaselines, error) {
 	// InfluxDB uses dzd_pubkey as a tag, which we extract and map to device_pk.
 	v.log.Debug("telemetry/usage: executing main influxdb query", "from", startTime.UTC(), "to", endTime.UTC())
 	queryStart := time.Now()
 
-	rows, err := v.cfg.InfluxDB.QueryIntfCounters(ctx, startTime, endTime)
+	rows, err := queryIntfCountersChunked(ctx, v.cfg.InfluxDB, startTime, endTime, v.cfg.QueryChunk)
 	queryDuration := time.Since(queryStart)
 	metrics.RecordInfluxQuery(v.cfg.DZEnv, "interface_usage", queryDuration, len(rows), err)
 	if err != nil {


### PR DESCRIPTION
## Reason
Address indexer-error alerting:  https://doublezero.grafana.net/alerting/grafana/lake-indexer-errors/view?orgId=1

## Summary of Changes
- Chunk the `RefreshTelemetryUsage` InfluxDB query: instead of one Flux `pivot()` over the full `[queryStart, now]` window, split into contiguous sub-windows of at most `QueryChunk` (default 5m) and concatenate the rows.
- Fixes continuous `RefreshTelemetryUsage` failures in `lake-staging` (testnet + mainnet-beta) where the query hit InfluxDB Cloud's heap limit (`request too large … 'deduplicate batches': Heap exhausted`) or timed out (`context deadline exceeded`).
- Breaks the self-reinforcing failure loop: a failed query writes nothing, so the ClickHouse high-water mark freezes and the window grows to the `QueryWindow` (1h) cap, making every subsequent full-hour pivot too large to ever succeed. Bounded chunks let the activity recover on its own.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +36 / -1    | +35  |
| Tests        |     1 | +93 / -0    | +93  |
| **Total**    |     2 | +129 / -1   | +128 |

Small, focused change: one core-logic helper plus a config default, backed by pure unit tests.

<details>
<summary>Key files (click to expand)</summary>

- `indexer/pkg/dz/telemetry/usage/view.go` — added `queryIntfCountersChunked` (splits `[start, end)` into ≤`QueryChunk` half-open sub-windows and concatenates rows); added `QueryChunk` to `ViewConfig` with a 5m default in `Validate`; routed `queryInfluxDB` through the helper.
- `indexer/pkg/dz/telemetry/usage/chunk_test.go` — regression tests for window splitting, remainder clamping, and error propagation.

</details>

## Testing Verification
- `_SplitsWindow`: a 1h window produces 12 sub-queries, each ≤ chunk size, contiguous, exactly covering `[start, end)` — this is the assertion that fails against the old single-shot query.
- `_RemainderWindow`: 12m window → 3 chunks with the last clamped to the 2m remainder (no overshoot past `end`).
- `_PropagatesError`: a failing chunk aborts immediately and propagates the error.
- Sub-windows exactly partition `[start, end)` (half-open, matching Flux `range`), so the concatenated result is identical to the prior single query and downstream time-sort/forward-fill is unchanged. Steady-state windows are a few minutes (one chunk), so no behavior change in the common case.
- Full `dztelemusage` package tests pass against the ClickHouse testcontainer.
