### PR TITLE
Tiredsolid scoreboard (internal)

### DIFF
--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -36,6 +36,7 @@ var externalRemoteTables = []struct {
 	{"dzdp", "offsets"},
 	{"dzdp", "location_decisions"},
 	{"dzdp", "location_state"},
+	{"feeds", "hyperliquid_bbo_feed_race_summary"},
 }
 
 // externalRemoteDatabases lists remote databases to mirror in full, discovering

--- a/admin/remotetables/setup.go
+++ b/admin/remotetables/setup.go
@@ -37,6 +37,7 @@ var externalRemoteTables = []struct {
 	{"dzdp", "location_decisions"},
 	{"dzdp", "location_state"},
 	{"feeds", "hyperliquid_bbo_feed_race_summary"},
+	{"feeds", "hyperliquid_bbo_observations"},
 }
 
 // externalRemoteDatabases lists remote databases to mirror in full, discovering

--- a/admin/remotetables/setup_test.go
+++ b/admin/remotetables/setup_test.go
@@ -56,3 +56,16 @@ func TestDiscoverProxyableTablesSkipsMaterializedViewInnerTables(t *testing.T) {
 		require.False(t, strings.HasPrefix(n, ".inner"), "internal MV inner table must be excluded: %s", n)
 	}
 }
+
+func TestExternalRemoteTablesIncludesFeeds(t *testing.T) {
+	found := false
+	for _, e := range externalRemoteTables {
+		if e.RemoteDB == "feeds" && e.RemoteTable == "hyperliquid_bbo_feed_race_summary" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("externalRemoteTables missing feeds.hyperliquid_bbo_feed_race_summary")
+	}
+}

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -35,6 +35,9 @@ var publisherDB = "shredder"
 // dzdpDB is the ClickHouse database name for DZDP tables e.g. location_state (default: "dzdp").
 var dzdpDB = "dzdp"
 
+// feedsDB is the ClickHouse database name for the Hyperliquid feeds tables (default: "feeds").
+var feedsDB = "feeds"
+
 // EnvDBs maps environment names to their ClickHouse connection pools.
 // The mainnet-beta entry always points to DB.
 var EnvDBs map[string]driver.Conn
@@ -81,6 +84,16 @@ func GetDZDPDB() string {
 // SetDZDPDB sets the DZDP database name.
 func SetDZDPDB(db string) {
 	dzdpDB = db
+}
+
+// GetFeedsDB returns the feeds database name.
+func GetFeedsDB() string {
+	return feedsDB
+}
+
+// SetFeedsDB sets the feeds database name.
+func SetFeedsDB(db string) {
+	feedsDB = db
 }
 
 // Database returns the configured database name.
@@ -152,6 +165,10 @@ func Load() error {
 
 	if db := os.Getenv("CLICKHOUSE_DZDP_DB"); db != "" {
 		dzdpDB = db
+	}
+
+	if db := os.Getenv("CLICKHOUSE_FEEDS_DB"); db != "" {
+		feedsDB = db
 	}
 
 	// Build env -> database mapping.

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -1,0 +1,15 @@
+package config
+
+import "testing"
+
+func TestFeedsDBDefaultAndSetter(t *testing.T) {
+	SetFeedsDB("feeds")
+	if got := GetFeedsDB(); got != "feeds" {
+		t.Fatalf("default GetFeedsDB() = %q, want %q", got, "feeds")
+	}
+	SetFeedsDB("feeds_qa")
+	if got := GetFeedsDB(); got != "feeds_qa" {
+		t.Fatalf("after SetFeedsDB, GetFeedsDB() = %q, want %q", got, "feeds_qa")
+	}
+	SetFeedsDB("feeds") // restore default for other tests
+}

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -43,6 +43,7 @@ type API struct {
 	ShredderDB    string
 	PublisherDB   string
 	DZDPDB        string
+	FeedsDB       string
 
 	// PostgreSQL
 	PgPool *pgxpool.Pool

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
+// in display order, mapping each raw feed name to its label.
+var hyperliquidCompetitors = []struct{ Feed, Label string }{
+	{"hyperliquid_public_bbo", "Public API"},
+	{"hydromancer_bbo", "Hydromancer"},
+	{"hyperpc_shared_bbo", "HyperPC"},
+	{"quicknode_l2book_bbo", "QuickNode"},
+}
+
+// hyperliquidWindows maps window params to ClickHouse interval expressions.
+var hyperliquidWindows = map[string]string{
+	"1h":  "1 HOUR",
+	"24h": "24 HOUR",
+	"7d":  "7 DAY",
+}
+
+var hyperliquidSymbolRe = regexp.MustCompile(`^[A-Za-z0-9:_.-]{1,32}$`)
+
+// sanitizeHyperliquidSymbol returns the symbol if safe to inline, else "".
+func sanitizeHyperliquidSymbol(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.EqualFold(s, "all") || !hyperliquidSymbolRe.MatchString(s) {
+		return ""
+	}
+	return s
+}
+
+// HyperliquidCompetitor is DoubleZero's head-to-head record vs one competitor feed.
+type HyperliquidCompetitor struct {
+	Feed      string  `json:"feed"`
+	Label     string  `json:"label"`
+	DZWinPct  float64 `json:"dz_win_pct"`
+	LeadP50Ms float64 `json:"lead_p50_ms"`
+	LeadP95Ms float64 `json:"lead_p95_ms"`
+	Races     uint64  `json:"races"`
+}
+
+// HyperliquidNode is the per-vantage breakdown.
+type HyperliquidNode struct {
+	MeasurementNodeID string                  `json:"measurement_node_id"`
+	LocationCode      string                  `json:"location_code"`
+	DZWinSharePct     float64                 `json:"dz_win_share_pct"`
+	TotalRaces        uint64                  `json:"total_races"`
+	Competitors       []HyperliquidCompetitor `json:"competitors"`
+}
+
+// HyperliquidRace is one recent race for the live strip.
+type HyperliquidRace struct {
+	EventTs       time.Time `json:"event_ts"`
+	Symbol        string    `json:"symbol"`
+	LocationCode  string    `json:"location_code"`
+	WinnerFeed    string    `json:"winner_feed"`
+	IsDZ          bool      `json:"is_dz"`
+	RunnerUpFeed  string    `json:"runner_up_feed"`
+	RunnerUpLabel string    `json:"runner_up_label"`
+	LeadMs        float64   `json:"lead_ms"`
+}
+
+// HyperliquidScoreboardResponse is the API response.
+type HyperliquidScoreboardResponse struct {
+	Window        string                  `json:"window"`
+	Symbol        string                  `json:"symbol,omitempty"`
+	GeneratedAt   time.Time               `json:"generated_at"`
+	FeedType      string                  `json:"feed_type"`
+	DZWinSharePct float64                 `json:"dz_win_share_pct"`
+	TotalRaces    uint64                  `json:"total_races"`
+	Competitors   []HyperliquidCompetitor `json:"competitors"`
+	Nodes         []HyperliquidNode       `json:"nodes"`
+	RecentRaces   []HyperliquidRace       `json:"recent_races"`
+}
+
+// labelForFeed maps a raw competitor feed to its display label (falls back to the raw name).
+func labelForFeed(feed string) string {
+	for _, c := range hyperliquidCompetitors {
+		if c.Feed == feed {
+			return c.Label
+		}
+	}
+	return feed
+}
+
+// FetchHyperliquidScoreboardData computes the aggregated scoreboard for a window and
+// optional symbol. Empty symbol means all symbols.
+func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol string) (*HyperliquidScoreboardResponse, error) {
+	interval, ok := hyperliquidWindows[window]
+	if !ok {
+		window = "24h"
+		interval = hyperliquidWindows[window]
+	}
+	symbol = sanitizeHyperliquidSymbol(symbol)
+	symbolFilter := ""
+	if symbol != "" {
+		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
+	}
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+
+	resp := &HyperliquidScoreboardResponse{
+		Window:      window,
+		Symbol:      symbol,
+		GeneratedAt: time.Now().UTC(),
+		FeedType:    "bbo",
+		Competitors: []HyperliquidCompetitor{},
+		Nodes:       []HyperliquidNode{},
+		RecentRaces: []HyperliquidRace{},
+	}
+
+	// Headline: DZ win share over all DZ-vs-competitor pairwise comparisons.
+	headlineQ := fmt.Sprintf(`
+		SELECT
+			100.0 * countIf(startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
+			      / nullIf(countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0) AS dz_win_share_pct,
+			countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) AS total_races
+		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+		WHERE feed != loser_feed AND loser_feed != '' %s
+		  AND event_ts >= now() - INTERVAL %s`, db, symbolFilter, interval)
+	var winShare float64
+	var totalRaces uint64
+	if err := a.envDB(ctx).QueryRow(ctx, headlineQ).Scan(&winShare, &totalRaces); err != nil {
+		return nil, err
+	}
+	resp.DZWinSharePct = winShare
+	resp.TotalRaces = totalRaces
+
+	// Per-competitor: win%, lead p50/p95 (over DZ wins), and total comparable races.
+	compQ := fmt.Sprintf(`
+		SELECT competitor,
+			countIf(dz_won = 1) AS dz_wins,
+			countIf(dz_won = 0) AS dz_losses,
+			quantileExactLowIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
+			quantileExactLowIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+		FROM (
+			SELECT
+				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
+				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
+				lead_time_p50_ms AS lead_ms
+			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			WHERE feed != loser_feed AND loser_feed != ''
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
+			  AND event_ts >= now() - INTERVAL %s
+		)
+		GROUP BY competitor`, db, symbolFilter, interval)
+	rows, err := a.envDB(ctx).Query(ctx, compQ)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type stat struct {
+		wins, losses     uint64
+		leadP50, leadP95 float64
+	}
+	byFeed := map[string]stat{}
+	for rows.Next() {
+		var competitor string
+		var s stat
+		if err := rows.Scan(&competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+			return nil, err
+		}
+		byFeed[competitor] = s
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Emit competitors in configured order.
+	for _, c := range hyperliquidCompetitors {
+		s, ok := byFeed[c.Feed]
+		if !ok {
+			continue
+		}
+		races := s.wins + s.losses
+		var winPct float64
+		if races > 0 {
+			winPct = 100.0 * float64(s.wins) / float64(races)
+		}
+		resp.Competitors = append(resp.Competitors, HyperliquidCompetitor{
+			Feed:      c.Feed,
+			Label:     c.Label,
+			DZWinPct:  winPct,
+			LeadP50Ms: s.leadP50,
+			LeadP95Ms: s.leadP95,
+			Races:     races,
+		})
+	}
+
+	return resp, nil
+}

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
@@ -247,8 +249,11 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		SELECT competitor, measurement_node_id, any(location_code) AS location_code,
 			uniqCombinedIf(rk, dz_won = 1) AS dz_wins,
 			uniqCombinedIf(rk, dz_won = 0) AS dz_losses,
-			toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)) AS lead_p50,
-			toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)) AS lead_p95
+			-- ifNotFinite guards the empty-set case: when DZ won zero races in a (competitor, node)
+			-- cell, quantileTDigestIf over no rows returns NaN, which fails JSON encoding of the whole
+			-- response (and poisons the page cache). Coalesce to 0 so a swept cell serializes cleanly.
+			ifNotFinite(toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)), 0) AS lead_p50,
+			ifNotFinite(toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)), 0) AS lead_p95
 		FROM (
 			SELECT measurement_node_id, location_code,
 				%[1]s AS rk,
@@ -261,11 +266,6 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 			  AND event_ts >= now() - INTERVAL %[4]s
 		)
 		GROUP BY competitor, measurement_node_id WITH ROLLUP`, raceKeyTuple, db, symbolFilter, interval)
-	rows, err := a.envDB(ctx).Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
 
 	type stat struct {
 		wins, losses     uint64
@@ -279,29 +279,59 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	byFeed := map[string]stat{}
 	nodeMap := map[string]*nodeAgg{}
 	var nodeOrder []string
-	for rows.Next() {
-		var competitor, node, loc string
-		var s stat
-		if err := rows.Scan(&competitor, &node, &loc, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
-			return nil, err
+	var recent []HyperliquidRace
+	var prices map[string]float64
+
+	// The main ROLLUP scan, the recent-races scan, and the live-price lookup are three independent
+	// ClickHouse reads; run them concurrently so their latencies overlap rather than stack under
+	// the request timeout. gctx cancels the siblings if the main scan or recent-races hard-fails.
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		rows, err := a.envDB(gctx).Query(gctx, q)
+		if err != nil {
+			return err
 		}
-		switch {
-		case competitor == "":
-			// Grand-total ROLLUP row; the headline is derived from per-node cells instead.
-			continue
-		case node == "":
-			byFeed[competitor] = s
-		default:
-			na, ok := nodeMap[node]
-			if !ok {
-				na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
-				nodeMap[node] = na
-				nodeOrder = append(nodeOrder, node)
+		defer rows.Close()
+		for rows.Next() {
+			var competitor, node, loc string
+			var s stat
+			if err := rows.Scan(&competitor, &node, &loc, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+				return err
 			}
-			na.byFeed[competitor] = s
+			switch {
+			case competitor == "":
+				// Grand-total ROLLUP row; the headline is derived from per-node cells instead.
+				continue
+			case node == "":
+				byFeed[competitor] = s
+			default:
+				na, ok := nodeMap[node]
+				if !ok {
+					na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
+					nodeMap[node] = na
+					nodeOrder = append(nodeOrder, node)
+				}
+				na.byFeed[competitor] = s
+			}
 		}
-	}
-	if err := rows.Err(); err != nil {
+		return rows.Err()
+	})
+	g.Go(func() error {
+		r, err := a.fetchHyperliquidRecentRaces(gctx, time.Time{}, 10)
+		if err != nil {
+			return err
+		}
+		recent = r
+		return nil
+	})
+	g.Go(func() error {
+		// Best-effort: a live-price lookup failure must not fail the whole scoreboard.
+		if p, err := a.fetchHyperliquidPrices(gctx); err == nil {
+			prices = p
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
@@ -367,14 +397,10 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		resp.DZWinSharePct = 100.0 * float64(globalWins) / float64(globalRaces)
 	}
 
-	recent, err := a.fetchHyperliquidRecentRaces(ctx, time.Time{}, 10)
-	if err != nil {
-		return nil, err
+	if recent != nil {
+		resp.RecentRaces = recent
 	}
-	resp.RecentRaces = recent
-
-	// Live prices per symbol for the recent-races grid (best-effort; cheap latest-BBO lookup).
-	if prices, err := a.fetchHyperliquidPrices(ctx); err == nil {
+	if prices != nil {
 		resp.Prices = prices
 	}
 
@@ -441,19 +467,33 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time
 	return out, rows.Err()
 }
 
-// hyperliquidScoreboardCacheKey returns the cache key for the default request shape, or "".
+// hyperliquidScoreboardCacheKey returns the cache key for a cacheable request shape, or "".
+// A symbol filter is a non-default view and is never cached. Each supported window has its own
+// cached key: the 1h view is refreshed by the page-cache worker; the heavier 24h/7d views are
+// refreshed on a slow background cadence (StartHyperliquidBackgroundRefresher) so they are served
+// from cache instead of running a multi-day scan on the request path.
 func hyperliquidScoreboardCacheKey(r *http.Request) string {
-	if r.URL.Query().Get("since_ts") != "" || r.URL.Query().Get("symbol") != "" {
+	if r.URL.Query().Get("symbol") != "" {
 		return ""
 	}
-	// 1h is the cacheable default — a 24h/7d aggregation over the full proxied table is too
-	// slow to refresh within the cache deadline (the summary table has no time-based index),
-	// so only the 1h view is cached; longer windows fall through to a (slower) live query.
 	window := strings.TrimSpace(r.URL.Query().Get("window"))
-	if window != "" && window != "1h" {
+	if window == "" {
+		window = "1h"
+	}
+	if _, ok := hyperliquidWindows[window]; !ok {
 		return ""
 	}
-	return "hyperliquid_scoreboard"
+	return hyperliquidScoreboardWindowKey(window)
+}
+
+// hyperliquidScoreboardWindowKey is the page-cache key for a given window. The 1h key keeps its
+// original name (populated by the page-cache worker); 24h/7d get suffixed keys populated by the
+// background refresher.
+func hyperliquidScoreboardWindowKey(window string) string {
+	if window == "1h" {
+		return "hyperliquid_scoreboard"
+	}
+	return "hyperliquid_scoreboard:" + window
 }
 
 // hyperliquidFeedsTableExists reports whether the proxied summary table is queryable.
@@ -535,13 +575,18 @@ func (a *API) FetchHyperliquidCompositeLatency(ctx context.Context) (*Hyperliqui
 	}, nil
 }
 
-// StartHyperliquidCompositeLatencyRefresher periodically computes the composite latency and
-// writes it to the page cache (Postgres) so all replicas share one value. The query is far too
-// slow for the 60s page-cache worker, so it runs here on its own slow cadence.
-func (a *API) StartHyperliquidCompositeLatencyRefresher(ctx context.Context) {
+// StartHyperliquidBackgroundRefresher periodically computes the Hyperliquid views that are too
+// heavy for the 60s page-cache worker and writes them to the page cache (Postgres) so all replicas
+// share them and the request path never runs a multi-day scan:
+//   - the composite feed latency, and
+//   - the 24h and 7d scoreboards (the 1h scoreboard stays on the ordinary page-cache worker).
+//
+// Each computation gets its own timeout so a slow one can't starve the others; the composite
+// latency is refreshed first so the 24h/7d scoreboards pick up its freshly-cached value.
+func (a *API) StartHyperliquidBackgroundRefresher(ctx context.Context) {
 	const interval = 10 * time.Minute
 	const runTimeout = 3 * time.Minute
-	refresh := func() {
+	refreshComposite := func() {
 		rctx, cancel := context.WithTimeout(ctx, runTimeout)
 		defer cancel()
 		val, err := a.FetchHyperliquidCompositeLatency(rctx)
@@ -552,6 +597,23 @@ func (a *API) StartHyperliquidCompositeLatencyRefresher(ctx context.Context) {
 		if err := a.WritePageCache(ctx, hyperliquidCompositeLatencyCacheKey, val); err != nil {
 			slog.Warn("hyperliquid composite latency cache write failed", "error", err)
 		}
+	}
+	refreshScoreboard := func(window string) {
+		rctx, cancel := context.WithTimeout(ctx, runTimeout)
+		defer cancel()
+		val, err := a.FetchHyperliquidScoreboardData(rctx, window, "")
+		if err != nil {
+			slog.Warn("hyperliquid scoreboard refresh failed", "window", window, "error", err)
+			return
+		}
+		if err := a.WritePageCache(ctx, hyperliquidScoreboardWindowKey(window), val); err != nil {
+			slog.Warn("hyperliquid scoreboard cache write failed", "window", window, "error", err)
+		}
+	}
+	refresh := func() {
+		refreshComposite()
+		refreshScoreboard("24h")
+		refreshScoreboard("7d")
 	}
 	go func() {
 		refresh()
@@ -591,15 +653,9 @@ func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
 	}
 	symbol := r.URL.Query().Get("symbol")
 
-	// Degrade gracefully if the proxy table isn't available (e.g. local dev).
-	if !a.hyperliquidFeedsTableExists(ctx) {
-		writeJSON(w, &HyperliquidScoreboardResponse{
-			Window: window, GeneratedAt: time.Now().UTC(), FeedType: "bbo",
-			Competitors: []HyperliquidCompetitor{}, Nodes: []HyperliquidNode{}, RecentRaces: []HyperliquidRace{},
-		})
-		return
-	}
-
+	// FetchHyperliquidScoreboardData already degrades to an empty-but-valid response when the
+	// proxy table is absent (e.g. local dev), so no separate existence check is needed here —
+	// that avoids a redundant EXISTS TABLE round-trip per uncached request.
 	resp, err := a.FetchHyperliquidScoreboardData(ctx, window, symbol)
 	if err != nil {
 		logError("HyperliquidScoreboard error", "error", err)

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -234,19 +234,22 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		RecentRaces: []HyperliquidRace{},
 	}
 
-	// The headline (DZ win share + total races) is derived from the per-node aggregation
-	// below rather than its own scan — counts partition cleanly by competitor, so summing the
-	// per-node cells gives the same totals while saving a full scan of the (very large) table.
-
-	// Per-competitor: win%, lead p50/p95 (over DZ wins), and total comparable races.
-	compQ := fmt.Sprintf(`
-		SELECT competitor,
+	// Single scan grouped per (competitor, node) WITH ROLLUP: the (competitor, node) rows give the
+	// per-vantage breakdown and the rolled-up (competitor) rows give per-competitor totals, so the
+	// per-competitor stats come from the same scan instead of a second full-table scan. A race key
+	// includes measurement_node_id, so races partition cleanly by node — the ROLLUP counts are
+	// exact and the headline is derivable by summing per-node cells. One query (vs two) also
+	// refreshes atomically: on the memory-constrained proxy ClickHouse the refresh succeeds or
+	// retries as a unit, instead of needing two independent scans to both survive the
+	// OvercommitTracker when other page-cache queries have the server near its memory ceiling.
+	q := fmt.Sprintf(`
+		SELECT competitor, measurement_node_id, any(location_code) AS location_code,
 			uniqCombinedIf(rk, dz_won = 1) AS dz_wins,
 			uniqCombinedIf(rk, dz_won = 0) AS dz_losses,
 			toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)) AS lead_p50,
 			toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)) AS lead_p95
 		FROM (
-			SELECT
+			SELECT measurement_node_id, location_code,
 				%[1]s AS rk,
 				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
 				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
@@ -256,8 +259,8 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %[3]s
 			  AND event_ts >= now() - INTERVAL %[4]s
 		)
-		GROUP BY competitor`, raceKeyTuple, db, symbolFilter, interval)
-	rows, err := a.envDB(ctx).Query(ctx, compQ)
+		GROUP BY competitor, measurement_node_id WITH ROLLUP`, raceKeyTuple, db, symbolFilter, interval)
+	rows, err := a.envDB(ctx).Query(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -267,14 +270,35 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		wins, losses     uint64
 		leadP50, leadP95 float64
 	}
+	type nodeAgg struct {
+		loc    string
+		byFeed map[string]stat
+	}
+	// byFeed holds per-competitor totals (ROLLUP rows where node == ""); nodeMap holds per-node cells.
 	byFeed := map[string]stat{}
+	nodeMap := map[string]*nodeAgg{}
+	var nodeOrder []string
 	for rows.Next() {
-		var competitor string
+		var competitor, node, loc string
 		var s stat
-		if err := rows.Scan(&competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+		if err := rows.Scan(&competitor, &node, &loc, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
 			return nil, err
 		}
-		byFeed[competitor] = s
+		switch {
+		case competitor == "":
+			// Grand-total ROLLUP row; the headline is derived from per-node cells instead.
+			continue
+		case node == "":
+			byFeed[competitor] = s
+		default:
+			na, ok := nodeMap[node]
+			if !ok {
+				na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
+				nodeMap[node] = na
+				nodeOrder = append(nodeOrder, node)
+			}
+			na.byFeed[competitor] = s
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -299,55 +323,6 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 			LeadP95Ms: s.leadP95,
 			Races:     races,
 		})
-	}
-
-	// Per-node: same comparison, grouped by measurement node + competitor.
-	nodeQ := fmt.Sprintf(`
-		SELECT measurement_node_id, location_code, competitor,
-			uniqCombinedIf(rk, dz_won = 1) AS dz_wins,
-			uniqCombinedIf(rk, dz_won = 0) AS dz_losses,
-			toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)) AS lead_p50,
-			toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)) AS lead_p95
-		FROM (
-			SELECT measurement_node_id, location_code,
-				%[1]s AS rk,
-				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
-				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
-				lead_time_p50_ms AS lead_ms
-			FROM %[2]s.hyperliquid_bbo_feed_race_summary
-			WHERE feed != loser_feed AND loser_feed != ''
-			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %[3]s
-			  AND event_ts >= now() - INTERVAL %[4]s
-		)
-		GROUP BY measurement_node_id, location_code, competitor`, raceKeyTuple, db, symbolFilter, interval)
-	nrows, err := a.envDB(ctx).Query(ctx, nodeQ)
-	if err != nil {
-		return nil, err
-	}
-	defer nrows.Close()
-
-	type nodeAgg struct {
-		loc    string
-		byFeed map[string]stat
-	}
-	nodeMap := map[string]*nodeAgg{}
-	var nodeOrder []string
-	for nrows.Next() {
-		var node, loc, competitor string
-		var s stat
-		if err := nrows.Scan(&node, &loc, &competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
-			return nil, err
-		}
-		na, ok := nodeMap[node]
-		if !ok {
-			na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
-			nodeMap[node] = na
-			nodeOrder = append(nodeOrder, node)
-		}
-		na.byFeed[competitor] = s
-	}
-	if err := nrows.Err(); err != nil {
-		return nil, err
 	}
 
 	var globalWins, globalRaces uint64

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -608,4 +608,3 @@ func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, resp)
 }
-

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -117,8 +117,8 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	// Headline: DZ win share over all DZ-vs-competitor pairwise comparisons.
 	headlineQ := fmt.Sprintf(`
 		SELECT
