### PR TITLE
telemetry/usage: cap per-refresh catch-up window to bound memory (draft)

### DIFF
--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -196,6 +196,13 @@ func (cfg *ViewConfig) Validate() error {
 // longer than 5 minutes, triggering a ClickHouse re-query.
 const baselineCacheTTL = 5 * time.Minute
 
+// maxCatchupChunks bounds a single refresh to maxCatchupChunks × QueryChunk of
+// data. After downtime maxTime can fall behind the query window, making one
+// refresh span the entire window at once; capping it spreads the catch-up over
+// successive refreshes (maxTime advances after each) so peak memory stays near
+// steady state. 3 × 5m = 15m per refresh, ~3× the normal incremental span.
+const maxCatchupChunks = 3
+
 type View struct {
 	log       *slog.Logger
 	cfg       ViewConfig
@@ -404,9 +411,25 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 
 	// Query InfluxDB for interface usage data
 	// Convert times to UTC for InfluxDB query (InfluxDB stores times in UTC)
+	// Bound how much a single refresh ingests. After downtime maxTime can fall
+	// behind the query window, making [queryStart, now) span the whole window.
+	// queryIntfCountersChunked bounds InfluxDB's server-side memory per chunk,
+	// but the indexer still materializes every chunk's rows, the converted usage
+	// slice, and the ClickHouse batch for the entire span at once — which
+	// OOM-crashlooped the pod: it died before InsertInterfaceUsage, so maxTime
+	// never advanced and every restart re-ran the same giant query. Capping the
+	// span lets a large catch-up proceed across successive refreshes (maxTime
+	// advances after each), keeping peak memory near steady state.
+	queryEnd := now
+	if maxCatchup := v.cfg.QueryChunk * maxCatchupChunks; maxCatchup > 0 && queryEnd.Sub(queryStart) > maxCatchup {
+		queryEnd = queryStart.Add(maxCatchup)
+		v.log.Info("telemetry/usage: capping catch-up window to bound memory",
+			"queryStart", queryStart.UTC(), "queryEnd", queryEnd.UTC(), "target", now.UTC())
+	}
+
 	queryStartUTC := queryStart.UTC()
-	nowUTC := now.UTC()
-	usage, endBaselines, err := v.queryInfluxDB(ctx, queryStartUTC, nowUTC, baselines, alreadyWritten)
+	queryEndUTC := queryEnd.UTC()
+	usage, endBaselines, err := v.queryInfluxDB(ctx, queryStartUTC, queryEndUTC, baselines, alreadyWritten)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return result, err


### PR DESCRIPTION
## Problem

Prod `lake-indexer` OOMKilled-crashlooped (exit 137) under its 12Gi limit and stopped ingesting. Heap profiling (`-alloc_space`) showed **77%** of allocations in `RefreshTelemetryUsage → usage.(*View).Refresh`:

- `queryInfluxDB` ≈ 119 GB cumulative (InfluxDB CSV → `[]map[string]any` via `QueryTableResult.Next`)
- `convertRowsToUsage` + helpers ≈ 75 GB (materializes the full result set)
- full-set `sort.Slice` ≈ 14 GB
- `FactDataset.WriteBatch` ≈ 42 GB (single ClickHouse batch)

Steady-state RSS is ~1.5 GiB; the OOM was a transient cold-start spike >12Gi.

## Root cause

`--device-usage-query-window` defaults to **1h**, refresh **5m**. Normally `maxTime` is recent, so each refresh queries an incremental ~5–10m window — cheap. But after downtime (here ~1.5 days, caused by an unrelated migration-grant issue keeping the pod from starting), `maxTime` fell behind the 1h window, so `Refresh` queried the **entire `[now-1h, now)` span at once**. `queryIntfCountersChunked` bounds InfluxDB's *server-side* memory per chunk, but the indexer still holds **every chunk's rows + the converted `[]InterfaceUsage` + the ClickHouse batch for the whole span simultaneously** — the 12× cold-start spike.

It's **self-sustaining**: the OOM happens *before* `InsertInterfaceUsage`, so `maxTime` never advances, and every restart re-runs the same giant query. (Mitigated in prod by bumping the limit to 24Gi — see infra#1694 — but that's headroom, not a fix: any >1h gap can re-trigger it.)

## Fix (this PR)

Cap a single refresh to `maxCatchupChunks × QueryChunk` (3 × 5m = **15m**). A large catch-up now proceeds across successive refreshes — `maxTime` advances after each capped insert, so the next cycle resumes forward — keeping peak memory near the steady-state incremental size and converging at ~2× realtime.

- **Steady state unchanged:** normal incremental span (~5–10m) is below the cap, so `queryEnd == now` and behavior is identical.
- **No converter changes:** forward-fill, deltas, and sparse baselines are untouched. Baselines are only cached when fully caught up (`queryEnd == now`) to avoid mid-catch-up drift.
- **Self-healing:** even without the 24Gi bump, a gap can no longer pin the indexer in a crashloop.

## Follow-up (not in this PR)

The deeper fix is to **stream per chunk end-to-end** (query → convert → insert, carrying the per-key converter state across chunks) so peak memory is bounded by one chunk *regardless* of window size or a misconfigured large `--device-usage-query-window`. That's a larger, correctness-sensitive refactor of `convertRowsToUsage` (externalize `lastKnownValues`/`firstRowSeen`/`lastTime`) and deserves its own PR + golden test asserting streamed output == current batched output. This PR is the low-risk stopgap that removes the crashloop.

Follow up ticket https://github.com/malbeclabs/infra/issues/1695


## Test notes

- `go test ./indexer/pkg/dz/telemetry/usage/...` (existing `view_test.go`, `chunk_test.go`).
- Suggest adding a case: `maxTime` older than `QueryWindow` ⇒ `queryEnd == queryStart + maxCatchupChunks*QueryChunk` and successive refreshes converge to `now`.
