### PR TITLE
api: fix shreds rewards detail header join (cannot determine join keys)

### DIFF
--- a/api/handlers/shreds_rewards.go
+++ b/api/handlers/shreds_rewards.go
@@ -609,26 +609,29 @@ func (a *API) GetShredsRewardsDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Header: vote pubkey, validator name, activated stake, DZ user IP.
-	// Same join shape as the list endpoint. A single-row anchor SELECT lets
-	// the LEFT JOINs return zero values for unknown node_ids without erroring.
+	// The single-row anchor carries the node_id so the LEFT JOINs have a real
+	// join key (ON v.node_pubkey = one.node_id); this returns zero values for
+	// unknown node_ids instead of erroring. Joining directly on a bound param
+	// (ON v.node_pubkey = ?) leaves no key relating the two tables, which
+	// ClickHouse rejects with "cannot determine join keys".
 	const headerQuery = `
 		SELECT
 			coalesce(v.vote_pubkey, ''),
 			coalesce(va.name, ''),
 			toUInt64(coalesce(v.activated_stake_lamports, 0)),
 			coalesce(u.client_ip, '')
-		FROM (SELECT 1 AS x) one
+		FROM (SELECT ? AS node_id) one
 		LEFT JOIN solana_vote_accounts_current v
-			ON v.node_pubkey = ? AND v.epoch_vote_account = 'true'
+			ON v.node_pubkey = one.node_id AND v.epoch_vote_account = 'true'
 		LEFT JOIN validatorsapp_validators_current va
 			ON v.vote_pubkey = va.vote_account
 		LEFT JOIN solana_gossip_nodes_current g
-			ON g.pubkey = ?
+			ON g.pubkey = one.node_id
 		LEFT JOIN dz_users_current u
 			ON u.client_ip = g.gossip_ip AND u.status = 'activated'
 		LIMIT 1
 	`
-	if err := a.envDB(ctx).QueryRow(ctx, headerQuery, nodeID, nodeID).Scan(
+	if err := a.envDB(ctx).QueryRow(ctx, headerQuery, nodeID).Scan(
 		&resp.VotePubkey, &resp.ValidatorName, &resp.ActivatedStake, &resp.DZUserIP,
 	); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		// Tolerate missing rows; leave fields zero-valued.


### PR DESCRIPTION
## Summary

- Fixes `GetShredsRewardsDetail`'s header query, which failed on every request with ClickHouse error 403 `INVALID_JOIN_ON_EXPRESSION` ("Cannot determine join keys").

The query anchored on `FROM (SELECT 1 AS x) one` and then `LEFT JOIN solana_vote_accounts_current v ON v.node_pubkey = ? AND v.epoch_vote_account = 'true'`. The `ON` clause referenced only `v` plus a bound parameter, so there was no key relating the anchor row to `v` — ClickHouse rejects such a join. The fix makes the anchor carry the node_id (`FROM (SELECT ? AS node_id) one`) and joins on it (`ON v.node_pubkey = one.node_id`, `ON g.pubkey = one.node_id`), preserving the "always return one row, zero-valued for unknown node_ids" behavior the code intended.

## Testing Verification

- Reproduced from prod logs: `shreds rewards detail header scan failed error="code: 403 ... Cannot determine join keys in LEFT JOIN ... ON (v.node_pubkey = '<pubkey>') AND (v.epoch_vote_account = 'true')"`, recurring for every validator viewed.
- Validated the corrected query against prod ClickHouse with a real node pubkey from the logs: returns one row (vote_pubkey, validator name, stake, DZ IP) with no join-key error.
- Confirmed the sibling per-epoch query in the same handler is unaffected (it uses a `WHERE node_id = ?` filter, not a join on the param).
