### PR TITLE
scoreboard: surface turbine-root in DZ lead-time and publishing stats

### DIFF
--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -102,24 +102,26 @@ type EdgeScoreboardLeader struct {
 
 // EdgeScoreboardResponse is the response for the edge scoreboard endpoint.
 type EdgeScoreboardResponse struct {
-	Window             string                           `json:"window"`
-	LeadersOnly        bool                             `json:"leaders_only"`
-	GeneratedAt        time.Time                        `json:"generated_at"`
-	CurrentEpoch       uint64                           `json:"current_epoch"`
-	CurrentSlot        uint64                           `json:"current_slot"`
-	TotalSlots         uint64                           `json:"total_slots"`
-	GlobalTotalSlots   uint64                           `json:"global_total_slots"`
-	DZSlots            uint64                           `json:"dz_slots"`
-	TotalDZLeaderSlots uint64                           `json:"total_dz_leader_slots"`
-	CompletenessPct    float64                          `json:"completeness_pct"`
-	PublisherCount     uint64                           `json:"publisher_count"`
-	PublishingCount    uint64                           `json:"publishing_count"`
-	PublishingStakePct float64                          `json:"publishing_stake_pct"`
-	Nodes              []EdgeScoreboardNode             `json:"nodes"`
-	RecentSlots        []EdgeScoreboardSlotRace         `json:"recent_slots"`
-	SlotBuckets        []EdgeScoreboardSlotBucket       `json:"slot_buckets,omitempty"`
-	SlotBucketSize     uint64                           `json:"slot_bucket_size,omitempty"`
-	SlotLeaders        map[string]*EdgeScoreboardLeader `json:"slot_leaders,omitempty"`
+	Window                 string                           `json:"window"`
+	LeadersOnly            bool                             `json:"leaders_only"`
+	GeneratedAt            time.Time                        `json:"generated_at"`
+	CurrentEpoch           uint64                           `json:"current_epoch"`
+	CurrentSlot            uint64                           `json:"current_slot"`
+	TotalSlots             uint64                           `json:"total_slots"`
+	GlobalTotalSlots       uint64                           `json:"global_total_slots"`
+	DZSlots                uint64                           `json:"dz_slots"`
+	TotalDZLeaderSlots     uint64                           `json:"total_dz_leader_slots"`
+	CompletenessPct        float64                          `json:"completeness_pct"`
+	PublisherCount         uint64                           `json:"publisher_count"`
+	PublishingCount        uint64                           `json:"publishing_count"`
+	PublishingStakePct     float64                          `json:"publishing_stake_pct"`
+	RootPublishingCount    uint64                           `json:"root_publishing_count"`
+	RootPublishingStakePct float64                          `json:"root_publishing_stake_pct"`
+	Nodes                  []EdgeScoreboardNode             `json:"nodes"`
+	RecentSlots            []EdgeScoreboardSlotRace         `json:"recent_slots"`
+	SlotBuckets            []EdgeScoreboardSlotBucket       `json:"slot_buckets,omitempty"`
+	SlotBucketSize         uint64                           `json:"slot_bucket_size,omitempty"`
+	SlotLeaders            map[string]*EdgeScoreboardLeader `json:"slot_leaders,omitempty"`
 	// DataLagMs is how far behind wall clock the latest row in slot_feed_race_summary_v2 is
 	// (server now − max(event_ts)). The client adds this to its own queue depth to show a
 	// pill reflecting actual on-chain time.
@@ -137,17 +139,23 @@ const maxValidSlot = 1_000_000_000_000
 // the per-validator local re-broadcast (dz_rebop) plus three regional retransmit feeds.
 const retransmitFeeds = `'dz_rebop', 'edge-solana-retrans-amer', 'edge-solana-retrans-eu', 'edge-solana-retrans-apac'`
 
-// dzFeeds combines the DZ leader feed with every retransmit variant. It backs the
-// dz_slots completeness count (q1) and the all-slots lead-time pool (q2b), so the root
-// feed is deliberately excluded here to keep those metrics on the existing 'dz' baseline.
+// dzFeeds combines the DZ leader feed with every retransmit variant (root excluded). It
+// backs the dz_slots completeness count (q1), so the root feed is deliberately excluded
+// here to keep that metric on the existing 'dz' + retransmit baseline.
 const dzFeeds = `'dz', ` + retransmitFeeds
 
 // rootFeed is the multicast group validators publish to when they are the root of the
 // turbine tree — the earliest hop of the DZ shred path, before regional retransmit.
 const rootFeed = `'edge-solana-root'`
 
+// dzEdgeFeeds is the full set of DZ delivery paths that make up the synthesized dz_edge
+// feed: leader (dz), turbine-root (edge-solana-root), and every retransmit variant. It
+// backs the lead-time pool (q2b) so the p50/p95 advantage reflects whichever DZ path
+// arrived first — matching the win-rate's dz_edge = dz + dz_root + dz_retransmit.
+const dzEdgeFeeds = dzFeeds + `, ` + rootFeed
+
 // scoreboardFeeds is the whitelist of feed names included in edge scoreboard results.
-const scoreboardFeeds = dzFeeds + `, ` + rootFeed + `, 'jito', 'turbine'`
+const scoreboardFeeds = dzEdgeFeeds + `, 'jito', 'turbine'`
 
 // scoreboardLoserFeeds is the whitelist of competitor feeds shown in lead-time comparisons.
 const scoreboardLoserFeeds = `'jito', 'turbine'`
@@ -398,6 +406,8 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 	var totalDZLeaderSlots, globalTotalSlots uint64
 	var publisherCount, publishingCount uint64
 	var publishingStakePct float64
+	var rootPublishingCount uint64
+	var rootPublishingStakePct float64
 
 	if cursorMode {
 		// Derive a slot window from the cursor. slotWindowMin/slotWindowMax (below)
@@ -688,16 +698,28 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				return nil
 			}
 			publisherCount = pc.TotalPublishers
-			var publishingStake int64
-			var pubCount uint64
+			var publishingStake, rootStake int64
+			var pubCount, rootCount uint64
 			for _, p := range pc.Publishers {
-				if p.LeaderSlots > 0 && p.VotePubkey != "" && p.NodePubkey != "" {
+				if p.VotePubkey == "" || p.NodePubkey == "" {
+					continue
+				}
+				if p.LeaderSlots > 0 {
 					pubCount++
 					publishingStake += int64(p.ActivatedStake)
+				}
+				// Turbine-root participation, derived the same way as the leader metric.
+				// Reads zero until the shredder populates publisher_shred_stats with the
+				// edge-solana-root feed (see rootPublisherFeed in publisher_check.go).
+				if p.RootSlots > 0 {
+					rootCount++
+					rootStake += int64(p.ActivatedStake)
 				}
 			}
 			publishingCount = pubCount
 			publishingStakePct = float64(publishingStake) / float64(pc.TotalNetworkStake) * 100
+			rootPublishingCount = rootCount
+			rootPublishingStakePct = float64(rootStake) / float64(pc.TotalNetworkStake) * 100
 			return nil
 		})
 
@@ -846,9 +868,10 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 		// Group A2: pairwise lead times (q2b) for the synthetic dz_edge feed vs competitors.
 		// Runs in parallel with Group A so it is never starved by q2+q2c consuming
 		// the 45s budget, which caused intermittent empty lead-time columns.
-		// Leaders-only uses feed='dz' (leader path only). All-slots pools dz + regional
-		// retransmit feeds so retransmit wins are represented — direct quantile over the
-		// combined rows (no per-slot argMin CTE, which was too expensive over the full table).
+		// Both modes pool the full DZ path set (dz + turbine-root + regional retransmit) so the
+		// p50/p95 reflects whichever DZ path arrived first — matching the win-rate's dz_edge.
+		// Direct quantile over the combined rows (no per-slot argMin CTE, which was too
+		// expensive over the full table). Leaders-only additionally scopes to DZ-leader slots.
 		g.Go(func() error {
 			var q2b string
 			if leadersOnly {
@@ -860,13 +883,13 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					quantile(0.5)(lead_time_p50_ms) AS p50_ms,
 					quantile(0.95)(lead_time_p95_ms) AS p95_ms
 				FROM %s.slot_feed_race_summary_v2
-				WHERE feed_type = 'shred' AND feed = 'dz' AND loser_feed IN (%s)
+				WHERE feed_type = 'shred' AND feed IN (%s) AND loser_feed IN (%s)
 					AND slot IN (SELECT slot FROM dz_leader_slots)
 					AND lead_time_p50_ms <= 500
 					%s
 				GROUP BY host, loser_feed
 			SETTINGS final=1
-`, dzLeaderCTE, shredderDB, scoreboardLoserFeeds, rangeFilter)
+`, dzLeaderCTE, shredderDB, dzEdgeFeeds, scoreboardLoserFeeds, rangeFilter)
 			} else {
 				q2b = fmt.Sprintf(`
 				SELECT
@@ -880,7 +903,7 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					%s
 				GROUP BY host, loser_feed
 			SETTINGS final=1
-`, shredderDB, dzFeeds, scoreboardLoserFeeds, rangeFilter)
+`, shredderDB, dzEdgeFeeds, scoreboardLoserFeeds, rangeFilter)
 			}
 			t := time.Now()
 			rows2b, err := a.envDB(gctx).Query(gctx, q2b)
@@ -1533,25 +1556,27 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 	}
 
 	return &EdgeScoreboardResponse{
-		Window:             window,
-		LeadersOnly:        leadersOnly,
-		GeneratedAt:        time.Now().UTC(),
-		CurrentEpoch:       globalMaxEpoch,
-		CurrentSlot:        globalMaxSlot,
-		TotalSlots:         totalSlots,
-		GlobalTotalSlots:   globalTotalSlots,
-		DZSlots:            dzSlots,
-		TotalDZLeaderSlots: totalDZLeaderSlots,
-		CompletenessPct:    completenessPct,
-		PublisherCount:     publisherCount,
-		PublishingCount:    publishingCount,
-		PublishingStakePct: publishingStakePct,
-		Nodes:              nodes,
-		RecentSlots:        recentSlots,
-		SlotBuckets:        slotBuckets,
-		SlotBucketSize:     slotBucketSize,
-		SlotLeaders:        slotLeaders,
-		DataLagMs:          dataLagMs,
+		Window:                 window,
+		LeadersOnly:            leadersOnly,
+		GeneratedAt:            time.Now().UTC(),
+		CurrentEpoch:           globalMaxEpoch,
+		CurrentSlot:            globalMaxSlot,
+		TotalSlots:             totalSlots,
+		GlobalTotalSlots:       globalTotalSlots,
+		DZSlots:                dzSlots,
+		TotalDZLeaderSlots:     totalDZLeaderSlots,
+		CompletenessPct:        completenessPct,
+		PublisherCount:         publisherCount,
+		PublishingCount:        publishingCount,
+		PublishingStakePct:     publishingStakePct,
+		RootPublishingCount:    rootPublishingCount,
+		RootPublishingStakePct: rootPublishingStakePct,
+		Nodes:                  nodes,
+		RecentSlots:            recentSlots,
+		SlotBuckets:            slotBuckets,
+		SlotBucketSize:         slotBucketSize,
+		SlotLeaders:            slotLeaders,
+		DataLagMs:              dataLagMs,
 	}, nil
 }
 

--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -335,6 +335,48 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp)
 }
 
+// FetchRootPublishingStats returns the number of distinct validators publishing via the
+// turbine-root path and the sum of their activated stake (in lamports).
+//
+// edge-solana-root is intentionally not written to publisher_shred_stats (it would
+// otherwise pollute the retransmitter detection in publisher_check.go), so turbine-root
+// participation is re-derived from the timing events table instead. slot_feed_race_summary_v2
+// carries no publisher identity, so each root-observed slot is mapped to its scheduled
+// leader via the leader schedule and that leader's stake via vote accounts. Scope is the
+// current + previous epoch, matching the leader publishing metric's 2-epoch default.
+func (a *API) FetchRootPublishingStats(ctx context.Context) (count uint64, stake int64, err error) {
+	const slotsPerEpoch = 432_000
+	shredderDB := fmt.Sprintf("`%s`", a.ShredderDB)
+
+	query := fmt.Sprintf(`
+		WITH
+		root_slots AS (
+			SELECT DISTINCT slot
+			FROM %[1]s.slot_feed_race_summary_v2
+			WHERE feed_type = 'shred' AND feed = %[2]s
+				AND epoch >= (SELECT max(epoch) FROM %[1]s.slot_feed_race_summary_v2 WHERE feed_type = 'shred') - 1
+		),
+		sched AS (
+			SELECT toUInt64(epoch * %[3]d + arrayJoin(JSONExtract(slots, 'Array(UInt64)'))) AS slot, node_pubkey
+			FROM dim_solana_leader_schedule_history
+			WHERE epoch >= (SELECT max(epoch) FROM dim_solana_leader_schedule_history) - 1
+		),
+		root_leaders AS (
+			SELECT DISTINCT s.node_pubkey AS node_pubkey
+			FROM sched s INNER JOIN root_slots r ON s.slot = r.slot
+		)
+		SELECT count(), COALESCE(sum(v.activated_stake_lamports), 0)
+		FROM root_leaders rl
+		INNER JOIN solana_vote_accounts_current v
+			ON v.node_pubkey = rl.node_pubkey AND v.epoch_vote_account = 'true'
+	`, shredderDB, rootFeed, slotsPerEpoch)
+
+	t := time.Now()
+	err = a.envDB(ctx).QueryRow(ctx, query).Scan(&count, &stake)
+	metrics.RecordClickHouseQuery("edge_scoreboard:root_publishing", time.Since(t), err)
+	return count, stake, err
+}
+
 // FetchEdgeScoreboardData performs the actual edge scoreboard queries.
 // When leadersOnly is true, results are scoped to slots where the leader published via DZ.
 // sinceSlot > 0 or beforeSlot > 0 enables cursor mode: only recent_slots are returned
@@ -680,9 +722,10 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 
 		// Group P: publisher / publishing-shred / stake-% headline numbers.
 		// Reads the publisher_check page-cache entry (refreshed by the worker every 30s)
-		// and derives the three values from it. The previous in-place query (q1d) ran
-		// sequentially before this errgroup and consumed most of the deadline budget in
-		// prod, surfacing as "context deadline exceeded" on q1d / q8 in the worker.
+		// for the leader publishing count/stake and the network-stake denominator, then
+		// runs a follow-up query for the turbine-root numbers. The previous in-place query
+		// (q1d) ran sequentially before this errgroup and consumed most of the deadline
+		// budget in prod, surfacing as "context deadline exceeded" on q1d / q8 in the worker.
 		g.Go(func() error {
 			data, err := a.readPageCache(gctx, "publisher_check")
 			if err != nil {
@@ -698,8 +741,8 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 				return nil
 			}
 			publisherCount = pc.TotalPublishers
-			var publishingStake, rootStake int64
-			var pubCount, rootCount uint64
+			var publishingStake int64
+			var pubCount uint64
 			for _, p := range pc.Publishers {
 				if p.VotePubkey == "" || p.NodePubkey == "" {
 					continue
@@ -708,16 +751,15 @@ func (a *API) FetchEdgeScoreboardData(ctx context.Context, window string, leader
 					pubCount++
 					publishingStake += int64(p.ActivatedStake)
 				}
-				// Turbine-root participation, derived the same way as the leader metric.
-				// Reads zero until the shredder populates publisher_shred_stats with the
-				// edge-solana-root feed (see rootPublisherFeed in publisher_check.go).
-				if p.RootSlots > 0 {
-					rootCount++
-					rootStake += int64(p.ActivatedStake)
-				}
 			}
 			publishingCount = pubCount
 			publishingStakePct = float64(publishingStake) / float64(pc.TotalNetworkStake) * 100
+
+			rootCount, rootStake, rerr := a.FetchRootPublishingStats(gctx)
+			if rerr != nil {
+				log.Printf("EdgeScoreboard root publishing query error: %v", rerr)
+				return nil
+			}
 			rootPublishingCount = rootCount
 			rootPublishingStakePct = float64(rootStake) / float64(pc.TotalNetworkStake) * 100
 			return nil

--- a/api/handlers/edge_scoreboard.go
+++ b/api/handlers/edge_scoreboard.go
@@ -128,6 +128,41 @@ type EdgeScoreboardResponse struct {
 	DataLagMs uint64 `json:"data_lag_ms,omitempty"`
 }
 
+// EdgeScoreboardMatrixPair is one directed head-to-head cell: among shreds that both
+// `winner` and `loser` delivered, `winner` arrived first `wins` times and `loser` arrived
+// first `reverse` times. WinPct = wins / (wins + reverse). Complete is true only when both
+// directions had pairwise rows in the source table — when false, the reverse count is
+// unknown (the shredder may not emit that pairing) and WinPct should be treated as n/a.
+type EdgeScoreboardMatrixPair struct {
+	Winner   string  `json:"winner"`
+	Loser    string  `json:"loser"`
+	Wins     uint64  `json:"wins"`
+	Reverse  uint64  `json:"reverse"`
+	Total    uint64  `json:"total"`
+	WinPct   float64 `json:"win_pct"`
+	Complete bool    `json:"complete"`
+}
+
+// EdgeScoreboardMatrixResponse is the response for the head-to-head win-rate matrix.
+// Sources is the canonical row/column order (only keys present in the data). Pairs holds
+// every ordered (winner, loser) cell that had data in at least one direction.
+type EdgeScoreboardMatrixResponse struct {
+	Window      string                     `json:"window"`
+	LeadersOnly bool                       `json:"leaders_only"`
+	GeneratedAt time.Time                  `json:"generated_at"`
+	Sources     []string                   `json:"sources"`
+	Pairs       []EdgeScoreboardMatrixPair `json:"pairs"`
+}
+
+// matrixSourceOrder is the canonical row/column ordering for the win-rate matrix, matching
+// the scoreboard's feed rollup keys: DZ leader, turbine-root, regional retransmit, then the
+// non-DZ competitors. Only keys that actually appear in the data are surfaced.
+var matrixSourceOrder = []string{"dz", "dz_root", "dz_retransmit", "jito", "turbine"}
+
+// loserFeedRollup mirrors feedRollup but maps the loser_feed column, so pairwise rows can be
+// grouped on the same rollup keys (dz_root, dz_retransmit) as the winning feed.
+const loserFeedRollup = `CASE WHEN loser_feed = 'edge-solana-root' THEN 'dz_root' WHEN loser_feed = 'dz_rebop' OR loser_feed LIKE 'edge-solana-retrans-%' THEN 'dz_retransmit' ELSE loser_feed END`
+
 // maxValidSlot caps max(slot) queries against shredder tables to exclude corrupted rows.
 // Occasional bad inserts produce slot values near 2^64; any of those poison the preamble
 // `SELECT max(slot)` so the derived slot-range filter excludes all real data. Valid Solana
@@ -333,6 +368,163 @@ func (a *API) GetEdgeScoreboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, resp)
+}
+
+// GetEdgeScoreboardMatrix serves the head-to-head win-rate matrix: for each ordered pair of
+// shred sources (dz leader, turbine-root, retransmit, jito, turbine), what fraction of the
+// shreds they both delivered did the row source arrive first. Gated client-side behind the
+// scoreboard's ?matrix=1 flag; accepts the same window / leaders_only params.
+func (a *API) GetEdgeScoreboardMatrix(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if _, ok := validWindows[window]; !ok {
+		window = "1h"
+	}
+	leadersOnly := strings.TrimSpace(r.URL.Query().Get("leaders_only")) != "false"
+
+	resp, err := a.FetchEdgeScoreboardMatrix(ctx, window, leadersOnly)
+	if err != nil {
+		logError("EdgeScoreboardMatrix error", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+// FetchEdgeScoreboardMatrix computes the pairwise win-rate matrix across scoreboard feeds.
+//
+// It reads the pairwise rows of slot_feed_race_summary_v2 (loser_feed != ”), rolling up both
+// feed and loser_feed to the scoreboard keys, and sums shreds_won per (winner, loser). A cell
+// (A,B) reports wins = shreds where A arrived before B and reverse = shreds where B arrived
+// before A; win_pct = wins / (wins + reverse). When the source table only carries one
+// direction of a pairing, complete is false and the percentage is left for the client to
+// render as n/a rather than a misleading 100%.
+func (a *API) FetchEdgeScoreboardMatrix(ctx context.Context, window string, leadersOnly bool) (*EdgeScoreboardMatrixResponse, error) {
+	interval := validWindows[window]
+	var timeFilter string
+	if interval != "" {
+		timeFilter = fmt.Sprintf("AND event_ts >= now() - INTERVAL %s", interval)
+	}
+
+	shredderDB := fmt.Sprintf("`%s`", a.ShredderDB)
+	publisherDB := fmt.Sprintf("`%s`", a.PublisherDB)
+
+	// Derive a slot lower bound from max(slot) so the (host, slot, …) primary index can seek
+	// directly to the window instead of scanning the whole monthly partition. Mirrors the
+	// main scoreboard fetch; max(slot) is O(1) against the primary key.
+	rangeFilter := timeFilter
+	if slotWindow, ok := slotsPerWindow[window]; ok {
+		var maxSlot uint64
+		err := a.envDB(ctx).QueryRow(ctx, fmt.Sprintf(
+			`SELECT max(slot) FROM %s.slot_feed_race_summary_v2 WHERE slot < %d`,
+			shredderDB, maxValidSlot,
+		)).Scan(&maxSlot)
+		if err != nil {
+			return nil, fmt.Errorf("matrix max slot: %w", err)
+		}
+		if maxSlot > slotWindow {
+			rangeFilter = fmt.Sprintf("%s AND slot >= %d", timeFilter, maxSlot-slotWindow)
+		}
+	}
+
+	// In leaders-only mode, scope pairwise rows to slots where the scheduled leader published
+	// via DZ, matching the main scoreboard's default view.
+	var ctePrefix, leaderScope string
+	if leadersOnly {
+		ctePrefix = fmt.Sprintf(`WITH dz_leader_slots AS (
+			SELECT DISTINCT slot
+			FROM %s.publisher_shred_stats
+			WHERE is_scheduled_leader = true %s
+		)`, publisherDB, timeFilter)
+		leaderScope = "AND slot IN (SELECT slot FROM dz_leader_slots)"
+	}
+
+	// winner_key != loser_key drops self-pairs created when two variants that roll up to the
+	// same key (e.g. two regional retransmit feeds) raced each other.
+	query := fmt.Sprintf(`%[1]s
+		SELECT winner_key, loser_key, sum(shreds_won) AS wins
+		FROM (
+			SELECT %[5]s AS winner_key, %[6]s AS loser_key, shreds_won
+			FROM %[2]s.slot_feed_race_summary_v2
+			WHERE feed_type = 'shred' AND loser_feed != '' AND host != ''
+				AND feed IN (%[3]s) AND loser_feed IN (%[3]s)
+				%[7]s
+				%[4]s
+		)
+		WHERE winner_key != loser_key
+		GROUP BY winner_key, loser_key
+	SETTINGS final=1
+`, ctePrefix, shredderDB, scoreboardFeeds, rangeFilter, feedRollup, loserFeedRollup, leaderScope)
+
+	t := time.Now()
+	rows, err := a.envDB(ctx).Query(ctx, query)
+	metrics.RecordClickHouseQuery("edge_scoreboard:matrix", time.Since(t), err)
+	if err != nil {
+		return nil, fmt.Errorf("matrix query: %w", err)
+	}
+	defer rows.Close()
+
+	type pairKey struct{ winner, loser string }
+	directed := make(map[pairKey]uint64)
+	present := make(map[string]bool)
+	for rows.Next() {
+		var winner, loser string
+		var wins uint64
+		if err := rows.Scan(&winner, &loser, &wins); err != nil {
+			return nil, fmt.Errorf("matrix scan: %w", err)
+		}
+		directed[pairKey{winner, loser}] = wins
+		present[winner] = true
+		present[loser] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("matrix rows: %w", err)
+	}
+
+	sources := make([]string, 0, len(matrixSourceOrder))
+	for _, s := range matrixSourceOrder {
+		if present[s] {
+			sources = append(sources, s)
+		}
+	}
+
+	pairs := make([]EdgeScoreboardMatrixPair, 0)
+	for _, winner := range sources {
+		for _, loser := range sources {
+			if winner == loser {
+				continue
+			}
+			wins, fwd := directed[pairKey{winner, loser}]
+			reverse, rev := directed[pairKey{loser, winner}]
+			if !fwd && !rev {
+				continue
+			}
+			total := wins + reverse
+			var pct float64
+			if total > 0 {
+				pct = float64(wins) / float64(total) * 100
+			}
+			pairs = append(pairs, EdgeScoreboardMatrixPair{
+				Winner:   winner,
+				Loser:    loser,
+				Wins:     wins,
+				Reverse:  reverse,
+				Total:    total,
+				WinPct:   pct,
+				Complete: fwd && rev,
+			})
+		}
+	}
+
+	return &EdgeScoreboardMatrixResponse{
+		Window:      window,
+		LeadersOnly: leadersOnly,
+		GeneratedAt: time.Now().UTC(),
+		Sources:     sources,
+		Pairs:       pairs,
+	}, nil
 }
 
 // FetchRootPublishingStats returns the number of distinct validators publishing via the

--- a/api/handlers/edge_scoreboard_test.go
+++ b/api/handlers/edge_scoreboard_test.go
@@ -275,6 +275,65 @@ func TestGetEdgeScoreboard_WithData(t *testing.T) {
 	assert.Len(t, dzEdgeFeed.LeadTimes, 2, "fra dz_edge should have 2 pairwise lead times")
 }
 
+// TestFetchRootPublishingStats verifies turbine-root participation is re-derived from the
+// timing events table (slot_feed_race_summary_v2) by mapping each root-observed slot to its
+// scheduled leader (leader schedule) and that leader's stake (vote accounts) — rather than
+// from publisher_shred_stats, which is intentionally not populated with the root feed.
+func TestFetchRootPublishingStats(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	createShredderTables(t, api)
+	ctx := t.Context()
+
+	const epoch = 2
+	const slotsPerEpoch = 432_000
+	// Absolute slots = epoch*slotsPerEpoch + relative slot. nodepub1/nodepub2 lead root-observed
+	// slots; nodepub3 leads a slot that only the (excluded) dz feed delivered.
+	rootSlot1 := uint64(epoch*slotsPerEpoch + 100)  // nodepub1
+	rootSlot2 := uint64(epoch*slotsPerEpoch + 200)  // nodepub2
+	dzOnlySlot := uint64(epoch*slotsPerEpoch + 300) // nodepub3
+
+	// Timing events: two slots delivered via edge-solana-root, one via dz only.
+	err := api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.slot_feed_race_summary_v2
+			(event_ts, host, feed_type, epoch, slot, feed, loser_feed, total_shreds, shreds_won)
+		VALUES
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[3]d, 'edge-solana-root', '', 100, 50),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[4]d, 'edge-solana-root', '', 100, 50),
+			(now(), 'slc-qa-bm1', 'shred', %[2]d, %[5]d, 'dz',               '', 100, 50)
+	`, "`"+api.ShredderDB+"`", epoch, rootSlot1, rootSlot2, dzOnlySlot))
+	require.NoError(t, err)
+
+	// Leader schedule: relative slots per leader within the epoch.
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_solana_leader_schedule_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash, node_pubkey, epoch, slots, slot_count)
+		VALUES
+			('nodepub1', now(), now(), generateUUIDv4(), 0, 1, 'nodepub1', 2, '[100]', 1),
+			('nodepub2', now(), now(), generateUUIDv4(), 0, 2, 'nodepub2', 2, '[200]', 1),
+			('nodepub3', now(), now(), generateUUIDv4(), 0, 3, 'nodepub3', 2, '[300]', 1)
+	`)
+	require.NoError(t, err)
+
+	// Vote accounts: stake per leader. nodepub3 has stake but leads no root slot.
+	err = api.DB.Exec(ctx, `
+		INSERT INTO dim_solana_vote_accounts_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 vote_pubkey, epoch, node_pubkey, activated_stake_lamports, epoch_vote_account, commission_percentage)
+		VALUES
+			('votepub1', now(), now(), generateUUIDv4(), 0, 1, 'votepub1', 2, 'nodepub1', 50000000000, 'true', 0),
+			('votepub2', now(), now(), generateUUIDv4(), 0, 2, 'votepub2', 2, 'nodepub2', 10000000000, 'true', 0),
+			('votepub3', now(), now(), generateUUIDv4(), 0, 3, 'votepub3', 2, 'nodepub3', 5000000000, 'true', 0)
+	`)
+	require.NoError(t, err)
+
+	count, stake, err := api.FetchRootPublishingStats(ctx)
+	require.NoError(t, err)
+	// nodepub1 + nodepub2 lead root-observed slots; nodepub3 (dz-only) is excluded.
+	assert.Equal(t, uint64(2), count)
+	assert.Equal(t, int64(60000000000), stake)
+}
+
 func TestGetEdgeScoreboard_WindowParam(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -58,7 +58,9 @@ type PublisherCheckItem struct {
 	MulticastConnected      bool   `json:"multicast_connected"`
 	PublishingLeaderShreds  bool   `json:"publishing_leader_shreds"`
 	PublishingRetransmitted bool   `json:"publishing_retransmitted"`
+	PublishingRoot          bool   `json:"publishing_root"`
 	LeaderSlots             uint64 `json:"leader_slots"`
+	RootSlots               uint64 `json:"root_slots"`
 	TotalSlots              uint64 `json:"total_slots"`
 	TotalUniqueShreds       uint64 `json:"total_unique_shreds"`
 	SlotsNeedingRepair      uint64 `json:"slots_needing_repair"`
@@ -170,16 +172,43 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 	// both to keep history continuous across the cutover.
 	const leaderFeedFilter = "feed IN ('', 'dz')"
 
+	// rootPublisherFeed is the feed value the shredder writes to publisher_shred_stats for
+	// shreds a validator publishes as the turbine-tree root (the earliest DZ hop). It only
+	// produces rows once the shredder enables `publisher_stats: true` on the edge-solana-root
+	// source; until then root_slots reads zero for every publisher. Kept as a named constant
+	// so it's trivial to realign if the shredder uses a different feed string.
+	const rootPublisherFeed = "edge-solana-root"
+
 	var perSlotWhere string
 	var args []any
+	// rootStatsCTE counts, per publisher, the distinct slots that carried a turbine-root
+	// publish in the same epoch/slot window as the leader stats. Its epoch/slot bounds are
+	// inlined (validated ints) to avoid disturbing the positional `?` arg ordering below.
+	var rootStatsCTE string
 	if slotsParam > 0 {
 		perSlotWhere = `WHERE ` + leaderFeedFilter + `
 			AND epoch >= (SELECT epoch FROM current_epoch) - 1
 			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
 		args = []any{slotsParam, shredGroupPK}