-			100.0 * countIf(startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
-			      / nullIf(countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0) AS dz_win_share_pct,
+			ifNull(100.0 * countIf(startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
+			      / nullIf(countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0), 0) AS dz_win_share_pct,
 			countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) AS total_races
 		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
 		WHERE feed != loser_feed AND loser_feed != '' %s
@@ -136,8 +136,8 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		SELECT competitor,
 			countIf(dz_won = 1) AS dz_wins,
 			countIf(dz_won = 0) AS dz_losses,
-			quantileExactLowIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
-			quantileExactLowIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
+			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
 		FROM (
 			SELECT
 				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -29,10 +29,18 @@ var hyperliquidWindows = map[string]string{
 
 // raceKeyTuple is the summary table's ReplacingMergeTree sorting key. The remote
 // materialized view refreshes on overlapping windows, so each logical race appears as
-// several rows that only FINAL (or a uniqExact over this key) collapses. uniqExact over
-// the key gives exact race counts without paying FINAL's merge cost, which dominated query
-// time against the full production table. Win rates are ratios and lead-time percentiles are
-// duplicate-insensitive, so dropping FINAL keeps them correct.
+// several rows that only FINAL (or a uniq over this key) collapses. Counting distinct keys
+// dedups without paying FINAL's merge cost, which dominated query time against the full
+// production table. Win rates are ratios and lead-time percentiles are duplicate-insensitive,
+// so dropping FINAL keeps them correct.
+//
+// The dedup uses uniqCombined (not uniqExact) and lead percentiles use quantileTDigest (not
+// quantileExact): the exact variants buffer per-group state proportional to the number of
+// races in the window (~7.5M matchup rows/hour at current volume, ~750 MiB of aggregation
+// state), which tripped the ClickHouse OvercommitTracker and got the page-cache refresh killed
+// under concurrent load. The approximate variants use bounded (~KB/group) memory; at scoreboard
+// scale their sub-1% error is invisible, and they are exact at the small cardinalities the
+// unit tests assert.
 const raceKeyTuple = "(measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)"
 
 // hyperliquidLiquidSymbols is the curated universe of the most-liquid Hyperliquid markets
@@ -209,10 +217,10 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	// Per-competitor: win%, lead p50/p95 (over DZ wins), and total comparable races.
 	compQ := fmt.Sprintf(`
 		SELECT competitor,
-			uniqExactIf(rk, dz_won = 1) AS dz_wins,
-			uniqExactIf(rk, dz_won = 0) AS dz_losses,
-			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
-			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+			uniqCombinedIf(rk, dz_won = 1) AS dz_wins,
+			uniqCombinedIf(rk, dz_won = 0) AS dz_losses,
+			toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)) AS lead_p50,
+			toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)) AS lead_p95
 		FROM (
 			SELECT
 				%[1]s AS rk,
@@ -272,10 +280,10 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	// Per-node: same comparison, grouped by measurement node + competitor.
 	nodeQ := fmt.Sprintf(`
 		SELECT measurement_node_id, location_code, competitor,
-			uniqExactIf(rk, dz_won = 1) AS dz_wins,
-			uniqExactIf(rk, dz_won = 0) AS dz_losses,
-			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
-			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+			uniqCombinedIf(rk, dz_won = 1) AS dz_wins,
+			uniqCombinedIf(rk, dz_won = 0) AS dz_losses,
+			toFloat64(quantileTDigestIf(0.5)(lead_ms, dz_won = 1)) AS lead_p50,
+			toFloat64(quantileTDigestIf(0.95)(lead_ms, dz_won = 1)) AS lead_p95
 		FROM (
 			SELECT measurement_node_id, location_code,
 				%[1]s AS rk,
@@ -505,9 +513,9 @@ func (a *API) FetchHyperliquidCompositeLatency(ctx context.Context) (*Hyperliqui
 			GROUP BY location_code, symbol, source_ts_ms HAVING count() >= 2
 		)
 		SELECT
-			quantileExact(0.5)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6),
-			quantileExact(0.9)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6),
-			quantileExact(0.99)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)
+			toFloat64(quantileTDigest(0.5)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)),
+			toFloat64(quantileTDigest(0.9)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)),
+			toFloat64(quantileTDigest(0.99)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6))
 		FROM c`, db, hyperliquidLiquidSymbolFilter())
 	var p50, p90, p99 float64
 	if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&p50, &p90, &p99); err != nil {

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -193,5 +193,85 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		})
 	}
 
+	// Per-node: same comparison, grouped by measurement node + competitor.
+	nodeQ := fmt.Sprintf(`
+		SELECT measurement_node_id, location_code, competitor,
+			countIf(dz_won = 1) AS dz_wins,
+			countIf(dz_won = 0) AS dz_losses,
+			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
+			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+		FROM (
+			SELECT measurement_node_id, location_code,
+				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
+				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
+				lead_time_p50_ms AS lead_ms
+			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			WHERE feed != loser_feed AND loser_feed != ''
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
+			  AND event_ts >= now() - INTERVAL %s
+		)
+		GROUP BY measurement_node_id, location_code, competitor`, db, symbolFilter, interval)
+	nrows, err := a.envDB(ctx).Query(ctx, nodeQ)
+	if err != nil {
+		return nil, err
+	}
+	defer nrows.Close()
+
+	type nodeAgg struct {
+		loc    string
+		byFeed map[string]stat
+	}
+	nodeMap := map[string]*nodeAgg{}
+	var nodeOrder []string
+	for nrows.Next() {
+		var node, loc, competitor string
+		var s stat
+		if err := nrows.Scan(&node, &loc, &competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+			return nil, err
+		}
+		na, ok := nodeMap[node]
+		if !ok {
+			na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
+			nodeMap[node] = na
+			nodeOrder = append(nodeOrder, node)
+		}
+		na.byFeed[competitor] = s
+	}
+	if err := nrows.Err(); err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodeOrder {
+		na := nodeMap[node]
+		n := HyperliquidNode{
+			MeasurementNodeID: node,
+			LocationCode:      na.loc,
+			Competitors:       []HyperliquidCompetitor{},
+		}
+		var wins, races uint64
+		for _, c := range hyperliquidCompetitors {
+			s, ok := na.byFeed[c.Feed]
+			if !ok {
+				continue
+			}
+			r := s.wins + s.losses
+			var winPct float64
+			if r > 0 {
+				winPct = 100.0 * float64(s.wins) / float64(r)
+			}
+			n.Competitors = append(n.Competitors, HyperliquidCompetitor{
+				Feed: c.Feed, Label: c.Label, DZWinPct: winPct,
+				LeadP50Ms: s.leadP50, LeadP95Ms: s.leadP95, Races: r,
+			})
+			wins += s.wins
+			races += r
+		}
+		n.TotalRaces = races
+		if races > 0 {
+			n.DZWinSharePct = 100.0 * float64(wins) / float64(races)
+		}
+		resp.Nodes = append(resp.Nodes, n)
+	}
+
 	return resp, nil
 }

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -25,6 +25,14 @@ var hyperliquidWindows = map[string]string{
 	"7d":  "7 DAY",
 }
 
+// raceKeyTuple is the summary table's ReplacingMergeTree sorting key. The remote
+// materialized view refreshes on overlapping windows, so each logical race appears as
+// several rows that only FINAL (or a uniqExact over this key) collapses. uniqExact over
+// the key gives exact race counts without paying FINAL's merge cost, which dominated query
+// time against the full production table. Win rates are ratios and lead-time percentiles are
+// duplicate-insensitive, so dropping FINAL keeps them correct.
+const raceKeyTuple = "(measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)"
+
 var hyperliquidSymbolRe = regexp.MustCompile(`^[A-Za-z0-9:_.-]{1,32}$`)
 
 // sanitizeHyperliquidSymbol returns the symbol if safe to inline, else "".
@@ -95,7 +103,7 @@ func labelForFeed(feed string) string {
 func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol string) (*HyperliquidScoreboardResponse, error) {
 	interval, ok := hyperliquidWindows[window]
 	if !ok {
-		window = "24h"
+		window = "1h"
 		interval = hyperliquidWindows[window]
 	}
 	symbol = sanitizeHyperliquidSymbol(symbol)
@@ -130,41 +138,29 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		RecentRaces: []HyperliquidRace{},
 	}
 
-	// Headline: DZ win share over all DZ-vs-competitor pairwise comparisons.
-	headlineQ := fmt.Sprintf(`
-		SELECT
-			ifNull(100.0 * countIf(startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
-			      / nullIf(countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0), 0) AS dz_win_share_pct,
-			countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) AS total_races
-		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
-		WHERE feed != loser_feed AND loser_feed != '' %s
-		  AND event_ts >= now() - INTERVAL %s`, db, symbolFilter, interval)
-	var winShare float64
-	var totalRaces uint64
-	if err := a.envDB(ctx).QueryRow(ctx, headlineQ).Scan(&winShare, &totalRaces); err != nil {
-		return nil, err
-	}
-	resp.DZWinSharePct = winShare
-	resp.TotalRaces = totalRaces
+	// The headline (DZ win share + total races) is derived from the per-node aggregation
+	// below rather than its own scan — counts partition cleanly by competitor, so summing the
+	// per-node cells gives the same totals while saving a full scan of the (very large) table.
 
 	// Per-competitor: win%, lead p50/p95 (over DZ wins), and total comparable races.
 	compQ := fmt.Sprintf(`
 		SELECT competitor,
-			countIf(dz_won = 1) AS dz_wins,
-			countIf(dz_won = 0) AS dz_losses,
+			uniqExactIf(rk, dz_won = 1) AS dz_wins,
+			uniqExactIf(rk, dz_won = 0) AS dz_losses,
 			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
 			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
 		FROM (
 			SELECT
+				%[1]s AS rk,
 				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
 				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
 				lead_time_p50_ms AS lead_ms
-			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			FROM %[2]s.hyperliquid_bbo_feed_race_summary
 			WHERE feed != loser_feed AND loser_feed != ''
-			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
-			  AND event_ts >= now() - INTERVAL %s
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %[3]s
+			  AND event_ts >= now() - INTERVAL %[4]s
 		)
-		GROUP BY competitor`, db, symbolFilter, interval)
+		GROUP BY competitor`, raceKeyTuple, db, symbolFilter, interval)
 	rows, err := a.envDB(ctx).Query(ctx, compQ)
 	if err != nil {
 		return nil, err
@@ -212,21 +208,22 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	// Per-node: same comparison, grouped by measurement node + competitor.
 	nodeQ := fmt.Sprintf(`
 		SELECT measurement_node_id, location_code, competitor,
-			countIf(dz_won = 1) AS dz_wins,
-			countIf(dz_won = 0) AS dz_losses,
+			uniqExactIf(rk, dz_won = 1) AS dz_wins,
+			uniqExactIf(rk, dz_won = 0) AS dz_losses,
 			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
 			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
 		FROM (
 			SELECT measurement_node_id, location_code,
+				%[1]s AS rk,
 				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
 				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
 				lead_time_p50_ms AS lead_ms
-			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			FROM %[2]s.hyperliquid_bbo_feed_race_summary
 			WHERE feed != loser_feed AND loser_feed != ''
-			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
-			  AND event_ts >= now() - INTERVAL %s
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %[3]s
+			  AND event_ts >= now() - INTERVAL %[4]s
 		)
-		GROUP BY measurement_node_id, location_code, competitor`, db, symbolFilter, interval)
+		GROUP BY measurement_node_id, location_code, competitor`, raceKeyTuple, db, symbolFilter, interval)
 	nrows, err := a.envDB(ctx).Query(ctx, nodeQ)
 	if err != nil {
 		return nil, err
@@ -257,6 +254,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		return nil, err
 	}
 
+	var globalWins, globalRaces uint64
 	for _, node := range nodeOrder {
 		na := nodeMap[node]
 		n := HyperliquidNode{
@@ -287,6 +285,14 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 			n.DZWinSharePct = 100.0 * float64(wins) / float64(races)
 		}
 		resp.Nodes = append(resp.Nodes, n)
+		globalWins += wins
+		globalRaces += races
+	}
+
+	// Headline derived from the per-node totals (no extra scan).
+	resp.TotalRaces = globalRaces
+	if globalRaces > 0 {
+		resp.DZWinSharePct = 100.0 * float64(globalWins) / float64(globalRaces)
 	}
 
 	recent, err := a.fetchHyperliquidRecentRaces(ctx, symbol, time.Time{}, 50)
@@ -299,7 +305,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 }
 
 // fetchHyperliquidRecentRaces returns the most recent races (one row per race,
-// winner + closest competitor + lead). sinceTs zero -> last 2 minutes.
+// winner + closest competitor + lead). sinceTs zero -> last 5 minutes.
 func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, sinceTs time.Time, limit int) ([]HyperliquidRace, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 50
@@ -309,7 +315,9 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, si
 	if symbol != "" {
 		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
 	}
-	timeFilter := "AND event_ts >= now() - INTERVAL 2 MINUTE"
+	// 5 minutes (not 2): the remote materialized view lags ~50-90s, so a tighter window
+	// intermittently comes up empty. The LIMIT still returns only the newest races.
+	timeFilter := "AND event_ts >= now() - INTERVAL 5 MINUTE"
 	if !sinceTs.IsZero() {
 		timeFilter = fmt.Sprintf("AND event_ts > toDateTime64(%d, 9)", sinceTs.Unix())
 	}
@@ -323,7 +331,7 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, si
 			startsWith(feed,'tob_') AS is_dz,
 			argMin(loser_feed, lead_time_p50_ms) AS runner_up_feed,
 			min(lead_time_p50_ms) AS lead_ms
-		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+		FROM %s.hyperliquid_bbo_feed_race_summary
 		WHERE loser_feed != '' AND feed != loser_feed %s %s
 		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
 		ORDER BY max_event_ts DESC
@@ -352,8 +360,11 @@ func hyperliquidScoreboardCacheKey(r *http.Request) string {
 	if r.URL.Query().Get("since_ts") != "" || r.URL.Query().Get("symbol") != "" {
 		return ""
 	}
+	// 1h is the cacheable default — a 24h/7d aggregation over the full proxied table is too
+	// slow to refresh within the cache deadline (the summary table has no time-based index),
+	// so only the 1h view is cached; longer windows fall through to a (slower) live query.
 	window := strings.TrimSpace(r.URL.Query().Get("window"))
-	if window != "" && window != "24h" {
+	if window != "" && window != "1h" {
 		return ""
 	}
 	return "hyperliquid_scoreboard"
@@ -388,7 +399,7 @@ func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
 
 	window := strings.TrimSpace(r.URL.Query().Get("window"))
 	if _, ok := hyperliquidWindows[window]; !ok {
-		window = "24h"
+		window = "1h"
 	}
 	symbol := r.URL.Query().Get("symbol")
 

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -155,13 +155,14 @@ type HyperliquidScoreboardResponse struct {
 	RecentRaces   []HyperliquidRace       `json:"recent_races"`
 	// Prices is the latest BBO mid price per recent-race symbol (live, for the grid).
 	Prices map[string]float64 `json:"prices,omitempty"`
-	// CompositeLatency is DoubleZero's composite first-arrival feed latency (24h); nil until the
+	// CompositeLatency is DoubleZero's Tokyo first-arrival feed latency (24h); nil until the
 	// background refresher computes it (the query is too heavy for the request path).
 	CompositeLatency *HyperliquidCompositeLatency `json:"composite_latency,omitempty"`
 }
 
-// HyperliquidCompositeLatency is DoubleZero's composite first-arrival latency (blocktime ->
-// receive, earliest across all tob_ DZ feeds) over a fixed 24h window, p50/p90/p99 in ms.
+// HyperliquidCompositeLatency is DoubleZero's Tokyo first-arrival latency (blocktime -> receive,
+// earliest across the tob_ DZ feeds at the Tokyo vantage point) over a fixed 24h window,
+// p50/p90/p99 in ms.
 type HyperliquidCompositeLatency struct {
 	Window      string    `json:"window"`
 	P50Ms       float64   `json:"p50_ms"`
@@ -492,30 +493,31 @@ func (a *API) fetchHyperliquidPrices(ctx context.Context) (map[string]float64, e
 	return out, rows.Err()
 }
 
-// FetchHyperliquidCompositeLatency computes DoubleZero's composite first-arrival latency
-// (p50/p90/p99 in ms) over the last 24h across the liquid symbols and all vantage points, from
-// the raw observations table: per (metro, symbol, block) the earliest receive across DZ tob_
-// feeds, restricted to blocks where >=2 DZ feeds delivered. This is a heavy full-day scan over
-// the proxied table (~tens of seconds) — it must run on a slow background cadence, never in the
-// request path or the 60s page-cache loop.
+// FetchHyperliquidCompositeLatency computes DoubleZero's Tokyo first-arrival feed latency
+// (p50/p90/p99 in ms) over the last 24h across the liquid symbols, from the raw observations
+// table: per (symbol, block) the earliest receive across DZ tob_ feeds at the Tokyo vantage
+// point, restricted to blocks where >=2 DZ feeds delivered. Scoped to Tokyo (DZ's fastest metro,
+// nearest Hyperliquid) so the headline reflects best-case DZ delivery rather than an all-metro
+// average — this matches the Grafana "tob_* (first-arrival, all DZ)" panel. This is a heavy
+// full-day scan over the proxied table (~tens of seconds) — it must run on a slow background
+// cadence, never in the request path or the 60s page-cache loop.
 func (a *API) FetchHyperliquidCompositeLatency(ctx context.Context) (*HyperliquidCompositeLatency, error) {
 	db := fmt.Sprintf("`%s`", a.FeedsDB)
-	// Single GROUP BY over (metro, symbol, block): min(recv) is associative, so the earlier
-	// per-source pre-aggregation was redundant, and uniqExact(source) >= 2 enforces ">=2 distinct
-	// DZ feeds delivered" directly. Filtering to tob_ feeds in WHERE (not after grouping) drops
-	// competitor rows before they enter the hash table. The prior two-CTE form grouped every
-	// source by a source-keyed tuple over 24h of the 667 GiB observations table, which on the
-	// memory-constrained proxy ClickHouse (feeds is a remoteSecure() proxy, so the GROUP BY runs
-	// locally) built a hash table that tripped the OvercommitTracker (code 241). This form keeps
-	// tiny per-group state; max_bytes_before_external_group_by spills to disk as a safety net so
-	// high block cardinality degrades to a slower query instead of an OOM.
+	// Single GROUP BY over (symbol, block) at Tokyo: min(recv) is associative, so a per-source
+	// pre-aggregation is redundant, and uniqExact(source) >= 2 enforces ">=2 distinct Tokyo DZ
+	// feeds delivered" directly (this >=2 requirement is what keeps p99 realistic; without it a
+	// single laggy feed inflates the tail). Filtering to tob_ feeds and Tokyo in WHERE (not after
+	// grouping) drops other rows before they enter the hash table. This keeps tiny per-group state;
+	// max_bytes_before_external_group_by spills to disk as a safety net so high block cardinality
+	// degrades to a slower query instead of an OOM on the memory-constrained proxy ClickHouse.
 	q := fmt.Sprintf(`
 		WITH c AS (
-			SELECT location_code, symbol, source_ts_ms, min(recv_ts_ns) AS r
+			SELECT symbol, source_ts_ms, min(recv_ts_ns) AS r
 			FROM %[1]s.hyperliquid_bbo_observations
 			WHERE recv_ts_ns >= toUInt64(toUnixTimestamp64Nano(now64(9) - toIntervalHour(24)))
-			  AND startsWith(source, 'tob_') %[2]s
-			GROUP BY location_code, symbol, source_ts_ms
+			  AND startsWith(source, 'tob_')
+			  AND location_code = 'tyo' %[2]s
+			GROUP BY symbol, source_ts_ms
 			HAVING uniqExact(source) >= 2
 		)
 		SELECT

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -329,6 +330,69 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, si
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// hyperliquidScoreboardCacheKey returns the cache key for the default request shape, or "".
+func hyperliquidScoreboardCacheKey(r *http.Request) string {
+	if r.URL.Query().Get("since_ts") != "" || r.URL.Query().Get("symbol") != "" {
+		return ""
+	}
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if window != "" && window != "24h" {
+		return ""
+	}
+	return "hyperliquid_scoreboard"
+}
+
+// hyperliquidFeedsTableExists reports whether the proxied summary table is queryable.
+func (a *API) hyperliquidFeedsTableExists(ctx context.Context) bool {
+	var n uint8
+	q := fmt.Sprintf("EXISTS TABLE `%s`.hyperliquid_bbo_feed_race_summary", a.FeedsDB)
+	if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&n); err != nil {
+		return false
+	}
+	return n == 1
+}
+
+// GetHyperliquidScoreboard serves the Hyperliquid BBO scoreboard.
+func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
+	if isMainnet(r.Context()) {
+		if key := hyperliquidScoreboardCacheKey(r); key != "" {
+			if data, err := a.readPageCache(r.Context(), key); err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache", "HIT")
+				_, _ = w.Write(data)
+				return
+			}
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if _, ok := hyperliquidWindows[window]; !ok {
+		window = "24h"
+	}
+	symbol := r.URL.Query().Get("symbol")
+
+	// Degrade gracefully if the proxy table isn't available (e.g. local dev).
+	if !a.hyperliquidFeedsTableExists(ctx) {
+		writeJSON(w, &HyperliquidScoreboardResponse{
+			Window: window, GeneratedAt: time.Now().UTC(), FeedType: "bbo",
+			Competitors: []HyperliquidCompetitor{}, Nodes: []HyperliquidNode{}, RecentRaces: []HyperliquidRace{},
+		})
+		return
+	}
+
+	resp, err := a.FetchHyperliquidScoreboardData(ctx, window, symbol)
+	if err != nil {
+		logError("HyperliquidScoreboard error", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, resp)
 }
 
 // FetchHyperliquidScoreboardLatest returns only the recent-races strip (fast cache).

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
@@ -14,7 +16,7 @@ import (
 var hyperliquidCompetitors = []struct{ Feed, Label string }{
 	{"hyperliquid_public_bbo", "Public API"},
 	{"hydromancer_bbo", "Hydromancer"},
-	{"hyperpc_shared_bbo", "HyperPC"},
+	{"hyperpc_shared_bbo", "HypeRPC"},
 	{"quicknode_l2book_bbo", "QuickNode"},
 }
 
@@ -32,6 +34,41 @@ var hyperliquidWindows = map[string]string{
 // time against the full production table. Win rates are ratios and lead-time percentiles are
 // duplicate-insensitive, so dropping FINAL keeps them correct.
 const raceKeyTuple = "(measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)"
+
+// hyperliquidLiquidSymbols is the curated universe of the most-liquid Hyperliquid markets
+// (highest open interest) the scoreboard races on. Thin symbols add noise and aren't
+// representative, so the aggregations are restricted to this set by default.
+var hyperliquidLiquidSymbols = []string{
+	// xyz: synthetic equity/commodity perps
+	"xyz:SP500", "xyz:XYZ100", "xyz:MU", "xyz:SKHX", "xyz:SPCX", "xyz:CL", "xyz:NVDA", "xyz:BRENTOIL",
+	// native crypto perps
+	"BTC", "ETH", "SOL", "HYPE", "ZEC",
+}
+
+// hyperliquidLiquidSymbolFilter returns the SQL clause restricting races to the liquid universe.
+func hyperliquidLiquidSymbolFilter() string {
+	return hyperliquidSymbolInClause(hyperliquidLiquidSymbols)
+}
+
+// hyperliquidRecentRaceSymbols are the top-4-by-volume native perps and top-4 HIP-3 (xyz:) DEX
+// perps shown in the recent-races grid. Only a subset (currently BTC/ETH) have competitor feeds;
+// the rest render as DoubleZero-exclusive coverage in the UI.
+var hyperliquidRecentRaceSymbols = []string{
+	"BTC", "ETH", "SOL", "HYPE", // native perps
+	"xyz:SP500", "xyz:XYZ100", "xyz:MU", "xyz:SKHX", // HIP-3 DEX perps
+}
+
+func hyperliquidRecentRaceSymbolFilter() string {
+	return hyperliquidSymbolInClause(hyperliquidRecentRaceSymbols)
+}
+
+func hyperliquidSymbolInClause(symbols []string) string {
+	quoted := make([]string, len(symbols))
+	for i, s := range symbols {
+		quoted[i] = "'" + s + "'"
+	}
+	return "AND symbol IN (" + strings.Join(quoted, ", ") + ")"
+}
 
 var hyperliquidSymbolRe = regexp.MustCompile(`^[A-Za-z0-9:_.-]{1,32}$`)
 
@@ -69,6 +106,7 @@ type HyperliquidRace struct {
 	Symbol        string    `json:"symbol"`
 	LocationCode  string    `json:"location_code"`
 	WinnerFeed    string    `json:"winner_feed"`
+	WinnerLabel   string    `json:"winner_label"`
 	IsDZ          bool      `json:"is_dz"`
 	RunnerUpFeed  string    `json:"runner_up_feed"`
 	RunnerUpLabel string    `json:"runner_up_label"`
@@ -86,7 +124,24 @@ type HyperliquidScoreboardResponse struct {
 	Competitors   []HyperliquidCompetitor `json:"competitors"`
 	Nodes         []HyperliquidNode       `json:"nodes"`
 	RecentRaces   []HyperliquidRace       `json:"recent_races"`
+	// Prices is the latest BBO mid price per recent-race symbol (live, for the grid).
+	Prices map[string]float64 `json:"prices,omitempty"`
+	// CompositeLatency is DoubleZero's composite first-arrival feed latency (24h); nil until the
+	// background refresher computes it (the query is too heavy for the request path).
+	CompositeLatency *HyperliquidCompositeLatency `json:"composite_latency,omitempty"`
 }
+
+// HyperliquidCompositeLatency is DoubleZero's composite first-arrival latency (blocktime ->
+// receive, earliest across all tob_ DZ feeds) over a fixed 24h window, p50/p90/p99 in ms.
+type HyperliquidCompositeLatency struct {
+	Window      string    `json:"window"`
+	P50Ms       float64   `json:"p50_ms"`
+	P90Ms       float64   `json:"p90_ms"`
+	P99Ms       float64   `json:"p99_ms"`
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+const hyperliquidCompositeLatencyCacheKey = "hyperliquid_composite_latency"
 
 // labelForFeed maps a raw competitor feed to its display label (falls back to the raw name).
 func labelForFeed(feed string) string {
@@ -96,6 +151,15 @@ func labelForFeed(feed string) string {
 		}
 	}
 	return feed
+}
+
+// hyperliquidFeedDisplay returns "DoubleZero" for any tob_ DZ feed, else the competitor label.
+// Used so a competitor-won recent race reads "Hydromancer … vs DoubleZero", not a raw tob_ id.
+func hyperliquidFeedDisplay(feed string) string {
+	if strings.HasPrefix(feed, "tob_") {
+		return "DoubleZero"
+	}
+	return labelForFeed(feed)
 }
 
 // FetchHyperliquidScoreboardData computes the aggregated scoreboard for a window and
@@ -122,7 +186,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		}, nil
 	}
 
-	symbolFilter := ""
+	symbolFilter := hyperliquidLiquidSymbolFilter()
 	if symbol != "" {
 		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
 	}
@@ -295,29 +359,38 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		resp.DZWinSharePct = 100.0 * float64(globalWins) / float64(globalRaces)
 	}
 
-	recent, err := a.fetchHyperliquidRecentRaces(ctx, symbol, time.Time{}, 50)
+	recent, err := a.fetchHyperliquidRecentRaces(ctx, time.Time{}, 10)
 	if err != nil {
 		return nil, err
 	}
 	resp.RecentRaces = recent
+
+	// Live prices per symbol for the recent-races grid (best-effort; cheap latest-BBO lookup).
+	if prices, err := a.fetchHyperliquidPrices(ctx); err == nil {
+		resp.Prices = prices
+	}
+
+	// Attach the background-refreshed 24h composite latency (best-effort; absent until the slow
+	// refresher has populated the cache).
+	if raw, err := a.readPageCache(ctx, hyperliquidCompositeLatencyCacheKey); err == nil && len(raw) > 0 {
+		var cl HyperliquidCompositeLatency
+		if json.Unmarshal(raw, &cl) == nil {
+			resp.CompositeLatency = &cl
+		}
+	}
 
 	return resp, nil
 }
 
 // fetchHyperliquidRecentRaces returns the most recent races (one row per race,
 // winner + closest competitor + lead). sinceTs zero -> last 5 minutes.
