### PR TITLE
indexer,api: log non-actionable failures at warn, not error

### DIFF
--- a/api/handlers/swap_rate.go
+++ b/api/handlers/swap_rate.go
@@ -61,7 +61,7 @@ func (a *API) GetSwapRate(w http.ResponseWriter, r *http.Request) {
 	out, err := fetchSwapRateWithRetry(r.Context())
 	if err != nil {
 		if entry != nil {
-			logError("swap rate: oracle fetch failed, serving stale cache", "error", err)
+			logWarn("swap rate: oracle fetch failed, serving stale cache", "error", err)
 			writeSwapRateJSON(w, entry.resp, true)
 			return
 		}

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -124,7 +124,7 @@ func Start(ctx context.Context, cfg Config) error {
 				if ctx.Err() != nil {
 					return
 				}
-				log.Error("dzingest: workflow interrupted, reattaching", "id", wfID, "error", err)
+				log.Warn("dzingest: workflow interrupted, reattaching", "id", wfID, "error", err)
 				current = tc.GetWorkflow(ctx, wfID, "")
 			} else {
 				return

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -125,7 +125,7 @@ func Start(ctx context.Context, cfg Config) error {
 				if ctx.Err() != nil {
 					return
 				}
-				log.Error("rollup: workflow interrupted, reattaching", "id", wfID, "error", err)
+				log.Warn("rollup: workflow interrupted, reattaching", "id", wfID, "error", err)
 				current = tc.GetWorkflow(ctx, wfID, "")
 			} else {
 				return

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -94,7 +94,7 @@ func Start(ctx context.Context, cfg Config) error {
 				if ctx.Err() != nil {
 					return
 				}
-				log.Error("solingest: workflow interrupted, reattaching", "id", wfID, "error", err)
+				log.Warn("solingest: workflow interrupted, reattaching", "id", wfID, "error", err)
 				current = tc.GetWorkflow(ctx, wfID, "")
 			} else {
 				return


### PR DESCRIPTION
## Summary

The `lake-api-errors` / `lake-indexer-errors` alerts fire on true `ERR`-level log lines. A few code paths log at `Error` for conditions that are self-recovering or already handled, so they raise alerts despite needing no human action. This lowers those to `Warn` so only genuinely-actionable failures alert.

- **`workflow interrupted, reattaching`** (`dzingest.go`, `rollup.go`, `solingest.go`): the long-running workflow future returned an error and the code reattaches — routine on worker restarts/deploys. Real crash-loops are already covered by the separate `lake-indexer-crash-loop` / `-down` alerts. `Error` → `Warn`.
- **`swap rate: oracle fetch failed, serving stale cache`** (`swap_rate.go`): a handled fallback — it serves the cached rate and returns success. `Error` → `Warn`. The sibling "no cached fallback" path (which returns 502) stays at `Error`.

No behavior change beyond log severity.

## Testing Verification
- Verified against a 24h Loki inventory of true `ERR` lines: these messages appear there today (i.e. they currently alert) and are non-actionable.

## Follow-ups (not in this PR)

- Rollup activity failures emit Temporal `Activity error` at `ERR` (staging). The clean fix (mirror dzingest's return-nil + failure-threshold) must stay backfill-safe (`BackfillRollupWorkflow` relies on error propagation/retries), so it needs a live-vs-backfill-aware design + tests.