+		rootStatsCTE = fmt.Sprintf(`,
+		root_stats AS (
+			SELECT dz_user_pubkey, uniqExact(slot) AS root_slots
+			FROM %[1]s
+			WHERE feed = '%[2]s'
+				AND epoch >= (SELECT epoch FROM current_epoch) - 1
+				AND slot >= (SELECT max(slot) FROM %[1]s WHERE %[3]s AND epoch >= (SELECT epoch FROM current_epoch) - 1) - %[4]d
+			GROUP BY dz_user_pubkey
+		)`, shredStatsTable, rootPublisherFeed, leaderFeedFilter, slotsParam)
 	} else {
 		perSlotWhere = `WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
 		args = []any{epochsParam, shredGroupPK}
+		rootStatsCTE = fmt.Sprintf(`,
+		root_stats AS (
+			SELECT dz_user_pubkey, uniqExact(slot) AS root_slots
+			FROM %[1]s
+			WHERE feed = '%[2]s' AND epoch >= (SELECT epoch FROM current_epoch) - %[3]d + 1
+			GROUP BY dz_user_pubkey
+		)`, shredStatsTable, rootPublisherFeed, epochsParam)
 	}
 
 	query := fmt.Sprintf(`
@@ -210,7 +239,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 				max(slot) AS max_slot
 			FROM per_slot
 			GROUP BY dz_user_pubkey
-		)
+		)%s
 		SELECT
 			u.dz_ip AS publisher_ip,
 			u.client_ip,
