### PR TITLE
indexer: support testnet Solana RPC URL for shred-subscription reads

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -726,6 +726,7 @@ func run() error {
 	type secondaryEnvConfig struct {
 		database       string
 		dzLedgerRPCURL string
+		solanaRPCURL   string // overrides shred-subscription RPC; empty = read shreds from DZ ledger
 		noInflux       bool
 		mrouteS3Bucket string // empty = mroute ingest disabled for this env
 		msdpS3Bucket   string // empty = MSDP ingest disabled for this env
@@ -754,6 +755,17 @@ func run() error {
 		cfg.dzLedgerRPCURL = rpcURL
 		secondaryEnvs["testnet"] = cfg
 	}
+	if rpcURL := os.Getenv("SOLANA_RPC_URL_TESTNET"); rpcURL != "" {
+		cfg := secondaryEnvs["testnet"]
+		cfg.solanaRPCURL = rpcURL
+		secondaryEnvs["testnet"] = cfg
+	}
+	// Uncomment for devnet shred oracle instance.
+	// if rpcURL := os.Getenv("SOLANA_RPC_URL_DEVNET"); rpcURL != "" {
+	// 	cfg := secondaryEnvs["devnet"]
+	// 	cfg.solanaRPCURL = rpcURL
+	// 	secondaryEnvs["devnet"] = cfg
+	// }
 	if *noInfluxDevnetFlag {
 		cfg := secondaryEnvs["devnet"]
 		cfg.noInflux = true
@@ -811,6 +823,7 @@ func run() error {
 				clickhouseAddr:             *clickhouseAddrFlag,
 				clickhouseDatabase:         envCfg.database,
 				dzLedgerRPCURL:             envCfg.dzLedgerRPCURL,
+				solanaRPCURL:               envCfg.solanaRPCURL,
 				clickhouseUsername:         *clickhouseUsernameFlag,
 				clickhousePassword:         *clickhousePasswordFlag,
 				clickhouseSecure:           *clickhouseSecureFlag,
@@ -900,6 +913,11 @@ type secondaryNetworkConfig struct {
 	// DZ ledger RPC URL override (optional).
 	dzLedgerRPCURL string
 
+	// Solana RPC URL for shred-subscription reads (optional). When set, the
+	// secondary network indexer reads shred-subscription state from this
+	// endpoint instead of the DZ ledger.
+	solanaRPCURL string
+
 	// ISIS configuration (optional).
 	isisS3Bucket string
 	isisS3Region string
@@ -981,9 +999,13 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	var shredsClient *shreds.Client
 	var secondaryShredsRawRPC *solanarpc.Client
 	if env != config.EnvDevnet {
-		secondaryShredsRawRPC = shreds.NewRPCClient(networkConfig.LedgerPublicRPCURL)
+		shredsRPCURL := networkConfig.LedgerPublicRPCURL
+		if cfg.solanaRPCURL != "" {
+			shredsRPCURL = cfg.solanaRPCURL
+		}
+		secondaryShredsRawRPC = shreds.NewRPCClient(shredsRPCURL)
 		shredsClient = shreds.New(secondaryShredsRawRPC, shreds.ProgramID)
-		log.Info("shreds subscription client initialized", "env", env)
+		log.Info("shreds subscription client initialized", "env", env, "rpc_url", shredsRPCURL)
 	}
 
 	// Initialize InfluxDB client for device usage (optional).


### PR DESCRIPTION
## Summary of Changes

Adds a `SOLANA_RPC_URL_TESTNET` env var to the secondary network indexer, mirroring the existing `DZ_LEDGER_RPC_URL_TESTNET` pattern. When set, the shred-subscription client reads from this endpoint; when unset it falls back to the DZ ledger (today's behavior). Serviceability, telemetry, and geolocation read paths are unaffected.

### Context (parent issue)

Part of [malbeclabs/infra#1762](https://github.com/malbeclabs/infra/issues/1762) / epic [#1758](https://github.com/malbeclabs/infra/issues/1758). The testnet shred-subscription program is moving from the DZ Ledger testnet to a Solana devnet deployment, in lockstep with the [shred-oracle cutover](https://github.com/malbeclabs/infra/issues/1760).

This is the Phase 1 read-path change, kept off the critical path so it can bake in prod ahead of the coordinated flip. The flip itself is a separate infra step: setting `SOLANA_RPC_URL_TESTNET` on the lake-indexer Deployment in lockstep with the [oracle overlay removal](https://github.com/malbeclabs/infra/pull/1803).

## Why merging + promoting to prod has no impact

The new behavior is gated on `SOLANA_RPC_URL_TESTNET`, which is not set on the prod Deployment or in `lake-indexer-env` and has no default. Unset, the RPC selection resolves to the same DZ-ledger endpoint used today. This is a read-path-only change: no schema, migrations, or write path, so existing `dim_dz_shred_*` / `fact_dz_shred_escrow_events` rows are untouched. The only visible change in prod is the added `rpc_url` log field, which will show the current DZ-ledger URL — confirming behavior is unchanged.

## Rollback

Revert the commit. The env var is additive and only consumed when set; no state migration.