-func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, sinceTs time.Time, limit int) ([]HyperliquidRace, error) {
-	if limit <= 0 || limit > 500 {
-		limit = 50
+func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time, perSymbol int) ([]HyperliquidRace, error) {
+	if perSymbol <= 0 || perSymbol > 50 {
+		perSymbol = 10
 	}
-	symbol = sanitizeHyperliquidSymbol(symbol)
-	symbolFilter := ""
-	if symbol != "" {
-		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
-	}
-	// 5 minutes (not 2): the remote materialized view lags ~50-90s, so a tighter window
-	// intermittently comes up empty. The LIMIT still returns only the newest races.
-	timeFilter := "AND event_ts >= now() - INTERVAL 5 MINUTE"
+	// 15 min so the covered symbols fill a full column despite the ~50-90s MV lag; LIMIT n BY
+	// symbol then keeps only the newest n per symbol.
+	timeFilter := "AND event_ts >= now() - INTERVAL 15 MINUTE"
 	if !sinceTs.IsZero() {
 		timeFilter = fmt.Sprintf("AND event_ts > toDateTime64(%d, 9)", sinceTs.Unix())
 	}
@@ -332,10 +405,13 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, si
 			argMin(loser_feed, lead_time_p50_ms) AS runner_up_feed,
 			min(lead_time_p50_ms) AS lead_ms
 		FROM %s.hyperliquid_bbo_feed_race_summary
-		WHERE loser_feed != '' AND feed != loser_feed %s %s
+		-- Only DoubleZero-vs-competitor matchups (exactly one side is a tob_* DZ feed) — exclude
+		-- DZ-vs-DZ races (e.g. tob_gcp_tyo vs tob_aws_tyo), which otherwise flood the feed.
+		WHERE loser_feed != '' AND feed != loser_feed
+		  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s %s
 		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
 		ORDER BY max_event_ts DESC
-		LIMIT %d`, db, symbolFilter, timeFilter, limit)
+		LIMIT %d BY symbol`, db, hyperliquidRecentRaceSymbolFilter(), timeFilter, perSymbol)
 	rows, err := a.envDB(ctx).Query(ctx, q)
 	if err != nil {
 		return nil, err
@@ -349,7 +425,8 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, si
 			return nil, err
 		}
 		r.IsDZ = isDZ == 1
-		r.RunnerUpLabel = labelForFeed(r.RunnerUpFeed)
+		r.WinnerLabel = hyperliquidFeedDisplay(r.WinnerFeed)
+		r.RunnerUpLabel = hyperliquidFeedDisplay(r.RunnerUpFeed)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -378,6 +455,100 @@ func (a *API) hyperliquidFeedsTableExists(ctx context.Context) bool {
 		return false
 	}
 	return n == 1
+}
+
+// fetchHyperliquidPrices returns the latest BBO mid price per recent-race symbol — a cheap
+// latest-observation lookup (~0.4s) used to show a live price next to each symbol's races.
+// Price = (bid_px_raw + ask_px_raw)/2 * 10^price_exp.
+func (a *API) fetchHyperliquidPrices(ctx context.Context) (map[string]float64, error) {
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+	q := fmt.Sprintf(`
+		SELECT symbol, argMax((bid_px_raw + ask_px_raw) / 2 * pow(10, price_exp), recv_ts_ns) AS price
+		FROM %s.hyperliquid_bbo_observations
+		WHERE recv_ts_ns >= toUInt64(toUnixTimestamp64Nano(now64(9) - toIntervalMinute(1))) %s
+		GROUP BY symbol`, db, hyperliquidRecentRaceSymbolFilter())
+	rows, err := a.envDB(ctx).Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]float64{}
+	for rows.Next() {
+		var sym string
+		var price float64
+		if err := rows.Scan(&sym, &price); err != nil {
+			return nil, err
+		}
+		out[sym] = price
+	}
+	return out, rows.Err()
+}
+
+// FetchHyperliquidCompositeLatency computes DoubleZero's composite first-arrival latency
+// (p50/p90/p99 in ms) over the last 24h across the liquid symbols and all vantage points, from
+// the raw observations table: per (metro, symbol, block) the earliest receive across DZ tob_
+// feeds, restricted to blocks where >=2 DZ feeds delivered. This is a heavy full-day scan over
+// the proxied table (~tens of seconds) — it must run on a slow background cadence, never in the
+// request path or the 60s page-cache loop.
+func (a *API) FetchHyperliquidCompositeLatency(ctx context.Context) (*HyperliquidCompositeLatency, error) {
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+	q := fmt.Sprintf(`
+		WITH d AS (
+			SELECT location_code, symbol, source_ts_ms, source, min(recv_ts_ns) AS r
+			FROM %[1]s.hyperliquid_bbo_observations
+			WHERE recv_ts_ns >= toUInt64(toUnixTimestamp64Nano(now64(9) - toIntervalHour(24))) %[2]s
+			GROUP BY location_code, symbol, source_ts_ms, source
+		),
+		c AS (
+			SELECT location_code, symbol, source_ts_ms, min(r) AS r
+			FROM d WHERE startsWith(source, 'tob_')
+			GROUP BY location_code, symbol, source_ts_ms HAVING count() >= 2
+		)
+		SELECT
+			quantileExact(0.5)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6),
+			quantileExact(0.9)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6),
+			quantileExact(0.99)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)
+		FROM c`, db, hyperliquidLiquidSymbolFilter())
+	var p50, p90, p99 float64
+	if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&p50, &p90, &p99); err != nil {
+		return nil, err
+	}
+	return &HyperliquidCompositeLatency{
+		Window: "24h", P50Ms: p50, P90Ms: p90, P99Ms: p99, GeneratedAt: time.Now().UTC(),
+	}, nil
+}
+
+// StartHyperliquidCompositeLatencyRefresher periodically computes the composite latency and
+// writes it to the page cache (Postgres) so all replicas share one value. The query is far too
+// slow for the 60s page-cache worker, so it runs here on its own slow cadence.
+func (a *API) StartHyperliquidCompositeLatencyRefresher(ctx context.Context) {
+	const interval = 10 * time.Minute
+	const runTimeout = 3 * time.Minute
+	refresh := func() {
+		rctx, cancel := context.WithTimeout(ctx, runTimeout)
+		defer cancel()
+		val, err := a.FetchHyperliquidCompositeLatency(rctx)
+		if err != nil {
+			slog.Warn("hyperliquid composite latency refresh failed", "error", err)
+			return
+		}
+		if err := a.WritePageCache(ctx, hyperliquidCompositeLatencyCacheKey, val); err != nil {
+			slog.Warn("hyperliquid composite latency cache write failed", "error", err)
+		}
+	}
+	go func() {
+		refresh()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				refresh()
+			}
+		}
+	}()
 }
 
 // GetHyperliquidScoreboard serves the Hyperliquid BBO scoreboard.

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -99,6 +99,21 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		interval = hyperliquidWindows[window]
 	}
 	symbol = sanitizeHyperliquidSymbol(symbol)
+
+	// Guard: if the feeds summary table doesn't exist (e.g. local dev without the
+	// proxy/seed), return an empty-but-valid response so the page-cache refresher
+	// caches a clean empty payload instead of logging an error every cycle.
+	if !a.hyperliquidFeedsTableExists(ctx) {
+		return &HyperliquidScoreboardResponse{
+			Window:      window,
+			GeneratedAt: time.Now().UTC(),
+			FeedType:    "bbo",
+			Competitors: []HyperliquidCompetitor{},
+			Nodes:       []HyperliquidNode{},
+			RecentRaces: []HyperliquidRace{},
+		}, nil
+	}
+
 	symbolFilter := ""
 	if symbol != "" {
 		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
@@ -395,17 +410,3 @@ func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp)
 }
 
-// FetchHyperliquidScoreboardLatest returns only the recent-races strip (fast cache).
-func (a *API) FetchHyperliquidScoreboardLatest(ctx context.Context, limit int) (*HyperliquidScoreboardResponse, error) {
-	races, err := a.fetchHyperliquidRecentRaces(ctx, "", time.Time{}, limit)
-	if err != nil {
-		return nil, err
-	}
-	return &HyperliquidScoreboardResponse{
-		GeneratedAt: time.Now().UTC(),
-		FeedType:    "bbo",
-		RecentRaces: races,
-		Competitors: []HyperliquidCompetitor{},
-		Nodes:       []HyperliquidNode{},
-	}, nil
-}

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -273,5 +273,75 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		resp.Nodes = append(resp.Nodes, n)
 	}
 
+	recent, err := a.fetchHyperliquidRecentRaces(ctx, symbol, time.Time{}, 50)
+	if err != nil {
+		return nil, err
+	}
+	resp.RecentRaces = recent
+
 	return resp, nil
+}
+
+// fetchHyperliquidRecentRaces returns the most recent races (one row per race,
+// winner + closest competitor + lead). sinceTs zero -> last 2 minutes.
+func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, sinceTs time.Time, limit int) ([]HyperliquidRace, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	symbol = sanitizeHyperliquidSymbol(symbol)
+	symbolFilter := ""
+	if symbol != "" {
+		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
+	}
+	timeFilter := "AND event_ts >= now() - INTERVAL 2 MINUTE"
+	if !sinceTs.IsZero() {
+		timeFilter = fmt.Sprintf("AND event_ts > toDateTime64(%d, 9)", sinceTs.Unix())
+	}
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+	q := fmt.Sprintf(`
+		SELECT
+			max(event_ts) AS max_event_ts,
+			symbol,
+			location_code,
+			feed AS winner_feed,
+			startsWith(feed,'tob_') AS is_dz,
+			argMin(loser_feed, lead_time_p50_ms) AS runner_up_feed,
+			min(lead_time_p50_ms) AS lead_ms
+		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+		WHERE loser_feed != '' AND feed != loser_feed %s %s
+		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
+		ORDER BY max_event_ts DESC
+		LIMIT %d`, db, symbolFilter, timeFilter, limit)
+	rows, err := a.envDB(ctx).Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []HyperliquidRace{}
+	for rows.Next() {
+		var r HyperliquidRace
+		var isDZ uint8
+		if err := rows.Scan(&r.EventTs, &r.Symbol, &r.LocationCode, &r.WinnerFeed, &isDZ, &r.RunnerUpFeed, &r.LeadMs); err != nil {
+			return nil, err
+		}
+		r.IsDZ = isDZ == 1
+		r.RunnerUpLabel = labelForFeed(r.RunnerUpFeed)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// FetchHyperliquidScoreboardLatest returns only the recent-races strip (fast cache).
+func (a *API) FetchHyperliquidScoreboardLatest(ctx context.Context, limit int) (*HyperliquidScoreboardResponse, error) {
+	races, err := a.fetchHyperliquidRecentRaces(ctx, "", time.Time{}, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &HyperliquidScoreboardResponse{
+		GeneratedAt: time.Now().UTC(),
+		FeedType:    "bbo",
+		RecentRaces: races,
+		Competitors: []HyperliquidCompetitor{},
+		Nodes:       []HyperliquidNode{},
+	}, nil
 }

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -500,23 +500,30 @@ func (a *API) fetchHyperliquidPrices(ctx context.Context) (map[string]float64, e
 // request path or the 60s page-cache loop.
 func (a *API) FetchHyperliquidCompositeLatency(ctx context.Context) (*HyperliquidCompositeLatency, error) {
 	db := fmt.Sprintf("`%s`", a.FeedsDB)
+	// Single GROUP BY over (metro, symbol, block): min(recv) is associative, so the earlier
+	// per-source pre-aggregation was redundant, and uniqExact(source) >= 2 enforces ">=2 distinct
+	// DZ feeds delivered" directly. Filtering to tob_ feeds in WHERE (not after grouping) drops
+	// competitor rows before they enter the hash table. The prior two-CTE form grouped every
+	// source by a source-keyed tuple over 24h of the 667 GiB observations table, which on the
+	// memory-constrained proxy ClickHouse (feeds is a remoteSecure() proxy, so the GROUP BY runs
+	// locally) built a hash table that tripped the OvercommitTracker (code 241). This form keeps
+	// tiny per-group state; max_bytes_before_external_group_by spills to disk as a safety net so
+	// high block cardinality degrades to a slower query instead of an OOM.
 	q := fmt.Sprintf(`
-		WITH d AS (
-			SELECT location_code, symbol, source_ts_ms, source, min(recv_ts_ns) AS r
+		WITH c AS (
+			SELECT location_code, symbol, source_ts_ms, min(recv_ts_ns) AS r
 			FROM %[1]s.hyperliquid_bbo_observations
-			WHERE recv_ts_ns >= toUInt64(toUnixTimestamp64Nano(now64(9) - toIntervalHour(24))) %[2]s
-			GROUP BY location_code, symbol, source_ts_ms, source
-		),
-		c AS (
-			SELECT location_code, symbol, source_ts_ms, min(r) AS r
-			FROM d WHERE startsWith(source, 'tob_')
-			GROUP BY location_code, symbol, source_ts_ms HAVING count() >= 2
+			WHERE recv_ts_ns >= toUInt64(toUnixTimestamp64Nano(now64(9) - toIntervalHour(24)))
+			  AND startsWith(source, 'tob_') %[2]s
+			GROUP BY location_code, symbol, source_ts_ms
+			HAVING uniqExact(source) >= 2
 		)
 		SELECT
 			toFloat64(quantileTDigest(0.5)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)),
 			toFloat64(quantileTDigest(0.9)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6)),
 			toFloat64(quantileTDigest(0.99)((toInt64(r) - toInt64(source_ts_ms) * 1000000) / 1e6))
-		FROM c`, db, hyperliquidLiquidSymbolFilter())
+		FROM c
+		SETTINGS max_bytes_before_external_group_by = 2000000000`, db, hyperliquidLiquidSymbolFilter())
 	var p50, p90, p99 float64
 	if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&p50, &p90, &p99); err != nil {
 		return nil, err

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -18,6 +18,7 @@ import (
 var hyperliquidCompetitors = []struct{ Feed, Label string }{
 	{"hyperliquid_public_bbo", "Public API"},
 	{"hydromancer_bbo", "Hydromancer"},
+	{"dwellir_l2book_bbo", "Dwellir"},
 	{"quicknode_l2book_bbo", "QuickNode"},
 }
 

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -16,8 +16,29 @@ import (
 var hyperliquidCompetitors = []struct{ Feed, Label string }{
 	{"hyperliquid_public_bbo", "Public API"},
 	{"hydromancer_bbo", "Hydromancer"},
-	{"hyperpc_shared_bbo", "HypeRPC"},
 	{"quicknode_l2book_bbo", "QuickNode"},
+}
+
+// hyperliquidExcludedFeeds are competitor feeds withheld from every scoreboard measurement
+// (per-competitor, per-node, headline totals, and recent races) because their upstream data is
+// currently unreliable. hyperpc_shared_bbo (HypeRPC) arrives a median ~100s stale during
+// recurring multi-hour backlog episodes — vs ~300ms for the other feeds — which would render
+// DoubleZero "winning" by seconds-to-minutes and is a HypeRPC-side feed fault, not a real result.
+// Remove entries here (and re-add to hyperliquidCompetitors) once the feed is fixed.
+var hyperliquidExcludedFeeds = []string{"hyperpc_shared_bbo"}
+
+// hyperliquidExcludedFeedsClause returns a SQL predicate dropping excluded feeds from either
+// side of a race, or "" if none are excluded.
+func hyperliquidExcludedFeedsClause() string {
+	if len(hyperliquidExcludedFeeds) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(hyperliquidExcludedFeeds))
+	for i, f := range hyperliquidExcludedFeeds {
+		quoted[i] = "'" + f + "'"
+	}
+	in := strings.Join(quoted, ", ")
+	return fmt.Sprintf("AND feed NOT IN (%[1]s) AND loser_feed NOT IN (%[1]s)", in)
 }
 
 // hyperliquidWindows maps window params to ClickHouse interval expressions.
@@ -198,6 +219,9 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	if symbol != "" {
 		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
 	}
+	// Drop excluded (unreliable) competitor feeds from the per-competitor and per-node
+	// aggregations. Flows into both compQ and nodeQ via the shared symbolFilter slot.
+	symbolFilter = strings.TrimSpace(symbolFilter + " " + hyperliquidExcludedFeedsClause())
 	db := fmt.Sprintf("`%s`", a.FeedsDB)
 
 	resp := &HyperliquidScoreboardResponse{
@@ -419,7 +443,8 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time
 		  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s %s
 		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
 		ORDER BY max_event_ts DESC
-		LIMIT %d BY symbol`, db, hyperliquidRecentRaceSymbolFilter(), timeFilter, perSymbol)
+		LIMIT %d BY symbol`, db,
+		strings.TrimSpace(hyperliquidRecentRaceSymbolFilter()+" "+hyperliquidExcludedFeedsClause()), timeFilter, perSymbol)
 	rows, err := a.envDB(ctx).Query(ctx, q)
 	if err != nil {
 		return nil, err

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -76,6 +76,28 @@ func TestHyperliquidScoreboard_PerNode(t *testing.T) {
 	assert.InDelta(t, 50.0, byNode["nyc-rec1"].DZWinSharePct, 0.1)
 }
 
+func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// A DZ-won race (BTC) and a competitor-won race (ETH), both pairwise.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.5)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "quicknode_l2book_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
+
+	races, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(races.RecentRaces), 2)
+
+	bySym := map[string]handlers.HyperliquidRace{}
+	for _, r := range races.RecentRaces {
+		bySym[r.Symbol] = r
+	}
+	assert.True(t, bySym["BTC"].IsDZ)
+	assert.Equal(t, "Hydromancer", bySym["BTC"].RunnerUpLabel)
+	assert.InDelta(t, 1.5, bySym["BTC"].LeadMs, 0.001)
+	assert.False(t, bySym["ETH"].IsDZ)
+}
+
 func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -1,7 +1,10 @@
 package handlers_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/malbeclabs/lake/api/handlers"
@@ -52,6 +55,35 @@ func insertPairwise(t *testing.T, api *handlers.API, node, loc, symbol string, s
 		(event_ts, capture_run_id, measurement_node_id, host, location_code, symbol, source_ts_ms, bbo_hash, feed, loser_feed, total_events, events_won, lead_time_p50_ms, lead_time_p95_ms)
 		VALUES (now64(9), 'run1', '%s', '%s', '%s', '%s', %d, %d, '%s', '%s', 1, 1, %f, %f)
 	`, db, node, node, loc, symbol, srcTs, hash, winner, loser, leadMs, leadMs)))
+}
+
+func TestGetHyperliquidScoreboard_Empty(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api) // empty table -> empty-but-valid response
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
+	rr := httptest.NewRecorder()
+	api.GetHyperliquidScoreboard(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp handlers.HyperliquidScoreboardResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "24h", resp.Window)
+	assert.Equal(t, "MISS", rr.Header().Get("X-Cache"))
+}
+
+func TestGetHyperliquidScoreboard_MissingTable(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	// Do NOT create the table -> handler must degrade to empty 200, not 500.
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
+	rr := httptest.NewRecorder()
+	api.GetHyperliquidScoreboard(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp handlers.HyperliquidScoreboardResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Competitors)
 }
 
 func TestHyperliquidScoreboard_PerNode(t *testing.T) {

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -86,6 +86,20 @@ func TestGetHyperliquidScoreboard_MissingTable(t *testing.T) {
 	assert.Empty(t, resp.Competitors)
 }
 
+func TestFetchHyperliquidScoreboardData_MissingTable(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	// Do NOT create the table -> FetchHyperliquidScoreboardData must return an
+	// empty-but-valid response (nil error, non-nil resp, empty slices).
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "24h", resp.Window)
+	assert.Empty(t, resp.Competitors)
+	assert.Empty(t, resp.Nodes)
+	assert.Empty(t, resp.RecentRaces)
+}
+
 func TestHyperliquidScoreboard_PerNode(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -171,6 +171,6 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	assert.Equal(t, "Hydromancer", hydro.Label)
 	assert.InDelta(t, 75.0, hydro.DZWinPct, 0.1)
 	assert.EqualValues(t, 4, hydro.Races)
-	// Lead p50 over the 3 DZ wins (1.0, 2.0, 3.0) = 2.0 (quantileExact(0.5)).
+	// Lead p50 over the 3 DZ wins (1.0, 2.0, 3.0) = 2.0 (quantileTDigest(0.5), exact at this size).
 	assert.InDelta(t, 2.0, hydro.LeadP50Ms, 0.001)
 }

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -68,7 +68,7 @@ func TestGetHyperliquidScoreboard_Empty(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	var resp handlers.HyperliquidScoreboardResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	assert.Equal(t, "24h", resp.Window)
+	assert.Equal(t, "1h", resp.Window)
 	assert.Equal(t, "MISS", rr.Header().Get("X-Cache"))
 }
 

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -58,17 +58,18 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)
 
-	// 3 races at node tyo: DZ (tob_*) beats Hydromancer twice, loses once.
+	// 4 races at node tyo: DZ (tob_*) beats Hydromancer three times, loses once.
 	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 4000, 4, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
 
-	// DZ won 2 of 3 comparable races = 66.67%.
-	assert.InDelta(t, 66.67, resp.DZWinSharePct, 0.1)
-	assert.EqualValues(t, 3, resp.TotalRaces)
+	// DZ won 3 of 4 comparable races = 75%.
+	assert.InDelta(t, 75.0, resp.DZWinSharePct, 0.1)
+	assert.EqualValues(t, 4, resp.TotalRaces)
 
 	var hydro *handlers.HyperliquidCompetitor
 	for i := range resp.Competitors {
@@ -78,8 +79,8 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	}
 	require.NotNil(t, hydro)
 	assert.Equal(t, "Hydromancer", hydro.Label)
-	assert.InDelta(t, 66.67, hydro.DZWinPct, 0.1)
-	assert.EqualValues(t, 3, hydro.Races)
-	// Lead p50 over the 2 DZ wins (1.0, 3.0) = 1.0 (quantileExact lower).
-	assert.InDelta(t, 1.0, hydro.LeadP50Ms, 0.001)
+	assert.InDelta(t, 75.0, hydro.DZWinPct, 0.1)
+	assert.EqualValues(t, 4, hydro.Races)
+	// Lead p50 over the 3 DZ wins (1.0, 2.0, 3.0) = 2.0 (quantileExact(0.5)).
+	assert.InDelta(t, 2.0, hydro.LeadP50Ms, 0.001)
 }

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -1,0 +1,85 @@
+package handlers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createFeedsTable creates the hyperliquid_bbo_feed_race_summary table in the feeds DB.
+func createFeedsTable(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	db := "`" + api.FeedsDB + "`"
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", db)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.hyperliquid_bbo_feed_race_summary (
+			event_ts DateTime64(9),
+			ingested_at DateTime64(9) DEFAULT now64(9),
+			capture_run_id String,
+			measurement_node_id String,
+			host String,
+			location_code LowCardinality(String),
+			feed_type LowCardinality(String) DEFAULT 'bbo',
+			symbol LowCardinality(String),
+			source_ts_ms UInt64,
+			bbo_hash UInt64,
+			feed LowCardinality(String),
+			loser_feed LowCardinality(String) DEFAULT '',
+			total_events UInt64,
+			events_won UInt64,
+			lead_time_p50_ms Float64 DEFAULT 0,
+			lead_time_p95_ms Float64 DEFAULT 0,
+			send_lead_time_p50_ms Nullable(Float64) DEFAULT NULL,
+			send_lead_time_p95_ms Nullable(Float64) DEFAULT NULL
+		) ENGINE = ReplacingMergeTree(ingested_at)
+		PARTITION BY toDate(event_ts)
+		ORDER BY (measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)
+	`, db)))
+}
+
+// pairwiseRow inserts one pairwise race row (winner feed beat loser_feed by leadMs).
+func insertPairwise(t *testing.T, api *handlers.API, node, loc, symbol string, srcTs, hash uint64, winner, loser string, leadMs float64) {
+	t.Helper()
+	ctx := t.Context()
+	db := "`" + api.FeedsDB + "`"
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.hyperliquid_bbo_feed_race_summary
+		(event_ts, capture_run_id, measurement_node_id, host, location_code, symbol, source_ts_ms, bbo_hash, feed, loser_feed, total_events, events_won, lead_time_p50_ms, lead_time_p95_ms)
+		VALUES (now64(9), 'run1', '%s', '%s', '%s', '%s', %d, %d, '%s', '%s', 1, 1, %f, %f)
+	`, db, node, node, loc, symbol, srcTs, hash, winner, loser, leadMs, leadMs)))
+}
+
+func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// 3 races at node tyo: DZ (tob_*) beats Hydromancer twice, loses once.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	// DZ won 2 of 3 comparable races = 66.67%.
+	assert.InDelta(t, 66.67, resp.DZWinSharePct, 0.1)
+	assert.EqualValues(t, 3, resp.TotalRaces)
+
+	var hydro *handlers.HyperliquidCompetitor
+	for i := range resp.Competitors {
+		if resp.Competitors[i].Feed == "hydromancer_bbo" {
+			hydro = &resp.Competitors[i]
+		}
+	}
+	require.NotNil(t, hydro)
+	assert.Equal(t, "Hydromancer", hydro.Label)
+	assert.InDelta(t, 66.67, hydro.DZWinPct, 0.1)
+	assert.EqualValues(t, 3, hydro.Races)
+	// Lead p50 over the 2 DZ wins (1.0, 3.0) = 1.0 (quantileExact lower).
+	assert.InDelta(t, 1.0, hydro.LeadP50Ms, 0.001)
+}

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -144,6 +144,36 @@ func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
 	assert.False(t, bySym["ETH"].IsDZ)
 }
 
