### PR TITLE
indexer: treat S3 403 as not-exported in shreds leaf fetch

### DIFF
--- a/indexer/pkg/dz/shreds/validatorrewards/s3.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/s3.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 )
 
 // S3BaseURL is the base URL for the DoubleZero Foundation's public
@@ -75,24 +76,35 @@ func (c *S3Client) FetchLeaderSlotData(ctx context.Context, solanaEpoch uint64) 
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		metrics.ShredLeafFetchTotal.WithLabelValues("error").Inc()
 		return nil, false, fmt.Errorf("HTTP request to %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	// 404, or 403 from a public bucket without s3:ListBucket, both mean the
-	// object for this epoch does not exist — treat as "not exported yet".
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+	// object for this epoch does not exist — treat as "not exported yet". They
+	// are recorded under distinct metric statuses ("not_found" vs "forbidden")
+	// so a real access loss — a 403 where a 200 is expected — stays visible even
+	// though neither is returned as an error.
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		metrics.ShredLeafFetchTotal.WithLabelValues("not_found").Inc()
 		return nil, false, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	case resp.StatusCode == http.StatusForbidden:
+		metrics.ShredLeafFetchTotal.WithLabelValues("forbidden").Inc()
+		return nil, false, nil
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		metrics.ShredLeafFetchTotal.WithLabelValues("error").Inc()
 		return nil, false, fmt.Errorf("S3 returned status %d for epoch %d", resp.StatusCode, solanaEpoch)
 	}
 
 	var entries []ValidatorLeaderSlotEntry
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		metrics.ShredLeafFetchTotal.WithLabelValues("error").Inc()
 		return nil, false, fmt.Errorf("decode leader-slot JSON for epoch %d: %w", solanaEpoch, err)
 	}
 
+	metrics.ShredLeafFetchTotal.WithLabelValues("ok").Inc()
 	return entries, true, nil
 }
 

--- a/indexer/pkg/dz/shreds/validatorrewards/s3.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/s3.go
@@ -58,8 +58,12 @@ func (c *S3Client) SetBaseURL(url string) {
 //
 // Return shapes:
 //   - 200: (entries, true, nil)
-//   - 404: (nil, false, nil) — signals "not exported yet" without it being
-//     an error condition
+//   - 404 or 403: (nil, false, nil) — signals "not exported yet" without it
+//     being an error condition. A public S3 bucket whose policy grants
+//     s3:GetObject but not s3:ListBucket returns 403 (AccessDenied), not 404,
+//     for a key that does not exist, to avoid leaking object existence. The
+//     export only publishes a subset of epochs (e.g. testnet epochs are not
+//     exported at all), so both statuses mean "no data for this epoch".
 //   - any other status or transport/decode error: (nil, false, err)
 func (c *S3Client) FetchLeaderSlotData(ctx context.Context, solanaEpoch uint64) ([]ValidatorLeaderSlotEntry, bool, error) {
 	url := fmt.Sprintf("%s/%d.json", c.baseURL, solanaEpoch)
@@ -75,7 +79,9 @@ func (c *S3Client) FetchLeaderSlotData(ctx context.Context, solanaEpoch uint64) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	// 404, or 403 from a public bucket without s3:ListBucket, both mean the
+	// object for this epoch does not exist — treat as "not exported yet".
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
 		return nil, false, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/indexer/pkg/dz/shreds/validatorrewards/s3_test.go
+++ b/indexer/pkg/dz/shreds/validatorrewards/s3_test.go
@@ -114,6 +114,18 @@ func TestS3Client_Fetch_NotFound(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+func TestS3Client_Fetch_Forbidden(t *testing.T) {
+	// A public bucket without s3:ListBucket returns 403 for a missing key.
+	// Treat it as "not exported yet", same as 404, not an error.
+	srv := newTestServer(t, http.StatusForbidden, []byte(""))
+	c := newClientFor(t, srv)
+
+	got, ok, err := c.FetchLeaderSlotData(context.Background(), 951)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
 func TestS3Client_Fetch_ServerError(t *testing.T) {
 	srv := newTestServer(t, http.StatusInternalServerError, []byte("boom"))
 	c := newClientFor(t, srv)

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -26,6 +26,21 @@ var (
 		[]string{"view_type", "status"},
 	)
 
+	// ShredLeafFetchTotal counts validator-rewards leaf-export fetches from the
+	// foundation S3 bucket by HTTP outcome. 403 ("forbidden") is treated as
+	// "not exported yet" (the public bucket returns 403 for missing keys), so it
+	// is no longer logged as an error — this metric is what keeps a real access
+	// loss visible: only mainnet ever produces "ok", so a sustained collapse of
+	// "ok" to zero, or a 403 where a 200 is expected, indicates the export
+	// access was lost rather than the epoch simply being unpublished.
+	ShredLeafFetchTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_shred_leaf_fetch_total",
+			Help: "Total validator-rewards leaf-export fetches from S3 by HTTP outcome (ok, not_found, forbidden, error)",
+		},
+		[]string{"status"},
+	)
+
 	ViewRefreshDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "doublezero_data_indexer_view_refresh_duration_seconds",


### PR DESCRIPTION
## Summary

- Treats S3 **403** the same as 404 ("not exported yet") in the shreds leaf fetch, so benign 403s stop being logged as errors. A public bucket without `s3:ListBucket` returns 403 for missing keys, and the export doesn't publish testnet/unpublished epochs.
- Adds a `doublezero_data_indexer_shred_leaf_fetch_total{status}` counter (`ok` / `not_found` / `forbidden` / `error`) so a **real access loss stays visible** now that 403s aren't errors: only mainnet ever produces `ok`, so a sustained collapse of `ok` to zero — or a `forbidden` where a `200` is expected — signals lost access rather than an unpublished epoch.

## Testing Verification

- Verified the 403 semantics against the live bucket: mainnet epochs with data → 200; a nonexistent epoch (`999999`) → 403 `AccessDenied`; testnet epochs → 403 — confirming 403 = missing key on this bucket.
- Existing fetch-path tests (OK / NotFound / Forbidden / ServerError) cover the unchanged return behavior; the metric increments at each outcome.

## Follow-ups (not in this PR)

- **Alert** is a separate infra (Grafana) PR. Alert on the metric (e.g. mainnet `ok` rate == 0 over a window spanning an epoch) — or, since successful fetches are sparse by design, on ClickHouse leaf-data freshness (`dim_dz_shred_validator_rewards_leaves` not advancing). Confirm the indexer `/metrics` is actually scraped into Grafana Cloud first.