### PR TITLE
rollup: source device-interface rollup from gNMI interface_state with per-device fallback to InfluxDB

### DIFF
--- a/indexer/pkg/rollup/activities.go
+++ b/indexer/pkg/rollup/activities.go
@@ -18,6 +18,10 @@ type Activities struct {
 	Log          *slog.Logger
 	IngestionLog *ingestionlog.Writer
 	Network      string
+	// TelemetryDatabase is the gNMI interface_state DB (e.g. telemetry_mainnet_beta).
+	// When set, the device-interface rollup prefers it per device and falls back to the
+	// InfluxDB fact table for devices not present there. Empty = fact-only (current behavior).
+	TelemetryDatabase string
 }
 
 // tableRef returns a qualified table reference. If sourceDB is non-empty, the
@@ -593,7 +597,227 @@ func (a *Activities) ComputeDeviceInterfaceRollup(ctx context.Context, input Bac
 		return nil, nil
 	}
 
-	// Collect unique device PKs and (device_pk, tunnel_id) pairs for state resolution
+	if err := a.resolveDeviceInterfaceState(ctx, buckets, input.WindowEnd, srcDB); err != nil {
+		return nil, err
+	}
+
+	a.logRollup("computed device interface rollup buckets", len(buckets), input, time.Since(start))
+
+	return buckets, nil
+}
+
+// ComputeDeviceInterfaceRollupFromGNMI computes the device-interface rollup from the
+// gNMI interface_state table (raw cumulative counters) rather than the InfluxDB-derived
+// fact table. interface_state has no deltas, so we derive per-sample deltas with window
+// functions (per device+interface ordered by timestamp), cast to Int64 so counter resets
+// read negative and are dropped, and produce the SAME Nullable(Int64)/Nullable(Float64)
+// delta columns the fact table carries. The outer aggregation is then identical to
+// ComputeDeviceInterfaceRollup, so both sources roll up the same way; only the input
+// sampling cadence differs. Link/tunnel enrichment and the de-junk filter are added in a
+// later step; this step emits empty link context.
+func (a *Activities) ComputeDeviceInterfaceRollupFromGNMI(ctx context.Context, input BackfillChunkInput) ([]DeviceInterfaceBucket, error) {
+	safeHeartbeat(ctx, "computing device interface rollup from gnmi")
+	start := time.Now()
+
+	interfaceState := tableRef(input.TelemetryDatabase, "interface_state")
+	linksHistory := tableRef(input.SourceDatabase, "dim_dz_links_history")
+
+	query := `
+		WITH links AS (
+			SELECT pk, side_a_pk, side_a_iface_name, side_z_pk, side_z_iface_name
+			FROM (
+				SELECT *, ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+				FROM ` + linksHistory + `
+			)
+			WHERE rn = 1 AND is_deleted = 0
+		),
+		link_map AS (
+			SELECT side_a_pk AS device_pk, side_a_iface_name AS intf, pk AS link_pk, 'A' AS link_side FROM links WHERE side_a_pk != '' AND side_a_iface_name != ''
+			UNION ALL
+			SELECT side_z_pk AS device_pk, side_z_iface_name AS intf, pk AS link_pk, 'Z' AS link_side FROM links WHERE side_z_pk != '' AND side_z_iface_name != ''
+		)
+		SELECT
+			d.device_pk,
+			d.intf,
+			d.bucket,
+			anyIf(lm.link_pk, lm.link_pk != '') as link_pk,
+			anyIf(lm.link_side, lm.link_side != '') as link_side,
+			if(startsWith(d.intf, 'Tunnel'), toInt64OrNull(substring(d.intf, 7)), NULL) as user_tunnel_id,
+			-- Error/discard counters
+			toUInt64(SUM(greatest(0, in_errors_delta))) as in_errors,
+			toUInt64(SUM(greatest(0, out_errors_delta))) as out_errors,
+			toUInt64(SUM(greatest(0, in_fcs_errors_delta))) as in_fcs_errors,
+			toUInt64(SUM(greatest(0, in_discards_delta))) as in_discards,
+			toUInt64(SUM(greatest(0, out_discards_delta))) as out_discards,
+			toUInt64(SUM(greatest(0, carrier_transitions_delta))) as carrier_transitions,
+			-- In BPS percentiles
+			avgIf(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as avg_in_bps,
+			minIf(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as min_in_bps,
+			quantileIf(0.50)(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as p50_in_bps,
+			quantileIf(0.90)(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as p90_in_bps,
+			quantileIf(0.95)(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as p95_in_bps,
+			quantileIf(0.99)(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as p99_in_bps,
+			maxIf(in_octets_delta * 8 / delta_duration, delta_duration > 0 AND in_octets_delta >= 0) as max_in_bps,
+			-- Out BPS percentiles
+			avgIf(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as avg_out_bps,
+			minIf(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as min_out_bps,
+			quantileIf(0.50)(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as p50_out_bps,
+			quantileIf(0.90)(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as p90_out_bps,
+			quantileIf(0.95)(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as p95_out_bps,
+			quantileIf(0.99)(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as p99_out_bps,
+			maxIf(out_octets_delta * 8 / delta_duration, delta_duration > 0 AND out_octets_delta >= 0) as max_out_bps,
+			-- In PPS percentiles
+			avgIf(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as avg_in_pps,
+			minIf(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as min_in_pps,
+			quantileIf(0.50)(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as p50_in_pps,
+			quantileIf(0.90)(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as p90_in_pps,
+			quantileIf(0.95)(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as p95_in_pps,
+			quantileIf(0.99)(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as p99_in_pps,
+			maxIf(in_pkts_delta / delta_duration, delta_duration > 0 AND in_pkts_delta >= 0) as max_in_pps,
+			-- Out PPS percentiles
+			avgIf(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as avg_out_pps,
+			minIf(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as min_out_pps,
+			quantileIf(0.50)(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as p50_out_pps,
+			quantileIf(0.90)(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as p90_out_pps,
+			quantileIf(0.95)(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as p95_out_pps,
+			quantileIf(0.99)(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as p99_out_pps,
+			maxIf(out_pkts_delta / delta_duration, delta_duration > 0 AND out_pkts_delta >= 0) as max_out_pps,
+			-- In Multicast PPS percentiles
+			avgIf(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as avg_in_mcast_pps,
+			minIf(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as min_in_mcast_pps,
+			quantileIf(0.50)(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as p50_in_mcast_pps,
+			quantileIf(0.90)(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as p90_in_mcast_pps,
+			quantileIf(0.95)(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as p95_in_mcast_pps,
+			quantileIf(0.99)(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as p99_in_mcast_pps,
+			maxIf(in_multicast_pkts_delta / delta_duration, delta_duration > 0 AND in_multicast_pkts_delta >= 0) as max_in_mcast_pps,
+			-- Out Multicast PPS percentiles
+			avgIf(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as avg_out_mcast_pps,
+			minIf(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as min_out_mcast_pps,
+			quantileIf(0.50)(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as p50_out_mcast_pps,
+			quantileIf(0.90)(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as p90_out_mcast_pps,
+			quantileIf(0.95)(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as p95_out_mcast_pps,
+			quantileIf(0.99)(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as p99_out_mcast_pps,
+			maxIf(out_multicast_pkts_delta / delta_duration, delta_duration > 0 AND out_multicast_pkts_delta >= 0) as max_out_mcast_pps
+		FROM (
+			SELECT
+				device_pubkey as device_pk,
+				interface_name as intf,
+				toStartOfFiveMinutes(timestamp) as bucket,
+				-- Per-sample deltas; NULL for the first sample of each partition (no baseline).
+				-- Cast to Int64 so counter resets produce negatives (dropped downstream).
+				if(rn > 1, toInt64(in_errors) - toInt64(prev_in_errors), NULL) as in_errors_delta,
+				if(rn > 1, toInt64(out_errors) - toInt64(prev_out_errors), NULL) as out_errors_delta,
+				if(rn > 1, toInt64(in_fcs_errors) - toInt64(prev_in_fcs_errors), NULL) as in_fcs_errors_delta,
+				if(rn > 1, toInt64(in_discards) - toInt64(prev_in_discards), NULL) as in_discards_delta,
+				if(rn > 1, toInt64(out_discards) - toInt64(prev_out_discards), NULL) as out_discards_delta,
+				if(rn > 1, toInt64(carrier_transitions) - toInt64(prev_carrier_transitions), NULL) as carrier_transitions_delta,
+				if(rn > 1, toInt64(in_octets) - toInt64(prev_in_octets), NULL) as in_octets_delta,
+				if(rn > 1, toInt64(out_octets) - toInt64(prev_out_octets), NULL) as out_octets_delta,
+				if(rn > 1, toInt64(in_pkts) - toInt64(prev_in_pkts), NULL) as in_pkts_delta,
+				if(rn > 1, toInt64(out_pkts) - toInt64(prev_out_pkts), NULL) as out_pkts_delta,
+				if(rn > 1, toInt64(in_multicast_pkts) - toInt64(prev_in_multicast_pkts), NULL) as in_multicast_pkts_delta,
+				if(rn > 1, toInt64(out_multicast_pkts) - toInt64(prev_out_multicast_pkts), NULL) as out_multicast_pkts_delta,
+				if(rn > 1, (toUnixTimestamp64Milli(timestamp) - toUnixTimestamp64Milli(prev_ts)) / 1000.0, NULL) as delta_duration
+			FROM (
+				SELECT
+					device_pubkey, interface_name, timestamp,
+					in_errors, out_errors, in_fcs_errors, in_discards, out_discards, carrier_transitions,
+					in_octets, out_octets, in_pkts, out_pkts, in_multicast_pkts, out_multicast_pkts,
+					row_number() OVER w as rn,
+					lagInFrame(timestamp) OVER w as prev_ts,
+					lagInFrame(in_errors) OVER w as prev_in_errors,
+					lagInFrame(out_errors) OVER w as prev_out_errors,
+					lagInFrame(in_fcs_errors) OVER w as prev_in_fcs_errors,
+					lagInFrame(in_discards) OVER w as prev_in_discards,
+					lagInFrame(out_discards) OVER w as prev_out_discards,
+					lagInFrame(carrier_transitions) OVER w as prev_carrier_transitions,
+					lagInFrame(in_octets) OVER w as prev_in_octets,
+					lagInFrame(out_octets) OVER w as prev_out_octets,
+					lagInFrame(in_pkts) OVER w as prev_in_pkts,
+					lagInFrame(out_pkts) OVER w as prev_out_pkts,
+					lagInFrame(in_multicast_pkts) OVER w as prev_in_multicast_pkts,
+					lagInFrame(out_multicast_pkts) OVER w as prev_out_multicast_pkts
+				FROM ` + interfaceState + `
+				WHERE timestamp >= $1 AND timestamp < $2
+				WINDOW w AS (PARTITION BY device_pubkey, interface_name ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+			)
+		) d
+		LEFT JOIN link_map lm ON d.device_pk = lm.device_pk AND d.intf = lm.intf
+		GROUP BY d.device_pk, d.intf, d.bucket
+		HAVING link_pk != '' OR user_tunnel_id IS NOT NULL OR avg_in_bps > 0 OR avg_out_bps > 0
+		ORDER BY d.device_pk, d.intf, d.bucket
+	`
+
+	rows, err := a.ClickHouse.Query(ctx, query, input.WindowStart, input.WindowEnd)
+	if err != nil {
+		return nil, fmt.Errorf("device interface gnmi query: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now()
+	var buckets []DeviceInterfaceBucket
+
+	for rows.Next() {
+		var b DeviceInterfaceBucket
+		b.IngestedAt = now
+		if err := rows.Scan(
+			&b.DevicePK, &b.Intf, &b.BucketTS,
+			&b.LinkPK, &b.LinkSide,
+			&b.UserTunnelID,
+			&b.InErrors, &b.OutErrors, &b.InFcsErrors, &b.InDiscards, &b.OutDiscards, &b.CarrierTransitions,
+			&b.InBps.Avg, &b.InBps.Min, &b.InBps.P50, &b.InBps.P90, &b.InBps.P95, &b.InBps.P99, &b.InBps.Max,
+			&b.OutBps.Avg, &b.OutBps.Min, &b.OutBps.P50, &b.OutBps.P90, &b.OutBps.P95, &b.OutBps.P99, &b.OutBps.Max,
+			&b.InPps.Avg, &b.InPps.Min, &b.InPps.P50, &b.InPps.P90, &b.InPps.P95, &b.InPps.P99, &b.InPps.Max,
+			&b.OutPps.Avg, &b.OutPps.Min, &b.OutPps.P50, &b.OutPps.P90, &b.OutPps.P95, &b.OutPps.P99, &b.OutPps.Max,
+			&b.InMcastPps.Avg, &b.InMcastPps.Min, &b.InMcastPps.P50, &b.InMcastPps.P90, &b.InMcastPps.P95, &b.InMcastPps.P99, &b.InMcastPps.Max,
+			&b.OutMcastPps.Avg, &b.OutMcastPps.Min, &b.OutMcastPps.P50, &b.OutMcastPps.P90, &b.OutMcastPps.P95, &b.OutMcastPps.P99, &b.OutMcastPps.Max,
+		); err != nil {
+			return nil, fmt.Errorf("device interface gnmi scan: %w", err)
+		}
+		b.BucketTS = b.BucketTS.UTC()
+		buckets = append(buckets, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device interface gnmi rows: %w", err)
+	}
+
+	if err := a.resolveDeviceInterfaceState(ctx, buckets, input.WindowEnd, input.SourceDatabase); err != nil {
+		return nil, err
+	}
+
+	a.logRollup("computed device interface rollup buckets from gnmi", len(buckets), input, time.Since(start))
+	return buckets, nil
+}
+
+// coalesceDeviceInterfaceBuckets merges gNMI-sourced and fact-table-sourced rollup buckets
+// per device: for any device present in the gNMI buckets, its gNMI buckets win and the
+// fact-table buckets for that device are dropped; devices not present in the gNMI buckets
+// fall back to their fact-table buckets. This lets monitoring shift to gNMI device-by-device
+// as contributors upgrade, with no flag day.
+func coalesceDeviceInterfaceBuckets(gnmiBuckets, factBuckets []DeviceInterfaceBucket) []DeviceInterfaceBucket {
+	gnmiDevices := make(map[string]struct{})
+	for _, b := range gnmiBuckets {
+		gnmiDevices[b.DevicePK] = struct{}{}
+	}
+	out := make([]DeviceInterfaceBucket, 0, len(gnmiBuckets)+len(factBuckets))
+	out = append(out, gnmiBuckets...)
+	for _, b := range factBuckets {
+		if _, ok := gnmiDevices[b.DevicePK]; !ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// resolveDeviceInterfaceState resolves device Status, ISIS state, and user PK onto the
+// given buckets. Shared by the InfluxDB (ComputeDeviceInterfaceRollup) and gNMI
+// (ComputeDeviceInterfaceRollupFromGNMI) device-interface rollups so both produce
+// fully-resolved buckets.
+func (a *Activities) resolveDeviceInterfaceState(ctx context.Context, buckets []DeviceInterfaceBucket, asOf time.Time, srcDB string) error {
+	if len(buckets) == 0 {
+		return nil
+	}
+
 	devicePKs := make(map[string]struct{})
 	tunnelKeys := make(map[tunnelKey]struct{})
 	for i := range buckets {
@@ -603,25 +827,19 @@ func (a *Activities) ComputeDeviceInterfaceRollup(ctx context.Context, input Bac
 		}
 	}
 
-	// Resolve device status from dim_dz_devices_history
-	deviceStatus, err := a.resolveDeviceStatus(ctx, devicePKs, input.WindowEnd, srcDB)
+	deviceStatus, err := a.resolveDeviceStatus(ctx, devicePKs, asOf, srcDB)
 	if err != nil {
-		return nil, fmt.Errorf("resolve device status: %w", err)
+		return fmt.Errorf("resolve device status: %w", err)
+	}
+	isisDeviceState, err := a.resolveISISDeviceState(ctx, devicePKs, asOf, srcDB)
+	if err != nil {
+		return fmt.Errorf("resolve ISIS device state: %w", err)
+	}
+	userPKs, err := a.resolveUserPKs(ctx, tunnelKeys, asOf, srcDB)
+	if err != nil {
+		return fmt.Errorf("resolve user PKs: %w", err)
 	}
 
-	// Resolve ISIS device state from dim_isis_devices_history
-	isisDeviceState, err := a.resolveISISDeviceState(ctx, devicePKs, input.WindowEnd, srcDB)
-	if err != nil {
-		return nil, fmt.Errorf("resolve ISIS device state: %w", err)
-	}
-
-	// Resolve user PKs from dim_dz_users_history
-	userPKs, err := a.resolveUserPKs(ctx, tunnelKeys, input.WindowEnd, srcDB)
-	if err != nil {
-		return nil, fmt.Errorf("resolve user PKs: %w", err)
-	}
-
-	// Apply resolved state to buckets
 	for i := range buckets {
 		b := &buckets[i]
 		if status, ok := deviceStatus[b.DevicePK]; ok {
@@ -638,10 +856,7 @@ func (a *Activities) ComputeDeviceInterfaceRollup(ctx context.Context, input Bac
 			}
 		}
 	}
-
-	a.logRollup("computed device interface rollup buckets", len(buckets), input, time.Since(start))
-
-	return buckets, nil
+	return nil
 }
 
 // resolveDeviceStatus queries dim_dz_devices_history to get the most recent status
@@ -862,13 +1077,22 @@ func (a *Activities) RollupLinks(ctx context.Context, input BackfillChunkInput) 
 // RollupDeviceInterfaces computes device interface rollup buckets and writes
 // them to ClickHouse in a single activity.
 func (a *Activities) RollupDeviceInterfaces(ctx context.Context, input BackfillChunkInput) (int, error) {
+	input.TelemetryDatabase = a.TelemetryDatabase
 	var count int
 	err := a.IngestionLog.Wrap(ctx, "rollup", "RollupDeviceInterfaces", a.Network, func() (ingestionlog.RefreshResult, error) {
 		var result ingestionlog.RefreshResult
-		buckets, err := a.ComputeDeviceInterfaceRollup(ctx, input)
+		factBuckets, err := a.ComputeDeviceInterfaceRollup(ctx, input)
 		if err != nil {
 			return result, err
 		}
+		// gNMI is additive: if it fails (e.g. misconfigured or unavailable), fall back to
+		// fact-only so the rollup is never worse than the InfluxDB-only behavior.
+		gnmiBuckets, gerr := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, input)
+		if gerr != nil {
+			a.Log.Warn("gnmi device interface rollup failed; falling back to fact-only", "error", gerr)
+			gnmiBuckets = nil
+		}
+		buckets := coalesceDeviceInterfaceBuckets(gnmiBuckets, factBuckets)
 		if err := a.WriteDeviceInterfaceBuckets(ctx, buckets); err != nil {
 			return result, err
 		}

--- a/indexer/pkg/rollup/activities.go
+++ b/indexer/pkg/rollup/activities.go
@@ -632,9 +632,16 @@ func (a *Activities) ComputeDeviceInterfaceRollupFromGNMI(ctx context.Context, i
 			WHERE rn = 1 AND is_deleted = 0
 		),
 		link_map AS (
-			SELECT side_a_pk AS device_pk, side_a_iface_name AS intf, pk AS link_pk, 'A' AS link_side FROM links WHERE side_a_pk != '' AND side_a_iface_name != ''
-			UNION ALL
-			SELECT side_z_pk AS device_pk, side_z_iface_name AS intf, pk AS link_pk, 'Z' AS link_side FROM links WHERE side_z_pk != '' AND side_z_iface_name != ''
+			-- One row per (device_pk, intf): an interface maps to at most one link side, so
+			-- collapse any duplicates (e.g. a re-created link sharing an interface) to avoid
+			-- fanning out the per-sample delta rows in the JOIN below (double-counting SUMs).
+			SELECT device_pk, intf, any(link_pk) AS link_pk, any(link_side) AS link_side
+			FROM (
+				SELECT side_a_pk AS device_pk, side_a_iface_name AS intf, pk AS link_pk, 'A' AS link_side FROM links WHERE side_a_pk != '' AND side_a_iface_name != ''
+				UNION ALL
+				SELECT side_z_pk AS device_pk, side_z_iface_name AS intf, pk AS link_pk, 'Z' AS link_side FROM links WHERE side_z_pk != '' AND side_z_iface_name != ''
+			)
+			GROUP BY device_pk, intf
 		)
 		SELECT
 			d.device_pk,
@@ -738,17 +745,21 @@ func (a *Activities) ComputeDeviceInterfaceRollupFromGNMI(ctx context.Context, i
 					lagInFrame(in_multicast_pkts) OVER w as prev_in_multicast_pkts,
 					lagInFrame(out_multicast_pkts) OVER w as prev_out_multicast_pkts
 				FROM ` + interfaceState + `
-				WHERE timestamp >= $1 AND timestamp < $2
+				WHERE timestamp >= $1 AND timestamp < $3
 				WINDOW w AS (PARTITION BY device_pubkey, interface_name ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
 			)
 		) d
 		LEFT JOIN link_map lm ON d.device_pk = lm.device_pk AND d.intf = lm.intf
+		WHERE d.bucket >= toStartOfFiveMinutes($2) AND d.bucket < $3
 		GROUP BY d.device_pk, d.intf, d.bucket
-		HAVING link_pk != '' OR user_tunnel_id IS NOT NULL OR avg_in_bps > 0 OR avg_out_bps > 0
 		ORDER BY d.device_pk, d.intf, d.bucket
 	`
 
-	rows, err := a.ClickHouse.Query(ctx, query, input.WindowStart, input.WindowEnd)
+	// Baseline lookback: scan samples up to 10m before WindowStart so the first in-window
+	// sample of each interface diffs against a real prior (mirrors the InfluxDB baseline);
+	// the outer query keeps only buckets in [WindowStart, WindowEnd) so lookback rows are dropped.
+	lookbackStart := input.WindowStart.Add(-10 * time.Minute)
+	rows, err := a.ClickHouse.Query(ctx, query, lookbackStart, input.WindowStart, input.WindowEnd)
 	if err != nil {
 		return nil, fmt.Errorf("device interface gnmi query: %w", err)
 	}
@@ -790,19 +801,27 @@ func (a *Activities) ComputeDeviceInterfaceRollupFromGNMI(ctx context.Context, i
 }
 
 // coalesceDeviceInterfaceBuckets merges gNMI-sourced and fact-table-sourced rollup buckets
-// per device: for any device present in the gNMI buckets, its gNMI buckets win and the
-// fact-table buckets for that device are dropped; devices not present in the gNMI buckets
-// fall back to their fact-table buckets. This lets monitoring shift to gNMI device-by-device
-// as contributors upgrade, with no flag day.
+// per (device, interface, bucket) key — the destination table's ReplacingMergeTree grain.
+// For any key present in the gNMI buckets, the gNMI bucket wins; every other key falls back
+// to its fact-table bucket. Keying at the row grain (not per device) keeps fact coverage for
+// buckets/interfaces gNMI hasn't produced (mid-window gNMI start, stalls, partial-interface
+// coverage), and because every live key is rewritten each cycle it supersedes stale rows.
+// This lets monitoring shift to gNMI device-by-device as contributors upgrade, with no flag day.
 func coalesceDeviceInterfaceBuckets(gnmiBuckets, factBuckets []DeviceInterfaceBucket) []DeviceInterfaceBucket {
-	gnmiDevices := make(map[string]struct{})
-	for _, b := range gnmiBuckets {
-		gnmiDevices[b.DevicePK] = struct{}{}
+	// Key on the destination table's replacement grain: (bucket_ts, device_pk, intf).
+	type diKey struct {
+		device string
+		intf   string
+		bucket int64
 	}
+	seen := make(map[diKey]struct{}, len(gnmiBuckets))
 	out := make([]DeviceInterfaceBucket, 0, len(gnmiBuckets)+len(factBuckets))
-	out = append(out, gnmiBuckets...)
-	for _, b := range factBuckets {
-		if _, ok := gnmiDevices[b.DevicePK]; !ok {
+	for _, b := range gnmiBuckets { // gNMI wins per key
+		seen[diKey{b.DevicePK, b.Intf, b.BucketTS.UTC().UnixNano()}] = struct{}{}
+		out = append(out, b)
+	}
+	for _, b := range factBuckets { // fact fills every key gNMI did not produce
+		if _, ok := seen[diKey{b.DevicePK, b.Intf, b.BucketTS.UTC().UnixNano()}]; !ok {
 			out = append(out, b)
 		}
 	}

--- a/indexer/pkg/rollup/activities_test.go
+++ b/indexer/pkg/rollup/activities_test.go
@@ -476,6 +476,314 @@ func TestComputeDeviceInterfaceRollup_WithData(t *testing.T) {
 	assert.Equal(t, uint64(1), count)
 }
 
+// TestComputeDeviceInterfaceRollupFromGNMI_ComputesDeltas verifies the gNMI
+// branch derives per-bucket deltas from interface_state's RAW CUMULATIVE counters
+// (the InfluxDB fact table arrives pre-delta'd; interface_state does not).
+func TestComputeDeviceInterfaceRollupFromGNMI_ComputesDeltas(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+
+	// interface_state lives in the telemetry_* schema; create it in the test DB.
+	require.NoError(t, conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS interface_state (
+			timestamp DateTime64(9),
+			device_pubkey LowCardinality(String),
+			interface_name String,
+			admin_status LowCardinality(String),
+			oper_status LowCardinality(String),
+			ifindex UInt32, mtu UInt16, last_change Int64,
+			carrier_transitions UInt64,
+			in_octets UInt64, out_octets UInt64, in_pkts UInt64, out_pkts UInt64,
+			in_errors UInt64, out_errors UInt64, in_discards UInt64, out_discards UInt64,
+			in_fcs_errors UInt64,
+			in_unicast_pkts UInt64, in_multicast_pkts UInt64, in_broadcast_pkts UInt64,
+			out_unicast_pkts UInt64, out_multicast_pkts UInt64, out_broadcast_pkts UInt64
+		) ENGINE = MergeTree() ORDER BY (device_pubkey, interface_name, timestamp)
+	`))
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+
+	// 3 cumulative samples in one 5-min bucket -> 2 consecutive deltas.
+	// per minute: in_octets +125000, in_pkts +100, in_errors +10, out_errors +5,
+	// in_discards +2, in_multicast_pkts +30.
+	for i := range 3 {
+		ts := bucketStart.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, conn.Exec(ctx, `INSERT INTO interface_state
+			(timestamp, device_pubkey, interface_name, admin_status, oper_status, ifindex, mtu, last_change,
+			 carrier_transitions, in_octets, out_octets, in_pkts, out_pkts, in_errors, out_errors, in_discards, out_discards,
+			 in_fcs_errors, in_unicast_pkts, in_multicast_pkts, in_broadcast_pkts, out_unicast_pkts, out_multicast_pkts, out_broadcast_pkts)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)`,
+			ts, "device-1", "Ethernet1/1", "UP", "UP", uint32(1), uint16(9000), int64(0),
+			uint64(0),
+			uint64(1000+125000*i), uint64(500+62500*i), uint64(10+100*i), uint64(5+50*i),
+			uint64(10*i), uint64(5*i), uint64(2*i), uint64(1*i),
+			uint64(0), uint64(0), uint64(30*i), uint64(0), uint64(0), uint64(0), uint64(0)))
+	}
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, BackfillChunkInput{
+		WindowStart: now.Add(-10 * time.Minute),
+		WindowEnd:   now.Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.Len(t, buckets, 1)
+
+	b := buckets[0]
+	assert.Equal(t, "device-1", b.DevicePK)
+	assert.Equal(t, "Ethernet1/1", b.Intf)
+	// 2 deltas summed
+	assert.Equal(t, uint64(20), b.InErrors)
+	assert.Equal(t, uint64(10), b.OutErrors)
+	assert.Equal(t, uint64(4), b.InDiscards)
+	// rates derived from cumulative diffs
+	assert.Greater(t, b.InBps.Avg, float64(0))
+	assert.Greater(t, b.InPps.Avg, float64(0))
+	assert.Greater(t, b.InMcastPps.Avg, float64(0))
+}
+
+// TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk verifies the gNMI
+// branch enriches link/tunnel context (from dim_dz_links_history / Tunnel<N> name)
+// and drops junk interfaces: not mapped to a link or tunnel and carrying no traffic.
+func TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS interface_state (
+			timestamp DateTime64(9),
+			device_pubkey LowCardinality(String), interface_name String,
+			admin_status LowCardinality(String), oper_status LowCardinality(String),
+			ifindex UInt32, mtu UInt16, last_change Int64,
+			carrier_transitions UInt64,
+			in_octets UInt64, out_octets UInt64, in_pkts UInt64, out_pkts UInt64,
+			in_errors UInt64, out_errors UInt64, in_discards UInt64, out_discards UInt64,
+			in_fcs_errors UInt64,
+			in_unicast_pkts UInt64, in_multicast_pkts UInt64, in_broadcast_pkts UInt64,
+			out_unicast_pkts UInt64, out_multicast_pkts UInt64, out_broadcast_pkts UInt64
+		) ENGINE = MergeTree() ORDER BY (device_pubkey, interface_name, timestamp)
+	`))
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+
+	// device-1/Ethernet1/1 is side A of link-1.
+	require.NoError(t, conn.Exec(ctx, `INSERT INTO dim_dz_links_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, pk, status, side_a_pk, side_a_iface_name, side_z_pk, side_z_iface_name) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		"link-entity-1", now, now, "00000000-0000-0000-0000-000000000031", uint8(0), "link-1", "activated", "device-1", "Ethernet1/1", "device-2", "Ethernet9/9"))
+
+	// octetsStep>0 => traffic; octetsStep==0 => flat (no traffic).
+	insert := func(intf string, octetsStep uint64) {
+		for i := range 3 {
+			ts := bucketStart.Add(time.Duration(i) * time.Minute)
+			require.NoError(t, conn.Exec(ctx, `INSERT INTO interface_state
+				(timestamp, device_pubkey, interface_name, admin_status, oper_status, ifindex, mtu, last_change,
+				 carrier_transitions, in_octets, out_octets, in_pkts, out_pkts, in_errors, out_errors, in_discards, out_discards,
+				 in_fcs_errors, in_unicast_pkts, in_multicast_pkts, in_broadcast_pkts, out_unicast_pkts, out_multicast_pkts, out_broadcast_pkts)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)`,
+				ts, "device-1", intf, "UP", "UP", uint32(1), uint16(9000), int64(0),
+				uint64(0),
+				uint64(1000+octetsStep*uint64(i)), uint64(500+octetsStep*uint64(i)), uint64(10+100*i), uint64(5+50*i),
+				uint64(0), uint64(0), uint64(0), uint64(0),
+				uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0)))
+		}
+	}
+	insert("Ethernet1/1", 125000) // link-mapped + traffic -> keep
+	insert("Tunnel500", 125000)   // user tunnel + traffic -> keep
+	insert("Ethernet48", 0)       // no link/tunnel, flat octets (no traffic) -> drop
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, BackfillChunkInput{
+		WindowStart: now.Add(-10 * time.Minute),
+		WindowEnd:   now.Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	byIntf := make(map[string]DeviceInterfaceBucket)
+	for _, b := range buckets {
+		byIntf[b.Intf] = b
+	}
+
+	_, hasJunk := byIntf["Ethernet48"]
+	assert.False(t, hasJunk, "junk interface (no link/tunnel, no traffic) should be dropped")
+
+	eth, ok := byIntf["Ethernet1/1"]
+	require.True(t, ok, "link-mapped interface should be kept")
+	assert.Equal(t, "link-1", eth.LinkPK)
+	assert.Equal(t, "A", eth.LinkSide)
+
+	tun, ok := byIntf["Tunnel500"]
+	require.True(t, ok, "user-tunnel interface should be kept")
+	require.NotNil(t, tun.UserTunnelID)
+	assert.Equal(t, int64(500), *tun.UserTunnelID)
+}
+
+// TestCoalesceDeviceInterfaceBuckets_PrefersGNMI verifies the per-device merge: a device
+// present in the gNMI buckets wins (its fact-table buckets are dropped), and a device with
+// no gNMI data falls back to its fact-table buckets.
+func TestCoalesceDeviceInterfaceBuckets_PrefersGNMI(t *testing.T) {
+	t.Parallel()
+	gnmi := []DeviceInterfaceBucket{
+		{DevicePK: "d1", Intf: "Ethernet1", InErrors: 99},
+	}
+	fact := []DeviceInterfaceBucket{
+		{DevicePK: "d1", Intf: "Ethernet1", InErrors: 1}, // superseded by gNMI
+		{DevicePK: "d2", Intf: "Ethernet2", InErrors: 7}, // no gNMI for d2 -> kept
+	}
+
+	out := coalesceDeviceInterfaceBuckets(gnmi, fact)
+
+	byDev := make(map[string]DeviceInterfaceBucket)
+	for _, b := range out {
+		byDev[b.DevicePK] = b
+	}
+
+	require.Len(t, out, 2)
+	require.Contains(t, byDev, "d1")
+	require.Contains(t, byDev, "d2")
+	assert.Equal(t, uint64(99), byDev["d1"].InErrors, "d1 should come from gNMI, not fact")
+	assert.Equal(t, uint64(7), byDev["d2"].InErrors, "d2 has no gNMI data -> fall back to fact")
+}
+
+// TestComputeDeviceInterfaceRollupFromGNMI_ResolvesDeviceState verifies the gNMI branch
+// resolves device Status (from dim_dz_devices_history) onto its buckets, like the fact path.
+func TestComputeDeviceInterfaceRollupFromGNMI_ResolvesDeviceState(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS interface_state (
+			timestamp DateTime64(9),
+			device_pubkey LowCardinality(String), interface_name String,
+			admin_status LowCardinality(String), oper_status LowCardinality(String),
+			ifindex UInt32, mtu UInt16, last_change Int64,
+			carrier_transitions UInt64,
+			in_octets UInt64, out_octets UInt64, in_pkts UInt64, out_pkts UInt64,
+			in_errors UInt64, out_errors UInt64, in_discards UInt64, out_discards UInt64,
+			in_fcs_errors UInt64,
+			in_unicast_pkts UInt64, in_multicast_pkts UInt64, in_broadcast_pkts UInt64,
+			out_unicast_pkts UInt64, out_multicast_pkts UInt64, out_broadcast_pkts UInt64
+		) ENGINE = MergeTree() ORDER BY (device_pubkey, interface_name, timestamp)
+	`))
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+
+	require.NoError(t, conn.Exec(ctx, `INSERT INTO dim_dz_devices_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, pk, status, device_type, code, metro_pk) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		"dev-entity-9", now, now, "00000000-0000-0000-0000-000000000041", uint8(0), "device-9", "soft-drained", "router", "DEV9", "metro-1"))
+
+	for i := range 3 {
+		ts := bucketStart.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, conn.Exec(ctx, `INSERT INTO interface_state
+			(timestamp, device_pubkey, interface_name, admin_status, oper_status, ifindex, mtu, last_change,
+			 carrier_transitions, in_octets, out_octets, in_pkts, out_pkts, in_errors, out_errors, in_discards, out_discards,
+			 in_fcs_errors, in_unicast_pkts, in_multicast_pkts, in_broadcast_pkts, out_unicast_pkts, out_multicast_pkts, out_broadcast_pkts)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)`,
+			ts, "device-9", "Ethernet1/1", "UP", "UP", uint32(1), uint16(9000), int64(0),
+			uint64(0),
+			uint64(1000+125000*i), uint64(500+62500*i), uint64(10+100*i), uint64(5+50*i),
+			uint64(0), uint64(0), uint64(0), uint64(0),
+			uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0)))
+	}
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, BackfillChunkInput{
+		WindowStart: now.Add(-10 * time.Minute),
+		WindowEnd:   now.Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, buckets)
+	assert.Equal(t, "soft-drained", buckets[0].Status, "gNMI bucket should have device Status resolved")
+}
+
+// TestDeviceInterfaceRollup_GNMIMatchesInfluxForSameData seeds equivalent underlying data
+// into both sources (raw cumulative counters in interface_state; the equivalent precomputed
+// deltas in the fact table) and asserts the two rollups produce matching totals and average
+// rates. This guards that the gNMI delta math equals the InfluxDB path given the same samples.
+func TestDeviceInterfaceRollup_GNMIMatchesInfluxForSameData(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS interface_state (
+			timestamp DateTime64(9),
+			device_pubkey LowCardinality(String), interface_name String,
+			admin_status LowCardinality(String), oper_status LowCardinality(String),
+			ifindex UInt32, mtu UInt16, last_change Int64,
+			carrier_transitions UInt64,
+			in_octets UInt64, out_octets UInt64, in_pkts UInt64, out_pkts UInt64,
+			in_errors UInt64, out_errors UInt64, in_discards UInt64, out_discards UInt64,
+			in_fcs_errors UInt64,
+			in_unicast_pkts UInt64, in_multicast_pkts UInt64, in_broadcast_pkts UInt64,
+			out_unicast_pkts UInt64, out_multicast_pkts UInt64, out_broadcast_pkts UInt64
+		) ENGINE = MergeTree() ORDER BY (device_pubkey, interface_name, timestamp)
+	`))
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+
+	// Per minute: in_octets +125000, out_octets +62500, in_pkts +100, out_pkts +50,
+	// in_errors +10, out_errors +5, in_discards +2, in_multicast_pkts +30.
+	// gNMI: 3 cumulative samples (-> 2 deltas).
+	for i := range 3 {
+		ts := bucketStart.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, conn.Exec(ctx, `INSERT INTO interface_state
+			(timestamp, device_pubkey, interface_name, admin_status, oper_status, ifindex, mtu, last_change,
+			 carrier_transitions, in_octets, out_octets, in_pkts, out_pkts, in_errors, out_errors, in_discards, out_discards,
+			 in_fcs_errors, in_unicast_pkts, in_multicast_pkts, in_broadcast_pkts, out_unicast_pkts, out_multicast_pkts, out_broadcast_pkts)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)`,
+			ts, "device-eq", "Ethernet1/1", "UP", "UP", uint32(1), uint16(9000), int64(0),
+			uint64(0),
+			uint64(1000+125000*i), uint64(500+62500*i), uint64(10+100*i), uint64(5+50*i),
+			uint64(10*i), uint64(5*i), uint64(2*i), uint64(0),
+			uint64(0), uint64(0), uint64(30*i), uint64(0), uint64(0), uint64(0), uint64(0)))
+	}
+	// Fact: the equivalent 2 delta rows (matching the 2 gNMI deltas).
+	for i := 1; i < 3; i++ {
+		ts := bucketStart.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, conn.Exec(ctx, `INSERT INTO fact_dz_device_interface_counters (event_ts, ingested_at, device_pk, host, intf, link_pk, link_side, in_errors_delta, out_errors_delta, in_fcs_errors_delta, in_discards_delta, out_discards_delta, carrier_transitions_delta, in_octets_delta, out_octets_delta, in_pkts_delta, out_pkts_delta, in_multicast_pkts_delta, out_multicast_pkts_delta, delta_duration) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
+			ts, ts, "device-eq", "host", "Ethernet1/1", "", "",
+			int64(10), int64(5), int64(0), int64(2), int64(0), int64(0),
+			int64(125000), int64(62500), int64(100), int64(50),
+			int64(30), int64(0), float64(60.0)))
+	}
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	input := BackfillChunkInput{WindowStart: now.Add(-10 * time.Minute), WindowEnd: now.Add(5 * time.Minute)}
+
+	gnmi, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, gnmi, 1)
+	fact, err := a.ComputeDeviceInterfaceRollup(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, fact, 1)
+
+	g, f := gnmi[0], fact[0]
+	// Totals match exactly.
+	assert.Equal(t, f.InErrors, g.InErrors)
+	assert.Equal(t, f.OutErrors, g.OutErrors)
+	assert.Equal(t, f.InDiscards, g.InDiscards)
+	assert.Equal(t, f.OutDiscards, g.OutDiscards)
+	assert.Equal(t, f.CarrierTransitions, g.CarrierTransitions)
+	// Average rates match (same samples, same aggregation).
+	assert.InDelta(t, f.InBps.Avg, g.InBps.Avg, 1.0)
+	assert.InDelta(t, f.OutBps.Avg, g.OutBps.Avg, 1.0)
+	assert.InDelta(t, f.InPps.Avg, g.InPps.Avg, 0.01)
+	assert.InDelta(t, f.InMcastPps.Avg, g.InMcastPps.Avg, 0.01)
+}
+
+// TestTelemetryDatabaseForNetwork verifies the gNMI telemetry DB name derived per network.
+func TestTelemetryDatabaseForNetwork(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "telemetry_mainnet_beta", telemetryDatabaseForNetwork("mainnet-beta"))
+	assert.Equal(t, "telemetry_testnet", telemetryDatabaseForNetwork("testnet"))
+	assert.Equal(t, "telemetry_devnet", telemetryDatabaseForNetwork("devnet"))
+	assert.Equal(t, "", telemetryDatabaseForNetwork(""), "empty network -> gNMI off (fact-only)")
+}
+
 func TestComputeDeviceInterfaceRollup_WithUserTunnel(t *testing.T) {
 	t.Parallel()
 	conn := setupTestDB(t)

--- a/indexer/pkg/rollup/activities_test.go
+++ b/indexer/pkg/rollup/activities_test.go
@@ -543,10 +543,10 @@ func TestComputeDeviceInterfaceRollupFromGNMI_ComputesDeltas(t *testing.T) {
 	assert.Greater(t, b.InMcastPps.Avg, float64(0))
 }
 
-// TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk verifies the gNMI
-// branch enriches link/tunnel context (from dim_dz_links_history / Tunnel<N> name)
-// and drops junk interfaces: not mapped to a link or tunnel and carrying no traffic.
-func TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk(t *testing.T) {
+// TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAllInterfaces verifies the gNMI
+// branch enriches link/tunnel context (from dim_dz_links_history / Tunnel<N> name) and,
+// like the InfluxDB path, keeps every interface (no de-junk filter).
+func TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAllInterfaces(t *testing.T) {
 	t.Parallel()
 	conn := setupTestDB(t)
 	ctx := context.Background()
@@ -606,7 +606,7 @@ func TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk(t *testing.T)
 	}
 
 	_, hasJunk := byIntf["Ethernet48"]
-	assert.False(t, hasJunk, "junk interface (no link/tunnel, no traffic) should be dropped")
+	assert.True(t, hasJunk, "no de-junk filter: all interfaces kept, matching the InfluxDB path")
 
 	eth, ok := byIntf["Ethernet1/1"]
 	require.True(t, ok, "link-mapped interface should be kept")
@@ -619,31 +619,146 @@ func TestComputeDeviceInterfaceRollupFromGNMI_EnrichesAndDropsJunk(t *testing.T)
 	assert.Equal(t, int64(500), *tun.UserTunnelID)
 }
 
+func createInterfaceStateTable(t *testing.T, ctx context.Context, conn clickhouse.Conn) {
+	t.Helper()
+	require.NoError(t, conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS interface_state (
+			timestamp DateTime64(9),
+			device_pubkey LowCardinality(String), interface_name String,
+			admin_status LowCardinality(String), oper_status LowCardinality(String),
+			ifindex UInt32, mtu UInt16, last_change Int64,
+			carrier_transitions UInt64,
+			in_octets UInt64, out_octets UInt64, in_pkts UInt64, out_pkts UInt64,
+			in_errors UInt64, out_errors UInt64, in_discards UInt64, out_discards UInt64,
+			in_fcs_errors UInt64,
+			in_unicast_pkts UInt64, in_multicast_pkts UInt64, in_broadcast_pkts UInt64,
+			out_unicast_pkts UInt64, out_multicast_pkts UInt64, out_broadcast_pkts UInt64
+		) ENGINE = MergeTree() ORDER BY (device_pubkey, interface_name, timestamp)
+	`))
+}
+
+const insertInterfaceStateSQL = `INSERT INTO interface_state
+	(timestamp, device_pubkey, interface_name, admin_status, oper_status, ifindex, mtu, last_change,
+	 carrier_transitions, in_octets, out_octets, in_pkts, out_pkts, in_errors, out_errors, in_discards, out_discards,
+	 in_fcs_errors, in_unicast_pkts, in_multicast_pkts, in_broadcast_pkts, out_unicast_pkts, out_multicast_pkts, out_broadcast_pkts)
+	VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)`
+
+// TestComputeDeviceInterfaceRollupFromGNMI_NoLinkMapFanout verifies that an interface
+// mapped by more than one link row does not fan out the per-sample delta rows in the JOIN
+// (which would double-count the SUM counters).
+func TestComputeDeviceInterfaceRollupFromGNMI_NoLinkMapFanout(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+	createInterfaceStateTable(t, ctx, conn)
+
+	now := time.Now().Truncate(5 * time.Minute)
+	bucketStart := now.Add(-5 * time.Minute)
+
+	// Two active links both map device-fan/Ethernet1/1 as side A (e.g. a re-created link).
+	require.NoError(t, conn.Exec(ctx, `INSERT INTO dim_dz_links_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, pk, status, side_a_pk, side_a_iface_name, side_z_pk, side_z_iface_name) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		"link-entity-A", now, now, "00000000-0000-0000-0000-000000000051", uint8(0), "link-A", "activated", "device-fan", "Ethernet1/1", "device-za", "Ethernet9/9"))
+	require.NoError(t, conn.Exec(ctx, `INSERT INTO dim_dz_links_history (entity_id, snapshot_ts, ingested_at, op_id, is_deleted, pk, status, side_a_pk, side_a_iface_name, side_z_pk, side_z_iface_name) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		"link-entity-B", now, now, "00000000-0000-0000-0000-000000000052", uint8(0), "link-B", "activated", "device-fan", "Ethernet1/1", "device-zb", "Ethernet9/9"))
+
+	// 3 cumulative samples -> 2 deltas of in_errors=10 each (true total 20).
+	for i := range 3 {
+		ts := bucketStart.Add(time.Duration(i) * time.Minute)
+		require.NoError(t, conn.Exec(ctx, insertInterfaceStateSQL,
+			ts, "device-fan", "Ethernet1/1", "UP", "UP", uint32(1), uint16(9000), int64(0),
+			uint64(0), uint64(1000+125000*i), uint64(500), uint64(10), uint64(5),
+			uint64(10*i), uint64(0), uint64(0), uint64(0),
+			uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0)))
+	}
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, BackfillChunkInput{
+		WindowStart: now.Add(-10 * time.Minute),
+		WindowEnd:   now.Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.Len(t, buckets, 1, "duplicate link rows must not fan out into extra rows")
+	assert.Equal(t, uint64(20), buckets[0].InErrors, "two link rows must not double-count deltas")
+	assert.Equal(t, "link-A", buckets[0].LinkPK)
+}
+
+// TestComputeDeviceInterfaceRollupFromGNMI_BaselineLookbackIncludesFirstInWindowDelta
+// verifies the pre-window baseline so the first in-window sample is not undercounted, using
+// the live geometry: WindowStart exactly on the bucket boundary.
+func TestComputeDeviceInterfaceRollupFromGNMI_BaselineLookbackIncludesFirstInWindowDelta(t *testing.T) {
+	t.Parallel()
+	conn := setupTestDB(t)
+	ctx := context.Background()
+	createInterfaceStateTable(t, ctx, conn)
+
+	windowStart := time.Now().Truncate(5 * time.Minute) // exact 5-min bucket boundary
+	windowEnd := windowStart.Add(5 * time.Minute)
+
+	// baseline 60s before WindowStart (previous bucket), then 3 in-window samples.
+	// in_errors cumulative 100/110/120/130 -> 3 in-window deltas of 10 = 30.
+	samples := []struct {
+		ts   time.Time
+		errs uint64
+		oct  uint64
+	}{
+		{windowStart.Add(-60 * time.Second), 100, 100000},
+		{windowStart, 110, 225000},
+		{windowStart.Add(60 * time.Second), 120, 350000},
+		{windowStart.Add(120 * time.Second), 130, 475000},
+	}
+	for _, s := range samples {
+		require.NoError(t, conn.Exec(ctx, insertInterfaceStateSQL,
+			s.ts, "device-bl", "Ethernet1/1", "UP", "UP", uint32(1), uint16(9000), int64(0),
+			uint64(0), s.oct, uint64(0), uint64(0), uint64(0),
+			s.errs, uint64(0), uint64(0), uint64(0),
+			uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0)))
+	}
+
+	a := &Activities{ClickHouse: conn, Log: laketesting.NewLogger()}
+	buckets, err := a.ComputeDeviceInterfaceRollupFromGNMI(ctx, BackfillChunkInput{
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
+	})
+	require.NoError(t, err)
+	require.Len(t, buckets, 1, "only the in-window bucket is emitted; the baseline bucket is dropped")
+	assert.Equal(t, windowStart.UTC(), buckets[0].BucketTS.UTC())
+	assert.Equal(t, uint64(30), buckets[0].InErrors, "first in-window delta (vs pre-window baseline) must be included")
+}
+
 // TestCoalesceDeviceInterfaceBuckets_PrefersGNMI verifies the per-device merge: a device
 // present in the gNMI buckets wins (its fact-table buckets are dropped), and a device with
 // no gNMI data falls back to its fact-table buckets.
-func TestCoalesceDeviceInterfaceBuckets_PrefersGNMI(t *testing.T) {
+func TestCoalesceDeviceInterfaceBuckets_PerKeyPreferGNMI(t *testing.T) {
 	t.Parallel()
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(1300, 0).UTC() // a later bucket
 	gnmi := []DeviceInterfaceBucket{
-		{DevicePK: "d1", Intf: "Ethernet1", InErrors: 99},
+		// gNMI covers only the recent bucket of d1/Ethernet1
+		{DevicePK: "d1", Intf: "Ethernet1", BucketTS: t2, InErrors: 99},
 	}
 	fact := []DeviceInterfaceBucket{
-		{DevicePK: "d1", Intf: "Ethernet1", InErrors: 1}, // superseded by gNMI
-		{DevicePK: "d2", Intf: "Ethernet2", InErrors: 7}, // no gNMI for d2 -> kept
+		{DevicePK: "d1", Intf: "Ethernet1", BucketTS: t2, InErrors: 1}, // same key -> gNMI wins
+		{DevicePK: "d1", Intf: "Ethernet1", BucketTS: t1, InErrors: 5}, // older bucket gNMI didn't cover -> kept
+		{DevicePK: "d1", Intf: "Ethernet2", BucketTS: t2, InErrors: 7}, // other interface gNMI didn't cover -> kept
+		{DevicePK: "d2", Intf: "Ethernet1", BucketTS: t2, InErrors: 3}, // other device -> kept
 	}
 
 	out := coalesceDeviceInterfaceBuckets(gnmi, fact)
 
-	byDev := make(map[string]DeviceInterfaceBucket)
+	type key struct {
+		d, i string
+		b    int64
+	}
+	got := make(map[key]uint64)
 	for _, b := range out {
-		byDev[b.DevicePK] = b
+		got[key{b.DevicePK, b.Intf, b.BucketTS.UTC().UnixNano()}] = b.InErrors
 	}
 
-	require.Len(t, out, 2)
-	require.Contains(t, byDev, "d1")
-	require.Contains(t, byDev, "d2")
-	assert.Equal(t, uint64(99), byDev["d1"].InErrors, "d1 should come from gNMI, not fact")
-	assert.Equal(t, uint64(7), byDev["d2"].InErrors, "d2 has no gNMI data -> fall back to fact")
+	require.Len(t, out, 4, "every distinct (device,intf,bucket) key kept exactly once")
+	assert.Equal(t, uint64(99), got[key{"d1", "Ethernet1", t2.UnixNano()}], "gNMI wins for the key it covers")
+	assert.Equal(t, uint64(5), got[key{"d1", "Ethernet1", t1.UnixNano()}], "older bucket gNMI didn't cover -> fact kept")
+	assert.Equal(t, uint64(7), got[key{"d1", "Ethernet2", t2.UnixNano()}], "other interface gNMI didn't cover -> fact kept")
+	assert.Equal(t, uint64(3), got[key{"d2", "Ethernet1", t2.UnixNano()}], "other device -> fact kept")
 }
 
 // TestComputeDeviceInterfaceRollupFromGNMI_ResolvesDeviceState verifies the gNMI branch

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -93,10 +93,11 @@ func Start(ctx context.Context, cfg Config) error {
 	// Register rollup workflows
 	ingestionLogWriter := ingestionlog.NewWriter(chConn, log)
 	activities := &Activities{
-		ClickHouse:   chConn,
-		Log:          log.With("component", "rollup"),
-		IngestionLog: ingestionLogWriter,
-		Network:      cfg.Network,
+		ClickHouse:        chConn,
+		Log:               log.With("component", "rollup"),
+		IngestionLog:      ingestionLogWriter,
+		Network:           cfg.Network,
+		TelemetryDatabase: telemetryDatabaseForNetwork(cfg.Network),
 	}
 
 	w := worker.New(tc, tq, worker.Options{})
@@ -218,4 +219,14 @@ func envOrDefault(key, defaultValue string) string {
 		return v
 	}
 	return defaultValue
+}
+
+// telemetryDatabaseForNetwork returns the gNMI telemetry database for a DZ network
+// (e.g. "mainnet-beta" -> "telemetry_mainnet_beta"). It is a sibling database on the
+// same ClickHouse cluster as the lake DB. Empty network -> "" (gNMI off, fact-only).
+func telemetryDatabaseForNetwork(network string) string {
+	if network == "" {
+		return ""
+	}
+	return "telemetry_" + strings.ReplaceAll(network, "-", "_")
 }

--- a/indexer/pkg/rollup/types.go
+++ b/indexer/pkg/rollup/types.go
@@ -117,4 +117,7 @@ type BackfillChunkInput struct {
 	WindowStart    time.Time
 	WindowEnd      time.Time
 	SourceDatabase string // if set, read from this database (e.g. remote proxy tables)
+	// TelemetryDatabase is the database holding the gNMI interface_state table
+	// (e.g. telemetry_mainnet_beta). Used by ComputeDeviceInterfaceRollupFromGNMI.
+	TelemetryDatabase string
 }


### PR DESCRIPTION
## Summary

Adds a gNMI-based source for the device-interface rollup. The rollup can now compute buckets from the `interface_state` table (gNMI/OpenConfig counters in ClickHouse) and coalesces per device with the existing InfluxDB-fed `fact_dz_device_interface_counters`: for each device, gNMI is used when present, otherwise the InfluxDB path. This lets the rollup move to the gNMI source device-by-device while remaining backward compatible.

## Details

- `ComputeDeviceInterfaceRollupFromGNMI` derives per-sample deltas from `interface_state`'s raw cumulative counters via window functions (per device + interface, ordered by time; values cast to Int64 so counter resets read negative and are dropped), then applies the same aggregation as the InfluxDB path so both sources roll up identically. Only the input sampling cadence differs.
- Enrichment: maps interfaces to links via `dim_dz_links_history` (side A/Z iface names) and parses `Tunnel<N>` for user tunnels.
- Filter: keeps interfaces mapped to a link/tunnel or carrying traffic; drops unmapped idle interfaces.
- `coalesceDeviceInterfaceBuckets` prefers gNMI per device and falls back to the fact table for devices without gNMI data.
- Shared `resolveDeviceInterfaceState` resolves device Status / ISIS / user PK for both sources.
- `RollupDeviceInterfaces` runs both computes and coalesces. The gNMI compute is non-fatal: on error it logs and falls back to fact-only, so the rollup is never worse than the InfluxDB-only path.
- `Activities.TelemetryDatabase` is derived from the network (`telemetry_<env>`); empty disables the gNMI source (fact-only).

## Tests

- gNMI delta computation, link/tunnel enrichment + filtering, per-device coalesce, device-state resolution, and per-network telemetry-DB derivation.
- Cross-source equivalence: identical input through both paths yields matching totals and average rates.
- Existing fact-table rollup tests are unchanged; the InfluxDB path behaves identically.
