### PR TITLE
multicast: report devices with no mroute telemetry as unknown, not unhealthy

### DIFF
--- a/api/testing/clickhouse.go
+++ b/api/testing/clickhouse.go
@@ -89,7 +89,10 @@ func (cfg *ClickHouseDBConfig) Validate() error {
 		cfg.Port = "9000"
 	}
 	if cfg.ContainerImage == "" {
-		cfg.ContainerImage = "clickhouse/clickhouse-server:latest"
+		// Pin to the version we run in dev/prod (docker-compose.yml,
+		// k8s/base/clickhouse.yaml) rather than :latest, so tests don't
+		// silently break on upstream ClickHouse changes.
+		cfg.ContainerImage = "clickhouse/clickhouse-server:25.12"
 	}
 	return nil
 }

--- a/indexer/db/clickhouse/migrations/20260616000001_health_multicast_user_no_telemetry_reason.sql
+++ b/indexer/db/clickhouse/migrations/20260616000001_health_multicast_user_no_telemetry_reason.sql
@@ -1,0 +1,431 @@
+-- +goose Up
+
+-- +goose StatementBegin
+-- health_multicast_user: distinguish "device exports no mroute telemetry"
+-- from a genuine forwarding fault.
+--
+-- When a device's state-collect agent isn't reporting (the device has zero
+-- rows in enriched_ip_mroute), every (S, G) RPF/OIF lookup in this view is
+-- silently empty. The original verdict then read as a confirmed fault
+-- ("Tunnel<N> not seen as RPF interface for ...", health_status='unhealthy'),
+-- implying a dataplane problem when the real cause is simply missing
+-- telemetry. We can't determine health without data, so the device-reports-
+-- nothing case now resolves to health_status='unknown' with a reason that
+-- says so. Both the health_status and mismatch_reason no-telemetry branches
+-- are evaluated first, so they supersede the per-mode logic whenever the
+-- device reports nothing.
+CREATE OR REPLACE VIEW health_multicast_user
+AS
+WITH
+multicast_users AS (
+    SELECT
+        u.pk AS mu_user_pk,
+        u.dz_ip AS mu_user_dz_ip,
+        u.tunnel_id AS mu_user_tunnel_id,
+        u.device_pk AS mu_user_device_pk,
+        u.owner_pubkey AS mu_user_owner_pubkey,
+        d.code AS mu_user_device_code,
+        JSONExtract(u.publishers, 'Array(String)') AS mu_publisher_group_pks,
+        JSONExtract(u.subscribers, 'Array(String)') AS mu_subscriber_group_pks
+    FROM dz_users_current u
+    LEFT ANY JOIN dz_devices_current d ON u.device_pk = d.pk
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+),
+publisher_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'P' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_publisher_group_pks AS gpk
+),
+subscriber_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'S' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_subscriber_group_pks AS gpk
+),
+all_memberships AS (
+    SELECT * FROM publisher_memberships
+    UNION ALL
+    SELECT * FROM subscriber_memberships
+),
+user_group_modes AS (
+    SELECT
+        mu_user_pk AS ug_user_pk,
+        mu_user_dz_ip AS ug_user_dz_ip,
+        mu_user_tunnel_id AS ug_user_tunnel_id,
+        mu_user_device_pk AS ug_user_device_pk,
+        mu_user_owner_pubkey AS ug_user_owner_pubkey,
+        any(mu_user_device_code) AS ug_user_device_code,
+        mem_group_pk AS ug_multicast_group_pk,
+        arrayStringConcat(arraySort(groupUniqArray(mem_role)), '+') AS ug_mode
+    FROM all_memberships
+    GROUP BY mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+             mu_user_owner_pubkey, mem_group_pk
+),
+oif_per_dgs AS (
+    SELECT
+        device_pk AS oif_device_pk,
+        group_address AS oif_group_address,
+        source_address AS oif_source_address,
+        groupUniqArrayIf(
+            toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$')),
+            match(oif_name, '^Tunnel\\d+$')
+        ) AS oif_tunnel_ids
+    FROM enriched_ip_mroute_oifs
+    WHERE source_address != '' AND source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address, source_address
+),
+sources_per_dg AS (
+    SELECT
+        device_pk AS tg_device_pk,
+        group_address AS tg_group_address,
+        countDistinct(source_address) AS tg_total_sources
+    FROM enriched_ip_mroute
+    WHERE source_address != '' AND source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address
+),
+oif_sources_per_dg AS (
+    SELECT
+        oif_device_pk AS s_device_pk,
+        oif_group_address AS s_group_address,
+        groupArray(oif_source_address) AS s_sources,
+        groupArray(oif_tunnel_ids) AS s_oifs_per_source
+    FROM oif_per_dgs
+    GROUP BY oif_device_pk, oif_group_address
+),
+iif_per_dgs AS (
+    SELECT
+        device_pk AS iif_device_pk,
+        group_address AS iif_group_address,
+        source_address AS iif_source_address,
+        toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')) AS iif_tunnel_id
+    FROM enriched_ip_mroute
+    WHERE match(rpf_interface, '^Tunnel\\d+$')
+      AND source_address != '' AND source_address != '0.0.0.0'
+),
+-- Per-device flag: does the device export ANY mroute telemetry at all?
+-- A device whose state-collect agent isn't reporting has zero rows in
+-- enriched_ip_mroute (no source filter — wildcard/Null0 rows count), so
+-- dm_present = 0 marks "no telemetry" as distinct from "reports mroutes
+-- but not the expected (S, G)".
+devices_with_mroutes AS (
+    SELECT DISTINCT device_pk AS dm_device_pk, toUInt8(1) AS dm_present
+    FROM enriched_ip_mroute
+)
+SELECT
+    ug.ug_user_pk AS user_pk,
+    ug.ug_user_owner_pubkey AS user_owner_pubkey,
+    ug.ug_user_dz_ip AS user_dz_ip,
+    ug.ug_user_tunnel_id AS user_tunnel_id,
+    ug.ug_user_device_pk AS user_device_pk,
+    ug.ug_user_device_code AS user_device_code,
+    ug.ug_multicast_group_pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.multicast_ip AS group_address,
+    ug.ug_mode AS mode,
+    multiIf(
+        ug.ug_mode = 'P', 'iif',
+        ug.ug_mode = 'S', 'oif',
+        ug.ug_mode = 'P+S', 'iif|oif',
+        ''
+    ) AS expected_tunnel_position,
+    (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AS publisher_iif_observed,
+    coalesce(tg.tg_total_sources, 0) AS subscriber_total_sources,
+    arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) AS subscriber_oif_present_sources,
+    (subscriber_total_sources > 0
+        AND subscriber_oif_present_sources = subscriber_total_sources) AS subscriber_oif_observed,
+    multiIf(
+        ug.ug_mode = 'P', (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+        ug.ug_mode = 'S', (coalesce(tg.tg_total_sources, 0) > 0
+                           AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
+        ug.ug_mode = 'P+S', (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+                            AND (coalesce(tg.tg_total_sources, 0) > 0
+                                 AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
+        false
+    ) AS reconciled,
+    -- health_status. The no-telemetry branch is first: if the device reports
+    -- no mroutes at all we can't determine health, so it's 'unknown' (not a
+    -- confirmed 'unhealthy'). The rest is the per-mode control-plane verdict.
+    multiIf(
+        dm.dm_present = 0, 'unknown',
+        ug.ug_mode = 'P' AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'healthy',
+        ug.ug_mode = 'P', 'unhealthy',
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0, 'unhealthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'S', 'unhealthy',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'degraded',
+        ug.ug_mode = 'P+S'
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'degraded',
+        'unhealthy'
+    ) AS health_status,
+    -- mismatch_reason
+    -- The no-telemetry branch comes first: when the device reports no
+    -- mroutes at all, none of the per-mode checks are meaningful.
+    multiIf(
+        dm.dm_present = 0,
+            concat('no mroute telemetry observed from ', ug.ug_user_device_code,
+                ' — cannot verify Tunnel', toString(ug.ug_user_tunnel_id),
+                ' for group ', g.multicast_ip),
+        ug.ug_mode = 'P' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0,
+            concat('no (S, ', g.multicast_ip, ') mroutes on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list for the group on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('partial OIF coverage on ', ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('Tunnel', toString(ug.ug_user_tunnel_id),
+                ' missing on both halves: publisher RPF for (', ug.ug_user_dz_ip,
+                ', ', g.multicast_ip, ') and subscriber OIF on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('subscriber half: partial OIF coverage on ',
+                ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
+        ''
+    ) AS mismatch_reason
+FROM user_group_modes ug
+LEFT JOIN dz_multicast_groups_current g ON ug.ug_multicast_group_pk = g.pk
+LEFT JOIN iif_per_dgs iif
+    ON iif.iif_device_pk = ug.ug_user_device_pk
+    AND iif.iif_group_address = g.multicast_ip
+    AND iif.iif_source_address = ug.ug_user_dz_ip
+LEFT JOIN oif_sources_per_dg o
+    ON o.s_device_pk = ug.ug_user_device_pk
+    AND o.s_group_address = g.multicast_ip
+LEFT JOIN sources_per_dg tg
+    ON tg.tg_device_pk = ug.ug_user_device_pk
+    AND tg.tg_group_address = g.multicast_ip
+LEFT JOIN devices_with_mroutes dm
+    ON dm.dm_device_pk = ug.ug_user_device_pk;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+-- Restore the pre-no-telemetry definition (migration 20260603000003).
+CREATE OR REPLACE VIEW health_multicast_user
+AS
+WITH
+multicast_users AS (
+    SELECT
+        u.pk AS mu_user_pk,
+        u.dz_ip AS mu_user_dz_ip,
+        u.tunnel_id AS mu_user_tunnel_id,
+        u.device_pk AS mu_user_device_pk,
+        u.owner_pubkey AS mu_user_owner_pubkey,
+        d.code AS mu_user_device_code,
+        JSONExtract(u.publishers, 'Array(String)') AS mu_publisher_group_pks,
+        JSONExtract(u.subscribers, 'Array(String)') AS mu_subscriber_group_pks
+    FROM dz_users_current u
+    LEFT ANY JOIN dz_devices_current d ON u.device_pk = d.pk
+    WHERE u.status = 'activated' AND u.kind = 'multicast'
+),
+publisher_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'P' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_publisher_group_pks AS gpk
+),
+subscriber_memberships AS (
+    SELECT
+        mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+        mu_user_owner_pubkey, mu_user_device_code,
+        gpk AS mem_group_pk,
+        'S' AS mem_role
+    FROM multicast_users
+    ARRAY JOIN mu_subscriber_group_pks AS gpk
+),
+all_memberships AS (
+    SELECT * FROM publisher_memberships
+    UNION ALL
+    SELECT * FROM subscriber_memberships
+),
+user_group_modes AS (
+    SELECT
+        mu_user_pk AS ug_user_pk,
+        mu_user_dz_ip AS ug_user_dz_ip,
+        mu_user_tunnel_id AS ug_user_tunnel_id,
+        mu_user_device_pk AS ug_user_device_pk,
+        mu_user_owner_pubkey AS ug_user_owner_pubkey,
+        any(mu_user_device_code) AS ug_user_device_code,
+        mem_group_pk AS ug_multicast_group_pk,
+        arrayStringConcat(arraySort(groupUniqArray(mem_role)), '+') AS ug_mode
+    FROM all_memberships
+    GROUP BY mu_user_pk, mu_user_dz_ip, mu_user_tunnel_id, mu_user_device_pk,
+             mu_user_owner_pubkey, mem_group_pk
+),
+oif_per_dgs AS (
+    SELECT
+        device_pk AS oif_device_pk,
+        group_address AS oif_group_address,
+        source_address AS oif_source_address,
+        groupUniqArrayIf(
+            toInt32OrZero(extract(oif_name, '^Tunnel(\\d+)$')),
+            match(oif_name, '^Tunnel\\d+$')
+        ) AS oif_tunnel_ids
+    FROM enriched_ip_mroute_oifs
+    WHERE source_address != '' AND source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address, source_address
+),
+sources_per_dg AS (
+    SELECT
+        device_pk AS tg_device_pk,
+        group_address AS tg_group_address,
+        countDistinct(source_address) AS tg_total_sources
+    FROM enriched_ip_mroute
+    WHERE source_address != '' AND source_address != '0.0.0.0'
+    GROUP BY device_pk, group_address
+),
+oif_sources_per_dg AS (
+    SELECT
+        oif_device_pk AS s_device_pk,
+        oif_group_address AS s_group_address,
+        groupArray(oif_source_address) AS s_sources,
+        groupArray(oif_tunnel_ids) AS s_oifs_per_source
+    FROM oif_per_dgs
+    GROUP BY oif_device_pk, oif_group_address
+),
+iif_per_dgs AS (
+    SELECT
+        device_pk AS iif_device_pk,
+        group_address AS iif_group_address,
+        source_address AS iif_source_address,
+        toInt32OrZero(extract(rpf_interface, '^Tunnel(\\d+)$')) AS iif_tunnel_id
+    FROM enriched_ip_mroute
+    WHERE match(rpf_interface, '^Tunnel\\d+$')
+      AND source_address != '' AND source_address != '0.0.0.0'
+)
+SELECT
+    ug.ug_user_pk AS user_pk,
+    ug.ug_user_owner_pubkey AS user_owner_pubkey,
+    ug.ug_user_dz_ip AS user_dz_ip,
+    ug.ug_user_tunnel_id AS user_tunnel_id,
+    ug.ug_user_device_pk AS user_device_pk,
+    ug.ug_user_device_code AS user_device_code,
+    ug.ug_multicast_group_pk AS multicast_group_pk,
+    g.code AS multicast_group_code,
+    g.multicast_ip AS group_address,
+    ug.ug_mode AS mode,
+    multiIf(
+        ug.ug_mode = 'P', 'iif',
+        ug.ug_mode = 'S', 'oif',
+        ug.ug_mode = 'P+S', 'iif|oif',
+        ''
+    ) AS expected_tunnel_position,
+    (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AS publisher_iif_observed,
+    coalesce(tg.tg_total_sources, 0) AS subscriber_total_sources,
+    arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) AS subscriber_oif_present_sources,
+    (subscriber_total_sources > 0
+        AND subscriber_oif_present_sources = subscriber_total_sources) AS subscriber_oif_observed,
+    multiIf(
+        ug.ug_mode = 'P', (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+        ug.ug_mode = 'S', (coalesce(tg.tg_total_sources, 0) > 0
+                           AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
+        ug.ug_mode = 'P+S', (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+                            AND (coalesce(tg.tg_total_sources, 0) > 0
+                                 AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0)),
+        false
+    ) AS reconciled,
+    multiIf(
+        ug.ug_mode = 'P' AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'healthy',
+        ug.ug_mode = 'P', 'unhealthy',
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0, 'unhealthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'S', 'unhealthy',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'healthy',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id)
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) > 0, 'degraded',
+        ug.ug_mode = 'P+S'
+            AND (iif.iif_tunnel_id = ug.ug_user_tunnel_id), 'degraded',
+        ug.ug_mode = 'P+S'
+            AND coalesce(tg.tg_total_sources, 0) > 0
+            AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = coalesce(tg.tg_total_sources, 0), 'degraded',
+        'unhealthy'
+    ) AS health_status,
+    multiIf(
+        ug.ug_mode = 'P' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND coalesce(tg.tg_total_sources, 0) = 0,
+            concat('no (S, ', g.multicast_ip, ') mroutes on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list for the group on ', ug.ug_user_device_code),
+        ug.ug_mode = 'S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('partial OIF coverage on ', ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id) AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('Tunnel', toString(ug.ug_user_tunnel_id),
+                ' missing on both halves: publisher RPF for (', ug.ug_user_dz_ip,
+                ', ', g.multicast_ip, ') and subscriber OIF on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND NOT (iif.iif_tunnel_id = ug.ug_user_tunnel_id),
+            concat('publisher half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen as RPF interface for (', ug.ug_user_dz_ip, ', ', g.multicast_ip,
+                ') on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) = 0,
+            concat('subscriber half: Tunnel', toString(ug.ug_user_tunnel_id),
+                ' not seen in any OIF list on ', ug.ug_user_device_code),
+        ug.ug_mode = 'P+S' AND arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, [])) < coalesce(tg.tg_total_sources, 0),
+            concat('subscriber half: partial OIF coverage on ',
+                ug.ug_user_device_code, ': Tunnel',
+                toString(ug.ug_user_tunnel_id), ' present for ',
+                toString(arrayCount(x -> has(x, ug.ug_user_tunnel_id), coalesce(o.s_oifs_per_source, []))), ' of ',
+                toString(coalesce(tg.tg_total_sources, 0)), ' publisher sources'),
+        ''
+    ) AS mismatch_reason
+FROM user_group_modes ug
+LEFT JOIN dz_multicast_groups_current g ON ug.ug_multicast_group_pk = g.pk
+LEFT JOIN iif_per_dgs iif
+    ON iif.iif_device_pk = ug.ug_user_device_pk
+    AND iif.iif_group_address = g.multicast_ip
+    AND iif.iif_source_address = ug.ug_user_dz_ip
+LEFT JOIN oif_sources_per_dg o
+    ON o.s_device_pk = ug.ug_user_device_pk
+    AND o.s_group_address = g.multicast_ip
+LEFT JOIN sources_per_dg tg
+    ON tg.tg_device_pk = ug.ug_user_device_pk
+    AND tg.tg_group_address = g.multicast_ip;
+-- +goose StatementEnd

--- a/indexer/pkg/clickhouse/testing/db.go
+++ b/indexer/pkg/clickhouse/testing/db.go
@@ -83,7 +83,10 @@ func (cfg *DBConfig) Validate() error {
 		cfg.Port = "9000"
 	}
 	if cfg.ContainerImage == "" {
-		cfg.ContainerImage = "clickhouse/clickhouse-server:latest"
+		// Pin to the version we run in dev/prod (docker-compose.yml,
+		// k8s/base/clickhouse.yaml) rather than :latest, so tests don't
+		// silently break on upstream ClickHouse changes.
+		cfg.ContainerImage = "clickhouse/clickhouse-server:25.12"
 	}
 	return nil
 }

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -47,20 +47,20 @@ func TestHealthMulticastUserRate(t *testing.T) {
 			('grp-rate-gap',   now(), now(), generateUUIDv4(), 0, 2, 'grp-rate-gap',   'o', 'rate-gap',   '233.99.1.2', 100000000, 'activated', 1, 1),
 			('grp-rate-idle',  now(), now(), generateUUIDv4(), 0, 3, 'grp-rate-idle',  'o', 'rate-idle',  '233.99.1.3', 100000000, 'activated', 1, 1)`))
 
-	// Users
+	// Users:
+	//   - grp-rate-clean: one active publisher at 10 Mbps, two subscribers (one matched, one mismatched).
+	//   - grp-rate-gap:   publisher will have no counter row.
+	//   - grp-rate-idle:  publisher has counter row with 0 bps.
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO dim_dz_users_history
 			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
 			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
 		VALUES
-			-- grp-rate-clean: one active publisher at 10 Mbps, two subscribers (one matched, one mismatched).
 			('u-pub-active', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-active', 'o', 'activated', 'multicast', '203.0.113.10', '10.99.1.10', 'd-fhr', 't1', 701, '["grp-rate-clean"]', '[]'),
 			('u-sub-recon',  now(), now(), generateUUIDv4(), 0, 2, 'u-sub-recon',  'o', 'activated', 'multicast', '203.0.113.11', '10.99.1.11', 'd-lhr', 't1', 801, '[]', '["grp-rate-clean"]'),
 			('u-sub-mis',    now(), now(), generateUUIDv4(), 0, 3, 'u-sub-mis',    'o', 'activated', 'multicast', '203.0.113.12', '10.99.1.12', 'd-lhr', 't1', 802, '[]', '["grp-rate-clean"]'),
-			-- grp-rate-gap: publisher will have no counter row.
 			('u-pub-nodata', now(), now(), generateUUIDv4(), 0, 4, 'u-pub-nodata', 'o', 'activated', 'multicast', '203.0.113.13', '10.99.1.13', 'd-fhr', 't1', 702, '["grp-rate-gap"]', '[]'),
 			('u-sub-gap',    now(), now(), generateUUIDv4(), 0, 5, 'u-sub-gap',    'o', 'activated', 'multicast', '203.0.113.14', '10.99.1.14', 'd-lhr', 't1', 803, '[]', '["grp-rate-gap"]'),
-			-- grp-rate-idle: publisher has counter row with 0 bps.
 			('u-pub-idle',   now(), now(), generateUUIDv4(), 0, 6, 'u-pub-idle',   'o', 'activated', 'multicast', '203.0.113.15', '10.99.1.15', 'd-fhr', 't1', 703, '["grp-rate-idle"]', '[]'),
 			('u-sub-idle',   now(), now(), generateUUIDv4(), 0, 7, 'u-sub-idle',   'o', 'activated', 'multicast', '203.0.113.16', '10.99.1.16', 'd-lhr', 't1', 804, '[]', '["grp-rate-idle"]')`))
 
@@ -93,17 +93,17 @@ func TestHealthMulticastUserRate(t *testing.T) {
 			('mr-lhr-idle',  now(), now(), generateUUIDv4(), 0, 4, 'd-lhr', 'default', 'sparse', '233.99.1.3', '10.99.1.15', 'SMP', 0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel804"]', 1, now())`))
 
 	// Counter rollup rows. NOTE: u-pub-nodata / Tunnel702 deliberately omitted.
+	//   - grp-rate-clean: publisher RX = 10 Mbps; matched subscriber TX = 10 Mbps; mismatched subscriber TX = 50 Mbps.
+	//   - grp-rate-gap:   subscriber has data; publisher does not.
+	//   - grp-rate-idle:  publisher and subscriber both report 0 bps.
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO device_interface_rollup_5m
 			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
 		VALUES
-			-- grp-rate-clean: publisher RX = 10 Mbps; matched subscriber TX = 10 Mbps; mismatched subscriber TX = 50 Mbps.
 			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel701', 701, 'u-pub-active', 10000000, 0, now()),
 			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel801', 801, 'u-sub-recon',  0, 10000000, now()),
 			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel802', 802, 'u-sub-mis',    0, 50000000, now()),
-			-- grp-rate-gap: subscriber has data; publisher does not.
 			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel803', 803, 'u-sub-gap',    0, 5000000,  now()),
-			-- grp-rate-idle: publisher and subscriber both report 0 bps.
 			(now() - INTERVAL 1 MINUTE, 'd-fhr', 'Tunnel703', 703, 'u-pub-idle',   0, 0, now()),
 			(now() - INTERVAL 1 MINUTE, 'd-lhr', 'Tunnel804', 804, 'u-sub-idle',   0, 0, now())`))
 
@@ -251,8 +251,6 @@ func TestHealthMulticastUserRate_PlusSubscriber(t *testing.T) {
 			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
 			 oif_list, oif_count, creation_time)
 		VALUES
-			-- u-ps is both publisher and subscriber on d-ps-mid: RPF=Tunnel901 (pub),
-			-- and OIF contains Tunnel901 reflecting OTHER publisher's traffic to it.
 			('mr-ps-pub',   now(), now(), generateUUIDv4(), 0, 1, 'd-ps-mid', 'default', 'sparse', '233.99.2.1', '10.99.2.1', 'SBNP', 0, 'Tunnel901',     '', '', 0, 0, '', 0, 0, '', 0, now()),
 			('mr-ps-sub',   now(), now(), generateUUIDv4(), 0, 2, 'd-ps-mid', 'default', 'sparse', '233.99.2.1', '10.99.2.2', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel901"]', 1, now()),
 			('mr-other-pub',now(), now(), generateUUIDv4(), 0, 3, 'd-ps-fhr', 'default', 'sparse', '233.99.2.1', '10.99.2.2', 'SBNP', 0, 'Tunnel902',     '', '', 0, 0, '', 0, 0, '', 0, now())`))

--- a/indexer/pkg/dz/mroute/health_multicast_user_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_test.go
@@ -15,7 +15,11 @@ import (
 //   - u-sub-healthy: subscriber whose Tunnel<N> appears in OIF list of an
 //     mroute for the group → healthy
 //   - u-pub-silent: publisher whose Tunnel<N> is NOT present anywhere on
-//     the device → unhealthy with a specific mismatch_reason
+//     the device, but the device DOES report other mroutes → unhealthy
+//     with a "not seen as RPF interface" mismatch_reason
+//   - u-pub-notel: publisher on a device that reports NO mroutes at all →
+//     unhealthy, but the reason says telemetry is missing rather than
+//     implying a forwarding fault
 func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
@@ -30,7 +34,9 @@ func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 		VALUES ('d-sea', now(), now(), generateUUIDv4(), 0, 1,
 			'd-sea', 'activated', 'edge', 'sea001-dz001', '', '', '', 0, '[]'),
 			('d-nyc', now(), now(), generateUUIDv4(), 0, 2,
-			'd-nyc', 'activated', 'edge', 'nyc001-dz001', '', '', '', 0, '[]')`))
+			'd-nyc', 'activated', 'edge', 'nyc001-dz001', '', '', '', 0, '[]'),
+			('d-iad', now(), now(), generateUUIDv4(), 0, 3,
+			'd-iad', 'activated', 'hybrid', 'iad001-tsw', '', '', '', 0, '[]')`))
 
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO dim_dz_multicast_groups_history
@@ -47,6 +53,7 @@ func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 		VALUES
 			('u-pub-healthy', now(), now(), generateUUIDv4(), 0, 1, 'u-pub-healthy', 'o', 'activated', 'multicast', '203.0.113.10', '10.99.0.10', 'd-sea', 't1', 503, '["grp-r"]', '[]'),
 			('u-pub-silent',  now(), now(), generateUUIDv4(), 0, 2, 'u-pub-silent',  'o', 'activated', 'multicast', '203.0.113.11', '10.99.0.11', 'd-sea', 't1', 504, '["grp-r"]', '[]'),
+			('u-pub-notel',   now(), now(), generateUUIDv4(), 0, 4, 'u-pub-notel',   'o', 'activated', 'multicast', '203.0.113.13', '10.99.0.13', 'd-iad', 't1', 505, '["grp-r"]', '[]'),
 			('u-sub-healthy', now(), now(), generateUUIDv4(), 0, 3, 'u-sub-healthy', 'o', 'activated', 'multicast', '203.0.113.12', '10.99.0.12', 'd-nyc', 't1', 602, '[]', '["grp-r"]')`))
 
 	// FHR mroute for u-pub-healthy — its tunnel appears as RPF interface
@@ -88,37 +95,50 @@ func TestHealthMulticastUser_Reconciliation(t *testing.T) {
 		userPK, mode, mismatchReason, healthStatus string
 		pubIIF, subOIF, reconciled                 bool
 	}
-	got := []row{}
+	got := map[string]row{}
 	for rows.Next() {
 		var r row
 		require.NoError(t, rows.Scan(&r.userPK, &r.mode, &r.pubIIF, &r.subOIF, &r.reconciled, &r.healthStatus, &r.mismatchReason))
-		got = append(got, r)
+		got[r.userPK] = r
 	}
 	require.NoError(t, rows.Err())
-	require.Len(t, got, 3)
+	require.Len(t, got, 4)
 
 	// u-pub-healthy
-	assert.Equal(t, "u-pub-healthy", got[0].userPK)
-	assert.Equal(t, "P", got[0].mode)
-	assert.True(t, got[0].pubIIF)
-	assert.True(t, got[0].reconciled)
-	assert.Equal(t, "healthy", got[0].healthStatus)
+	assert.Equal(t, "P", got["u-pub-healthy"].mode)
+	assert.True(t, got["u-pub-healthy"].pubIIF)
+	assert.True(t, got["u-pub-healthy"].reconciled)
+	assert.Equal(t, "healthy", got["u-pub-healthy"].healthStatus)
 
-	// u-pub-silent
-	assert.Equal(t, "u-pub-silent", got[1].userPK)
-	assert.Equal(t, "P", got[1].mode)
-	assert.False(t, got[1].pubIIF, "Tunnel504 isn't on any mroute → IIF not observed")
-	assert.False(t, got[1].reconciled)
-	assert.Equal(t, "unhealthy", got[1].healthStatus)
-	assert.Contains(t, got[1].mismatchReason, "Tunnel504")
-	assert.Contains(t, got[1].mismatchReason, "RPF interface")
+	// u-pub-silent — device d-sea reports other mroutes, but Tunnel504 is
+	// nowhere on them, so this is a genuine "not seen as RPF" fault.
+	silent := got["u-pub-silent"]
+	assert.Equal(t, "P", silent.mode)
+	assert.False(t, silent.pubIIF, "Tunnel504 isn't on any mroute → IIF not observed")
+	assert.False(t, silent.reconciled)
+	assert.Equal(t, "unhealthy", silent.healthStatus)
+	assert.Contains(t, silent.mismatchReason, "Tunnel504")
+	assert.Contains(t, silent.mismatchReason, "RPF interface")
+	assert.NotContains(t, silent.mismatchReason, "no mroute telemetry",
+		"device reports mroutes, so this is a real fault, not a telemetry gap")
+
+	// u-pub-notel — device d-iad reports NO mroutes at all. We can't determine
+	// health without data, so it's 'unknown' (not a confirmed 'unhealthy'),
+	// and the reason names the telemetry gap rather than implying a fault.
+	notel := got["u-pub-notel"]
+	assert.Equal(t, "P", notel.mode)
+	assert.False(t, notel.reconciled)
+	assert.Equal(t, "unknown", notel.healthStatus)
+	assert.Contains(t, notel.mismatchReason, "no mroute telemetry observed from iad001-tsw")
+	assert.Contains(t, notel.mismatchReason, "Tunnel505")
+	assert.NotContains(t, notel.mismatchReason, "RPF interface",
+		"no-telemetry reason should not imply the tunnel is missing from an observed mroute")
 
 	// u-sub-healthy
-	assert.Equal(t, "u-sub-healthy", got[2].userPK)
-	assert.Equal(t, "S", got[2].mode)
-	assert.True(t, got[2].subOIF)
-	assert.True(t, got[2].reconciled)
-	assert.Equal(t, "healthy", got[2].healthStatus)
+	assert.Equal(t, "S", got["u-sub-healthy"].mode)
+	assert.True(t, got["u-sub-healthy"].subOIF)
+	assert.True(t, got["u-sub-healthy"].reconciled)
+	assert.Equal(t, "healthy", got["u-sub-healthy"].healthStatus)
 }
 
 // TestHealthMulticastUser_PartialDelivery covers the multi-publisher case:

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -178,7 +178,7 @@ const STATUS_DEFINITIONS: Array<{ status: MulticastHealthStatus; short: string }
   { status: 'healthy', short: 'control plane reconciles AND subscriber TX matches sum of publishers (±5% / 1 Mbps)' },
   { status: 'degraded', short: 'control plane reconciles but rates diverge, or partial control plane reconciliation' },
   { status: 'unhealthy', short: 'no (S,G) mroute, or rates diverge under a degraded control plane' },
-  { status: 'unknown', short: 'no counter data, or no traffic flowing in the 5-min window' },
+  { status: 'unknown', short: 'no mroute telemetry from the device, no counter data, or no traffic in the 5-min window' },
 ]
 
 const SECTION_HELP = {
@@ -498,15 +498,15 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
   return (
     <div className="p-4 space-y-6">
       {/* Under-development notice. The reconciliation logic and rate dimension
-          here surface real data, but the verdicts assume state-collect covers
-          every device — today only jump devices are collected, so non-jump
-          publishers/subscribers can falsely render as unhealthy. Wording is
-          deliberately concrete so operators read it as caveat, not "do not
-          trust this page". */}
+          here surface real data, but state-collect doesn't cover every device
+          yet — today only jump devices are collected. Users on a non-reporting
+          device now render as `unknown` (not a false `unhealthy`), so the
+          caveat is that absence of data ≠ a fault. Wording is deliberately
+          concrete so operators read it as caveat, not "do not trust this page". */}
       <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-100">
         <div className="font-medium">This view is under development.</div>
         <div className="mt-1 text-amber-700 dark:text-amber-200/90">
-          Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
+          Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-reporting device shows as <span className="font-mono">unknown</span> (no mroute telemetry observed) rather than a verdict — it is not necessarily unhealthy. Treat verdicts as a starting point, not ground truth.
         </div>
       </div>
 


### PR DESCRIPTION
## Summary of Changes
- Multicast publishers/subscribers on a device that exports **no mroute telemetry** now resolve to `health_status='unknown'` ("no mroute telemetry observed from `<device>`") instead of a false `unhealthy`. A genuine RPF mismatch on a *reporting* device still resolves to `unhealthy`.
- Reuses the existing `unknown` status — already wired through the rate view (which defaults to it), API counts, and web badges/sort — so no API or schema changes were needed.
- Updates the Multicast health UI copy: the `unknown` definition now covers the no-telemetry case, and the under-development banner explains non-reporting devices show `unknown` (not `unhealthy`).
- Pins the ClickHouse testcontainer image to `25.12` (matching `docker-compose.yml` / `k8s/base/clickhouse.yaml`) instead of `:latest`, which had drifted to 26.3 and broke a test; also moves SQL `--` comments out of `INSERT ... VALUES` blocks that the newer Values parser rejects.

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net   |
|--------------|-------|---------------|-------|
| Core logic   |     2 | +438 / -7     | +431  |
| Tests        |     2 | +51 / -33     |  +18  |
| Scaffolding  |     2 | +8 / -2       |   +6  |
| **Total**    |     6 | +497 / -42    | +455  |

The line count is dominated by the migration re-declaring the full `health_multicast_user` view in its Up and Down blocks; the actual semantic change is two added `multiIf` branches (`health_status` and `mismatch_reason`).

<details>
<summary>Key files (click to expand)</summary>

- `indexer/db/clickhouse/migrations/20260616000001_health_multicast_user_no_telemetry_reason.sql` — adds a `devices_with_mroutes` flag to `health_multicast_user`; a device with zero observed mroutes resolves `health_status` to `unknown` with a "no mroute telemetry observed" reason.
- `indexer/pkg/dz/mroute/health_multicast_user_test.go` — adds a publisher on a non-reporting device (asserts `unknown` + telemetry-gap reason) and a contrasting reporting-device fault case (asserts `unhealthy` + "RPF interface").
- `web/src/components/multicast-group-health-tab.tsx` — broadens the `unknown` status definition and rewrites the under-development banner to reflect the new behavior.
- `indexer/pkg/clickhouse/testing/db.go`, `api/testing/clickhouse.go` — pin the testcontainer ClickHouse image to `25.12`.
- `indexer/pkg/dz/mroute/health_multicast_user_rate_test.go` — relocate embedded `--` comments out of `INSERT ... VALUES`.

</details>

## Testing Verification
- `health_multicast_user_test.go` covers both new paths: a publisher on a zero-mroute device resolves to `unknown` with "no mroute telemetry observed from …" (and *not* "RPF interface"), while a publisher whose reporting device lacks its tunnel still resolves to `unhealthy`.
- Confirmed the root cause of the pre-existing rate-test failure against ClickHouse 26.3 (the `Values` parser rejects `--` comments between `VALUES` tuples); `mroute` package and API `Multicast` tests pass on the pinned `25.12` image.
