### PR TITLE
scoreboard: label main lead-time value as p50

### DIFF
--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -2313,7 +2313,7 @@ export function EdgeScoreboardPage() {
                 <div key={competitor}>
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-muted-foreground">DZ Edge vs {FEED_LABELS[competitor] ?? competitor}</span>
-                    <span className="text-sm font-medium tabular-nums ml-4 shrink-0"><AnimatedStat value={lead.p50} fmt={formatMs} /></span>
+                    <span className="text-sm font-medium tabular-nums ml-4 shrink-0"><span className="text-xs text-muted-foreground font-normal mr-1">p50:</span><AnimatedStat value={lead.p50} fmt={formatMs} /></span>
                   </div>
                   <div className="text-xs text-muted-foreground mt-0.5">p95: <AnimatedStat value={lead.p95} fmt={formatMs} /></div>
                 </div>


### PR DESCRIPTION
## Summary

- The edge scoreboard's global stats card displayed the prominent lead-time value (p50) with no label, while p95 was labelled beneath it. Added a `p50:` prefix to the main value to clarify, per a request from Jito.

## Testing Verification

- Verified the label renders as a muted prefix consistent with the existing `p95:` line, without disrupting the card layout.

Resolves malbeclabs/infra#1662