@@ -223,6 +252,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 			COALESCE(s.total_slots, 0) AS total_slots,
 			COALESCE(s.leader_slots, 0) AS leader_slots,
 			COALESCE(s.retransmit_slots, 0) AS retransmit_slots,
+			COALESCE(rs.root_slots, 0) AS root_slots,
 			COALESCE(s.total_unique_shreds, 0) AS total_unique_shreds,
 			COALESCE(s.slots_needing_repair, 0) AS slots_needing_repair,
 			(SELECT epoch FROM current_epoch) AS epoch,
@@ -236,10 +266,11 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		LEFT JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip AND u.client_ip != ''
 		LEFT JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey AND v.epoch_vote_account = 'true'
 		LEFT JOIN stats s ON u.pk = s.dz_user_pubkey
+		LEFT JOIN root_stats rs ON u.pk = rs.dz_user_pubkey
 		LEFT JOIN validatorsapp_validators_current va ON v.vote_pubkey = va.vote_account
 		WHERE u.status = 'activated'
 			AND has(JSONExtract(u.publishers, 'Array(String)'), ?)
-	`, shredStatsTable, shredStatsTable, perSlotWhere)
+	`, shredStatsTable, shredStatsTable, perSlotWhere, rootStatsCTE)
 	if q != "" {
 		if strings.Contains(q, ".") {
 			query += " AND (u.dz_ip = ? OR u.client_ip = ?)"
@@ -267,7 +298,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 
 	for rows.Next() {
 		var p PublisherCheckItem
-		var totalSlots, leaderSlots, retransmitSlots uint64
+		var totalSlots, leaderSlots, retransmitSlots, rootSlots uint64
 		var stakeRaw int64
 		var rowEpoch uint64
 		var rowMaxSlot uint64
@@ -284,6 +315,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 			&totalSlots,
 			&leaderSlots,
 			&retransmitSlots,
+			&rootSlots,
 			&p.TotalUniqueShreds,
 			&p.SlotsNeedingRepair,
 			&rowEpoch,
@@ -306,8 +338,10 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		}
 		p.TotalSlots = totalSlots
 		p.LeaderSlots = leaderSlots
+		p.RootSlots = rootSlots
 		p.MulticastConnected = true // All rows are bebop group members
 		p.PublishingLeaderShreds = leaderSlots > 0
+		p.PublishingRoot = rootSlots > 0
 		p.PublishingRetransmitted = totalSlots > 0 &&
 			retransmitSlots >= retransmitMinSlots &&
 			float64(retransmitSlots)/float64(totalSlots) >= retransmitMinRatio

--- a/api/handlers/publisher_check.go
+++ b/api/handlers/publisher_check.go
@@ -58,9 +58,7 @@ type PublisherCheckItem struct {
 	MulticastConnected      bool   `json:"multicast_connected"`
 	PublishingLeaderShreds  bool   `json:"publishing_leader_shreds"`
 	PublishingRetransmitted bool   `json:"publishing_retransmitted"`
-	PublishingRoot          bool   `json:"publishing_root"`
 	LeaderSlots             uint64 `json:"leader_slots"`
-	RootSlots               uint64 `json:"root_slots"`
 	TotalSlots              uint64 `json:"total_slots"`
 	TotalUniqueShreds       uint64 `json:"total_unique_shreds"`
 	SlotsNeedingRepair      uint64 `json:"slots_needing_repair"`
@@ -169,46 +167,22 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 	// Only the dz source has `publisher_stats: true` in the shredder configs,
 	// so filtering to it preserves pre-per-feed-column numbers exactly. Pre-migration
 	// rows have feed='' (the ALTER added the column without a default), so include
-	// both to keep history continuous across the cutover.
+	// both to keep history continuous across the cutover. The turbine-root feed
+	// (edge-solana-root) is deliberately not written to publisher_shred_stats, so it
+	// never enters this filter; turbine-root participation is derived from the timing
+	// events table in the edge scoreboard instead (see edge_scoreboard.go Group P).
 	const leaderFeedFilter = "feed IN ('', 'dz')"
-
-	// rootPublisherFeed is the feed value the shredder writes to publisher_shred_stats for
-	// shreds a validator publishes as the turbine-tree root (the earliest DZ hop). It only
-	// produces rows once the shredder enables `publisher_stats: true` on the edge-solana-root
-	// source; until then root_slots reads zero for every publisher. Kept as a named constant
-	// so it's trivial to realign if the shredder uses a different feed string.
-	const rootPublisherFeed = "edge-solana-root"
 
 	var perSlotWhere string
 	var args []any
-	// rootStatsCTE counts, per publisher, the distinct slots that carried a turbine-root
-	// publish in the same epoch/slot window as the leader stats. Its epoch/slot bounds are
-	// inlined (validated ints) to avoid disturbing the positional `?` arg ordering below.
-	var rootStatsCTE string
 	if slotsParam > 0 {
 		perSlotWhere = `WHERE ` + leaderFeedFilter + `
 			AND epoch >= (SELECT epoch FROM current_epoch) - 1
 			AND slot >= (SELECT max(slot) FROM ` + shredStatsTable + ` WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - 1) - ?`
 		args = []any{slotsParam, shredGroupPK}
-		rootStatsCTE = fmt.Sprintf(`,
-		root_stats AS (
-			SELECT dz_user_pubkey, uniqExact(slot) AS root_slots
-			FROM %[1]s
-			WHERE feed = '%[2]s'
-				AND epoch >= (SELECT epoch FROM current_epoch) - 1
-				AND slot >= (SELECT max(slot) FROM %[1]s WHERE %[3]s AND epoch >= (SELECT epoch FROM current_epoch) - 1) - %[4]d
-			GROUP BY dz_user_pubkey
-		)`, shredStatsTable, rootPublisherFeed, leaderFeedFilter, slotsParam)
 	} else {
 		perSlotWhere = `WHERE ` + leaderFeedFilter + ` AND epoch >= (SELECT epoch FROM current_epoch) - ? + 1`
 		args = []any{epochsParam, shredGroupPK}
-		rootStatsCTE = fmt.Sprintf(`,
-		root_stats AS (
-			SELECT dz_user_pubkey, uniqExact(slot) AS root_slots
-			FROM %[1]s
-			WHERE feed = '%[2]s' AND epoch >= (SELECT epoch FROM current_epoch) - %[3]d + 1
-			GROUP BY dz_user_pubkey
-		)`, shredStatsTable, rootPublisherFeed, epochsParam)
 	}
 
 	query := fmt.Sprintf(`
@@ -239,7 +213,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 				max(slot) AS max_slot
 			FROM per_slot
 			GROUP BY dz_user_pubkey
-		)%s
+		)
 		SELECT
 			u.dz_ip AS publisher_ip,
 			u.client_ip,
@@ -252,7 +226,6 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 			COALESCE(s.total_slots, 0) AS total_slots,
 			COALESCE(s.leader_slots, 0) AS leader_slots,
 			COALESCE(s.retransmit_slots, 0) AS retransmit_slots,
-			COALESCE(rs.root_slots, 0) AS root_slots,
 			COALESCE(s.total_unique_shreds, 0) AS total_unique_shreds,
 			COALESCE(s.slots_needing_repair, 0) AS slots_needing_repair,
 			(SELECT epoch FROM current_epoch) AS epoch,
@@ -266,11 +239,10 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		LEFT JOIN solana_gossip_nodes_current g ON u.client_ip = g.gossip_ip AND u.client_ip != ''
 		LEFT JOIN solana_vote_accounts_current v ON g.pubkey = v.node_pubkey AND v.epoch_vote_account = 'true'
 		LEFT JOIN stats s ON u.pk = s.dz_user_pubkey
-		LEFT JOIN root_stats rs ON u.pk = rs.dz_user_pubkey
 		LEFT JOIN validatorsapp_validators_current va ON v.vote_pubkey = va.vote_account
 		WHERE u.status = 'activated'
 			AND has(JSONExtract(u.publishers, 'Array(String)'), ?)
-	`, shredStatsTable, shredStatsTable, perSlotWhere, rootStatsCTE)
+	`, shredStatsTable, shredStatsTable, perSlotWhere)
 	if q != "" {
 		if strings.Contains(q, ".") {
 			query += " AND (u.dz_ip = ? OR u.client_ip = ?)"
@@ -298,7 +270,7 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 
 	for rows.Next() {
 		var p PublisherCheckItem
-		var totalSlots, leaderSlots, retransmitSlots, rootSlots uint64
+		var totalSlots, leaderSlots, retransmitSlots uint64
 		var stakeRaw int64
 		var rowEpoch uint64
 		var rowMaxSlot uint64
@@ -315,7 +287,6 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 			&totalSlots,
 			&leaderSlots,
 			&retransmitSlots,
-			&rootSlots,
 			&p.TotalUniqueShreds,
 			&p.SlotsNeedingRepair,
 			&rowEpoch,
@@ -338,10 +309,8 @@ func (a *API) FetchPublisherCheckData(ctx context.Context, q string, epochsParam
 		}
 		p.TotalSlots = totalSlots
 		p.LeaderSlots = leaderSlots
-		p.RootSlots = rootSlots
 		p.MulticastConnected = true // All rows are bebop group members
 		p.PublishingLeaderShreds = leaderSlots > 0
-		p.PublishingRoot = rootSlots > 0
 		p.PublishingRetransmitted = totalSlots > 0 &&
 			retransmitSlots >= retransmitMinSlots &&
 			float64(retransmitSlots)/float64(totalSlots) >= retransmitMinRatio

--- a/api/main.go
+++ b/api/main.go
@@ -602,6 +602,7 @@ func main() {
 		r.Get("/api/dz/access-passes/{pk}/connections", api.GetAccessPassConnections)
 		r.Get("/api/dz/publisher-check", api.GetPublisherCheck)
 		r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
+		r.Get("/api/dz/edge/scoreboard/matrix", api.GetEdgeScoreboardMatrix)
 		r.Get("/api/dz/tenants", api.GetTenants)
 		r.Get("/api/dz/tenants/{pk}", api.GetTenant)
 		r.Get("/api/dz/shreds/overview", api.GetShredsOverview)

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -7,9 +7,11 @@ import 'uplot/dist/uPlot.min.css'
 
 import {
   fetchEdgeScoreboard,
+  fetchEdgeScoreboardMatrix,
   type EdgeScoreboardNode,
   type EdgeScoreboardSlotRace,
   type EdgeScoreboardLeader,
+  type EdgeScoreboardMatrixResponse,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { Tooltip } from '@/components/ui/tooltip'
@@ -1951,6 +1953,134 @@ function RecentSlotsChart({
   )
 }
 
+// MATRIX_LABELS are short row/column labels for the head-to-head matrix (the full
+// FEED_LABELS strings are too wide for a grid header).
+const MATRIX_LABELS: Record<string, string> = {
+  dz: 'DZ Leaders',
+  dz_root: 'DZ turbine-root',
+  dz_retransmit: 'DZ Retransmits',
+  jito: 'Jito Shredstream',
+  turbine: 'Turbine',
+}
+
+// matrixCellStyle shades a cell by how decisively the row source wins: emerald above 50%,
+// rose below, intensity scaled by distance from a coin-flip.
+function matrixCellStyle(pct: number): React.CSSProperties {
+  const mag = Math.min(Math.abs(pct - 50) / 50, 1)
+  const alpha = 0.08 + mag * 0.45
+  const rgb = pct >= 50 ? '16, 185, 129' : '244, 63, 94' // emerald-500 / rose-500
+  return { backgroundColor: `rgba(${rgb}, ${alpha.toFixed(3)})` }
+}
+
+function WinRateMatrix({ data, loading, error, rootPublishingCount, rootPublishingStakePct }: { data?: EdgeScoreboardMatrixResponse; loading: boolean; error: unknown; rootPublishingCount?: number; rootPublishingStakePct?: number }) {
+  const lookup = useMemo(() => {
+    const m = new Map<string, EdgeScoreboardMatrixResponse['pairs'][number]>()
+    for (const p of data?.pairs ?? []) m.set(`${p.winner}|${p.loser}`, p)
+    return m
+  }, [data])
+
+  const sources = data?.sources ?? []
+
+  if (error) {
+    return (
+      <div className="border border-border rounded-lg bg-card p-6 text-sm text-rose-400">
+        Failed to load win-rate matrix.
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-border rounded-lg bg-card overflow-hidden mb-6">
+      <div className="flex items-center gap-4 px-4 py-3 border-b border-border">
+        <h2 className="text-sm font-semibold flex-1">Head-to-Head Win Rate</h2>
+        {rootPublishingCount !== undefined && (
+          <div className="flex items-center gap-5 text-right">
+            <Tooltip content="Validators publishing shreds via the turbine-root path (earliest DZ hop, before regional retransmit).">
+              <div className="cursor-default">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Turbine-Root Publishing</div>
+                <div className="text-sm font-semibold tabular-nums">{Math.round(rootPublishingCount).toLocaleString()}</div>
+              </div>
+            </Tooltip>
+            <Tooltip content="Percentage of total network stake held by validators publishing via the turbine-root path.">
+              <div className="cursor-default">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Turbine-Root Stake</div>
+                <div className="text-sm font-semibold tabular-nums">{formatPct(rootPublishingStakePct ?? 0)}</div>
+              </div>
+            </Tooltip>
+          </div>
+        )}
+        {loading && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
+      </div>
+      <div className="px-4 py-3">
+        <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+          Among shreds that <span className="text-foreground">both</span> sources delivered, the % where the{' '}
+          <span className="text-foreground">row</span> source arrived <span className="text-foreground">before</span> the{' '}
+          <span className="text-foreground">column</span> source. Each cell is independent of the others (not normalized to 100%).
+        </p>
+        {!loading && sources.length === 0 ? (
+          <div className="text-sm text-muted-foreground py-6 text-center">No pairwise data in this window.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="p-2 text-left text-xs font-medium text-muted-foreground align-bottom">
+                    <span className="text-foreground">wins</span> ↓ over →
+                  </th>
+                  {sources.map((s) => (
+                    <th key={s} className="p-2 text-center text-xs font-medium whitespace-nowrap" style={{ color: FEED_COLORS[s] ?? undefined }}>
+                      {MATRIX_LABELS[s] ?? s}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sources.map((winner) => (
+                  <tr key={winner}>
+                    <td className="p-2 text-xs font-medium whitespace-nowrap" style={{ color: FEED_COLORS[winner] ?? undefined }}>
+                      {MATRIX_LABELS[winner] ?? winner}
+                    </td>
+                    {sources.map((loser) => {
+                      if (winner === loser) {
+                        return <td key={loser} className="p-2 text-center text-muted-foreground/30 bg-muted/20">—</td>
+                      }
+                      const pair = lookup.get(`${winner}|${loser}`)
+                      if (!pair || pair.total === 0) {
+                        return <td key={loser} className="p-2 text-center text-muted-foreground/40 text-xs">n/a</td>
+                      }
+                      const cell = (
+                        <td
+                          key={loser}
+                          className={cn('p-2 text-center tabular-nums cursor-default', !pair.complete && 'opacity-60')}
+                          style={pair.complete ? matrixCellStyle(pair.win_pct) : undefined}
+                        >
+                          <span className="font-medium">{pair.win_pct.toFixed(1)}%</span>
+                          {!pair.complete && <span className="text-amber-400 align-super text-[10px] ml-0.5">*</span>}
+                        </td>
+                      )
+                      const tip = pair.complete
+                        ? `${MATRIX_LABELS[winner] ?? winner} first on ${pair.wins.toLocaleString()} of ${pair.total.toLocaleString()} shared shreds vs ${MATRIX_LABELS[loser] ?? loser}`
+                        : `Only one direction is tracked in the source data — ${MATRIX_LABELS[winner] ?? winner} first on ${pair.wins.toLocaleString()} shreds, but reverse (${MATRIX_LABELS[loser] ?? loser} first) is not recorded. Rate is a lower-bound, not a true head-to-head.`
+                      return (
+                        <Tooltip key={loser} content={tip}>
+                          {cell}
+                        </Tooltip>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="text-[11px] text-muted-foreground mt-3">
+              <span className="text-amber-400">*</span> only one direction recorded in the source data; the reverse race isn't tracked, so the shown rate is a lower bound rather than a true head-to-head.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function EdgeScoreboardPage() {
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -1968,6 +2098,10 @@ export function EdgeScoreboardPage() {
       return p
     })
   }
+
+  // matrix=1 swaps the slot race / node table for the head-to-head win-rate matrix
+  // (source-vs-source). Opt-in flag, not surfaced in nav.
+  const matrixView = searchParams.get('matrix') === '1'
 
   const rawSlotCount = parseInt(searchParams.get('slot_count') ?? '200')
   const viewSlotCount = [50, 100, 200, 300, 500].includes(rawSlotCount) ? rawSlotCount : 200
@@ -2001,6 +2135,15 @@ export function EdgeScoreboardPage() {
   const { data, isLoading, isFetching, error } = useQuery({
     queryKey: ['edge-scoreboard', activeWindow, leadersOnly],
     queryFn: () => fetchEdgeScoreboard(activeWindow, leadersOnly),
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+    placeholderData: keepPreviousData,
+  })
+
+  const { data: matrixData, isLoading: matrixLoading, error: matrixError } = useQuery({
+    queryKey: ['edge-scoreboard-matrix', activeWindow, leadersOnly],
+    queryFn: () => fetchEdgeScoreboardMatrix(activeWindow, leadersOnly),
+    enabled: matrixView,
     refetchInterval: 30_000,
     staleTime: 15_000,
     placeholderData: keepPreviousData,
@@ -2292,26 +2435,6 @@ export function EdgeScoreboardPage() {
                     Percentage of total network stake held by validators actively publishing shreds.
                   </span>
                 </div>
-                <div className="group relative sm:border-l sm:border-border sm:pl-6">
-                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
-                    Turbine-Root Publishing
-                    <Info className="w-3 h-3 opacity-60" />
-                  </div>
-                  <div className="text-xl sm:text-2xl font-semibold tabular-nums">{Math.round(animRootPublishingCount ?? data.root_publishing_count).toLocaleString()}</div>
-                  <span className="pointer-events-none absolute top-full left-0 mt-2 z-30 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
-                    Validators publishing shreds via the turbine-root path (earliest DZ hop, before regional retransmit).
-                  </span>
-                </div>
-                <div className="group relative sm:border-l sm:border-border sm:pl-6">
-                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
-                    Turbine-Root Stake Weight
-                    <Info className="w-3 h-3 opacity-60" />
-                  </div>
-                  <div className="text-xl sm:text-2xl font-semibold tabular-nums">{formatPct(animRootPublishingStakePct ?? data.root_publishing_stake_pct)}</div>
-                  <span className="pointer-events-none absolute top-full left-0 mt-2 z-30 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
-                    Percentage of total network stake held by validators publishing via the turbine-root path.
-                  </span>
-                </div>
               </div>
             </div>
 
@@ -2349,8 +2472,19 @@ export function EdgeScoreboardPage() {
           </div>
         )}
 
+        {/* Head-to-head win-rate matrix (matrix=1 flag) */}
+        {matrixView && (
+          <WinRateMatrix
+            data={matrixData}
+            loading={matrixLoading}
+            error={matrixError}
+            rootPublishingCount={animRootPublishingCount ?? data?.root_publishing_count}
+            rootPublishingStakePct={animRootPublishingStakePct ?? data?.root_publishing_stake_pct}
+          />
+        )}
+
         {/* Win Rate by Slot chart */}
-        {data?.nodes && (
+        {!matrixView && data?.nodes && (
           <div className="mb-6">
             <div className="border border-border rounded-lg bg-card overflow-hidden">
               <div className="flex items-center px-4 py-3">
@@ -2433,6 +2567,7 @@ export function EdgeScoreboardPage() {
         )}
 
         {/* Node detail table */}
+        {!matrixView && (
         <div className="border border-border rounded-lg overflow-hidden bg-card mb-6">
           <div className="overflow-x-auto">
             <table className="min-w-full">
@@ -2460,6 +2595,7 @@ export function EdgeScoreboardPage() {
             </table>
           </div>
         </div>
+        )}
 
 
       </div>

--- a/web/src/components/edge-scoreboard-page.tsx
+++ b/web/src/components/edge-scoreboard-page.tsx
@@ -2184,6 +2184,8 @@ export function EdgeScoreboardPage() {
 
   const animPublishingCount = useAnimatedNumber(data?.publishing_count)
   const animPublishingStakePct = useAnimatedNumber(data?.publishing_stake_pct)
+  const animRootPublishingCount = useAnimatedNumber(data?.root_publishing_count)
+  const animRootPublishingStakePct = useAnimatedNumber(data?.root_publishing_stake_pct)
   const animWinRate = useAnimatedNumber(globalStats?.winRate)
 
   if (isLoading && showLoader && !data) return (
@@ -2288,6 +2290,26 @@ export function EdgeScoreboardPage() {
                   <div className="text-xl sm:text-2xl font-semibold tabular-nums">{formatPct(animPublishingStakePct ?? data.publishing_stake_pct)}</div>
                   <span className="pointer-events-none absolute top-full left-0 mt-2 z-30 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
                     Percentage of total network stake held by validators actively publishing shreds.
+                  </span>
+                </div>
+                <div className="group relative sm:border-l sm:border-border sm:pl-6">
+                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
+                    Turbine-Root Publishing
+                    <Info className="w-3 h-3 opacity-60" />
+                  </div>
+                  <div className="text-xl sm:text-2xl font-semibold tabular-nums">{Math.round(animRootPublishingCount ?? data.root_publishing_count).toLocaleString()}</div>
+                  <span className="pointer-events-none absolute top-full left-0 mt-2 z-30 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
+                    Validators publishing shreds via the turbine-root path (earliest DZ hop, before regional retransmit).
+                  </span>
+                </div>
+                <div className="group relative sm:border-l sm:border-border sm:pl-6">
+                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
+                    Turbine-Root Stake Weight
+                    <Info className="w-3 h-3 opacity-60" />
+                  </div>
+                  <div className="text-xl sm:text-2xl font-semibold tabular-nums">{formatPct(animRootPublishingStakePct ?? data.root_publishing_stake_pct)}</div>
+                  <span className="pointer-events-none absolute top-full left-0 mt-2 z-30 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-normal opacity-0 group-hover:opacity-100 transition-opacity">
+                    Percentage of total network stake held by validators publishing via the turbine-root path.
                   </span>
                 </div>
               </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6096,6 +6096,38 @@ export async function fetchEdgeScoreboard(
   return res.json()
 }
 
+export interface EdgeScoreboardMatrixPair {
+  winner: string
+  loser: string
+  wins: number
+  reverse: number
+  total: number
+  win_pct: number
+  complete: boolean
+}
+
+export interface EdgeScoreboardMatrixResponse {
+  window: string
+  leaders_only: boolean
+  generated_at: string
+  sources: string[]
+  pairs: EdgeScoreboardMatrixPair[]
+}
+
+export async function fetchEdgeScoreboardMatrix(
+  window: string = '1h',
+  leadersOnly: boolean = true
+): Promise<EdgeScoreboardMatrixResponse> {
+  const params = new URLSearchParams()
+  params.set('window', window)
+  params.set('leaders_only', leadersOnly ? 'true' : 'false')
+  const res = await apiFetch(`/api/dz/edge/scoreboard/matrix?${params}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch edge scoreboard matrix')
+  }
+  return res.json()
+}
+
 // --- Unified Metrics Types ---
 
 export interface EntityStatusChange {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6043,6 +6043,8 @@ export interface EdgeScoreboardResponse {
   publisher_count: number
   publishing_count: number
   publishing_stake_pct: number
+  root_publishing_count: number
+  root_publishing_stake_pct: number
   nodes: EdgeScoreboardNode[]
   recent_slots: EdgeScoreboardSlotRace[]
   slot_buckets?: EdgeScoreboardSlotBucket[]


### PR DESCRIPTION
## Summary

- Lead-time (p50/p95) of DZ vs Turbine/Jito now pools the full DZ delivery path — leader (`dz`), turbine-root (`edge-solana-root`) and regional retransmit — so the advantage metric matches the win-rate's `dz_edge` aggregate instead of excluding root. Applies to both leaders-only and all-slots modes.
- Adds two headline cards to the shreds scoreboard: **Turbine-Root Publishing** (count of validators publishing via the turbine-root path) and **Turbine-Root Stake Weight** (% of network stake behind them), computed the same way as the existing leader publishing/stake metrics.
- Publisher check now derives per-publisher turbine-root participation (`root_slots` / `publishing_root`) from the `edge-solana-root` feed in `publisher_shred_stats`.

## Why

The scoreboard already counts turbine-root wins inside `dz_edge`, but the lead-time stat silently excluded root, so the two DZ metrics measured different feed sets. Pooling them makes "how much DZ wins" and "by how much" consistent. The new cards give the same leader-slot stake visibility for the turbine-root path.

## Notes

- The turbine-root cards read **0 until the shredder is configured to emit per-publisher stats for the `edge-solana-root` source** (tracked in the infra repo). The feed string lives in a single named constant (`rootPublisherFeed`) for easy realignment.

## Testing Verification

- Existing `TestGetEdgeScoreboard_WithData` still passes: it only seeds `feed='dz'` lead-time rows, so widening the q2b feed set adds no rows and `root_slots` stays 0 with no leader-metric drift.
- Verified the `root_stats` CTE shares the same epoch/slot window as the leader stats and dedups by slot, so multi-host observations don't double-count.
