### PR TITLE
api: fix geo concentration/validators timeout from location_state FINAL

### DIFF
--- a/api/handlers/geo_concentration.go
+++ b/api/handlers/geo_concentration.go
@@ -91,7 +91,21 @@ func (a *API) FetchGeoConcentrationData(ctx context.Context) (*GeoConcentrationR
 				coalesce(ls.lat, 0) AS dzdp_lat,
 				coalesce(ls.lng, 0) AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM (SELECT * FROM %s.location_state FINAL) AS ls
+			FROM (
+				-- location_state is append-only history: its sort key is
+				-- (target_ip, snapshot_at), so FINAL does NOT collapse to one row
+				-- per IP — it keeps every snapshot (~25k per IP, ~37M rows). Take
+				-- each IP's latest snapshot explicitly instead; joining the full
+				-- history exploded the downstream cross join (~35M rows) and timed
+				-- out the query.
+				SELECT
+					target_ip,
+					argMax(state, snapshot_at) AS state,
+					argMax(lat, snapshot_at) AS lat,
+					argMax(lng, snapshot_at) AS lng
+				FROM %s.location_state
+				GROUP BY target_ip
+			) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'honed'
 		),

--- a/api/handlers/geo_validators.go
+++ b/api/handlers/geo_validators.go
@@ -101,7 +101,21 @@ func (a *API) FetchGeoValidatorsData(ctx context.Context, metro, dzFilter string
 				coalesce(ls.lat, 0) AS dzdp_lat,
 				coalesce(ls.lng, 0) AS dzdp_lng,
 				gn.pubkey AS node_pubkey
-			FROM (SELECT * FROM %s.location_state FINAL) AS ls
+			FROM (
+				-- location_state is append-only history: its sort key is
+				-- (target_ip, snapshot_at), so FINAL does NOT collapse to one row
+				-- per IP — it keeps every snapshot (~25k per IP, ~37M rows). Take
+				-- each IP's latest snapshot explicitly instead; joining the full
+				-- history exploded the downstream cross join (~35M rows) and timed
+				-- out the query.
+				SELECT
+					target_ip,
+					argMax(state, snapshot_at) AS state,
+					argMax(lat, snapshot_at) AS lat,
+					argMax(lng, snapshot_at) AS lng
+				FROM %s.location_state
+				GROUP BY target_ip
+			) AS ls
 			JOIN solana_gossip_nodes_current gn ON ls.target_ip = gn.gossip_ip
 			WHERE ls.state = 'honed'
 		),


### PR DESCRIPTION
## Summary

- Fixes the sustained `page-cache` failures for `geo concentration` and `geo validators` (`consecutive_failures` in the hundreds, ERROR-level), which surfaced as `context deadline exceeded` and ClickHouse native-protocol `i/o timeout` on the query connection.
- Both handlers derived "current location per IP" with `(SELECT * FROM dzdp.location_state FINAL)`. But `location_state` is append-only history sorted by `(target_ip, snapshot_at)`, so `FINAL` collapses nothing — it returns every snapshot. The table holds ~40.5M rows across only **1,461 distinct IPs** (~25.7k snapshots/IP), so the `geolocated` CTE joined ~34.8M rows into the downstream `CROSS JOIN dz_metros_current`, producing a ~1B-row intermediate before the `GROUP BY` collapsed it. Under concurrent page-cache load with cold object-storage reads, that timed out, and it degraded steadily as snapshots accumulated.
- Replaced the `FINAL` subquery with an explicit latest-snapshot-per-IP aggregation (`argMax(..., snapshot_at) ... GROUP BY target_ip`), cutting `geolocated` from ~34.8M rows to ~1.1k. This is also semantically more correct: it reflects each IP's current state rather than mixing in historical snapshots.

## Testing Verification

- Measured against production ClickHouse via read-only MCP:
  - `geolocated` row count: **34,795,870 → 1,081**.
  - Full `geo_concentration` query (cold isolated run): returns 652 validators across 24 metros in ~43ms.
- Result parity: the rewrite returns 652 validators / 24 metros vs the original 657 / 25. The small delta is expected and intended — the original counted IPs with *any* historical `honed` snapshot, while the rewrite uses each IP's *latest* state, which is the correct "current concentration" semantic.
- Existing handler tests seed one snapshot per IP, so their results are unchanged.

## Note

- The same anti-pattern existed only in these two handlers (`geo_concentration.go`, `geo_validators.go`); no other query wraps `location_state` in `FINAL`.
