### PR TITLE
logger: disable ANSI escape codes in tint output

### DIFF
--- a/utils/pkg/logger/logger.go
+++ b/utils/pkg/logger/logger.go
@@ -17,7 +17,8 @@ func New(verbose bool) *slog.Logger {
 		logLevel = slog.LevelDebug
 	}
 	return slog.New(tint.NewHandler(os.Stdout, &tint.Options{
-		Level: logLevel,
+		Level:   logLevel,
+		NoColor: true,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				t := a.Value.Time().UTC()


### PR DESCRIPTION
## Summary of Changes

Sets `NoColor: true` on the `tint.Options` in `utils/pkg/logger/logger.go`. `tint.NewHandler` defaults `NoColor` to `false` and doesn't auto-detect TTY, so containers ship raw escape sequences like `[31mERR[0m`.

This pollutes Loki, breaks `detected_level` auto-extraction in Grafana Cloud, and forces alert queries to anchor on ANSI bytes instead of the standard level-extraction pattern.

The shared logger is installed as the slog default by every binary in this repo:

- **lake-indexer** (`indexer/cmd/indexer/main.go:71`) — daemon, in k8s
- **lake-api** (`api/main.go:231`) — daemon, in k8s
- **lake-admin** (`admin/cmd/admin/main.go:159`) — CLI
- **dev/controlcenter** (`dev/controlcenter/cmd/controlcenter/main.go:31`) — local tool

So this also fixes the structured-log lines in lake-api (the `INF`/`ERR` ones), not just lake-indexer. The chi router middleware access logs in lake-api use Go's stdlib `log` package separately and are unaffected (they were already ANSI-free).

None of these binaries are interactive enough to need colored output.

## Testing Verification

- `go vet ./utils/pkg/logger/ ./indexer/cmd/indexer/ ./admin/cmd/admin/ ./api/` clean.
- `go test ./utils/pkg/logger/` passes (no tests in this pkg).
- One-line option flip; no logic changes, no new deps.