### PR TITLE
web: sync maintenance calendar filters, view, and date to the url

### DIFF
--- a/web/src/components/maintenance-calendar-page.tsx
+++ b/web/src/components/maintenance-calendar-page.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useMaintenanceEvents } from './maintenance-calendar/use-maintenance-events'
 import { MaintenanceFilters } from './maintenance-calendar/filters'
@@ -8,8 +9,13 @@ import {
   startOfDay,
   getDays,
   formatDateRange,
+  formatISODate,
+  parseISODate,
+  isSameDay,
 } from './maintenance-calendar/date-utils'
 import type { CalendarView } from './maintenance-calendar/date-utils'
+
+const VALID_VIEWS: CalendarView[] = ['day', 'week', '2week', 'month']
 
 function navigate(anchor: Date, view: CalendarView, dir: -1 | 1): Date {
   const next = new Date(anchor)
@@ -21,8 +27,15 @@ function navigate(anchor: Date, view: CalendarView, dir: -1 | 1): Date {
 }
 
 export function MaintenanceCalendarPage() {
-  const [view, setView] = useState<CalendarView>('2week')
-  const [anchor, setAnchor] = useState(() => startOfDay(new Date()))
+  const [searchParams, setSearchParams] = useSearchParams()
+  const view = useMemo<CalendarView>(() => {
+    const v = searchParams.get('view') as CalendarView | null
+    return v && VALID_VIEWS.includes(v) ? v : '2week'
+  }, [searchParams])
+  const anchor = useMemo(
+    () => parseISODate(searchParams.get('date')) ?? startOfDay(new Date()),
+    [searchParams]
+  )
 
   const {
     events,
@@ -40,14 +53,35 @@ export function MaintenanceCalendarPage() {
 
   const days = view === 'day' ? [anchor] : getDays(view, anchor)
 
-  const handleNavigate = useCallback(
-    (dir: -1 | 1) => setAnchor((a) => navigate(a, view, dir)),
-    [view]
+  const setParam = useCallback(
+    (key: string, value: string | null) =>
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (value === null) next.delete(key)
+          else next.set(key, value)
+          return next
+        },
+        { replace: true }
+      ),
+    [setSearchParams]
   )
 
-  const handleViewChange = useCallback((v: CalendarView) => {
-    setView(v)
-  }, [])
+  const setAnchorParam = useCallback(
+    (d: Date) =>
+      setParam('date', isSameDay(d, startOfDay(new Date())) ? null : formatISODate(d)),
+    [setParam]
+  )
+
+  const handleNavigate = useCallback(
+    (dir: -1 | 1) => setAnchorParam(navigate(anchor, view, dir)),
+    [anchor, view, setAnchorParam]
+  )
+
+  const handleViewChange = useCallback(
+    (v: CalendarView) => setParam('view', v === '2week' ? null : v),
+    [setParam]
+  )
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -57,7 +91,7 @@ export function MaintenanceCalendarPage() {
         <div className="flex items-center gap-3">
           <button
             type="button"
-            onClick={() => setAnchor(startOfDay(new Date()))}
+            onClick={() => setAnchorParam(startOfDay(new Date()))}
             className="text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             Go to today

--- a/web/src/components/maintenance-calendar/date-utils.ts
+++ b/web/src/components/maintenance-calendar/date-utils.ts
@@ -6,6 +6,21 @@ export function startOfDay(d: Date): Date {
   return r
 }
 
+export function formatISODate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function parseISODate(s: string | null): Date | null {
+  if (!s) return null
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s)
+  if (!m) return null
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) // local, avoids UTC day-shift
+  return isNaN(d.getTime()) ? null : startOfDay(d)
+}
+
 export function isSameDay(a: Date, b: Date): boolean {
   return (
     a.getFullYear() === b.getFullYear() &&

--- a/web/src/components/maintenance-calendar/use-maintenance-events.ts
+++ b/web/src/components/maintenance-calendar/use-maintenance-events.ts
@@ -1,8 +1,59 @@
-import { useState, useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { fetchMaintenanceTickets, isTicketClosed } from '@/lib/ops-api'
 import { contributorHue } from './colors'
 import type { OpsTicket, OpsTicketStatus } from '@/lib/ops-api'
+
+const FILTER_KEYS = ['q', 'status', 'contributor', 'metro', 'device', 'link'] as const
+
+// Tolerate malformed percent-encoding (e.g. a bare "%") so a hand-edited URL
+// can't crash the calendar; fall back to the raw token.
+function safeDecode(v: string): string {
+  try {
+    return decodeURIComponent(v)
+  } catch {
+    return v
+  }
+}
+
+// Set values are comma-delimited; each value is URI-encoded so names containing
+// commas (e.g. "Acme, Inc") survive the round-trip.
+function parseSet(p: URLSearchParams, key: string): Set<string> {
+  return new Set(
+    (p.get(key) ?? '')
+      .split(',')
+      .filter(Boolean)
+      .map(safeDecode)
+  )
+}
+
+function serializeSet(set: Set<string>): string {
+  return [...set].map((v) => encodeURIComponent(v)).join(',')
+}
+
+function parseFilters(p: URLSearchParams): CalendarFilters {
+  return {
+    search: p.get('q') ?? '',
+    status: p.get('status') ?? '',
+    contributors: parseSet(p, 'contributor'),
+    metros: parseSet(p, 'metro'),
+    devices: parseSet(p, 'device'),
+    links: parseSet(p, 'link'),
+  }
+}
+
+function writeFilters(prev: URLSearchParams, f: CalendarFilters): URLSearchParams {
+  const next = new URLSearchParams(prev)
+  for (const k of FILTER_KEYS) next.delete(k) // preserves view/date params
+  if (f.search) next.set('q', f.search)
+  if (f.status) next.set('status', f.status)
+  if (f.contributors.size) next.set('contributor', serializeSet(f.contributors))
+  if (f.metros.size) next.set('metro', serializeSet(f.metros))
+  if (f.devices.size) next.set('device', serializeSet(f.devices))
+  if (f.links.size) next.set('link', serializeSet(f.links))
+  return next
+}
 
 export interface MaintenanceEvent {
   id: string
@@ -113,14 +164,12 @@ export function useMaintenanceEvents() {
   const isLoading = activeLoading || completedLoading
   const error = activeError ?? completedError
 
-  const [filters, setFilters] = useState<CalendarFilters>({
-    search: '',
-    contributors: new Set(),
-    metros: new Set(),
-    devices: new Set(),
-    links: new Set(),
-    status: '',
-  })
+  const [searchParams, setSearchParams] = useSearchParams()
+  const filters = useMemo(() => parseFilters(searchParams), [searchParams])
+  const setFilters = useCallback(
+    (f: CalendarFilters) => setSearchParams((prev) => writeFilters(prev, f), { replace: true }),
+    [setSearchParams]
+  )
 
   const filteredEvents = useMemo(
     () => applyFilters(allEvents, filters),


### PR DESCRIPTION
## Summary of Changes
- The Maintenance Calendar (`/ops/maintenance`) now reflects its filter selections, view mode, and visible date window in the URL query string, so a copied URL reproduces the exact filtered/zoomed chart for sharing.
- Filter state moved from local `useState` to `useSearchParams`; params at their default (e.g. the `2week` view, today's date) are omitted to keep URLs clean.
- Set-valued filters (contributor/metro/device/link) are comma-delimited with each value URI-encoded, so a contributor name containing a comma round-trips correctly.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +96 / -18   | +78  |
| Scaffolding  |     1 | +15 / -0    | +15  |

Small, focused frontend change — URL-backed view state plus two date helpers.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/maintenance-calendar/use-maintenance-events.ts` — filter state backed by `useSearchParams` instead of `useState`; adds comma-delimited, URI-encoded set serialization. Hook's public API unchanged, so the filter UI needed no edits.
- `web/src/components/maintenance-calendar-page.tsx` — `view` and `anchor` derived from URL params (`view`, `date`); navigation and "Go to today" write back to the URL.
- `web/src/components/maintenance-calendar/date-utils.ts` — adds `formatISODate` / `parseISODate` (local-time parse to avoid UTC day-shift).

</details>

## Testing Verification
- Verified the filter/view/date serialization round-trips correctly, including the edge case of a contributor name containing a comma or ampersand (caught and fixed a plain comma-join defect during development).
- Confirmed default-valued params are dropped from the URL and that adding filters preserves the existing `view`/`date` params.
