### PR TITLE
indexer: bound telemetry-usage catch-up window to fit activity timeout

### DIFF
--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -200,8 +200,16 @@ const baselineCacheTTL = 5 * time.Minute
 // data. After downtime maxTime can fall behind the query window, making one
 // refresh span the entire window at once; capping it spreads the catch-up over
 // successive refreshes (maxTime advances after each) so peak memory stays near
-// steady state. 3 × 5m = 15m per refresh, ~3× the normal incremental span.
-const maxCatchupChunks = 3
+// steady state.
+//
+// The cap must also keep each refresh inside the dzingest activity's
+// StartToCloseTimeout (5m). On mainnet-beta a 15m (3-chunk) window pulled ~6M
+// rows and the chunked InfluxDB pivot alone ran >5m, so the activity context
+// expired before InsertInterfaceUsage even started — every catch-up refresh
+// timed out, maxTime never advanced, and the window stayed pinned at the cap
+// (an unrecoverable loop). One chunk (5m) keeps the InfluxDB query and insert
+// comfortably under the activity deadline so maxTime advances every cycle.
+const maxCatchupChunks = 1
 
 type View struct {
 	log       *slog.Logger
@@ -444,7 +452,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		v.baselineCacheTime = now
 	}
 
-	v.log.Info("telemetry/usage: queried influxdb", "rows", len(usage), "from", queryStart, "to", now)
+	v.log.Info("telemetry/usage: queried influxdb", "rows", len(usage), "from", queryStart, "to", queryEnd)
 
 	if len(usage) == 0 {
 		v.log.Warn("telemetry/usage: no data returned from influxdb query", "from", queryStart, "to", now)

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -203,12 +203,17 @@ const baselineCacheTTL = 5 * time.Minute
 // steady state.
 //
 // The cap must also keep each refresh inside the dzingest activity's
-// StartToCloseTimeout (5m). On mainnet-beta a 15m (3-chunk) window pulled ~6M
-// rows and the chunked InfluxDB pivot alone ran >5m, so the activity context
-// expired before InsertInterfaceUsage even started — every catch-up refresh
-// timed out, maxTime never advanced, and the window stayed pinned at the cap
-// (an unrecoverable loop). One chunk (5m) keeps the InfluxDB query and insert
-// comfortably under the activity deadline so maxTime advances every cycle.
+// StartToCloseTimeout (5m). Each chunk is a separate Flux query bounded only by
+// the client's per-request HTTP timeout (defaultFluxHTTPTimeout, 4m); the Flux
+// query does not abort on the activity context deadline, so a 3-chunk (15m)
+// window can spend up to ~12m in InfluxDB alone. In prod this overran the 5m
+// deadline (observed >10m on both mainnet-beta and testnet), so ctx was already
+// expired by the time InsertInterfaceUsage ran — every catch-up refresh failed,
+// maxTime never advanced, and the window stayed pinned at the cap (an
+// unrecoverable loop; the overrun also spawned a doomed second Temporal attempt
+// that failed instantly on the already-expired ctx). One chunk caps each
+// refresh at a single <=4m query, leaving room for the insert inside the 5m
+// deadline so maxTime advances every cycle.
 const maxCatchupChunks = 1
 
 type View struct {


### PR DESCRIPTION
## Summary

- Fixes a stuck catch-up loop in telemetry-usage ingestion on mainnet-beta that produced sustained `RefreshTelemetryUsage` ERRORs (`context cancelled during batch insert: context deadline exceeded`, 100+ consecutive failures).
- The `RefreshTelemetryUsage` activity runs under a 5-minute `StartToCloseTimeout`. With `maxCatchupChunks = 3` (a 15-minute window), the mainnet InfluxDB query returned ~6M rows and the chunked pivot alone ran >5 minutes — the activity context expired *before* `InsertInterfaceUsage` even started, so `max(event_ts)` never advanced and every subsequent refresh re-queried the same too-large window. The prior cap bounded peak memory but not wall-clock time, so the failure mode became a permanent timeout loop.
- Reduces `maxCatchupChunks` from 3 to 1 (one 5-minute chunk per refresh) so the InfluxDB query and insert complete comfortably inside the activity deadline, `max(event_ts)` advances every cycle, and the loop recovers. Steady state is unaffected — the normal incremental window is ~1 minute and never reaches the cap.
- Also fixes a misleading log: `telemetry/usage: queried influxdb` printed the wall-clock `now` as `to` instead of the actual (capped) `queryEnd`, which hid the real query window and obscured this exact issue during diagnosis.

## Testing Verification

- Confirmed root cause against production logs: `queried influxdb rows=5976935` followed by `refresh completed duration=5m32s` and `Activity complete after timeout ... Error="context deadline exceeded"`, with the deadline landing on the first `ctx.Done()` check in the batch insert before any rows were written.
- Verified the catch-up cap is the only driver of per-refresh query size/duration, so shrinking it keeps each refresh under the 5m activity budget while still advancing the high-water mark every cycle.

## Follow-ups (not in this PR)

- ~6M rows for a 15m window implies the InfluxDB pivot is inherently slow (~18k rows/s); as interface count grows, consider moving telemetry-usage off the blocking main workflow loop and/or a dedicated longer timeout with heartbeating.
- A regression test asserting the catch-up window stays within the activity budget would harden this path.