+// A cell where DoubleZero won zero races (competitor swept it) makes the lead-time
+// quantile aggregate over an empty predicate set, which ClickHouse returns as NaN. If that
+// NaN reaches the float64 fields, json encoding of the whole response fails — breaking the
+// scoreboard for everyone and poisoning the page cache. The percentiles must coalesce to 0.
+func TestHyperliquidScoreboard_ZeroDZWins_Encodable(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// Only a competitor-won race: DZ has zero wins vs Hydromancer in this window.
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 10, 1, "hydromancer_bbo", "tob_aws_galaxy1", 3.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	// The entire response must be JSON-encodable — a single NaN anywhere fails encoding.
+	_, err = json.Marshal(resp)
+	require.NoError(t, err, "response must not contain NaN percentiles")
+
+	var hydro *handlers.HyperliquidCompetitor
+	for i := range resp.Competitors {
+		if resp.Competitors[i].Feed == "hydromancer_bbo" {
+			hydro = &resp.Competitors[i]
+		}
+	}
+	require.NotNil(t, hydro)
+	assert.InDelta(t, 0.0, hydro.DZWinPct, 0.001)
+	assert.InDelta(t, 0.0, hydro.LeadP50Ms, 0.001)
+	assert.InDelta(t, 0.0, hydro.LeadP95Ms, 0.001)
+}
+
 func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -54,6 +54,28 @@ func insertPairwise(t *testing.T, api *handlers.API, node, loc, symbol string, s
 	`, db, node, node, loc, symbol, srcTs, hash, winner, loser, leadMs, leadMs)))
 }
 
+func TestHyperliquidScoreboard_PerNode(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// tyo: DZ wins both vs QuickNode. nyc: DZ wins 1, loses 1 vs QuickNode.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "quicknode_l2book_bbo", 1.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "quicknode_l2book_bbo", "tob_aws_galaxy1", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.Len(t, resp.Nodes, 2)
+
+	byNode := map[string]handlers.HyperliquidNode{}
+	for _, n := range resp.Nodes {
+		byNode[n.MeasurementNodeID] = n
+	}
+	assert.InDelta(t, 100.0, byNode["tyo-rec1"].DZWinSharePct, 0.1)
+	assert.InDelta(t, 50.0, byNode["nyc-rec1"].DZWinSharePct, 0.1)
+}
+
 func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)

--- a/api/main.go
+++ b/api/main.go
@@ -362,6 +362,7 @@ func main() {
 		ShredderDB:    config.GetShredderDB(),
 		PublisherDB:   config.GetPublisherDB(),
 		DZDPDB:        config.GetDZDPDB(),
+		FeedsDB:       config.GetFeedsDB(),
 		PgPool:        config.PgPool,
 		Neo4jClient:   config.Neo4jClient,
 		Neo4jDatabase: config.Neo4jDatabase,

--- a/api/main.go
+++ b/api/main.go
@@ -383,9 +383,9 @@ func main() {
 				slog.Error("page cache worker failed", "error", err)
 			}
 		}()
-		// Composite feed latency is too heavy for the 60s page-cache loop; refresh it on its
-		// own slow cadence here (writes to the shared Postgres page cache).
-		api.StartHyperliquidCompositeLatencyRefresher(workerCtx)
+		// The composite feed latency and the 24h/7d scoreboards are too heavy for the 60s
+		// page-cache loop; refresh them on a slow cadence here (writes to the shared page cache).
+		api.StartHyperliquidBackgroundRefresher(workerCtx)
 	}
 
 	// Start metrics server

--- a/api/main.go
+++ b/api/main.go
@@ -383,6 +383,9 @@ func main() {
 				slog.Error("page cache worker failed", "error", err)
 			}
 		}()
+		// Composite feed latency is too heavy for the 60s page-cache loop; refresh it on its
+		// own slow cadence here (writes to the shared Postgres page cache).
+		api.StartHyperliquidCompositeLatencyRefresher(workerCtx)
 	}
 
 	// Start metrics server

--- a/api/main.go
+++ b/api/main.go
@@ -603,6 +603,7 @@ func main() {
 		r.Get("/api/dz/access-passes/{pk}/connections", api.GetAccessPassConnections)
 		r.Get("/api/dz/publisher-check", api.GetPublisherCheck)
 		r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
+		r.Get("/api/dz/hyperliquid/scoreboard", api.GetHyperliquidScoreboard)
 		r.Get("/api/dz/tenants", api.GetTenants)
 		r.Get("/api/dz/tenants/{pk}", api.GetTenant)
 		r.Get("/api/dz/shreds/overview", api.GetShredsOverview)

--- a/api/main.go
+++ b/api/main.go
@@ -603,7 +603,8 @@ func main() {
 		r.Get("/api/dz/access-passes/{pk}/connections", api.GetAccessPassConnections)
 		r.Get("/api/dz/publisher-check", api.GetPublisherCheck)
 		r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
-		r.Get("/api/dz/hyperliquid/scoreboard", api.GetHyperliquidScoreboard)
+		// Internal only (unannounced venue): allowed-domain Google users only.
+		r.With(handlers.RequireInternalDomain).Get("/api/dz/hyperliquid/scoreboard", api.GetHyperliquidScoreboard)
 		r.Get("/api/dz/tenants", api.GetTenants)
 		r.Get("/api/dz/tenants/{pk}", api.GetTenant)
 		r.Get("/api/dz/shreds/overview", api.GetShredsOverview)

--- a/api/testing/api.go
+++ b/api/testing/api.go
@@ -24,6 +24,7 @@ func NewTestAPIBare(t *testing.T, chDB *ClickHouseDB) *handlers.API {
 		ShredderDB:    dbName,
 		PublisherDB:   dbName,
 		DZDPDB:        "dzdp",
+		FeedsDB:       dbName,
 	}
 	api.Manager = handlers.NewWorkflowManager(api)
 	return api
@@ -44,6 +45,7 @@ func NewTestAPI(t *testing.T, chDB *ClickHouseDB) *handlers.API {
 		ShredderDB:    dbName,
 		PublisherDB:   dbName,
 		DZDPDB:        "dzdp",
+		FeedsDB:       dbName,
 	}
 	api.Manager = handlers.NewWorkflowManager(api)
 	return api
@@ -80,6 +82,7 @@ func NewTestAPIAll(t *testing.T, chDB *ClickHouseDB, pgDB *DB, neo4jDB *Neo4jDB,
 		api.Database = dbName
 		api.ShredderDB = dbName
 		api.DZDPDB = "dzdp"
+		api.FeedsDB = dbName
 	}
 
 	if pgDB != nil {

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -112,7 +112,7 @@ func (a *Activities) entries() []cacheEntry {
 			return api.FetchEdgeScoreboardData(ctx, "24h", true, 0, 0, 1000)
 		}},
 		{"hyperliquid scoreboard", "hyperliquid_scoreboard", func(ctx context.Context) (any, error) {
-			return api.FetchHyperliquidScoreboardData(ctx, "24h", "")
+			return api.FetchHyperliquidScoreboardData(ctx, "1h", "")
 		}},
 		{"bulk link metrics", "bulk_link_metrics", func(ctx context.Context) (any, error) {
 			return api.FetchBulkLinkMetricsData(ctx)

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -203,9 +203,6 @@ func (a *Activities) latestEntries() []cacheEntry {
 		{"edge scoreboard (latest, leaders)", "edge_scoreboard:latest:leaders", func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardLatest(ctx, true, 1000)
 		}},
-		{"hyperliquid scoreboard (latest)", "hyperliquid_scoreboard:latest", func(ctx context.Context) (any, error) {
-			return api.FetchHyperliquidScoreboardLatest(ctx, 50)
-		}},
 	}
 }
 

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -111,6 +111,9 @@ func (a *Activities) entries() []cacheEntry {
 		{"edge scoreboard (leaders)", "edge_scoreboard:leaders", func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardData(ctx, "24h", true, 0, 0, 1000)
 		}},
+		{"hyperliquid scoreboard", "hyperliquid_scoreboard", func(ctx context.Context) (any, error) {
+			return api.FetchHyperliquidScoreboardData(ctx, "24h", "")
+		}},
 		{"bulk link metrics", "bulk_link_metrics", func(ctx context.Context) (any, error) {
 			return api.FetchBulkLinkMetricsData(ctx)
 		}},
@@ -199,6 +202,9 @@ func (a *Activities) latestEntries() []cacheEntry {
 		}},
 		{"edge scoreboard (latest, leaders)", "edge_scoreboard:latest:leaders", func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardLatest(ctx, true, 1000)
+		}},
+		{"hyperliquid scoreboard (latest)", "hyperliquid_scoreboard:latest", func(ctx context.Context) (any, error) {
+			return api.FetchHyperliquidScoreboardLatest(ctx, 50)
 		}},
 	}
 }

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -71,9 +71,11 @@ the summary, exactly as it does for `shredder.slot_feed_race_summary_v2`.
 
 **Key semantics (verified against live data):**
 - **One row == one race.** `events_won == total_events == 1` and
-  `lead_time_p50_ms == lead_time_p95_ms` for every row. Therefore aggregating
-  `quantileExact(q)(lead_time_p50_ms)` across rows yields an **exact** lead-time
-  distribution, and counting rows counts races.
+  `lead_time_p50_ms == lead_time_p95_ms` for every row. So the set of `lead_time_p50_ms`
+  values across rows *is* the true per-race lead-time distribution (one sample per race), and
+  counting distinct race keys counts races. Query time uses the bounded-memory estimators
+  `quantileTDigest` / `uniqCombined` over that distribution rather than the exact variants (see
+  Design Decisions) — a sub-1% approximation, not a semantic change.
 - **Aggregate rows** (`loser_feed = ''`): one per `(race key, winner feed)` —
   used for "who won" counts.
 - **Pairwise rows** (`loser_feed != ''`): one per `(race key, winner, loser)` —
@@ -151,7 +153,7 @@ Notes:
   over pairwise rows (`loser_feed != '' AND feed != loser_feed`).
 - Per-competitor `dz_win_pct` and `lead_p50/p95_ms` come from pairwise rows where
   exactly one side is `tob_*` and the other is that competitor; lead percentiles
-  are `quantileExact` over `lead_time_p50_ms` for races DoubleZero won.
+  are `quantileTDigest` over `lead_time_p50_ms` for races DoubleZero won.
 - `nodes[]` is the same computation grouped by `measurement_node_id` /
   `location_code` (the per-vantage breakdown).
 - `recent_races[]` is the newest aggregate rows (`loser_feed=''`) ordered by
@@ -263,10 +265,22 @@ Changes made while validating the page against production data:
   deadline. Only the `1h` view is cached; `24h`/`7d` remain selectable but run as slower live
   queries. The proper fix (a time-ordered projection/materialized view on the remote summary,
   analogous to the shreds slot-range index) is deferred and tracked for the feeds owner.
-- **Queries dedup with `uniqExact` over the sorting key instead of `FINAL`.** `FINAL` dominated
-  query time; win rates are ratios and lead percentiles are duplicate-insensitive, so dropping
-  it keeps results correct while cutting latency. The headline is derived from the per-node
-  aggregation (one fewer scan), which also makes headline and per-competitor totals consistent.
+- **Queries dedup with a distinct-key count over the sorting key instead of `FINAL`.** `FINAL`
+  dominated query time; win rates are ratios and lead percentiles are duplicate-insensitive, so
+  dropping it keeps results correct while cutting latency. The headline is derived from the
+  per-node aggregation (one fewer scan), which also makes headline and per-competitor totals
+  consistent.
+- **Aggregations use approximate estimators (`uniqCombined`, `quantileTDigest`), not the exact
+  variants.** The exact functions (`uniqExact`, `quantileExact`) buffer per-group state
+  proportional to the window's race count (~7.5M matchup rows/hour → ~750 MiB of aggregation
+  state at current volume). On the memory-constrained preview/dev ClickHouse — where the `feeds`
+  tables are `remoteSecure()` proxies, so the GROUP BY runs on the small local instance — that
+  tripped the OvercommitTracker and got the page-cache refresh killed (`code 241`) under the
+  concurrent refresh load. The approximate estimators use bounded (~KB/group) memory; at
+  scoreboard scale their sub-1% error is invisible (win % is a ratio, race totals and lead-time
+  percentiles are display-only), and they are exact at the small cardinalities the unit tests
+  assert. This does **not** reduce rows *read* — the `event_ts` filter still does not prune
+  through the proxy (no time index), the separately-tracked deferred item below.
 - **Recent-races window widened to 5 minutes** (the remote MV lags ~50-90s, so a 2-minute
   window intermittently came up empty). The `LIMIT` still returns only the newest races.
 - **Local dev uses a `remoteSecure()` proxy to production** (`scripts/setup-feeds-remote-local.sh`,

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -253,3 +253,23 @@ are explicitly out of v1 scope:
 - Absolute **blocktime → receive** latency panels (p50/p90/p99).
 - The **gossip** feed type (`hyperliquid_gossip_*` tables, currently empty).
 - Per-symbol leaderboard, time-series charts, and historical drill-downs.
+
+## Implementation Revisions (post-review, 2026-06-29)
+
+Changes made while validating the page against production data:
+
+- **Default window is `1h`, not `24h`.** The summary table has no time-based index, so a 24h
+  aggregation over the (proxied) production table runs ~60s and exceeds the page-cache refresh
+  deadline. Only the `1h` view is cached; `24h`/`7d` remain selectable but run as slower live
+  queries. The proper fix (a time-ordered projection/materialized view on the remote summary,
+  analogous to the shreds slot-range index) is deferred and tracked for the feeds owner.
+- **Queries dedup with `uniqExact` over the sorting key instead of `FINAL`.** `FINAL` dominated
+  query time; win rates are ratios and lead percentiles are duplicate-insensitive, so dropping
+  it keeps results correct while cutting latency. The headline is derived from the per-node
+  aggregation (one fewer scan), which also makes headline and per-competitor totals consistent.
+- **Recent-races window widened to 5 minutes** (the remote MV lags ~50-90s, so a 2-minute
+  window intermittently came up empty). The `LIMIT` still returns only the newest races.
+- **Local dev uses a `remoteSecure()` proxy to production** (`scripts/setup-feeds-remote-local.sh`,
+  using the `feeds_reader` credentials) rather than static seed data, which was unrepresentative.
+- **Web page restyled** to match the shreds scoreboard (full-width layout, win-rate gauge,
+  per-vantage table).

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -30,7 +30,7 @@ across clouds/regions). All other feeds are competitors:
 | `tob_*` (all)            | **DoubleZero**| us                    |
 | `hyperliquid_public_bbo` | Public API    | baseline (free)       |
 | `hydromancer_bbo`        | Hydromancer   | paid competitor       |
-| `hyperpc_shared_bbo`     | HyperPC       | paid competitor       |
+| `hyperpc_shared_bbo`     | HypeRPC       | paid competitor       |
 | `quicknode_l2book_bbo`   | QuickNode     | paid competitor       |
 
 The competitor set lives as a small ordered slice of `{rawFeed, label}` in Go;
@@ -124,7 +124,7 @@ live query (`X-Cache: MISS`).
   "competitors": [
     { "feed": "hyperliquid_public_bbo", "label": "Public API",  "dz_win_pct": 99.1, "lead_p50_ms": 2.4, "lead_p95_ms": 8.1, "races": 12300000 },
     { "feed": "hydromancer_bbo",        "label": "Hydromancer", "dz_win_pct": 94.2, "lead_p50_ms": 0.9, "lead_p95_ms": 3.7, "races": 1100000 },
-    { "feed": "hyperpc_shared_bbo",     "label": "HyperPC",     "dz_win_pct": 97.8, "lead_p50_ms": 1.6, "lead_p95_ms": 5.2, "races": 400000 },
+    { "feed": "hyperpc_shared_bbo",     "label": "HypeRPC",     "dz_win_pct": 97.8, "lead_p50_ms": 1.6, "lead_p95_ms": 5.2, "races": 400000 },
     { "feed": "quicknode_l2book_bbo",   "label": "QuickNode",   "dz_win_pct": 95.0, "lead_p50_ms": 1.1, "lead_p95_ms": 4.4, "races": 900000 }
   ],
   "nodes": [
@@ -205,7 +205,7 @@ Hyperliquid ▸ BBO Scoreboard         window:[24h ▾]   symbol:[All ▾]
   vs Competitor   DZ win%    median lead    p95 lead    races
   Public API       99.1%      +2.4 ms        +8.1 ms     12.3M
   Hydromancer      94.2%      +0.9 ms        +3.7 ms      1.1M
-  HyperPC          97.8%      +1.6 ms        +5.2 ms      0.4M
+  HypeRPC          97.8%      +1.6 ms        +5.2 ms      0.4M
   QuickNode        95.0%      +1.1 ms        +4.4 ms      0.9M
 
   By vantage:   [chi]   [nyc]   [tyo]        (per-node cards, same stats)

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -1,0 +1,255 @@
+# Hyperliquid BBO Scoreboard Design
+
+**Status:** Approved · **Date:** 2026-06-29
+
+Live scoreboard proving DoubleZero delivers Hyperliquid best-bid/offer (BBO)
+market-data updates faster than competing feed providers. Displays DoubleZero's
+win share, per-competitor win rate and lead time, and a per-vantage breakdown,
+with a live strip of the most recent races.
+
+This is a sibling to the **Shreds / Edge Scoreboard** feature and deliberately
+reuses its patterns end to end (remote-proxied summary table → Go handler →
+page cache → React page). Where this doc is silent on a mechanism, the
+edge-scoreboard implementation (`api/handlers/edge_scoreboard.go`,
+`web/src/components/edge-scoreboard-page.tsx`) is the reference.
+
+## Concept
+
+For each Hyperliquid BBO update — uniquely identified by
+`(symbol, source_ts_ms, bbo_hash)` observed at a measurement vantage point —
+multiple **feeds** (transport/provider sources) deliver the same logical update.
+The feed with the lowest receive timestamp **wins** that race. This is the direct
+analog of a shredder "slot race", with a market-data update standing in for a
+Solana slot.
+
+**DoubleZero = every feed whose name starts with `tob_`** (our top-of-book feeds
+across clouds/regions). All other feeds are competitors:
+
+| Raw feed(s)              | Rollup label  | Role                  |
+|--------------------------|---------------|-----------------------|
+| `tob_*` (all)            | **DoubleZero**| us                    |
+| `hyperliquid_public_bbo` | Public API    | baseline (free)       |
+| `hydromancer_bbo`        | Hydromancer   | paid competitor       |
+| `hyperpc_shared_bbo`     | HyperPC       | paid competitor       |
+| `quicknode_l2book_bbo`   | QuickNode     | paid competitor       |
+
+The competitor set lives as a small ordered slice of `{rawFeed, label}` in Go;
+adding/renaming a competitor is a one-line change. The `tob_*` rollup is applied
+in SQL via `startsWith(feed, 'tob_')`.
+
+## Data Source
+
+**Table:** `{feeds_db}.hyperliquid_bbo_feed_race_summary` (default db: `feeds`)
+
+This summary table already exists on the remote ClickHouse Cloud instance
+(`btjr1b5uy8…`, the **same host as shredder**) and is maintained there by an
+existing refreshable materialized view (`hyperliquid_mv_bbo_feed_race_summary`,
+`REFRESH EVERY 1 MINUTE APPEND`) reading from raw `feeds.hyperliquid_bbo_observations`.
+**Lake does not build or own any materialized view** — it only proxies and reads
+the summary, exactly as it does for `shredder.slot_feed_race_summary_v2`.
+
+| Column                  | Type                  | Description                                                        |
+|-------------------------|-----------------------|-------------------------------------------------------------------|
+| event_ts                | DateTime64(9, UTC)    | Winner receive time for the race                                  |
+| ingested_at             | DateTime64(9, UTC)    | Row write time (ReplacingMergeTree version column)               |
+| capture_run_id          | String                | Capture session id (part of race key)                            |
+| measurement_node_id     | String                | Vantage recorder, e.g. `chi-mn-recorder1`                        |
+| host                    | String                | Recorder host                                                    |
+| location_code           | LowCardinality(String)| Vantage metro: `chi`, `nyc`, `tyo`                               |
+| feed_type               | LowCardinality(String)| Always `bbo` in v1 (gossip type exists but is unpopulated)       |
+| symbol                  | LowCardinality(String)| Trading symbol, e.g. `BTC`, `ETH`, `xyz:SILVER` (~300 distinct)  |
+| source_ts_ms            | UInt64                | Source-side update timestamp (part of race key)                  |
+| bbo_hash                | UInt64                | Hash of the BBO payload (part of race key)                       |
+| feed                    | LowCardinality(String)| The **winner** feed for the row                                  |
+| loser_feed              | LowCardinality(String)| `''` for aggregate rows; the loser feed for pairwise rows        |
+| total_events            | UInt64                | Always `1` (one race per row)                                    |
+| events_won              | UInt64                | Always `1` (one race per row)                                    |
+| lead_time_p50_ms        | Float64               | Lead in ms over `loser_feed` for this race (p50 == p95)          |
+| lead_time_p95_ms        | Float64               | Same value as p50 (single sample per row)                        |
+| send_lead_time_p50_ms   | Nullable(Float64)     | Send-timestamp-based lead (sparse; **unused in v1**)             |
+| send_lead_time_p95_ms   | Nullable(Float64)     | Same (unused in v1)                                              |
+
+**Key semantics (verified against live data):**
+- **One row == one race.** `events_won == total_events == 1` and
+  `lead_time_p50_ms == lead_time_p95_ms` for every row. Therefore aggregating
+  `quantileExact(q)(lead_time_p50_ms)` across rows yields an **exact** lead-time
+  distribution, and counting rows counts races.
+- **Aggregate rows** (`loser_feed = ''`): one per `(race key, winner feed)` —
+  used for "who won" counts.
+- **Pairwise rows** (`loser_feed != ''`): one per `(race key, winner, loser)` —
+  carry the per-race lead of the winner over that specific loser.
+- Query with `FINAL` to dedup the ReplacingMergeTree (overlapping MV append
+  windows write the same race key repeatedly).
+- The race key is `(capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash)`.
+
+### Why summary-only is sufficient and exact for v1
+
+Because each row is a single race with its exact lead, the summary table answers
+every v1 metric exactly and cheaply, with no need to touch the 33B-row /
+667 GiB raw `hyperliquid_bbo_observations` table. The raw table is required only
+for deferred features (see Non-Goals).
+
+**One semantic caveat (accepted for v1):** pairwise rows only relate the race
+*winner* to each loser. When a *third* feed wins a race in which both DoubleZero
+and competitor X participated, that race does not produce a direct `tob_*`-vs-`X`
+pairwise row, so it is excluded from the X head-to-head. Given `tob_*` wins the
+large majority of races, this is a negligible undercount. The exact fix (recompute
+head-to-head from raw observations) is the deferred raw-table path.
+
+## API
+
+**`GET /api/dz/hyperliquid/scoreboard`**
+
+Query params:
+- `window` — `1h`, `24h`, `7d` (default: `24h`)
+- `symbol` — a symbol to filter to, or omitted/`all` for the aggregate (default: all)
+- `since_ts` — RFC3339 / epoch cursor for the live tail (returns races after the
+  cursor; bypasses the standard cache, served from the fast-refresh cache)
+
+Param handling mirrors the edge scoreboard: the **default request shape**
+(`window=24h` or omitted, no `symbol`, no `since_ts`) is served from the page
+cache (`X-Cache: HIT`); any other shape bypasses the cache and runs a bounded
+live query (`X-Cache: MISS`).
+
+### Response
+
+```json
+{
+  "window": "24h",
+  "symbol": null,
+  "generated_at": "2026-06-29T17:00:00Z",
+  "feed_type": "bbo",
+  "dz_win_share_pct": 96.4,
+  "total_races": 13680322,
+  "competitors": [
+    { "feed": "hyperliquid_public_bbo", "label": "Public API",  "dz_win_pct": 99.1, "lead_p50_ms": 2.4, "lead_p95_ms": 8.1, "races": 12300000 },
+    { "feed": "hydromancer_bbo",        "label": "Hydromancer", "dz_win_pct": 94.2, "lead_p50_ms": 0.9, "lead_p95_ms": 3.7, "races": 1100000 },
+    { "feed": "hyperpc_shared_bbo",     "label": "HyperPC",     "dz_win_pct": 97.8, "lead_p50_ms": 1.6, "lead_p95_ms": 5.2, "races": 400000 },
+    { "feed": "quicknode_l2book_bbo",   "label": "QuickNode",   "dz_win_pct": 95.0, "lead_p50_ms": 1.1, "lead_p95_ms": 4.4, "races": 900000 }
+  ],
+  "nodes": [
+    {
+      "measurement_node_id": "aws-tyo-mn-recorder1",
+      "location_code": "tyo",
+      "dz_win_share_pct": 99.2,
+      "total_races": 4600000,
+      "competitors": [
+        { "feed": "hydromancer_bbo", "label": "Hydromancer", "dz_win_pct": 98.9, "lead_p50_ms": 0.6, "lead_p95_ms": 2.1, "races": 380000 }
+      ]
+    }
+  ],
+  "recent_races": [
+    { "event_ts": "2026-06-29T16:59:59.9Z", "symbol": "BTC", "winner_feed": "tob_gcp_tyo_hl_mainnet1", "is_dz": true, "runner_up_feed": "hydromancer_bbo", "runner_up_label": "Hydromancer", "lead_ms": 1.2, "location_code": "tyo" }
+  ]
+}
+```
+
+Notes:
+- `dz_win_share_pct` uses the dashboard's win-share definition:
+  `sumIf(events_won, startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
+   / nullIf(sumIf(events_won, startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0)`
+  over pairwise rows (`loser_feed != '' AND feed != loser_feed`).
+- Per-competitor `dz_win_pct` and `lead_p50/p95_ms` come from pairwise rows where
+  exactly one side is `tob_*` and the other is that competitor; lead percentiles
+  are `quantileExact` over `lead_time_p50_ms` for races DoubleZero won.
+- `nodes[]` is the same computation grouped by `measurement_node_id` /
+  `location_code` (the per-vantage breakdown).
+- `recent_races[]` is the newest aggregate rows (`loser_feed=''`) ordered by
+  `event_ts DESC`, joined to the closest competitor + lead.
+
+## Caching
+
+Registered in `api/worker/workflow.go` alongside the edge-scoreboard entries:
+- **`hyperliquid_scoreboard`** — default view (all symbols, `window=24h`,
+  aggregated + per-node). Standard 30s refresh.
+- **`hyperliquid_scoreboard:latest`** — last N races for the live strip.
+  Fast refresh (~3–5s), mirroring `edge_scoreboard:latest`.
+
+Symbol-filtered or non-default-window requests bypass the cache and run bounded
+live queries. The handler reads the cache for the default shape exactly like
+`GetEdgeScoreboard`.
+
+## Backend Changes
+
+| File | Change |
+|------|--------|
+| `admin/remotetables/setup.go` | add `{"feeds", "hyperliquid_bbo_feed_race_summary"}` to `externalRemoteTables` |
+| `api/config/config.go` | add `feedsDB = "feeds"`, `CLICKHOUSE_FEEDS_DB` override, `GetFeedsDB()`/`SetFeedsDB()` |
+| `api/handlers/api.go` | add `FeedsDB string` field on `API` |
+| `api/main.go` | init `FeedsDB: config.GetFeedsDB()`; register `GET /api/dz/hyperliquid/scoreboard` |
+| `api/handlers/hyperliquid_scoreboard.go` (new) | `GetHyperliquidScoreboard`, `FetchHyperliquidScoreboardData`, response structs, rollup + competitor table |
+| `api/worker/workflow.go` | register `hyperliquid_scoreboard` + `hyperliquid_scoreboard:latest` cache entries |
+
+**Prerequisite (ops):** lake's existing remote reader (`REMOTE_CH_*`) must be
+granted `SELECT` on `feeds.*` on the ClickHouse Cloud instance. This preserves the
+single-credential proxy model (no new credential plumbing in
+`admin/remotetables/setup.go`). The separate `feeds_reader` credential is used only
+for the local seed script.
+
+## Web Changes
+
+| File | Change |
+|------|--------|
+| `web/src/App.tsx` | route `/dz/hyperliquid` → redirect to `/dz/hyperliquid/scoreboard` → `HyperliquidScoreboardPage` |
+| `web/src/components/sidebar.tsx` | new **"Hyperliquid"** collapsible group under the **Edge** section, sibling to **Shreds**; child **Scoreboard**; `isHyperliquidRoute` detection |
+| `web/src/components/hyperliquid-scoreboard-page.tsx` (new) | the page (header, headline, per-competitor table, per-node cards, live races strip, window + symbol selectors) |
+| `web/src/lib/api.ts` | `fetchHyperliquidScoreboard(window, symbol, opts)` + `HyperliquidScoreboardResponse` / `…Competitor` / `…Node` / `…Race` types |
+
+### Page layout
+
+```
+Hyperliquid ▸ BBO Scoreboard         window:[24h ▾]   symbol:[All ▾]
+
+  DoubleZero wins  96.4%  of races            (all vantages, 24h)
+
+  vs Competitor   DZ win%    median lead    p95 lead    races
+  Public API       99.1%      +2.4 ms        +8.1 ms     12.3M
+  Hydromancer      94.2%      +0.9 ms        +3.7 ms      1.1M
+  HyperPC          97.8%      +1.6 ms        +5.2 ms      0.4M
+  QuickNode        95.0%      +1.1 ms        +4.4 ms      0.9M
+
+  By vantage:   [chi]   [nyc]   [tyo]        (per-node cards, same stats)
+
+  Recent races (live)   symbol  winner               lead vs runner-up
+  BTC   DoubleZero (tob_gcp_tyo)     +1.2 ms vs Hydromancer
+  ...                                            (polls :latest cache)
+```
+
+The page is built lean (not a fork of the ~1,950-line edge page). Shared chrome
+(`PageHeader`, `Tooltip`, formatting helpers) is reused; bespoke gauge/bar
+components are built locally for v1. Extracting shared scoreboard components is a
+possible later refactor, intentionally deferred to avoid coupling two large files.
+
+## Error Handling
+
+- **Missing proxy table** (e.g., local dev without the `feeds` proxy): the handler
+  returns an empty-but-valid response and the page renders a "no data yet" state —
+  the same failure mode shredder has. The page-cache refresher gates its
+  `feeds`-backed entries on table presence so it does not reproduce the noisy
+  repeating `Database … does not exist` log loop.
+- **Cache miss / transient DB error:** degrade to the last cached value when
+  present; the page never returns a 500 for a data-availability problem.
+
+## Testing
+
+- **Go** — `api/handlers/hyperliquid_scoreboard_test.go`: seed a local
+  `feeds.hyperliquid_bbo_feed_race_summary` with crafted rows (mirroring how
+  `edge_scoreboard_test.go` seeds `slot_feed_race_summary_v2`) and assert:
+  the `tob_*` rollup, `dz_win_share_pct`, per-competitor `dz_win_pct` and exact
+  lead percentiles, and per-node grouping — all against known inputs.
+- **Seed script** — `scripts/seed-hyperliquid-local.sh`: pull recent rows from
+  remote `feeds` (using the `feeds_reader` credentials) into local ClickHouse for
+  UI development; the analog of `seed-shredder-local.sh`.
+- **Web** — `tsc -b` clean; manual smoke against seeded/proxied data.
+
+## Non-Goals (deferred to v2+)
+
+These require the raw `hyperliquid_bbo_observations` table and/or new surfaces and
+are explicitly out of v1 scope:
+- Send-vs-receive **loss attribution** (`send_timestamp_ns`: "publisher sent late"
+  vs "network was slower").
+- Strict three-way **head-to-head** (recomputed from raw, removing the win-share
+  caveat above).
+- Absolute **blocktime → receive** latency panels (p50/p90/p99).
+- The **gossip** feed type (`hyperliquid_gossip_*` tables, currently empty).
+- Per-symbol leaderboard, time-series charts, and historical drill-downs.

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - User-facing product name is **"DoubleZero Data"**, not "Lake".
-- DoubleZero rollup = any feed where `startsWith(feed, 'tob_')`. Competitors (raw feed → label): `hyperliquid_public_bbo`→`Public API`, `hydromancer_bbo`→`Hydromancer`, `hyperpc_shared_bbo`→`HyperPC`, `quicknode_l2book_bbo`→`QuickNode`.
+- DoubleZero rollup = any feed where `startsWith(feed, 'tob_')`. Competitors (raw feed → label): `hyperliquid_public_bbo`→`Public API`, `hydromancer_bbo`→`Hydromancer`, `hyperpc_shared_bbo`→`HypeRPC`, `quicknode_l2book_bbo`→`QuickNode`.
 - Source table: `{FeedsDB}.hyperliquid_bbo_feed_race_summary`, default db name `feeds`, overridable via `CLICKHOUSE_FEEDS_DB`. Always query with `FINAL` (ReplacingMergeTree).
 - Race key columns: `(capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash)`.
 - Window values: `1h`, `24h`, `7d`; default `24h`. Default (cacheable) request shape = no `symbol`, no `since_ts`, window omitted or `24h`.
@@ -306,7 +306,7 @@ import (
 var hyperliquidCompetitors = []struct{ Feed, Label string }{
 	{"hyperliquid_public_bbo", "Public API"},
 	{"hydromancer_bbo", "Hydromancer"},
-	{"hyperpc_shared_bbo", "HyperPC"},
+	{"hyperpc_shared_bbo", "HypeRPC"},
 	{"quicknode_l2book_bbo", "QuickNode"},
 }
 

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
@@ -1,0 +1,1395 @@
+# Hyperliquid BBO Scoreboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a lean "Hyperliquid ▸ BBO Scoreboard" page (sibling to Shreds) that proves DoubleZero (`tob_*` feeds) delivers Hyperliquid best-bid/offer updates faster than competing providers, with a per-vantage breakdown and a live recent-races strip.
+
+**Architecture:** Backend is a near-clone of the shredder edge-scoreboard. We proxy the remote, pre-aggregated `feeds.hyperliquid_bbo_feed_race_summary` table into lake via `remoteSecure()`, compute win-share / per-competitor / per-node metrics from it (all exact, since every row is one race), serve them through a cached `GET /api/dz/hyperliquid/scoreboard` endpoint, and render a React page. No materialized view is built in lake (the remote owns it); the raw observations table is **not** used in v1.
+
+**Tech Stack:** Go (chi router, ClickHouse-go), ClickHouse, Temporal page-cache worker, React + Vite + TypeScript + Tailwind v4.
+
+## Global Constraints
+
+- User-facing product name is **"DoubleZero Data"**, not "Lake".
+- DoubleZero rollup = any feed where `startsWith(feed, 'tob_')`. Competitors (raw feed → label): `hyperliquid_public_bbo`→`Public API`, `hydromancer_bbo`→`Hydromancer`, `hyperpc_shared_bbo`→`HyperPC`, `quicknode_l2book_bbo`→`QuickNode`.
+- Source table: `{FeedsDB}.hyperliquid_bbo_feed_race_summary`, default db name `feeds`, overridable via `CLICKHOUSE_FEEDS_DB`. Always query with `FINAL` (ReplacingMergeTree).
+- Race key columns: `(capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash)`.
+- Window values: `1h`, `24h`, `7d`; default `24h`. Default (cacheable) request shape = no `symbol`, no `since_ts`, window omitted or `24h`.
+- Win-share / per-competitor counts use the production Grafana methodology (per-pairwise-comparison; `events_won` is always `1`, so `countIf` == `sumIf(events_won, …)`). Lead percentiles use `quantileExact` over `lead_time_p50_ms` (one sample per row = exact distribution).
+- Go commit style: `component: short description`, lowercase, **no Co-Authored-By footer**. Commits are SSH-signed (1Password agent is forwarded; approve the prompt).
+- TypeScript strict mode: `cd web && bunx tsc -b` must pass.
+- ClickHouse handler tests run against the local ClickHouse via the `apitesting` harness and require a running local ClickHouse (the k3d dev env). They are skipped/fail without it — run them in the dev environment.
+
+---
+
+### Task 1: Wire the `feeds` database config + API field + test harness
+
+**Files:**
+- Modify: `api/config/config.go` (after the `dzdpDB` block ~line 36, the getters ~line 84, and the env reads ~line 155)
+- Modify: `api/handlers/api.go:43-45` (API struct DB fields)
+- Modify: `api/main.go:362-364` (API init)
+- Modify: `api/testing/api.go` (NewTestAPIBare ~26, NewTestAPI ~46, NewTestAPIAll ~82)
+- Test: `api/config/config_test.go` (create)
+
+**Interfaces:**
+- Produces: `config.GetFeedsDB() string`, `config.SetFeedsDB(string)`, package var `feedsDB` (default `"feeds"`); `handlers.API.FeedsDB string` field; test APIs set `FeedsDB` to the per-test db name.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/config/config_test.go`:
+```go
+package config
+
+import "testing"
+
+func TestFeedsDBDefaultAndSetter(t *testing.T) {
+	SetFeedsDB("feeds")
+	if got := GetFeedsDB(); got != "feeds" {
+		t.Fatalf("default GetFeedsDB() = %q, want %q", got, "feeds")
+	}
+	SetFeedsDB("feeds_qa")
+	if got := GetFeedsDB(); got != "feeds_qa" {
+		t.Fatalf("after SetFeedsDB, GetFeedsDB() = %q, want %q", got, "feeds_qa")
+	}
+	SetFeedsDB("feeds") // restore default for other tests
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./api/config/ -run TestFeedsDBDefaultAndSetter -v`
+Expected: FAIL — `undefined: SetFeedsDB` / `undefined: GetFeedsDB`.
+
+- [ ] **Step 3: Add the config var, getters, and env override**
+
+In `api/config/config.go`, after the `dzdpDB` declaration (line 36):
+```go
+// feedsDB is the ClickHouse database name for the Hyperliquid feeds tables (default: "feeds").
+var feedsDB = "feeds"
+```
+After `SetDZDPDB` (line 84):
+```go
+// GetFeedsDB returns the feeds database name.
+func GetFeedsDB() string {
+	return feedsDB
+}
+
+// SetFeedsDB sets the feeds database name.
+func SetFeedsDB(db string) {
+	feedsDB = db
+}
+```
+In `Load()`, after the `CLICKHOUSE_DZDP_DB` block (line 155):
+```go
+	if db := os.Getenv("CLICKHOUSE_FEEDS_DB"); db != "" {
+		feedsDB = db
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./api/config/ -run TestFeedsDBDefaultAndSetter -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the `FeedsDB` field and wire it everywhere**
+
+In `api/handlers/api.go`, in the `API` struct next to the other DB names (after line 45 `DZDPDB string`):
+```go
+	FeedsDB       string
+```
+In `api/main.go`, in the `&handlers.API{...}` literal after line 364 `DZDPDB: config.GetDZDPDB(),`:
+```go
+		FeedsDB:       config.GetFeedsDB(),
+```
+In `api/testing/api.go`, add `FeedsDB: dbName,` after the `ShredderDB: dbName,` line in **both** `NewTestAPIBare` (line 24) and `NewTestAPI` (line 44); and in `NewTestAPIAll` add `api.FeedsDB = dbName` after line 81 `api.ShredderDB = dbName`.
+
+- [ ] **Step 6: Build to verify wiring**
+
+Run: `go build ./api/...`
+Expected: builds cleanly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/config/config.go api/config/config_test.go api/handlers/api.go api/main.go api/testing/api.go
+git commit -m "api: add feeds database config and FeedsDB wiring"
+```
+
+---
+
+### Task 2: Register the remote proxy table
+
+**Files:**
+- Modify: `admin/remotetables/setup.go` (the `externalRemoteTables` slice, ~lines 16-39)
+- Test: `admin/remotetables/setup_test.go` (create if absent, else add a test)
+
+**Interfaces:**
+- Produces: `externalRemoteTables` includes `{"feeds", "hyperliquid_bbo_feed_race_summary"}`, so `Setup()` creates a local `remoteSecure()` proxy `feeds.hyperliquid_bbo_feed_race_summary`.
+
+**Note (ops prerequisite, not code):** lake's existing remote reader (`REMOTE_CH_USER`) must have `SELECT` on `feeds.*` on the ClickHouse Cloud instance. Without it the proxy is created but queries fail; the handler degrades gracefully (Task 6). Record this as a deploy dependency.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `admin/remotetables/setup_test.go` (adjust the package name to match `setup.go`'s package if it differs):
+```go
+package remotetables
+
+import "testing"
+
+func TestExternalRemoteTablesIncludesFeeds(t *testing.T) {
+	found := false
+	for _, e := range externalRemoteTables {
+		if e.database == "feeds" && e.table == "hyperliquid_bbo_feed_race_summary" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("externalRemoteTables missing feeds.hyperliquid_bbo_feed_race_summary")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (and confirm field names)**
+
+Run: `go test ./admin/remotetables/ -run TestExternalRemoteTablesIncludesFeeds -v`
+Expected: FAIL. If it fails to **compile** on `e.database`/`e.table`, open `admin/remotetables/setup.go`, read the struct field names used by `externalRemoteTables` entries, and update the test to match (the entries were quoted in exploration as `{"shredder", "slot_feed_race_summary_v2"}` etc.).
+
+- [ ] **Step 3: Add the entry**
+
+In `admin/remotetables/setup.go`, in the `externalRemoteTables` slice, add alongside the `shredder` entries:
+```go
+	{"feeds", "hyperliquid_bbo_feed_race_summary"},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./admin/remotetables/ -run TestExternalRemoteTablesIncludesFeeds -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin/remotetables/setup.go admin/remotetables/setup_test.go
+git commit -m "admin: proxy feeds.hyperliquid_bbo_feed_race_summary remote table"
+```
+
+---
+
+### Task 3: Response types, seed helper, headline + per-competitor query
+
+**Files:**
+- Create: `api/handlers/hyperliquid_scoreboard.go`
+- Create: `api/handlers/hyperliquid_scoreboard_test.go`
+
+**Interfaces:**
+- Produces:
+  - Types `HyperliquidCompetitor`, `HyperliquidNode`, `HyperliquidRace`, `HyperliquidScoreboardResponse` (JSON shapes below).
+  - `var hyperliquidCompetitors = []struct{ Feed, Label string }{…}` (ordered).
+  - `var hyperliquidWindows = map[string]string{"1h":"1 HOUR","24h":"24 HOUR","7d":"7 DAY"}`.
+  - `func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol string) (*HyperliquidScoreboardResponse, error)` — in this task it fills `DZWinSharePct`, `TotalRaces`, `Competitors`; `Nodes`/`RecentRaces` come in Tasks 4–5.
+  - `func sanitizeHyperliquidSymbol(s string) string` — returns the symbol if it matches `^[A-Za-z0-9:_.-]{1,32}$`, else `""`.
+- Consumes: `a.FeedsDB`, `a.envDB(ctx)` (from Task 1 / existing).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/handlers/hyperliquid_scoreboard_test.go`:
+```go
+package handlers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createFeedsTable creates the hyperliquid_bbo_feed_race_summary table in the feeds DB.
+func createFeedsTable(t *testing.T, api *handlers.API) {
+	t.Helper()
+	ctx := t.Context()
+	db := "`" + api.FeedsDB + "`"
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", db)))
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.hyperliquid_bbo_feed_race_summary (
+			event_ts DateTime64(9),
+			ingested_at DateTime64(9) DEFAULT now64(9),
+			capture_run_id String,
+			measurement_node_id String,
+			host String,
+			location_code LowCardinality(String),
+			feed_type LowCardinality(String) DEFAULT 'bbo',
+			symbol LowCardinality(String),
+			source_ts_ms UInt64,
+			bbo_hash UInt64,
+			feed LowCardinality(String),
+			loser_feed LowCardinality(String) DEFAULT '',
+			total_events UInt64,
+			events_won UInt64,
+			lead_time_p50_ms Float64 DEFAULT 0,
+			lead_time_p95_ms Float64 DEFAULT 0,
+			send_lead_time_p50_ms Nullable(Float64) DEFAULT NULL,
+			send_lead_time_p95_ms Nullable(Float64) DEFAULT NULL
+		) ENGINE = ReplacingMergeTree(ingested_at)
+		PARTITION BY toDate(event_ts)
+		ORDER BY (measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)
+	`, db)))
+}
+
+// pairwiseRow inserts one pairwise race row (winner feed beat loser_feed by leadMs).
+func insertPairwise(t *testing.T, api *handlers.API, node, loc, symbol string, srcTs, hash uint64, winner, loser string, leadMs float64) {
+	t.Helper()
+	ctx := t.Context()
+	db := "`" + api.FeedsDB + "`"
+	require.NoError(t, api.DB.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.hyperliquid_bbo_feed_race_summary
+		(event_ts, capture_run_id, measurement_node_id, host, location_code, symbol, source_ts_ms, bbo_hash, feed, loser_feed, total_events, events_won, lead_time_p50_ms, lead_time_p95_ms)
+		VALUES (now64(9), 'run1', '%s', '%s', '%s', '%s', %d, %d, '%s', '%s', 1, 1, %f, %f)
+	`, db, node, node, loc, symbol, srcTs, hash, winner, loser, leadMs, leadMs)))
+}
+
+func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// 3 races at node tyo: DZ (tob_*) beats Hydromancer twice, loses once.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	// DZ won 2 of 3 comparable races = 66.67%.
+	assert.InDelta(t, 66.67, resp.DZWinSharePct, 0.1)
+	assert.EqualValues(t, 3, resp.TotalRaces)
+
+	var hydro *handlers.HyperliquidCompetitor
+	for i := range resp.Competitors {
+		if resp.Competitors[i].Feed == "hydromancer_bbo" {
+			hydro = &resp.Competitors[i]
+		}
+	}
+	require.NotNil(t, hydro)
+	assert.Equal(t, "Hydromancer", hydro.Label)
+	assert.InDelta(t, 66.67, hydro.DZWinPct, 0.1)
+	assert.EqualValues(t, 3, hydro.Races)
+	// Lead p50 over the 2 DZ wins (1.0, 3.0) = 1.0 (quantileExact lower).
+	assert.InDelta(t, 1.0, hydro.LeadP50Ms, 0.001)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./api/handlers/ -run TestHyperliquidScoreboard_HeadlineAndCompetitors -v`
+Expected: FAIL — `undefined: api.FetchHyperliquidScoreboardData` / `undefined: handlers.HyperliquidCompetitor`.
+
+- [ ] **Step 3: Create the handler file with types + the fetch**
+
+Create `api/handlers/hyperliquid_scoreboard.go`:
+```go
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
+// in display order, mapping each raw feed name to its label.
+var hyperliquidCompetitors = []struct{ Feed, Label string }{
+	{"hyperliquid_public_bbo", "Public API"},
+	{"hydromancer_bbo", "Hydromancer"},
+	{"hyperpc_shared_bbo", "HyperPC"},
+	{"quicknode_l2book_bbo", "QuickNode"},
+}
+
+// hyperliquidWindows maps window params to ClickHouse interval expressions.
+var hyperliquidWindows = map[string]string{
+	"1h":  "1 HOUR",
+	"24h": "24 HOUR",
+	"7d":  "7 DAY",
+}
+
+var hyperliquidSymbolRe = regexp.MustCompile(`^[A-Za-z0-9:_.-]{1,32}$`)
+
+// sanitizeHyperliquidSymbol returns the symbol if safe to inline, else "".
+func sanitizeHyperliquidSymbol(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.EqualFold(s, "all") || !hyperliquidSymbolRe.MatchString(s) {
+		return ""
+	}
+	return s
+}
+
+// HyperliquidCompetitor is DoubleZero's head-to-head record vs one competitor feed.
+type HyperliquidCompetitor struct {
+	Feed      string  `json:"feed"`
+	Label     string  `json:"label"`
+	DZWinPct  float64 `json:"dz_win_pct"`
+	LeadP50Ms float64 `json:"lead_p50_ms"`
+	LeadP95Ms float64 `json:"lead_p95_ms"`
+	Races     uint64  `json:"races"`
+}
+
+// HyperliquidNode is the per-vantage breakdown.
+type HyperliquidNode struct {
+	MeasurementNodeID string                  `json:"measurement_node_id"`
+	LocationCode      string                  `json:"location_code"`
+	DZWinSharePct     float64                 `json:"dz_win_share_pct"`
+	TotalRaces        uint64                  `json:"total_races"`
+	Competitors       []HyperliquidCompetitor `json:"competitors"`
+}
+
+// HyperliquidRace is one recent race for the live strip.
+type HyperliquidRace struct {
+	EventTs       time.Time `json:"event_ts"`
+	Symbol        string    `json:"symbol"`
+	LocationCode  string    `json:"location_code"`
+	WinnerFeed    string    `json:"winner_feed"`
+	IsDZ          bool      `json:"is_dz"`
+	RunnerUpFeed  string    `json:"runner_up_feed"`
+	RunnerUpLabel string    `json:"runner_up_label"`
+	LeadMs        float64   `json:"lead_ms"`
+}
+
+// HyperliquidScoreboardResponse is the API response.
+type HyperliquidScoreboardResponse struct {
+	Window        string                  `json:"window"`
+	Symbol        string                  `json:"symbol,omitempty"`
+	GeneratedAt   time.Time               `json:"generated_at"`
+	FeedType      string                  `json:"feed_type"`
+	DZWinSharePct float64                 `json:"dz_win_share_pct"`
+	TotalRaces    uint64                  `json:"total_races"`
+	Competitors   []HyperliquidCompetitor `json:"competitors"`
+	Nodes         []HyperliquidNode       `json:"nodes"`
+	RecentRaces   []HyperliquidRace       `json:"recent_races"`
+}
+
+// labelForFeed maps a raw competitor feed to its display label (falls back to the raw name).
+func labelForFeed(feed string) string {
+	for _, c := range hyperliquidCompetitors {
+		if c.Feed == feed {
+			return c.Label
+		}
+	}
+	return feed
+}
+
+// FetchHyperliquidScoreboardData computes the aggregated scoreboard for a window and
+// optional symbol. Empty symbol means all symbols.
+func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol string) (*HyperliquidScoreboardResponse, error) {
+	interval, ok := hyperliquidWindows[window]
+	if !ok {
+		window = "24h"
+		interval = hyperliquidWindows[window]
+	}
+	symbol = sanitizeHyperliquidSymbol(symbol)
+	symbolFilter := ""
+	if symbol != "" {
+		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
+	}
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+
+	resp := &HyperliquidScoreboardResponse{
+		Window:      window,
+		Symbol:      symbol,
+		GeneratedAt: time.Now().UTC(),
+		FeedType:    "bbo",
+		Competitors: []HyperliquidCompetitor{},
+		Nodes:       []HyperliquidNode{},
+		RecentRaces: []HyperliquidRace{},
+	}
+
+	// Headline: DZ win share over all DZ-vs-competitor pairwise comparisons.
+	headlineQ := fmt.Sprintf(`
+		SELECT
+			100.0 * countIf(startsWith(feed,'tob_') AND NOT startsWith(loser_feed,'tob_'))
+			      / nullIf(countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')), 0) AS dz_win_share_pct,
+			countIf(startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) AS total_races
+		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+		WHERE feed != loser_feed AND loser_feed != '' %s
+		  AND event_ts >= now() - INTERVAL %s`, db, symbolFilter, interval)
+	var winShare float64
+	var totalRaces uint64
+	if err := a.envDB(ctx).QueryRow(ctx, headlineQ).Scan(&winShare, &totalRaces); err != nil {
+		return nil, err
+	}
+	resp.DZWinSharePct = winShare
+	resp.TotalRaces = totalRaces
+
+	// Per-competitor: win%, lead p50/p95 (over DZ wins), and total comparable races.
+	compQ := fmt.Sprintf(`
+		SELECT competitor,
+			countIf(dz_won = 1) AS dz_wins,
+			countIf(dz_won = 0) AS dz_losses,
+			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
+			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+		FROM (
+			SELECT
+				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
+				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
+				lead_time_p50_ms AS lead_ms
+			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			WHERE feed != loser_feed AND loser_feed != ''
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
+			  AND event_ts >= now() - INTERVAL %s
+		)
+		GROUP BY competitor`, db, symbolFilter, interval)
+	rows, err := a.envDB(ctx).Query(ctx, compQ)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type stat struct {
+		wins, losses        uint64
+		leadP50, leadP95    float64
+	}
+	byFeed := map[string]stat{}
+	for rows.Next() {
+		var competitor string
+		var s stat
+		if err := rows.Scan(&competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+			return nil, err
+		}
+		byFeed[competitor] = s
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Emit competitors in configured order.
+	for _, c := range hyperliquidCompetitors {
+		s, ok := byFeed[c.Feed]
+		if !ok {
+			continue
+		}
+		races := s.wins + s.losses
+		var winPct float64
+		if races > 0 {
+			winPct = 100.0 * float64(s.wins) / float64(races)
+		}
+		resp.Competitors = append(resp.Competitors, HyperliquidCompetitor{
+			Feed:      c.Feed,
+			Label:     c.Label,
+			DZWinPct:  winPct,
+			LeadP50Ms: s.leadP50,
+			LeadP95Ms: s.leadP95,
+			Races:     races,
+		})
+	}
+
+	return resp, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./api/handlers/ -run TestHyperliquidScoreboard_HeadlineAndCompetitors -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/handlers/hyperliquid_scoreboard.go api/handlers/hyperliquid_scoreboard_test.go
+git commit -m "api: hyperliquid scoreboard headline and per-competitor query"
+```
+
+---
+
+### Task 4: Per-node (per-vantage) breakdown
+
+**Files:**
+- Modify: `api/handlers/hyperliquid_scoreboard.go` (add a query to `FetchHyperliquidScoreboardData`, populating `resp.Nodes`)
+- Modify: `api/handlers/hyperliquid_scoreboard_test.go` (add a test)
+
+**Interfaces:**
+- Consumes: `FetchHyperliquidScoreboardData` from Task 3.
+- Produces: `resp.Nodes []HyperliquidNode`, one per `measurement_node_id`, each with its own `DZWinSharePct`, `TotalRaces`, and ordered `Competitors`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `api/handlers/hyperliquid_scoreboard_test.go`:
+```go
+func TestHyperliquidScoreboard_PerNode(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// tyo: DZ wins both vs QuickNode. nyc: DZ wins 1, loses 1 vs QuickNode.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "quicknode_l2book_bbo", 1.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "quicknode_l2book_bbo", "tob_aws_galaxy1", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.Len(t, resp.Nodes, 2)
+
+	byNode := map[string]handlers.HyperliquidNode{}
+	for _, n := range resp.Nodes {
+		byNode[n.MeasurementNodeID] = n
+	}
+	assert.InDelta(t, 100.0, byNode["tyo-rec1"].DZWinSharePct, 0.1)
+	assert.InDelta(t, 50.0, byNode["nyc-rec1"].DZWinSharePct, 0.1)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./api/handlers/ -run TestHyperliquidScoreboard_PerNode -v`
+Expected: FAIL — `resp.Nodes` is empty (length 0, not 2).
+
+- [ ] **Step 3: Add the per-node query**
+
+In `FetchHyperliquidScoreboardData`, before `return resp, nil`, add:
+```go
+	// Per-node: same comparison, grouped by measurement node + competitor.
+	nodeQ := fmt.Sprintf(`
+		SELECT measurement_node_id, location_code, competitor,
+			countIf(dz_won = 1) AS dz_wins,
+			countIf(dz_won = 0) AS dz_losses,
+			quantileExactIf(0.5)(lead_ms, dz_won = 1) AS lead_p50,
+			quantileExactIf(0.95)(lead_ms, dz_won = 1) AS lead_p95
+		FROM (
+			SELECT measurement_node_id, location_code,
+				if(startsWith(feed,'tob_'), loser_feed, feed) AS competitor,
+				if(startsWith(feed,'tob_'), 1, 0) AS dz_won,
+				lead_time_p50_ms AS lead_ms
+			FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+			WHERE feed != loser_feed AND loser_feed != ''
+			  AND (startsWith(feed,'tob_') != startsWith(loser_feed,'tob_')) %s
+			  AND event_ts >= now() - INTERVAL %s
+		)
+		GROUP BY measurement_node_id, location_code, competitor`, db, symbolFilter, interval)
+	nrows, err := a.envDB(ctx).Query(ctx, nodeQ)
+	if err != nil {
+		return nil, err
+	}
+	defer nrows.Close()
+
+	type nodeAgg struct {
+		loc   string
+		byFeed map[string]stat
+	}
+	nodeMap := map[string]*nodeAgg{}
+	var nodeOrder []string
+	for nrows.Next() {
+		var node, loc, competitor string
+		var s stat
+		if err := nrows.Scan(&node, &loc, &competitor, &s.wins, &s.losses, &s.leadP50, &s.leadP95); err != nil {
+			return nil, err
+		}
+		na, ok := nodeMap[node]
+		if !ok {
+			na = &nodeAgg{loc: loc, byFeed: map[string]stat{}}
+			nodeMap[node] = na
+			nodeOrder = append(nodeOrder, node)
+		}
+		na.byFeed[competitor] = s
+	}
+	if err := nrows.Err(); err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodeOrder {
+		na := nodeMap[node]
+		n := HyperliquidNode{
+			MeasurementNodeID: node,
+			LocationCode:      na.loc,
+			Competitors:       []HyperliquidCompetitor{},
+		}
+		var wins, races uint64
+		for _, c := range hyperliquidCompetitors {
+			s, ok := na.byFeed[c.Feed]
+			if !ok {
+				continue
+			}
+			r := s.wins + s.losses
+			var winPct float64
+			if r > 0 {
+				winPct = 100.0 * float64(s.wins) / float64(r)
+			}
+			n.Competitors = append(n.Competitors, HyperliquidCompetitor{
+				Feed: c.Feed, Label: c.Label, DZWinPct: winPct,
+				LeadP50Ms: s.leadP50, LeadP95Ms: s.leadP95, Races: r,
+			})
+			wins += s.wins
+			races += r
+		}
+		n.TotalRaces = races
+		if races > 0 {
+			n.DZWinSharePct = 100.0 * float64(wins) / float64(races)
+		}
+		resp.Nodes = append(resp.Nodes, n)
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./api/handlers/ -run 'TestHyperliquidScoreboard_(HeadlineAndCompetitors|PerNode)' -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/handlers/hyperliquid_scoreboard.go api/handlers/hyperliquid_scoreboard_test.go
+git commit -m "api: hyperliquid scoreboard per-node breakdown"
+```
+
+---
+
+### Task 5: Recent races (live strip) + latest fetch
+
+**Files:**
+- Modify: `api/handlers/hyperliquid_scoreboard.go`
+- Modify: `api/handlers/hyperliquid_scoreboard_test.go`
+
+**Interfaces:**
+- Produces:
+  - `func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, sinceTs time.Time, limit int) ([]HyperliquidRace, error)` — newest races first; `sinceTs` zero means "last 2 minutes".
+  - `func (a *API) FetchHyperliquidScoreboardLatest(ctx context.Context, limit int) (*HyperliquidScoreboardResponse, error)` — a response with only `RecentRaces` populated (for the fast cache).
+  - `FetchHyperliquidScoreboardData` now populates `resp.RecentRaces` (last 2 min, limit 50).
+
+**Performance note:** the recent-races query is bounded to a short trailing window and a row limit because the summary table is large; it is refreshed on the fast cache cadence (Task 7), not per request. If it proves heavy without a symbol filter, narrow the trailing window further.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `api/handlers/hyperliquid_scoreboard_test.go`:
+```go
+func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api)
+
+	// A DZ-won race (BTC) and a competitor-won race (ETH), both pairwise.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.5)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "quicknode_l2book_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
+
+	races, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(races.RecentRaces), 2)
+
+	bySym := map[string]handlers.HyperliquidRace{}
+	for _, r := range races.RecentRaces {
+		bySym[r.Symbol] = r
+	}
+	assert.True(t, bySym["BTC"].IsDZ)
+	assert.Equal(t, "Hydromancer", bySym["BTC"].RunnerUpLabel)
+	assert.InDelta(t, 1.5, bySym["BTC"].LeadMs, 0.001)
+	assert.False(t, bySym["ETH"].IsDZ)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./api/handlers/ -run TestHyperliquidScoreboard_RecentRaces -v`
+Expected: FAIL — `RecentRaces` empty.
+
+- [ ] **Step 3: Add the recent-races fetch and wire it in**
+
+Add to `api/handlers/hyperliquid_scoreboard.go`:
+```go
+// fetchHyperliquidRecentRaces returns the most recent races (one row per race,
+// winner + closest competitor + lead). sinceTs zero -> last 2 minutes.
+func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, symbol string, sinceTs time.Time, limit int) ([]HyperliquidRace, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	symbol = sanitizeHyperliquidSymbol(symbol)
+	symbolFilter := ""
+	if symbol != "" {
+		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
+	}
+	timeFilter := "AND event_ts >= now() - INTERVAL 2 MINUTE"
+	if !sinceTs.IsZero() {
+		timeFilter = fmt.Sprintf("AND event_ts > toDateTime64(%d, 9)", sinceTs.Unix())
+	}
+	db := fmt.Sprintf("`%s`", a.FeedsDB)
+	q := fmt.Sprintf(`
+		SELECT
+			max(event_ts) AS event_ts,
+			symbol,
+			location_code,
+			feed AS winner_feed,
+			startsWith(feed,'tob_') AS is_dz,
+			argMin(loser_feed, lead_time_p50_ms) AS runner_up_feed,
+			min(lead_time_p50_ms) AS lead_ms
+		FROM %s.hyperliquid_bbo_feed_race_summary FINAL
+		WHERE loser_feed != '' AND feed != loser_feed %s %s
+		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
+		ORDER BY event_ts DESC
+		LIMIT %d`, db, symbolFilter, timeFilter, limit)
+	rows, err := a.envDB(ctx).Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []HyperliquidRace{}
+	for rows.Next() {
+		var r HyperliquidRace
+		var isDZ uint8
+		if err := rows.Scan(&r.EventTs, &r.Symbol, &r.LocationCode, &r.WinnerFeed, &isDZ, &r.RunnerUpFeed, &r.LeadMs); err != nil {
+			return nil, err
+		}
+		r.IsDZ = isDZ == 1
+		r.RunnerUpLabel = labelForFeed(r.RunnerUpFeed)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// FetchHyperliquidScoreboardLatest returns only the recent-races strip (fast cache).
+func (a *API) FetchHyperliquidScoreboardLatest(ctx context.Context, limit int) (*HyperliquidScoreboardResponse, error) {
+	races, err := a.fetchHyperliquidRecentRaces(ctx, "", time.Time{}, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &HyperliquidScoreboardResponse{
+		GeneratedAt: time.Now().UTC(),
+		FeedType:    "bbo",
+		RecentRaces: races,
+		Competitors: []HyperliquidCompetitor{},
+		Nodes:       []HyperliquidNode{},
+	}, nil
+}
+```
+In `FetchHyperliquidScoreboardData`, before `return resp, nil`:
+```go
+	recent, err := a.fetchHyperliquidRecentRaces(ctx, symbol, time.Time{}, 50)
+	if err != nil {
+		return nil, err
+	}
+	resp.RecentRaces = recent
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./api/handlers/ -run 'TestHyperliquidScoreboard' -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/handlers/hyperliquid_scoreboard.go api/handlers/hyperliquid_scoreboard_test.go
+git commit -m "api: hyperliquid scoreboard recent races strip"
+```
+
+---
+
+### Task 6: HTTP handler, caching, graceful degradation, route
+
+**Files:**
+- Modify: `api/handlers/hyperliquid_scoreboard.go` (add `GetHyperliquidScoreboard`, cache keys, table-exists check)
+- Modify: `api/main.go` (register route, after line 604)
+- Modify: `api/handlers/hyperliquid_scoreboard_test.go` (handler tests)
+
+**Interfaces:**
+- Consumes: `a.readPageCache`, `isMainnet`, `writeJSON`, `logError` (existing); `FetchHyperliquidScoreboardData`, `fetchHyperliquidRecentRaces` (Tasks 3–5).
+- Produces: `func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request)`; cache keys `hyperliquid_scoreboard` and `hyperliquid_scoreboard:latest`; `func (a *API) hyperliquidFeedsTableExists(ctx context.Context) bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `api/handlers/hyperliquid_scoreboard_test.go`:
+```go
+func TestGetHyperliquidScoreboard_Empty(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	createFeedsTable(t, api) // empty table -> empty-but-valid response
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
+	rr := httptest.NewRecorder()
+	api.GetHyperliquidScoreboard(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp handlers.HyperliquidScoreboardResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "24h", resp.Window)
+	assert.Equal(t, "MISS", rr.Header().Get("X-Cache"))
+}
+
+func TestGetHyperliquidScoreboard_MissingTable(t *testing.T) {
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	// Do NOT create the table -> handler must degrade to empty 200, not 500.
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
+	rr := httptest.NewRecorder()
+	api.GetHyperliquidScoreboard(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp handlers.HyperliquidScoreboardResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Competitors)
+}
+```
+Add imports `encoding/json`, `net/http`, `net/http/httptest` to the test file if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./api/handlers/ -run 'TestGetHyperliquidScoreboard' -v`
+Expected: FAIL — `undefined: api.GetHyperliquidScoreboard`.
+
+- [ ] **Step 3: Add the handler, cache keys, and table check**
+
+Add to `api/handlers/hyperliquid_scoreboard.go` (add `"context"`, `"encoding/json"`, `"net/http"`, `"strings"` to imports as needed):
+```go
+// hyperliquidScoreboardCacheKey returns the cache key for the default request shape, or "".
+func hyperliquidScoreboardCacheKey(r *http.Request) string {
+	if r.URL.Query().Get("since_ts") != "" || r.URL.Query().Get("symbol") != "" {
+		return ""
+	}
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if window != "" && window != "24h" {
+		return ""
+	}
+	return "hyperliquid_scoreboard"
+}
+
+// hyperliquidFeedsTableExists reports whether the proxied summary table is queryable.
+func (a *API) hyperliquidFeedsTableExists(ctx context.Context) bool {
+	var n uint8
+	q := fmt.Sprintf("EXISTS TABLE `%s`.hyperliquid_bbo_feed_race_summary", a.FeedsDB)
+	if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&n); err != nil {
+		return false
+	}
+	return n == 1
+}
+
+// GetHyperliquidScoreboard serves the Hyperliquid BBO scoreboard.
+func (a *API) GetHyperliquidScoreboard(w http.ResponseWriter, r *http.Request) {
+	if isMainnet(r.Context()) {
+		if key := hyperliquidScoreboardCacheKey(r); key != "" {
+			if data, err := a.readPageCache(r.Context(), key); err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache", "HIT")
+				_, _ = w.Write(data)
+				return
+			}
+		}
+	}
+	w.Header().Set("X-Cache", "MISS")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if _, ok := hyperliquidWindows[window]; !ok {
+		window = "24h"
+	}
+	symbol := r.URL.Query().Get("symbol")
+
+	// Degrade gracefully if the proxy table isn't available (e.g. local dev).
+	if !a.hyperliquidFeedsTableExists(ctx) {
+		writeJSON(w, &HyperliquidScoreboardResponse{
+			Window: window, GeneratedAt: time.Now().UTC(), FeedType: "bbo",
+			Competitors: []HyperliquidCompetitor{}, Nodes: []HyperliquidNode{}, RecentRaces: []HyperliquidRace{},
+		})
+		return
+	}
+
+	resp, err := a.FetchHyperliquidScoreboardData(ctx, window, symbol)
+	if err != nil {
+		logError("HyperliquidScoreboard error", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, resp)
+}
+```
+In `api/main.go`, after line 604 (`r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)`):
+```go
+		r.Get("/api/dz/hyperliquid/scoreboard", api.GetHyperliquidScoreboard)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./api/handlers/ -run 'TestGetHyperliquidScoreboard|TestHyperliquidScoreboard' -v`
+Expected: PASS. Then `go build ./api/...` (route compiles).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/handlers/hyperliquid_scoreboard.go api/main.go api/handlers/hyperliquid_scoreboard_test.go
+git commit -m "api: hyperliquid scoreboard HTTP handler, caching, and route"
+```
+
+---
+
+### Task 7: Page-cache registration
+
+**Files:**
+- Modify: `api/worker/workflow.go` (the `entries()` slice ~line 113, and the `latestEntries` slice ~line 199)
+
+**Interfaces:**
+- Consumes: `api.FetchHyperliquidScoreboardData`, `api.FetchHyperliquidScoreboardLatest` (Tasks 3–6).
+- Produces: cache entries keyed `hyperliquid_scoreboard` (30s) and `hyperliquid_scoreboard:latest` (fast).
+
+**Note:** the handler already degrades when the table is missing; the refresher will surface a query error for the cache entry if the proxy/grant isn't in place, which is logged with backoff per the existing failure-count mechanism (`failures sync.Map`). No extra gating needed in v1.
+
+- [ ] **Step 1: Add the standard cache entry**
+
+In `api/worker/workflow.go`, in `entries()` immediately after the `edge scoreboard (leaders)` entry (line 113):
+```go
+		{"hyperliquid scoreboard", "hyperliquid_scoreboard", func(ctx context.Context) (any, error) {
+			return api.FetchHyperliquidScoreboardData(ctx, "24h", "")
+		}},
+```
+
+- [ ] **Step 2: Add the fast (latest) cache entry**
+
+In `latestEntries` (after the `edge scoreboard (latest, leaders)` entry ~line 199):
+```go
+		{"hyperliquid scoreboard (latest)", "hyperliquid_scoreboard:latest", func(ctx context.Context) (any, error) {
+			return api.FetchHyperliquidScoreboardLatest(ctx, 50)
+		}},
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `go build ./api/...`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/worker/workflow.go
+git commit -m "api: register hyperliquid scoreboard page cache entries"
+```
+
+---
+
+### Task 8: Web API client + types
+
+**Files:**
+- Modify: `web/src/lib/api.ts` (add near the edge-scoreboard client, ~line 6095)
+
+**Interfaces:**
+- Produces: TS interfaces `HyperliquidCompetitor`, `HyperliquidNode`, `HyperliquidRace`, `HyperliquidScoreboardResponse`; `fetchHyperliquidScoreboard(window, symbol?, opts?)`.
+
+- [ ] **Step 1: Add types and fetch function**
+
+Append to `web/src/lib/api.ts`:
+```typescript
+export interface HyperliquidCompetitor {
+  feed: string
+  label: string
+  dz_win_pct: number
+  lead_p50_ms: number
+  lead_p95_ms: number
+  races: number
+}
+
+export interface HyperliquidNode {
+  measurement_node_id: string
+  location_code: string
+  dz_win_share_pct: number
+  total_races: number
+  competitors: HyperliquidCompetitor[]
+}
+
+export interface HyperliquidRace {
+  event_ts: string
+  symbol: string
+  location_code: string
+  winner_feed: string
+  is_dz: boolean
+  runner_up_feed: string
+  runner_up_label: string
+  lead_ms: number
+}
+
+export interface HyperliquidScoreboardResponse {
+  window: string
+  symbol?: string
+  generated_at: string
+  feed_type: string
+  dz_win_share_pct: number
+  total_races: number
+  competitors: HyperliquidCompetitor[]
+  nodes: HyperliquidNode[]
+  recent_races: HyperliquidRace[]
+}
+
+export async function fetchHyperliquidScoreboard(
+  window: string = '24h',
+  symbol?: string,
+): Promise<HyperliquidScoreboardResponse> {
+  const params = new URLSearchParams()
+  params.set('window', window)
+  if (symbol && symbol !== 'all') params.set('symbol', symbol)
+  const res = await apiFetch(`/api/dz/hyperliquid/scoreboard?${params}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch hyperliquid scoreboard')
+  }
+  return res.json()
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd web && bunx tsc -b`
+Expected: passes (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/lib/api.ts
+git commit -m "web: hyperliquid scoreboard api client and types"
+```
+
+---
+
+### Task 9: Web page component
+
+**Files:**
+- Create: `web/src/components/hyperliquid-scoreboard-page.tsx`
+
+**Interfaces:**
+- Consumes: `fetchHyperliquidScoreboard`, `HyperliquidScoreboardResponse` (Task 8); existing `PageHeader` component.
+- Produces: `export function HyperliquidScoreboardPage()`.
+
+- [ ] **Step 1: Create the component**
+
+Create `web/src/components/hyperliquid-scoreboard-page.tsx`:
+```tsx
+import { useEffect, useState, useCallback } from 'react'
+import { PageHeader } from './page-header'
+import {
+  fetchHyperliquidScoreboard,
+  type HyperliquidScoreboardResponse,
+} from '@/lib/api'
+
+const WINDOWS = ['1h', '24h', '7d']
+
+function pct(n: number): string {
+  return `${n.toFixed(1)}%`
+}
+function ms(n: number): string {
+  return `+${n.toFixed(2)} ms`
+}
+
+function CompetitorTable({ competitors }: { competitors: HyperliquidScoreboardResponse['competitors'] }) {
+  if (!competitors.length) {
+    return <div className="text-sm text-muted-foreground">No competitor races in this window.</div>
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-muted-foreground">
+          <th className="py-1 pr-4 font-normal">vs Competitor</th>
+          <th className="py-1 pr-4 font-normal">DZ win%</th>
+          <th className="py-1 pr-4 font-normal">median lead</th>
+          <th className="py-1 pr-4 font-normal">p95 lead</th>
+          <th className="py-1 pr-4 font-normal">races</th>
+        </tr>
+      </thead>
+      <tbody>
+        {competitors.map((c) => (
+          <tr key={c.feed} className="border-t border-border/50">
+            <td className="py-1 pr-4">{c.label}</td>
+            <td className="py-1 pr-4 tabular-nums">{pct(c.dz_win_pct)}</td>
+            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p50_ms)}</td>
+            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p95_ms)}</td>
+            <td className="py-1 pr-4 tabular-nums">{c.races.toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export function HyperliquidScoreboardPage() {
+  const [window, setWindow] = useState('24h')
+  const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setData(await fetchHyperliquidScoreboard(window))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load')
+    }
+  }, [window])
+
+  // Initial + window-change load, then poll every 15s for fresh recent races.
+  useEffect(() => {
+    load()
+    const id = setInterval(load, 15000)
+    return () => clearInterval(id)
+  }, [load])
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <PageHeader title="Hyperliquid · BBO Scoreboard" />
+
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">window:</span>
+        {WINDOWS.map((w) => (
+          <button
+            key={w}
+            onClick={() => setWindow(w)}
+            className={`rounded px-2 py-1 text-sm ${w === window ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+
+      {error && <div className="text-sm text-red-500">{error}</div>}
+      {!data && !error && <div className="text-sm text-muted-foreground">Loading…</div>}
+
+      {data && (
+        <>
+          <div className="rounded-lg border border-border p-4">
+            <div className="text-2xl font-semibold tabular-nums">
+              DoubleZero wins {pct(data.dz_win_share_pct)} of races
+            </div>
+            <div className="text-sm text-muted-foreground">
+              all vantages · {data.window} · {data.total_races.toLocaleString()} comparisons
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-2 text-sm font-medium">DoubleZero vs competitors</div>
+            <CompetitorTable competitors={data.competitors} />
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-3 text-sm font-medium">By vantage</div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {data.nodes.map((n) => (
+                <div key={n.measurement_node_id} className="rounded border border-border/60 p-3">
+                  <div className="mb-1 flex items-baseline justify-between">
+                    <span className="font-medium uppercase">{n.location_code}</span>
+                    <span className="tabular-nums">{pct(n.dz_win_share_pct)}</span>
+                  </div>
+                  <div className="mb-2 text-xs text-muted-foreground">
+                    {n.measurement_node_id} · {n.total_races.toLocaleString()} races
+                  </div>
+                  <CompetitorTable competitors={n.competitors} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-2 text-sm font-medium">Recent races (live)</div>
+            <table className="w-full text-sm">
+              <tbody>
+                {data.recent_races.map((r, i) => (
+                  <tr key={`${r.symbol}-${r.event_ts}-${i}`} className="border-t border-border/50">
+                    <td className="py-1 pr-4 font-medium">{r.symbol}</td>
+                    <td className="py-1 pr-4">
+                      {r.is_dz ? (
+                        <span className="text-emerald-500">DoubleZero ({r.winner_feed})</span>
+                      ) : (
+                        <span className="text-muted-foreground">{r.winner_feed}</span>
+                      )}
+                    </td>
+                    <td className="py-1 pr-4 tabular-nums">
+                      {ms(r.lead_ms)} vs {r.runner_up_label}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+```
+**Before writing:** confirm the `PageHeader` import path and props by opening `web/src/components/edge-scoreboard-page.tsx` (it imports `PageHeader` near line 16) — match its exact import path and prop names; adjust the `<PageHeader … />` usage if its API differs.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd web && bunx tsc -b`
+Expected: passes. Fix any `PageHeader` prop/import mismatches surfaced here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/hyperliquid-scoreboard-page.tsx
+git commit -m "web: hyperliquid scoreboard page component"
+```
+
+---
+
+### Task 10: Routing + sidebar navigation
+
+**Files:**
+- Modify: `web/src/App.tsx` (import ~line 69; routes ~line 737)
+- Modify: `web/src/components/sidebar.tsx` (route detection ~line 109-119; Edge section ~line 583-585)
+
+**Interfaces:**
+- Consumes: `HyperliquidScoreboardPage` (Task 9).
+- Produces: routes `/dz/hyperliquid` (redirect) and `/dz/hyperliquid/scoreboard`; a "Hyperliquid" group in the Edge sidebar section.
+
+- [ ] **Step 1: Add the import and routes**
+
+In `web/src/App.tsx`, near line 69 (after the `EdgeScoreboardPage` import):
+```tsx
+import { HyperliquidScoreboardPage } from './components/hyperliquid-scoreboard-page'
+```
+After the shreds routes (after line 737, the `/dz/edge/scoreboard` redirect):
+```tsx
+            <Route path="/dz/hyperliquid" element={<Navigate to="/dz/hyperliquid/scoreboard" replace />} />
+            <Route path="/dz/hyperliquid/scoreboard" element={<HyperliquidScoreboardPage />} />
+```
+
+- [ ] **Step 2: Add route detection in the sidebar**
+
+In `web/src/components/sidebar.tsx`, near the other `is…Route` consts (~line 109-119):
+```tsx
+  const isHyperliquidScoreboardRoute = location.pathname === '/dz/hyperliquid/scoreboard'
+  const isHyperliquidRoute = location.pathname.startsWith('/dz/hyperliquid')
+```
+
+- [ ] **Step 3: Add the nav group in the Edge section**
+
+In `web/src/components/sidebar.tsx`, inside the Edge section `<div className="space-y-1">`, after the Shreds block closes (after line 583 `</>` `)}`), add a sibling block. The `Link` and class-helper names (`navItemClass`, `navItemExpandedClass`, `subNavItemClass`) match the Shreds block above:
+```tsx
+            <Link to="/dz/hyperliquid/scoreboard" className={isHyperliquidRoute ? navItemExpandedClass : navItemClass(false)}>
+              <Activity className="h-4 w-4" />
+              Hyperliquid
+            </Link>
+            {isHyperliquidRoute && (
+              <>
+                <Link to="/dz/hyperliquid/scoreboard" className={subNavItemClass(isHyperliquidScoreboardRoute)}>
+                  Scoreboard
+                </Link>
+              </>
+            )}
+```
+Ensure an icon is imported: the Shreds entry uses `Puzzle` from `lucide-react` (see the import block at the top of `sidebar.tsx`). Add `Activity` to that existing `lucide-react` import (or reuse an already-imported icon if `Activity` is taken).
+
+- [ ] **Step 4: Type-check and verify the route renders**
+
+Run: `cd web && bunx tsc -b`
+Expected: passes. Then with the dev env up, open `http://localhost:5173/dz/hyperliquid/scoreboard` (or the Tailscale URL) and confirm the page renders and the "Hyperliquid" nav item appears under Edge with the Scoreboard child when active.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/App.tsx web/src/components/sidebar.tsx
+git commit -m "web: hyperliquid scoreboard route and sidebar nav"
+```
+
+---
+
+### Task 11: Local seed script (developer convenience)
+
+**Files:**
+- Create: `scripts/seed-hyperliquid-local.sh`
+
+**Interfaces:**
+- Consumes: `FEEDS_CH_*` env vars in `.env` (remote `feeds_reader` creds) and local ClickHouse (`CLICKHOUSE_ADDR_TCP`).
+- Produces: a local `feeds.hyperliquid_bbo_feed_race_summary` table populated with recent rows for UI development without the production proxy.
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/seed-hyperliquid-local.sh` (mirrors `scripts/seed-shredder-local.sh`):
+```bash
+#!/usr/bin/env bash
+# Seed local ClickHouse with recent rows from remote feeds.hyperliquid_bbo_feed_race_summary.
+# Reads credentials from .env (FEEDS_CH_*). Usage: ./scripts/seed-hyperliquid-local.sh [MINUTES]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+[[ -f "$ROOT_DIR/.env" ]] && { set -a; source "$ROOT_DIR/.env"; set +a; }
+
+REMOTE_HOST="${FEEDS_CH_HOST:?set FEEDS_CH_HOST in .env}"
+REMOTE_HTTPS_PORT="${FEEDS_CH_PORT:-8443}"
+REMOTE_DB="${FEEDS_CH_DB:-feeds}"
+REMOTE_USER="${FEEDS_CH_USER:?set FEEDS_CH_USER in .env}"
+REMOTE_PASS="${FEEDS_CH_PASSWORD:?set FEEDS_CH_PASSWORD in .env}"
+MINUTES="${1:-10}"
+
+LOCAL_HOST="${CLICKHOUSE_ADDR_TCP:-localhost:9100}"
+LOCAL_ADDR="${LOCAL_HOST%%:*}"
+LOCAL_PORT="${LOCAL_HOST##*:}"
+
+COLS="event_ts, ingested_at, capture_run_id, measurement_node_id, host, location_code, feed_type, symbol, source_ts_ms, bbo_hash, feed, loser_feed, total_events, events_won, lead_time_p50_ms, lead_time_p95_ms, send_lead_time_p50_ms, send_lead_time_p95_ms"
+
+echo "==> Creating local feeds.hyperliquid_bbo_feed_race_summary..."
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --multiquery <<'SQL'
+CREATE DATABASE IF NOT EXISTS feeds;
+DROP TABLE IF EXISTS feeds.hyperliquid_bbo_feed_race_summary;
+CREATE TABLE feeds.hyperliquid_bbo_feed_race_summary (
+  event_ts DateTime64(9), ingested_at DateTime64(9) DEFAULT now64(9),
+  capture_run_id String, measurement_node_id String, host String,
+  location_code LowCardinality(String), feed_type LowCardinality(String) DEFAULT 'bbo',
+  symbol LowCardinality(String), source_ts_ms UInt64, bbo_hash UInt64,
+  feed LowCardinality(String), loser_feed LowCardinality(String) DEFAULT '',
+  total_events UInt64, events_won UInt64,
+  lead_time_p50_ms Float64 DEFAULT 0, lead_time_p95_ms Float64 DEFAULT 0,
+  send_lead_time_p50_ms Nullable(Float64) DEFAULT NULL, send_lead_time_p95_ms Nullable(Float64) DEFAULT NULL
+) ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toDate(event_ts)
+ORDER BY (measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed);
+SQL
+
+echo "==> Fetching last ${MINUTES}m from remote..."
+curl -sS "https://${REMOTE_HOST}:${REMOTE_HTTPS_PORT}/?database=${REMOTE_DB}" \
+  --user "${REMOTE_USER}:${REMOTE_PASS}" \
+  --data-binary "SELECT ${COLS} FROM hyperliquid_bbo_feed_race_summary WHERE event_ts >= now() - INTERVAL ${MINUTES} MINUTE FORMAT TabSeparated" \
+  > /tmp/hl_feed_race.tsv
+
+ROWS=$(wc -l < /tmp/hl_feed_race.tsv | tr -d ' ')
+echo "==> Inserting ${ROWS} rows locally..."
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" \
+  --query "INSERT INTO feeds.hyperliquid_bbo_feed_race_summary (${COLS}) FORMAT TabSeparated" \
+  < /tmp/hl_feed_race.tsv
+rm -f /tmp/hl_feed_race.tsv
+echo "==> Done. Seeded ${ROWS} rows into feeds.hyperliquid_bbo_feed_race_summary"
+```
+
+- [ ] **Step 2: Make it executable and smoke-test**
+
+```bash
+chmod +x scripts/seed-hyperliquid-local.sh
+./scripts/seed-hyperliquid-local.sh 5
+```
+Expected: prints a row count and "Done". (Requires `FEEDS_CH_*` in `.env` and the local ClickHouse running.) Then load the page locally and confirm data renders.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/seed-hyperliquid-local.sh
+git commit -m "scripts: seed local hyperliquid feed race summary"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Proxy + config (`CLICKHOUSE_FEEDS_DB`, `FeedsDB`) → Tasks 1–2. ✓
+- `tob_*` rollup + competitor labels → Task 3 (`hyperliquidCompetitors`, `startsWith(feed,'tob_')`). ✓
+- Headline DZ win-share (Grafana formula) → Task 3. ✓
+- Per-competitor win% + exact lead p50/p95 → Task 3. ✓
+- Per-node breakdown → Task 4. ✓
+- Recent-races live strip + fast cache → Tasks 5, 7. ✓
+- Endpoint `/api/dz/hyperliquid/scoreboard`, default-shape caching, `X-Cache` → Task 6. ✓
+- Page cache `hyperliquid_scoreboard` (30s) + `:latest` (fast) → Task 7. ✓
+- Window set `1h/24h/7d`, default `24h` → Tasks 3, 6, 8. ✓
+- Symbol filter (default all, cache bypass) + sanitization → Tasks 3, 6, 8. ✓
+- Graceful degradation on missing proxy table → Task 6 (`hyperliquidFeedsTableExists`). ✓
+- Web nav (sibling group under Edge), route, page → Tasks 9–10. ✓
+- Go handler tests + local seed script → Tasks 3–6, 11. ✓
+- Non-goals (raw-table features, gossip, charts) → not implemented, by design. ✓
+
+**2. Placeholder scan:** No `TBD`/`TODO`/"handle errors appropriately"; every code step shows complete code. Two steps ask the implementer to confirm a neighboring file's exact identifiers before writing (`externalRemoteTables` field names in Task 2; `PageHeader` props and sidebar class/icon names in Tasks 9–10) — these are verification steps with a concrete fallback, not placeholders.
+
+**3. Type consistency:** `HyperliquidScoreboardResponse` / `HyperliquidCompetitor` / `HyperliquidNode` / `HyperliquidRace` field names and JSON tags match between Go (Tasks 3–5) and TS (Task 8). `FetchHyperliquidScoreboardData(ctx, window, symbol)`, `FetchHyperliquidScoreboardLatest(ctx, limit)`, and `fetchHyperliquidRecentRaces(ctx, symbol, sinceTs, limit)` signatures are consistent across Tasks 3–7. Cache keys `hyperliquid_scoreboard` / `hyperliquid_scoreboard:latest` match between Task 6 (read) and Task 7 (write).
+
+## Open Dependency
+
+Before the proxy (Task 2) yields data in staging/prod, lake's remote reader (`REMOTE_CH_USER`) must be granted `SELECT` on `feeds.*` on the ClickHouse Cloud instance. Local development uses `scripts/seed-hyperliquid-local.sh` instead and does not need the grant.

--- a/scripts/seed-hyperliquid-local.sh
+++ b/scripts/seed-hyperliquid-local.sh
@@ -2,6 +2,7 @@
 # Seed local ClickHouse with recent rows from remote feeds.hyperliquid_bbo_feed_race_summary.
 # Reads credentials from .env (FEEDS_CH_*). Usage: ./scripts/seed-hyperliquid-local.sh [MINUTES]
 set -euo pipefail
+trap 'rm -f /tmp/hl_feed_race.tsv' EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -13,6 +14,7 @@ REMOTE_DB="${FEEDS_CH_DB:-feeds}"
 REMOTE_USER="${FEEDS_CH_USER:?set FEEDS_CH_USER in .env}"
 REMOTE_PASS="${FEEDS_CH_PASSWORD:?set FEEDS_CH_PASSWORD in .env}"
 MINUTES="${1:-10}"
+if ! [[ "$MINUTES" =~ ^[0-9]+$ ]]; then echo "Error: MINUTES must be a positive integer, got '$MINUTES'" >&2; exit 1; fi
 
 LOCAL_HOST="${CLICKHOUSE_ADDR_TCP:-localhost:9100}"
 LOCAL_ADDR="${LOCAL_HOST%%:*}"
@@ -39,7 +41,7 @@ ORDER BY (measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed)
 SQL
 
 echo "==> Fetching last ${MINUTES}m from remote..."
-curl -sS "https://${REMOTE_HOST}:${REMOTE_HTTPS_PORT}/?database=${REMOTE_DB}" \
+curl -sS --fail-with-body "https://${REMOTE_HOST}:${REMOTE_HTTPS_PORT}/?database=${REMOTE_DB}" \
   --user "${REMOTE_USER}:${REMOTE_PASS}" \
   --data-binary "SELECT ${COLS} FROM hyperliquid_bbo_feed_race_summary WHERE event_ts >= now() - INTERVAL ${MINUTES} MINUTE FORMAT TabSeparated" \
   > /tmp/hl_feed_race.tsv

--- a/scripts/seed-hyperliquid-local.sh
+++ b/scripts/seed-hyperliquid-local.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Seed local ClickHouse with recent rows from remote feeds.hyperliquid_bbo_feed_race_summary.
+# Reads credentials from .env (FEEDS_CH_*). Usage: ./scripts/seed-hyperliquid-local.sh [MINUTES]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+[[ -f "$ROOT_DIR/.env" ]] && { set -a; source "$ROOT_DIR/.env"; set +a; }
+
+REMOTE_HOST="${FEEDS_CH_HOST:?set FEEDS_CH_HOST in .env}"
+REMOTE_HTTPS_PORT="${FEEDS_CH_PORT:-8443}"
+REMOTE_DB="${FEEDS_CH_DB:-feeds}"
+REMOTE_USER="${FEEDS_CH_USER:?set FEEDS_CH_USER in .env}"
+REMOTE_PASS="${FEEDS_CH_PASSWORD:?set FEEDS_CH_PASSWORD in .env}"
+MINUTES="${1:-10}"
+
+LOCAL_HOST="${CLICKHOUSE_ADDR_TCP:-localhost:9100}"
+LOCAL_ADDR="${LOCAL_HOST%%:*}"
+LOCAL_PORT="${LOCAL_HOST##*:}"
+
+COLS="event_ts, ingested_at, capture_run_id, measurement_node_id, host, location_code, feed_type, symbol, source_ts_ms, bbo_hash, feed, loser_feed, total_events, events_won, lead_time_p50_ms, lead_time_p95_ms, send_lead_time_p50_ms, send_lead_time_p95_ms"
+
+echo "==> Creating local feeds.hyperliquid_bbo_feed_race_summary..."
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --multiquery <<'SQL'
+CREATE DATABASE IF NOT EXISTS feeds;
+DROP TABLE IF EXISTS feeds.hyperliquid_bbo_feed_race_summary;
+CREATE TABLE feeds.hyperliquid_bbo_feed_race_summary (
+  event_ts DateTime64(9), ingested_at DateTime64(9) DEFAULT now64(9),
+  capture_run_id String, measurement_node_id String, host String,
+  location_code LowCardinality(String), feed_type LowCardinality(String) DEFAULT 'bbo',
+  symbol LowCardinality(String), source_ts_ms UInt64, bbo_hash UInt64,
+  feed LowCardinality(String), loser_feed LowCardinality(String) DEFAULT '',
+  total_events UInt64, events_won UInt64,
+  lead_time_p50_ms Float64 DEFAULT 0, lead_time_p95_ms Float64 DEFAULT 0,
+  send_lead_time_p50_ms Nullable(Float64) DEFAULT NULL, send_lead_time_p95_ms Nullable(Float64) DEFAULT NULL
+) ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toDate(event_ts)
+ORDER BY (measurement_node_id, symbol, source_ts_ms, bbo_hash, feed, loser_feed);
+SQL
+
+echo "==> Fetching last ${MINUTES}m from remote..."
+curl -sS "https://${REMOTE_HOST}:${REMOTE_HTTPS_PORT}/?database=${REMOTE_DB}" \
+  --user "${REMOTE_USER}:${REMOTE_PASS}" \
+  --data-binary "SELECT ${COLS} FROM hyperliquid_bbo_feed_race_summary WHERE event_ts >= now() - INTERVAL ${MINUTES} MINUTE FORMAT TabSeparated" \
+  > /tmp/hl_feed_race.tsv
+
+ROWS=$(wc -l < /tmp/hl_feed_race.tsv | tr -d ' ')
+echo "==> Inserting ${ROWS} rows locally..."
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" \
+  --query "INSERT INTO feeds.hyperliquid_bbo_feed_race_summary (${COLS}) FORMAT TabSeparated" \
+  < /tmp/hl_feed_race.tsv
+rm -f /tmp/hl_feed_race.tsv
+echo "==> Done. Seeded ${ROWS} rows into feeds.hyperliquid_bbo_feed_race_summary"

--- a/scripts/setup-feeds-remote-local.sh
+++ b/scripts/setup-feeds-remote-local.sh
@@ -21,12 +21,14 @@ LOCAL_HOST="${CLICKHOUSE_ADDR_TCP:-localhost:9100}"
 LOCAL_ADDR="${LOCAL_HOST%%:*}"
 LOCAL_PORT="${LOCAL_HOST##*:}"
 
-TABLE="hyperliquid_bbo_feed_race_summary"
+# summary feeds the scoreboard; observations feeds the composite-latency hero stat.
+TABLES=("hyperliquid_bbo_feed_race_summary" "hyperliquid_bbo_observations")
 
-echo "==> Creating local proxy feeds.${TABLE} -> ${REMOTE_HOST}:${REMOTE_SECURE_PORT}/${REMOTE_DB}.${TABLE}"
-clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --multiquery --query "
-CREATE DATABASE IF NOT EXISTS feeds;
-CREATE OR REPLACE TABLE feeds.${TABLE} AS remoteSecure('${REMOTE_HOST}:${REMOTE_SECURE_PORT}', '${REMOTE_DB}.${TABLE}', '${REMOTE_USER}', '${REMOTE_PASS}');
-"
-echo "==> Done. Local feeds.${TABLE} now serves production data via remoteSecure()."
-echo "    (Note: 24h/7d aggregations over the full table are slow; the API caches the 1h view.)"
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --query "CREATE DATABASE IF NOT EXISTS feeds"
+for TABLE in "${TABLES[@]}"; do
+  echo "==> Creating local proxy feeds.${TABLE} -> ${REMOTE_HOST}:${REMOTE_SECURE_PORT}/${REMOTE_DB}.${TABLE}"
+  clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --query "
+CREATE OR REPLACE TABLE feeds.${TABLE} AS remoteSecure('${REMOTE_HOST}:${REMOTE_SECURE_PORT}', '${REMOTE_DB}.${TABLE}', '${REMOTE_USER}', '${REMOTE_PASS}')"
+done
+echo "==> Done. Local feeds tables now serve production data via remoteSecure()."
+echo "    (Note: 24h aggregations over the full tables are slow; the API caches them.)"

--- a/scripts/setup-feeds-remote-local.sh
+++ b/scripts/setup-feeds-remote-local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Point the local ClickHouse `feeds` tables at production via a remoteSecure() proxy, so the
+# API serves real production Hyperliquid data locally — the equivalent of what
+# setup-remote-tables.sh does for shreds, but using the dedicated feeds_reader credentials.
+#
+# Reads FEEDS_CH_* from .env. Re-run after recreating the local cluster.
+# Usage: ./scripts/setup-feeds-remote-local.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+[[ -f "$ROOT_DIR/.env" ]] && { set -a; source "$ROOT_DIR/.env"; set +a; }
+
+REMOTE_HOST="${FEEDS_CH_HOST:?set FEEDS_CH_HOST in .env}"
+REMOTE_DB="${FEEDS_CH_DB:-feeds}"
+REMOTE_USER="${FEEDS_CH_USER:?set FEEDS_CH_USER in .env}"
+REMOTE_PASS="${FEEDS_CH_PASSWORD:?set FEEDS_CH_PASSWORD in .env}"
+REMOTE_SECURE_PORT="${FEEDS_CH_SECURE_PORT:-9440}"  # ClickHouse Cloud secure native port
+
+LOCAL_HOST="${CLICKHOUSE_ADDR_TCP:-localhost:9100}"
+LOCAL_ADDR="${LOCAL_HOST%%:*}"
+LOCAL_PORT="${LOCAL_HOST##*:}"
+
+TABLE="hyperliquid_bbo_feed_race_summary"
+
+echo "==> Creating local proxy feeds.${TABLE} -> ${REMOTE_HOST}:${REMOTE_SECURE_PORT}/${REMOTE_DB}.${TABLE}"
+clickhouse client --host "$LOCAL_ADDR" --port "$LOCAL_PORT" --multiquery --query "
+CREATE DATABASE IF NOT EXISTS feeds;
+CREATE OR REPLACE TABLE feeds.${TABLE} AS remoteSecure('${REMOTE_HOST}:${REMOTE_SECURE_PORT}', '${REMOTE_DB}.${TABLE}', '${REMOTE_USER}', '${REMOTE_PASS}');
+"
+echo "==> Done. Local feeds.${TABLE} now serves production data via remoteSecure()."
+echo "    (Note: 24h/7d aggregations over the full table are slow; the API caches the 1h view.)"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ import { ShredsRewardsPage } from '@/components/shreds-rewards-page'
 import { ShredsRewardsDetailPage } from '@/components/shreds-rewards-detail-page'
 import { PublisherCheckPage } from './components/publisher-check-page'
 import { EdgeScoreboardPage } from './components/edge-scoreboard-page'
+import { HyperliquidScoreboardPage } from './components/hyperliquid-scoreboard-page'
 import { MulticastGroupDetailPage } from '@/components/multicast-group-detail-page'
 import { AccessPassesPage } from '@/components/access-passes-page'
 import { AccessPassDetailPage } from '@/components/access-pass-detail-page'
@@ -735,6 +736,8 @@ function AppContent() {
             <Route path="/dz/shreds/rewards/:nodeId" element={<ShredsRewardsDetailPage />} />
             {/* Subscribe page hidden for now — see shreds-subscribe-page.tsx */}
             <Route path="/dz/edge/scoreboard" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
+            <Route path="/dz/hyperliquid" element={<Navigate to="/dz/hyperliquid/scoreboard" replace />} />
+            <Route path="/dz/hyperliquid/scoreboard" element={<HyperliquidScoreboardPage />} />
 
             {/* Geolocation routes */}
             <Route path="/dz/geoloc/probes" element={<GeolocProbesPage />} />

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -230,8 +230,10 @@ export function HyperliquidScoreboardPage() {
                   {data.composite_latency && (
                     <div className="w-full">
                       <div className="mb-1.5 text-xs text-muted-foreground">
-                        Composite feed latency{' '}
-                        <span className="text-muted-foreground/60">({data.composite_latency.window})</span>
+                        Tokyo feed latency{' '}
+                        <span className="text-muted-foreground/60">
+                          (blocktime → receive, first-arrival across DZ Tokyo feeds, {data.composite_latency.window})
+                        </span>
                       </div>
                       <div className="flex gap-5">
                         {([

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -32,6 +32,16 @@ function symbolDisplay(sym: string): string {
   return sym.startsWith('xyz:') ? sym.slice(4) : sym
 }
 
+// Vantage-point facility metadata (keyed by location_code), plus the row display order.
+const VANTAGE_INFO: Record<string, { facility: string; city: string; order: number }> = {
+  tyo: { facility: 'AWS ap-northeast-1b', city: 'Tokyo, JP', order: 0 },
+  chi: { facility: 'CyrusOne CHI1', city: 'Aurora, IL', order: 1 },
+  nyc: { facility: 'Equinix NY5', city: 'Secaucus, NJ', order: 2 },
+}
+function vantageOrder(locationCode: string): number {
+  return VANTAGE_INFO[locationCode]?.order ?? 99
+}
+
 function fmtPrice(p: number): string {
   if (p >= 1000) return `$${Math.round(p).toLocaleString()}`
   return `$${p.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
@@ -311,14 +321,29 @@ export function HyperliquidScoreboardPage() {
                         </td>
                       </tr>
                     ) : (
-                      data.nodes.map((n) => {
+                      [...data.nodes]
+                        .sort((a, b) => vantageOrder(a.location_code) - vantageOrder(b.location_code))
+                        .map((n) => {
                         const byFeed = new Map(n.competitors.map((c) => [c.feed, c]))
+                        const info = VANTAGE_INFO[n.location_code]
                         return (
                           <tr key={n.measurement_node_id} className="border-b border-border transition-colors last:border-b-0 hover:bg-muted/50">
                             <td className="px-3 py-3 sm:px-4">
-                              <div className="text-sm font-medium uppercase">{n.location_code}</div>
-                              <div className="text-xs text-muted-foreground">{n.measurement_node_id}</div>
-                              <div className="text-xs text-muted-foreground">{n.total_races.toLocaleString()} races</div>
+                              <div
+                                className="cursor-default"
+                                title={[
+                                  info?.facility ?? n.location_code.toUpperCase(),
+                                  info?.city,
+                                  n.measurement_node_id,
+                                  `${n.total_races.toLocaleString()} races`,
+                                ]
+                                  .filter(Boolean)
+                                  .join('\n')}
+                              >
+                                <div className="text-sm font-medium uppercase">{n.location_code}</div>
+                                <div className="text-xs text-muted-foreground">{info?.facility ?? n.measurement_node_id}</div>
+                                <div className="text-xs text-muted-foreground/70">{n.total_races.toLocaleString()} races</div>
+                              </div>
                             </td>
                             <td className="px-3 py-3 text-right text-sm tabular-nums sm:px-4">
                               <div className="mb-1.5">{pct(n.dz_win_share_pct)}</div>

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -109,6 +109,15 @@ function WinRateBar({ dzPct, segments }: { dzPct: number; segments: { label: str
   )
 }
 
+// relAge returns a short "just now" / "12s ago" / "3m ago" / "2h ago" string for a ms timestamp.
+function relAge(tsMs: number, nowMs: number): string {
+  const age = Math.round((nowMs - tsMs) / 1000)
+  if (age < 5) return 'just now'
+  if (age < 60) return `${age}s ago`
+  if (age < 3600) return `${Math.round(age / 60)}m ago`
+  return `${Math.round(age / 3600)}h ago`
+}
+
 export function HyperliquidScoreboardPage() {
   const [timeWindow, setTimeWindow] = useState<(typeof WINDOWS)[number]>('1h')
   const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
@@ -347,6 +356,9 @@ export function HyperliquidScoreboardPage() {
                   {section.symbols.map((sym) => {
                     const races = racesBySymbol[sym] ?? []
                     const price = data.prices?.[sym]
+                    const lastTs = races.length
+                      ? Math.max(...races.map((r) => new Date(r.event_ts).getTime()))
+                      : null
                     return (
                       <div key={sym} className="bg-card p-3">
                         <div className="mb-2 flex items-baseline justify-between gap-1">
@@ -355,6 +367,11 @@ export function HyperliquidScoreboardPage() {
                             <span className="text-xs tabular-nums text-muted-foreground">{fmtPrice(price)}</span>
                           )}
                         </div>
+                        {lastTs != null && (
+                          <div className="mb-1.5 text-[11px] tabular-nums text-muted-foreground/50">
+                            updated {relAge(lastTs, now)}
+                          </div>
+                        )}
                         {races.length === 0 ? (
                           <div className="flex flex-col gap-1">
                             <span className="inline-flex w-fit items-center rounded bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from './page-header'
 import {
   fetchHyperliquidScoreboard,
   type HyperliquidScoreboardResponse,
+  type HyperliquidRace,
 } from '@/lib/api'
 
 const WINDOWS = ['1h', '24h', '7d'] as const
@@ -18,6 +19,22 @@ function pct(n: number): string {
 function lead(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(2)} s`
   return `${n.toFixed(n < 10 ? 1 : 0)} ms`
+}
+
+// Recent-races grid: two sections of top symbols by volume. Only some symbols have competitor
+// feeds (currently BTC/ETH); the rest render as DoubleZero-exclusive coverage.
+const RECENT_SECTIONS = [
+  { title: 'Hyperliquid Perpetual Futures', symbols: ['BTC', 'ETH', 'SOL', 'HYPE'] },
+  { title: 'Hyperliquid HIP-3 DEX Perpetual Futures', symbols: ['xyz:SP500', 'xyz:XYZ100', 'xyz:MU', 'xyz:SKHX'] },
+] as const
+
+function symbolDisplay(sym: string): string {
+  return sym.startsWith('xyz:') ? sym.slice(4) : sym
+}
+
+function fmtPrice(p: number): string {
+  if (p >= 1000) return `$${Math.round(p).toLocaleString()}`
+  return `$${p.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
 
 // Three-quarter-arc win-rate gauge — mirrors the edge scoreboard's WinRateGauge.
@@ -65,6 +82,33 @@ function WinBar({ value }: { value: number }) {
   )
 }
 
+// Competitor colors for the win-rate bar — warm hues contrasting with DoubleZero green.
+const COMPETITOR_COLORS = ['#fbbf24', '#fb923c', '#ef4444', '#ec4899', '#a855f7'] // amber, orange, red, pink, purple
+function competitorColor(i: number): string {
+  return COMPETITOR_COLORS[i % COMPETITOR_COLORS.length]
+}
+
+// Win-rate bar: DoubleZero's share in green, the remaining loss split by competitor color.
+function WinRateBar({ dzPct, segments }: { dzPct: number; segments: { label: string; pct: number; color: string }[] }) {
+  return (
+    <div className="flex h-1.5 overflow-hidden rounded-full bg-muted-foreground/25">
+      <div
+        className="h-full transition-all duration-500"
+        style={{ width: `${Math.max(0, Math.min(100, dzPct))}%`, backgroundColor: DZ_COLOR }}
+        title={`DoubleZero ${pct(dzPct)}`}
+      />
+      {segments.map((s) => (
+        <div
+          key={s.label}
+          className="h-full transition-all duration-500"
+          style={{ width: `${Math.max(0, s.pct)}%`, backgroundColor: s.color }}
+          title={`${s.label} ${pct(s.pct)}`}
+        />
+      ))}
+    </div>
+  )
+}
+
 export function HyperliquidScoreboardPage() {
   const [timeWindow, setTimeWindow] = useState<(typeof WINDOWS)[number]>('1h')
   const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
@@ -99,6 +143,22 @@ export function HyperliquidScoreboardPage() {
 
   // Global competitor set drives the per-vantage table columns (stable order).
   const competitorCols = data?.competitors ?? []
+
+  // Win-rate bar segments: each competitor's share of all comparisons where it beat DoubleZero
+  // (so the green DZ share + the colored competitor segments fill the bar to ~100%).
+  const lossTotal = data?.total_races ?? 0
+  const lossSegments = (data?.competitors ?? []).map((c, i) => ({
+    label: c.label,
+    pct: lossTotal > 0 ? (c.races * (1 - c.dz_win_pct / 100) / lossTotal) * 100 : 0,
+    color: competitorColor(i),
+  }))
+
+  // Recent races grouped by symbol for the per-symbol grid.
+  const racesBySymbol = useMemo(() => {
+    const m: Record<string, HyperliquidRace[]> = {}
+    for (const r of data?.recent_races ?? []) (m[r.symbol] ??= []).push(r)
+    return m
+  }, [data?.recent_races])
 
   return (
     <div className="flex-1 overflow-auto">
@@ -158,6 +218,29 @@ export function HyperliquidScoreboardPage() {
                     <div className="mb-1 text-xs text-muted-foreground">Vantage points</div>
                     <div className="text-xl font-semibold tabular-nums sm:text-2xl">{data.nodes.length}</div>
                   </div>
+                  {data.composite_latency && (
+                    <div className="w-full">
+                      <div className="mb-1.5 text-xs text-muted-foreground">
+                        Composite feed latency{' '}
+                        <span className="text-muted-foreground/60">({data.composite_latency.window})</span>
+                      </div>
+                      <div className="flex gap-5">
+                        {([
+                          ['p50', data.composite_latency.p50_ms],
+                          ['p90', data.composite_latency.p90_ms],
+                          ['p99', data.composite_latency.p99_ms],
+                        ] as const).map(([label, v]) => (
+                          <div key={label}>
+                            <div className="text-xl font-semibold tabular-nums sm:text-2xl">
+                              {Math.round(v)}
+                              <span className="ml-1 text-xs font-normal text-muted-foreground">ms</span>
+                            </div>
+                            <div className="text-xs text-muted-foreground">{label}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -168,15 +251,18 @@ export function HyperliquidScoreboardPage() {
                     <span className="text-sm text-muted-foreground">DoubleZero Win Rate</span>
                     <span className="ml-4 shrink-0 text-sm font-medium tabular-nums">{pct(data.dz_win_share_pct)}</span>
                   </div>
-                  <WinBar value={data.dz_win_share_pct} />
+                  <WinRateBar dzPct={data.dz_win_share_pct} segments={lossSegments} />
                 </div>
-                {data.competitors.map((c) => (
+                {data.competitors.map((c, i) => (
                   <div key={c.feed}>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-muted-foreground">DoubleZero vs {c.label}</span>
+                      <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <span className="inline-block h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: competitorColor(i) }} />
+                        DoubleZero vs {c.label}
+                      </span>
                       <span className="ml-4 shrink-0 text-sm font-medium tabular-nums">
                         <span className="mr-1 text-xs font-normal text-muted-foreground">p50:</span>
-                        <span className="text-emerald-500">+{lead(c.lead_p50_ms)}</span>
+                        +{lead(c.lead_p50_ms)}
                       </span>
                     </div>
                     <div className="mt-0.5 text-xs text-muted-foreground">p95: +{lead(c.lead_p95_ms)}</div>
@@ -233,7 +319,7 @@ export function HyperliquidScoreboardPage() {
                                 <td key={col.feed} className="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums sm:px-4">
                                   {c ? (
                                     <>
-                                      <span className="text-emerald-500">+{lead(c.lead_p50_ms)}</span>{' '}
+                                      <span>+{lead(c.lead_p50_ms)}</span>{' '}
                                       <span className="text-muted-foreground">(+{lead(c.lead_p95_ms)})</span>
                                     </>
                                   ) : (
@@ -251,39 +337,58 @@ export function HyperliquidScoreboardPage() {
               </div>
             </div>
 
-            {/* Recent races */}
-            <div className="mb-6 overflow-hidden rounded-lg border border-border bg-card">
-              <div className="border-b border-border px-4 py-3 text-sm font-medium text-muted-foreground">Recent races</div>
-              {data.recent_races.length === 0 ? (
-                <div className="flex flex-col items-center gap-1 px-4 py-10 text-center">
-                  <div className="text-sm text-muted-foreground">No races in the last couple of minutes.</div>
-                  <div className="max-w-md text-xs text-muted-foreground/70">
-                    The live feed populates from the continuously-updating production source.
-                  </div>
+            {/* Recent races — per-symbol grid, split into native perps and HIP-3 DEX perps */}
+            {RECENT_SECTIONS.map((section) => (
+              <div key={section.title} className="mb-6 overflow-hidden rounded-lg border border-border bg-card">
+                <div className="border-b border-border px-4 py-3 text-sm font-medium text-muted-foreground">
+                  {section.title}
                 </div>
-              ) : (
-                <table className="min-w-full">
-                  <tbody>
-                    {data.recent_races.map((r, i) => (
-                      <tr key={`${r.symbol}-${r.event_ts}-${i}`} className="border-b border-border text-sm last:border-b-0 hover:bg-muted/50">
-                        <td className="px-4 py-2 font-medium">{r.symbol}</td>
-                        <td className="px-4 py-2">
-                          {r.is_dz ? (
-                            <span className="text-emerald-500">DoubleZero</span>
-                          ) : (
-                            <span className="text-muted-foreground">{r.runner_up_label}</span>
+                <div className="grid grid-cols-2 gap-px bg-border sm:grid-cols-4">
+                  {section.symbols.map((sym) => {
+                    const races = racesBySymbol[sym] ?? []
+                    const price = data.prices?.[sym]
+                    return (
+                      <div key={sym} className="bg-card p-3">
+                        <div className="mb-2 flex items-baseline justify-between gap-1">
+                          <span className="text-sm font-semibold">{symbolDisplay(sym)}</span>
+                          {price != null && (
+                            <span className="text-xs tabular-nums text-muted-foreground">{fmtPrice(price)}</span>
                           )}
-                          <span className="text-muted-foreground/60"> · {r.winner_feed}</span>
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-2 text-right tabular-nums text-muted-foreground">
-                          +{lead(r.lead_ms)} <span className="text-muted-foreground/60">vs {r.runner_up_label}</span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </div>
+                        </div>
+                        {races.length === 0 ? (
+                          <div className="flex flex-col gap-1">
+                            <span className="inline-flex w-fit items-center rounded bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                              Competitor feeds pending
+                            </span>
+                            <span className="text-[11px] text-muted-foreground/60">No head-to-head races yet</span>
+                          </div>
+                        ) : (
+                          <div className="space-y-1">
+                            {races.map((r, i) => {
+                              const won = r.is_dz
+                              const comp = won ? r.runner_up_label : r.winner_label
+                              return (
+                                <div key={i} className="flex items-baseline justify-between gap-1.5 text-xs">
+                                  <span className="flex min-w-0 items-baseline gap-1 truncate">
+                                    <span className={`shrink-0 font-semibold ${won ? 'text-emerald-500' : 'text-rose-400'}`}>
+                                      {won ? '▲ DoubleZero' : `▼ ${comp}`}
+                                    </span>
+                                    <span className="truncate text-muted-foreground/50">vs {won ? comp : 'DZ'}</span>
+                                  </span>
+                                  <span className={`shrink-0 tabular-nums ${won ? 'text-emerald-500' : 'text-rose-400'}`}>
+                                    +{lead(r.lead_ms)}
+                                  </span>
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
           </>
         )}
       </div>

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState, useCallback } from 'react'
+import { PageHeader } from './page-header'
+import {
+  fetchHyperliquidScoreboard,
+  type HyperliquidScoreboardResponse,
+} from '@/lib/api'
+
+const WINDOWS = ['1h', '24h', '7d']
+
+function pct(n: number): string {
+  return `${n.toFixed(1)}%`
+}
+function ms(n: number): string {
+  return `+${n.toFixed(2)} ms`
+}
+
+function CompetitorTable({ competitors }: { competitors: HyperliquidScoreboardResponse['competitors'] }) {
+  if (!competitors.length) {
+    return <div className="text-sm text-muted-foreground">No competitor races in this window.</div>
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-muted-foreground">
+          <th className="py-1 pr-4 font-normal">vs Competitor</th>
+          <th className="py-1 pr-4 font-normal">DZ win%</th>
+          <th className="py-1 pr-4 font-normal">median lead</th>
+          <th className="py-1 pr-4 font-normal">p95 lead</th>
+          <th className="py-1 pr-4 font-normal">races</th>
+        </tr>
+      </thead>
+      <tbody>
+        {competitors.map((c) => (
+          <tr key={c.feed} className="border-t border-border/50">
+            <td className="py-1 pr-4">{c.label}</td>
+            <td className="py-1 pr-4 tabular-nums">{pct(c.dz_win_pct)}</td>
+            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p50_ms)}</td>
+            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p95_ms)}</td>
+            <td className="py-1 pr-4 tabular-nums">{c.races.toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export function HyperliquidScoreboardPage() {
+  const [window, setWindow] = useState('24h')
+  const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setData(await fetchHyperliquidScoreboard(window))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load')
+    }
+  }, [window])
+
+  // Initial + window-change load, then poll every 15s for fresh recent races.
+  useEffect(() => {
+    load()
+    const id = setInterval(load, 15000)
+    return () => clearInterval(id)
+  }, [load])
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <PageHeader title="Hyperliquid · BBO Scoreboard" />
+
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">window:</span>
+        {WINDOWS.map((w) => (
+          <button
+            key={w}
+            onClick={() => setWindow(w)}
+            className={`rounded px-2 py-1 text-sm ${w === window ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+
+      {error && <div className="text-sm text-red-500">{error}</div>}
+      {!data && !error && <div className="text-sm text-muted-foreground">Loading…</div>}
+
+      {data && (
+        <>
+          <div className="rounded-lg border border-border p-4">
+            <div className="text-2xl font-semibold tabular-nums">
+              DoubleZero wins {pct(data.dz_win_share_pct)} of races
+            </div>
+            <div className="text-sm text-muted-foreground">
+              all vantages · {data.window} · {data.total_races.toLocaleString()} comparisons
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-2 text-sm font-medium">DoubleZero vs competitors</div>
+            <CompetitorTable competitors={data.competitors} />
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-3 text-sm font-medium">By vantage</div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {data.nodes.map((n) => (
+                <div key={n.measurement_node_id} className="rounded border border-border/60 p-3">
+                  <div className="mb-1 flex items-baseline justify-between">
+                    <span className="font-medium uppercase">{n.location_code}</span>
+                    <span className="tabular-nums">{pct(n.dz_win_share_pct)}</span>
+                  </div>
+                  <div className="mb-2 text-xs text-muted-foreground">
+                    {n.measurement_node_id} · {n.total_races.toLocaleString()} races
+                  </div>
+                  <CompetitorTable competitors={n.competitors} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-2 text-sm font-medium">Recent races (live)</div>
+            <table className="w-full text-sm">
+              <tbody>
+                {data.recent_races.map((r, i) => (
+                  <tr key={`${r.symbol}-${r.event_ts}-${i}`} className="border-t border-border/50">
+                    <td className="py-1 pr-4 font-medium">{r.symbol}</td>
+                    <td className="py-1 pr-4">
+                      {r.is_dz ? (
+                        <span className="text-emerald-500">DoubleZero ({r.winner_feed})</span>
+                      ) : (
+                        <span className="text-muted-foreground">{r.winner_feed}</span>
+                      )}
+                    </td>
+                    <td className="py-1 pr-4 tabular-nums">
+                      {ms(r.lead_ms)} vs {r.runner_up_label}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -1,148 +1,292 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { Trophy } from 'lucide-react'
 import { PageHeader } from './page-header'
 import {
   fetchHyperliquidScoreboard,
   type HyperliquidScoreboardResponse,
 } from '@/lib/api'
 
-const WINDOWS = ['1h', '24h', '7d']
+const WINDOWS = ['1h', '24h', '7d'] as const
+
+const DZ_COLOR = '#34d399' // emerald-400 — DoubleZero
 
 function pct(n: number): string {
   return `${n.toFixed(1)}%`
 }
-function ms(n: number): string {
-  return `+${n.toFixed(2)} ms`
+
+// DoubleZero's lead over a competitor. Sub-second in ms, larger in seconds.
+function lead(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(2)} s`
+  return `${n.toFixed(n < 10 ? 1 : 0)} ms`
 }
 
-function CompetitorTable({ competitors }: { competitors: HyperliquidScoreboardResponse['competitors'] }) {
-  if (!competitors.length) {
-    return <div className="text-sm text-muted-foreground">No competitor races in this window.</div>
-  }
+// Three-quarter-arc win-rate gauge — mirrors the edge scoreboard's WinRateGauge.
+function WinGauge({ value }: { value: number }) {
+  const size = 160
+  const r = 65
+  const c = size / 2
+  const circ = 2 * Math.PI * r
+  const arc = circ * 0.75
+  const gap = circ - arc
+  const fill = arc * (Math.min(100, Math.max(0, value)) / 100)
   return (
-    <table className="w-full text-sm">
-      <thead>
-        <tr className="text-left text-muted-foreground">
-          <th className="py-1 pr-4 font-normal">vs Competitor</th>
-          <th className="py-1 pr-4 font-normal">DZ win%</th>
-          <th className="py-1 pr-4 font-normal">median lead</th>
-          <th className="py-1 pr-4 font-normal">p95 lead</th>
-          <th className="py-1 pr-4 font-normal">races</th>
-        </tr>
-      </thead>
-      <tbody>
-        {competitors.map((c) => (
-          <tr key={c.feed} className="border-t border-border/50">
-            <td className="py-1 pr-4">{c.label}</td>
-            <td className="py-1 pr-4 tabular-nums">{pct(c.dz_win_pct)}</td>
-            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p50_ms)}</td>
-            <td className="py-1 pr-4 tabular-nums">{ms(c.lead_p95_ms)}</td>
-            <td className="py-1 pr-4 tabular-nums">{c.races.toLocaleString()}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="relative flex items-center justify-center shrink-0" style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="absolute inset-0">
+        <circle
+          cx={c} cy={c} r={r} fill="none" strokeWidth={4}
+          stroke="currentColor" className="text-muted-foreground/25"
+          strokeDasharray={`${arc} ${gap}`} strokeLinecap="round"
+          transform={`rotate(-225, ${c}, ${c})`}
+        />
+        <circle
+          cx={c} cy={c} r={r} fill="none" strokeWidth={4}
+          stroke={DZ_COLOR}
+          strokeDasharray={`${fill} ${circ - fill}`} strokeLinecap="round"
+          transform={`rotate(-225, ${c}, ${c})`}
+          style={{ transition: 'stroke-dasharray 0.5s ease-out' }}
+        />
+      </svg>
+      <div className="z-10 flex flex-col items-center">
+        <div className="text-2xl font-semibold tabular-nums">{value.toFixed(1)}%</div>
+        <div className="mt-0.5 text-center text-xs text-muted-foreground">DoubleZero<br />Win Rate</div>
+      </div>
+    </div>
+  )
+}
+
+function WinBar({ value }: { value: number }) {
+  return (
+    <div className="h-1 overflow-hidden rounded-full bg-muted-foreground/25">
+      <div
+        className="h-full rounded-full transition-all duration-500"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%`, backgroundColor: DZ_COLOR }}
+      />
+    </div>
   )
 }
 
 export function HyperliquidScoreboardPage() {
-  const [window, setWindow] = useState('24h')
+  const [timeWindow, setTimeWindow] = useState<(typeof WINDOWS)[number]>('1h')
   const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState(() => Date.now())
 
   const load = useCallback(async () => {
     try {
-      setData(await fetchHyperliquidScoreboard(window))
+      setData(await fetchHyperliquidScoreboard(timeWindow))
       setError(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load')
     }
-  }, [window])
+  }, [timeWindow])
 
-  // Initial + window-change load, then poll every 15s for fresh recent races.
   useEffect(() => {
-    load()
-    const id = setInterval(load, 15000)
-    return () => clearInterval(id)
+    let active = true
+    const run = () => { void load() }
+    run()
+    const poll = setInterval(run, 15000)
+    const tick = setInterval(() => active && setNow(Date.now()), 5000)
+    return () => { active = false; clearInterval(poll); clearInterval(tick) }
   }, [load])
 
+  const freshness = useMemo(() => {
+    if (!data?.generated_at) return null
+    const age = Math.round((now - new Date(data.generated_at).getTime()) / 1000)
+    if (age < 5) return 'just now'
+    if (age < 60) return `${age}s ago`
+    return `${Math.round(age / 60)}m ago`
+  }, [data?.generated_at, now])
+
+  // Global competitor set drives the per-vantage table columns (stable order).
+  const competitorCols = data?.competitors ?? []
+
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <PageHeader title="Hyperliquid · BBO Scoreboard" />
-
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">window:</span>
-        {WINDOWS.map((w) => (
-          <button
-            key={w}
-            onClick={() => setWindow(w)}
-            className={`rounded px-2 py-1 text-sm ${w === window ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
-          >
-            {w}
-          </button>
-        ))}
-      </div>
-
-      {error && <div className="text-sm text-red-500">{error}</div>}
-      {!data && !error && <div className="text-sm text-muted-foreground">Loading…</div>}
-
-      {data && (
-        <>
-          <div className="rounded-lg border border-border p-4">
-            <div className="text-2xl font-semibold tabular-nums">
-              DoubleZero wins {pct(data.dz_win_share_pct)} of races
-            </div>
-            <div className="text-sm text-muted-foreground">
-              all vantages · {data.window} · {data.total_races.toLocaleString()} comparisons
-            </div>
-          </div>
-
-          <div className="rounded-lg border border-border p-4">
-            <div className="mb-2 text-sm font-medium">DoubleZero vs competitors</div>
-            <CompetitorTable competitors={data.competitors} />
-          </div>
-
-          <div className="rounded-lg border border-border p-4">
-            <div className="mb-3 text-sm font-medium">By vantage</div>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              {data.nodes.map((n) => (
-                <div key={n.measurement_node_id} className="rounded border border-border/60 p-3">
-                  <div className="mb-1 flex items-baseline justify-between">
-                    <span className="font-medium uppercase">{n.location_code}</span>
-                    <span className="tabular-nums">{pct(n.dz_win_share_pct)}</span>
-                  </div>
-                  <div className="mb-2 text-xs text-muted-foreground">
-                    {n.measurement_node_id} · {n.total_races.toLocaleString()} races
-                  </div>
-                  <CompetitorTable competitors={n.competitors} />
-                </div>
+    <div className="flex-1 overflow-auto">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-8">
+        <PageHeader
+          icon={Trophy}
+          title="Hyperliquid Scoreboard"
+          subtitle={
+            <span className="flex items-center gap-2 text-xs text-muted-foreground/50">
+              <span>last {data?.window ?? timeWindow}</span>
+              {freshness && <span>· updated {freshness}</span>}
+            </span>
+          }
+          actions={
+            <div className="inline-flex overflow-hidden rounded-md border border-border text-sm">
+              {WINDOWS.map((w) => (
+                <button
+                  key={w}
+                  type="button"
+                  onClick={() => setTimeWindow(w)}
+                  className={
+                    w === timeWindow
+                      ? 'bg-emerald-500/10 px-3 py-1.5 font-medium text-emerald-400'
+                      : 'px-3 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                  }
+                >
+                  {w}
+                </button>
               ))}
             </div>
-          </div>
+          }
+        />
 
-          <div className="rounded-lg border border-border p-4">
-            <div className="mb-2 text-sm font-medium">Recent races (live)</div>
-            <table className="w-full text-sm">
-              <tbody>
-                {data.recent_races.map((r, i) => (
-                  <tr key={`${r.symbol}-${r.event_ts}-${i}`} className="border-t border-border/50">
-                    <td className="py-1 pr-4 font-medium">{r.symbol}</td>
-                    <td className="py-1 pr-4">
-                      {r.is_dz ? (
-                        <span className="text-emerald-500">DoubleZero ({r.winner_feed})</span>
-                      ) : (
-                        <span className="text-muted-foreground">{r.winner_feed}</span>
-                      )}
-                    </td>
-                    <td className="py-1 pr-4 tabular-nums">
-                      {ms(r.lead_ms)} vs {r.runner_up_label}
-                    </td>
-                  </tr>
+        {error && (
+          <div className="rounded-lg border border-border bg-card p-6 text-sm text-red-500">{error}</div>
+        )}
+        {!data && !error && (
+          <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">Loading…</div>
+        )}
+
+        {data && (
+          <>
+            {/* Hero stats — 3 columns: description+stats | metrics | gauge */}
+            <div className="mb-8 flex flex-col rounded-lg border border-border bg-card lg:flex-row">
+              {/* Left: description + summary stats */}
+              <div className="flex min-w-0 flex-1 flex-col justify-between p-4 sm:p-6">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  Scoreboard benchmarks Hyperliquid best-bid/offer delivery speed across DoubleZero and
+                  competing providers, comparing who delivers each order-book update first across {data.nodes.length} vantage points.
+                </p>
+                <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-border pt-4">
+                  <div>
+                    <div className="mb-1 text-xs text-muted-foreground">Head-to-head races</div>
+                    <div className="text-xl font-semibold tabular-nums sm:text-2xl">{data.total_races.toLocaleString()}</div>
+                  </div>
+                  <div className="sm:border-l sm:border-border sm:pl-6">
+                    <div className="mb-1 text-xs text-muted-foreground">Vantage points</div>
+                    <div className="text-xl font-semibold tabular-nums sm:text-2xl">{data.nodes.length}</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Middle: win rate + per-competitor leads */}
+              <div className="flex min-w-0 flex-1 flex-col justify-center gap-4 border-t border-border p-4 sm:p-6 lg:border-l lg:border-t-0">
+                <div className="pb-2">
+                  <div className="mb-1.5 flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">DoubleZero Win Rate</span>
+                    <span className="ml-4 shrink-0 text-sm font-medium tabular-nums">{pct(data.dz_win_share_pct)}</span>
+                  </div>
+                  <WinBar value={data.dz_win_share_pct} />
+                </div>
+                {data.competitors.map((c) => (
+                  <div key={c.feed}>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">DoubleZero vs {c.label}</span>
+                      <span className="ml-4 shrink-0 text-sm font-medium tabular-nums">
+                        <span className="mr-1 text-xs font-normal text-muted-foreground">p50:</span>
+                        <span className="text-emerald-500">+{lead(c.lead_p50_ms)}</span>
+                      </span>
+                    </div>
+                    <div className="mt-0.5 text-xs text-muted-foreground">p95: +{lead(c.lead_p95_ms)}</div>
+                  </div>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        </>
-      )}
+              </div>
+
+              {/* Right: gauge */}
+              <div className="flex shrink-0 items-center justify-center border-t border-border px-6 py-6 sm:px-8 lg:border-l lg:border-t-0 lg:py-0">
+                <WinGauge value={data.dz_win_share_pct} />
+              </div>
+            </div>
+
+            {/* Per-vantage table */}
+            <div className="mb-6 overflow-hidden rounded-lg border border-border bg-card">
+              <div className="overflow-x-auto">
+                <table className="min-w-full">
+                  <thead>
+                    <tr className="border-b border-border text-left text-sm text-muted-foreground">
+                      <th className="whitespace-nowrap px-3 py-3 font-medium sm:px-4">Vantage</th>
+                      <th className="whitespace-nowrap px-3 py-3 text-right font-medium sm:px-4">DZ Win Rate %</th>
+                      {competitorCols.map((c) => (
+                        <th key={c.feed} className="whitespace-nowrap px-3 py-3 text-right font-medium sm:px-4">
+                          vs {c.label}
+                          <span className="block text-xs font-normal">p50 (p95)</span>
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.nodes.length === 0 ? (
+                      <tr>
+                        <td colSpan={2 + competitorCols.length} className="px-4 py-12 text-center text-muted-foreground">
+                          No data available for the selected time window.
+                        </td>
+                      </tr>
+                    ) : (
+                      data.nodes.map((n) => {
+                        const byFeed = new Map(n.competitors.map((c) => [c.feed, c]))
+                        return (
+                          <tr key={n.measurement_node_id} className="border-b border-border transition-colors last:border-b-0 hover:bg-muted/50">
+                            <td className="px-3 py-3 sm:px-4">
+                              <div className="text-sm font-medium uppercase">{n.location_code}</div>
+                              <div className="text-xs text-muted-foreground">{n.measurement_node_id}</div>
+                              <div className="text-xs text-muted-foreground">{n.total_races.toLocaleString()} races</div>
+                            </td>
+                            <td className="px-3 py-3 text-right text-sm tabular-nums sm:px-4">
+                              <div className="mb-1.5">{pct(n.dz_win_share_pct)}</div>
+                              <WinBar value={n.dz_win_share_pct} />
+                            </td>
+                            {competitorCols.map((col) => {
+                              const c = byFeed.get(col.feed)
+                              return (
+                                <td key={col.feed} className="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums sm:px-4">
+                                  {c ? (
+                                    <>
+                                      <span className="text-emerald-500">+{lead(c.lead_p50_ms)}</span>{' '}
+                                      <span className="text-muted-foreground">(+{lead(c.lead_p95_ms)})</span>
+                                    </>
+                                  ) : (
+                                    '—'
+                                  )}
+                                </td>
+                              )
+                            })}
+                          </tr>
+                        )
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Recent races */}
+            <div className="mb-6 overflow-hidden rounded-lg border border-border bg-card">
+              <div className="border-b border-border px-4 py-3 text-sm font-medium text-muted-foreground">Recent races</div>
+              {data.recent_races.length === 0 ? (
+                <div className="flex flex-col items-center gap-1 px-4 py-10 text-center">
+                  <div className="text-sm text-muted-foreground">No races in the last couple of minutes.</div>
+                  <div className="max-w-md text-xs text-muted-foreground/70">
+                    The live feed populates from the continuously-updating production source.
+                  </div>
+                </div>
+              ) : (
+                <table className="min-w-full">
+                  <tbody>
+                    {data.recent_races.map((r, i) => (
+                      <tr key={`${r.symbol}-${r.event_ts}-${i}`} className="border-b border-border text-sm last:border-b-0 hover:bg-muted/50">
+                        <td className="px-4 py-2 font-medium">{r.symbol}</td>
+                        <td className="px-4 py-2">
+                          {r.is_dz ? (
+                            <span className="text-emerald-500">DoubleZero</span>
+                          ) : (
+                            <span className="text-muted-foreground">{r.runner_up_label}</span>
+                          )}
+                          <span className="text-muted-foreground/60"> · {r.winner_feed}</span>
+                        </td>
+                        <td className="whitespace-nowrap px-4 py-2 text-right tabular-nums text-muted-foreground">
+                          +{lead(r.lead_ms)} <span className="text-muted-foreground/60">vs {r.runner_up_label}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -59,6 +59,8 @@ export function Sidebar() {
   })
   const hasTopologies = (topologiesData?.topologies?.length ?? 0) > 0
   const showGeoloc = user?.is_internal_user === true
+  // Internal only (unannounced venue) — gated to allowed-domain Google users.
+  const showHyperliquid = user?.is_internal_user === true
 const { resolvedTheme, setTheme } = useTheme()
   const { updateAvailable, reload } = useVersionCheck()
 
@@ -583,15 +585,19 @@ const { resolvedTheme, setTheme } = useTheme()
                 </Link>
               </>
             )}
-            <Link to="/dz/hyperliquid/scoreboard" className={isHyperliquidRoute ? navItemExpandedClass : navItemClass(false)}>
-              <Activity className="h-4 w-4" />
-              Hyperliquid
-            </Link>
-            {isHyperliquidRoute && (
+            {showHyperliquid && (
               <>
-                <Link to="/dz/hyperliquid/scoreboard" className={subNavItemClass(isHyperliquidScoreboardRoute)}>
-                  Scoreboard
+                <Link to="/dz/hyperliquid/scoreboard" className={isHyperliquidRoute ? navItemExpandedClass : navItemClass(false)}>
+                  <Activity className="h-4 w-4" />
+                  Hyperliquid
                 </Link>
+                {isHyperliquidRoute && (
+                  <>
+                    <Link to="/dz/hyperliquid/scoreboard" className={subNavItemClass(isHyperliquidScoreboardRoute)}>
+                      Scoreboard
+                    </Link>
+                  </>
+                )}
               </>
             )}
           </div>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -116,7 +116,9 @@ const { resolvedTheme, setTheme } = useTheme()
     location.pathname === '/dz/shreds/rewards' ||
     location.pathname.startsWith('/dz/shreds/rewards/')
   const isShredsRoute = location.pathname.startsWith('/dz/shreds') || isShredsPublishersRoute
-  const isEdgeRoute = isShredsRoute
+  const isHyperliquidScoreboardRoute = location.pathname === '/dz/hyperliquid/scoreboard'
+  const isHyperliquidRoute = location.pathname.startsWith('/dz/hyperliquid')
+  const isEdgeRoute = isShredsRoute || isHyperliquidRoute
   const isGeolocRoute = location.pathname.startsWith('/dz/geoloc/')
   const isGeolocProbesRoute = location.pathname.startsWith('/dz/geoloc/probes')
   const isGeolocUsersRoute = location.pathname.startsWith('/dz/geoloc/users')
@@ -578,6 +580,17 @@ const { resolvedTheme, setTheme } = useTheme()
                 </Link>
                 <Link to="/dz/shreds/economics" className={subNavItemClass(isShredsEconomicsRoute)}>
                   Economics
+                </Link>
+              </>
+            )}
+            <Link to="/dz/hyperliquid/scoreboard" className={isHyperliquidRoute ? navItemExpandedClass : navItemClass(false)}>
+              <Activity className="h-4 w-4" />
+              Hyperliquid
+            </Link>
+            {isHyperliquidRoute && (
+              <>
+                <Link to="/dz/hyperliquid/scoreboard" className={subNavItemClass(isHyperliquidScoreboardRoute)}>
+                  Scoreboard
                 </Link>
               </>
             )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6871,6 +6871,7 @@ export interface HyperliquidRace {
   symbol: string
   location_code: string
   winner_feed: string
+  winner_label: string
   is_dz: boolean
   runner_up_feed: string
   runner_up_label: string
@@ -6887,6 +6888,16 @@ export interface HyperliquidScoreboardResponse {
   competitors: HyperliquidCompetitor[]
   nodes: HyperliquidNode[]
   recent_races: HyperliquidRace[]
+  prices?: Record<string, number>
+  composite_latency?: HyperliquidCompositeLatency
+}
+
+export interface HyperliquidCompositeLatency {
+  window: string
+  p50_ms: number
+  p90_ms: number
+  p99_ms: number
+  generated_at: string
 }
 
 export async function fetchHyperliquidScoreboard(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6848,3 +6848,57 @@ export async function fetchShredsRewardsDetail(nodeId: string): Promise<ShredsRe
   if (!res.ok) throw new Error('Failed to fetch shreds rewards detail')
   return res.json()
 }
+
+export interface HyperliquidCompetitor {
+  feed: string
+  label: string
+  dz_win_pct: number
+  lead_p50_ms: number
+  lead_p95_ms: number
+  races: number
+}
+
+export interface HyperliquidNode {
+  measurement_node_id: string
+  location_code: string
+  dz_win_share_pct: number
+  total_races: number
+  competitors: HyperliquidCompetitor[]
+}
+
+export interface HyperliquidRace {
+  event_ts: string
+  symbol: string
+  location_code: string
+  winner_feed: string
+  is_dz: boolean
+  runner_up_feed: string
+  runner_up_label: string
+  lead_ms: number
+}
+
+export interface HyperliquidScoreboardResponse {
+  window: string
+  symbol?: string
+  generated_at: string
+  feed_type: string
+  dz_win_share_pct: number
+  total_races: number
+  competitors: HyperliquidCompetitor[]
+  nodes: HyperliquidNode[]
+  recent_races: HyperliquidRace[]
+}
+
+export async function fetchHyperliquidScoreboard(
+  window: string = '24h',
+  symbol?: string,
+): Promise<HyperliquidScoreboardResponse> {
+  const params = new URLSearchParams()
+  params.set('window', window)
+  if (symbol && symbol !== 'all') params.set('symbol', symbol)
+  const res = await apiFetch(`/api/dz/hyperliquid/scoreboard?${params}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch hyperliquid scoreboard')
+  }
+  return res.json()
+}


### PR DESCRIPTION
Internal-only scoreboard for a new market-data venue (sibling to the Edge scoreboard). Gated to allowed-domain Google users.