### PR TITLE
permission-audit: index serviceability permission events and add internal audit page

### DIFF
--- a/admin/cmd/admin/main.go
+++ b/admin/cmd/admin/main.go
@@ -107,6 +107,8 @@ func run() error {
 	backfillRollupFlag := flag.Bool("start-backfill-rollup", false, "Trigger Temporal rollup backfill workflow (requires --start-time-ago or --start-time)")
 	backfillEscrowEventsFlag := flag.Bool("backfill-escrow-events", false, "Re-fetch all escrow events from on-chain transaction history via Temporal workflow")
 	backfillEscrowEventsTruncateFlag := flag.Bool("backfill-escrow-events-truncate", false, "Truncate the escrow events table before backfilling (use with --backfill-escrow-events)")
+	backfillPermissionEventsFlag := flag.Bool("backfill-permission-events", false, "Re-scan all serviceability permission events from on-chain transaction history via Temporal workflow")
+	backfillPermissionEventsTruncateFlag := flag.Bool("backfill-permission-events-truncate", false, "Truncate the permission events table + scan cursor before backfilling (use with --backfill-permission-events)")
 
 	// Backfill options (latency - epoch-based)
 	dzEnvFlag := flag.String("dz-env", config.EnvMainnetBeta, "DZ ledger environment (devnet, testnet, mainnet-beta)")
@@ -462,6 +464,13 @@ func run() error {
 		return admin.BackfillEscrowEvents(log, admin.BackfillEscrowEventsConfig{
 			Network:  *dzEnvFlag,
 			Truncate: *backfillEscrowEventsTruncateFlag,
+		})
+	}
+
+	if *backfillPermissionEventsFlag {
+		return admin.BackfillPermissionEvents(log, admin.BackfillPermissionEventsConfig{
+			Network:  *dzEnvFlag,
+			Truncate: *backfillPermissionEventsTruncateFlag,
 		})
 	}
 

--- a/admin/internal/admin/backfill_permission_events.go
+++ b/admin/internal/admin/backfill_permission_events.go
@@ -1,0 +1,68 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/dzingest"
+	"go.temporal.io/sdk/client"
+)
+
+// BackfillPermissionEventsConfig holds configuration for the backfill-permission-events command.
+type BackfillPermissionEventsConfig struct {
+	Network  string // DZ environment (e.g. "mainnet-beta")
+	Truncate bool   // If true, truncate the fact table + scan cursor before backfilling.
+}
+
+// BackfillPermissionEvents starts the BackfillPermissionEventsWorkflow on Temporal.
+func BackfillPermissionEvents(log *slog.Logger, cfg BackfillPermissionEventsConfig) error {
+	temporalAddr := os.Getenv("TEMPORAL_HOST_PORT")
+	if temporalAddr == "" {
+		temporalAddr = "localhost:7233"
+	}
+	temporalNamespace := os.Getenv("TEMPORAL_NAMESPACE")
+	if temporalNamespace == "" {
+		temporalNamespace = "default"
+	}
+
+	c, err := client.Dial(client.Options{
+		HostPort:  temporalAddr,
+		Namespace: temporalNamespace,
+		Logger:    log,
+	})
+	if err != nil {
+		return fmt.Errorf("connect to Temporal: %w", err)
+	}
+	defer c.Close()
+
+	input := dzingest.BackfillPermissionEventsInput{
+		Truncate: cfg.Truncate,
+	}
+
+	workflowID := fmt.Sprintf("backfill-permission-events-%d", time.Now().Unix())
+	run, err := c.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: dzingest.TaskQueue(cfg.Network),
+	}, dzingest.BackfillPermissionEventsWorkflow, input)
+	if err != nil {
+		return fmt.Errorf("start backfill workflow: %w", err)
+	}
+
+	log.Info("started permission events backfill workflow",
+		"workflow_id", run.GetID(),
+		"run_id", run.GetRunID(),
+		"network", cfg.Network,
+		"truncate", cfg.Truncate,
+	)
+
+	log.Info("waiting for completion...")
+	if err := run.Get(context.Background(), nil); err != nil {
+		return fmt.Errorf("backfill workflow failed: %w", err)
+	}
+
+	log.Info("permission events backfill complete")
+	return nil
+}

--- a/api/handlers/permission_audit.go
+++ b/api/handlers/permission_audit.go
@@ -3,23 +3,20 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"time"
 )
 
-const (
-	permissionAuditDefaultLimit = 200
-	permissionAuditMaxLimit     = 1000
-)
+const permissionAuditDefaultLimit = 200
 
 // PermissionAuditRow is a single serviceability Permission-management event.
 type PermissionAuditRow struct {
 	EventTS            time.Time `json:"eventTs"`
 	TxSignature        string    `json:"txSignature"`
 	Slot               uint64    `json:"slot"`
-	Signer             string    `json:"signer"`       // acting admin (transaction fee-payer)
-	PermissionPK       string    `json:"permissionPk"` // the Permission PDA
-	TargetPubkey       string    `json:"targetPubkey"` // grantee
+	InstructionIndex   uint16    `json:"instructionIndex"` // index within the tx; distinguishes multiple events in one tx
+	Signer             string    `json:"signer"`           // acting admin (transaction fee-payer)
+	PermissionPK       string    `json:"permissionPk"`     // the Permission PDA
+	TargetPubkey       string    `json:"targetPubkey"`     // grantee
 	EventType          string    `json:"eventType"`
 	PermissionsAdded   string    `json:"permissionsAdded"`
 	PermissionsRemoved string    `json:"permissionsRemoved"`
@@ -34,15 +31,7 @@ type PermissionAuditResponse struct {
 // GetPermissionAudit serves the serviceability permission audit trail. Gated to
 // internal-domain users (see RequireInternalDomain in api/main.go).
 func (a *API) GetPermissionAudit(w http.ResponseWriter, r *http.Request) {
-	limit := permissionAuditDefaultLimit
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
-	}
-	if limit > permissionAuditMaxLimit {
-		limit = permissionAuditMaxLimit
-	}
+	limit := ParsePagination(r, permissionAuditDefaultLimit).Limit
 
 	resp, err := a.FetchPermissionAuditData(r.Context(), limit)
 	if err != nil {
@@ -62,6 +51,7 @@ func (a *API) FetchPermissionAuditData(ctx context.Context, limit int) (Permissi
 			e.event_ts,
 			e.tx_signature,
 			e.slot,
+			e.instruction_index,
 			e.signer,
 			e.permission_pk,
 			if(e.target_pubkey != '', e.target_pubkey, tgt.target) AS target_pubkey,
@@ -69,14 +59,14 @@ func (a *API) FetchPermissionAuditData(ctx context.Context, limit int) (Permissi
 			e.permissions_added,
 			e.permissions_removed,
 			e.success
-		FROM fact_dz_permission_events FINAL AS e
+		FROM fact_dz_permission_events AS e FINAL
 		LEFT JOIN (
 			SELECT permission_pk, max(target_pubkey) AS target
 			FROM fact_dz_permission_events
 			WHERE target_pubkey != ''
 			GROUP BY permission_pk
 		) AS tgt USING (permission_pk)
-		ORDER BY e.event_ts DESC, e.slot DESC, e.tx_signature DESC
+		ORDER BY e.slot DESC, e.event_ts DESC, e.tx_signature DESC, e.instruction_index DESC
 		LIMIT ?
 	`
 
@@ -94,6 +84,7 @@ func (a *API) FetchPermissionAuditData(ctx context.Context, limit int) (Permissi
 			&row.EventTS,
 			&row.TxSignature,
 			&row.Slot,
+			&row.InstructionIndex,
 			&row.Signer,
 			&row.PermissionPK,
 			&row.TargetPubkey,

--- a/api/handlers/permission_audit.go
+++ b/api/handlers/permission_audit.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	permissionAuditDefaultLimit = 200
+	permissionAuditMaxLimit     = 1000
+)
+
+// PermissionAuditRow is a single serviceability Permission-management event.
+type PermissionAuditRow struct {
+	EventTS            time.Time `json:"eventTs"`
+	TxSignature        string    `json:"txSignature"`
+	Slot               uint64    `json:"slot"`
+	Signer             string    `json:"signer"`       // acting admin (transaction fee-payer)
+	PermissionPK       string    `json:"permissionPk"` // the Permission PDA
+	TargetPubkey       string    `json:"targetPubkey"` // grantee
+	EventType          string    `json:"eventType"`
+	PermissionsAdded   string    `json:"permissionsAdded"`
+	PermissionsRemoved string    `json:"permissionsRemoved"`
+	Success            bool      `json:"success"`
+}
+
+// PermissionAuditResponse is the payload for the permission audit page.
+type PermissionAuditResponse struct {
+	Events []PermissionAuditRow `json:"events"`
+}
+
+// GetPermissionAudit serves the serviceability permission audit trail. Gated to
+// internal-domain users (see RequireInternalDomain in api/main.go).
+func (a *API) GetPermissionAudit(w http.ResponseWriter, r *http.Request) {
+	limit := permissionAuditDefaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > permissionAuditMaxLimit {
+		limit = permissionAuditMaxLimit
+	}
+
+	resp, err := a.FetchPermissionAuditData(r.Context(), limit)
+	if err != nil {
+		logError("failed to fetch permission audit", "error", err)
+		http.Error(w, "failed to fetch permission audit", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+// FetchPermissionAuditData returns the most recent permission events, newest first.
+// The grantee (target_pubkey) is only carried by CreatePermission instructions, so it
+// is backfilled for the other event types by joining each permission PDA to its create row.
+func (a *API) FetchPermissionAuditData(ctx context.Context, limit int) (PermissionAuditResponse, error) {
+	const query = `
+		SELECT
+			e.event_ts,
+			e.tx_signature,
+			e.slot,
+			e.signer,
+			e.permission_pk,
+			if(e.target_pubkey != '', e.target_pubkey, tgt.target) AS target_pubkey,
+			e.event_type,
+			e.permissions_added,
+			e.permissions_removed,
+			e.success
+		FROM fact_dz_permission_events FINAL AS e
+		LEFT JOIN (
+			SELECT permission_pk, max(target_pubkey) AS target
+			FROM fact_dz_permission_events
+			WHERE target_pubkey != ''
+			GROUP BY permission_pk
+		) AS tgt USING (permission_pk)
+		ORDER BY e.event_ts DESC, e.slot DESC, e.tx_signature DESC
+		LIMIT ?
+	`
+
+	rows, err := a.safeQueryRows(ctx, query, limit)
+	if err != nil {
+		return PermissionAuditResponse{}, err
+	}
+	defer rows.Close()
+
+	resp := PermissionAuditResponse{Events: []PermissionAuditRow{}}
+	for rows.Next() {
+		var row PermissionAuditRow
+		var success uint8
+		if err := rows.Scan(
+			&row.EventTS,
+			&row.TxSignature,
+			&row.Slot,
+			&row.Signer,
+			&row.PermissionPK,
+			&row.TargetPubkey,
+			&row.EventType,
+			&row.PermissionsAdded,
+			&row.PermissionsRemoved,
+			&success,
+		); err != nil {
+			return PermissionAuditResponse{}, err
+		}
+		row.Success = success == 1
+		resp.Events = append(resp.Events, row)
+	}
+	if err := rows.Err(); err != nil {
+		return PermissionAuditResponse{}, err
+	}
+	return resp, nil
+}

--- a/api/main.go
+++ b/api/main.go
@@ -608,6 +608,8 @@ func main() {
 		r.Get("/api/dz/edge/scoreboard", api.GetEdgeScoreboard)
 		// Internal only (unannounced venue): allowed-domain Google users only.
 		r.With(handlers.RequireInternalDomain).Get("/api/dz/hyperliquid/scoreboard", api.GetHyperliquidScoreboard)
+		// Serviceability permission audit trail (internal only: allowed-domain Google users).
+		r.With(handlers.RequireInternalDomain).Get("/api/dz/permission-audit", api.GetPermissionAudit)
 		r.Get("/api/dz/tenants", api.GetTenants)
 		r.Get("/api/dz/tenants/{pk}", api.GetTenant)
 		r.Get("/api/dz/shreds/overview", api.GetShredsOverview)

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -341,7 +341,9 @@ func run() error {
 
 	// Raw Solana RPC on the DZ ledger for the permission-events audit indexer, which
 	// reads serviceability transaction history (getSignaturesForAddress + getTransaction).
-	permissionEventsRawRPC := solanarpc.New(networkConfig.LedgerPublicRPCURL)
+	// Retrying client so a transient RPC error on getTransaction doesn't drop a
+	// permission event from the audit trail (the refresh fails and retries instead).
+	permissionEventsRawRPC := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
 
 	// Shreds subscription client (mainnet-beta and testnet only, not devnet).
 	// Mainnet uses Solana proper RPC; testnet uses the DZ ledger RPC.
@@ -1003,7 +1005,9 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	geolocationClient := geolocsdk.New(log, dzRPCClient, networkConfig.GeolocationProgramID)
 
 	// Raw Solana RPC on the DZ ledger for the permission-events audit indexer.
-	permissionEventsRawRPC := solanarpc.New(networkConfig.LedgerPublicRPCURL)
+	// Retrying client so a transient RPC error on getTransaction doesn't drop a
+	// permission event from the audit trail (the refresh fails and retries instead).
+	permissionEventsRawRPC := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
 
 	// Shreds subscription client (testnet only, not devnet).
 	var shredsClient *shreds.Client

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -339,6 +339,10 @@ func run() error {
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
 	geolocationClient := geolocsdk.New(log, dzRPCClient, networkConfig.GeolocationProgramID)
 
+	// Raw Solana RPC on the DZ ledger for the permission-events audit indexer, which
+	// reads serviceability transaction history (getSignaturesForAddress + getTransaction).
+	permissionEventsRawRPC := solanarpc.New(networkConfig.LedgerPublicRPCURL)
+
 	// Shreds subscription client (mainnet-beta and testnet only, not devnet).
 	// Mainnet uses Solana proper RPC; testnet uses the DZ ledger RPC.
 	shredsEnabled := *dzEnvFlag != config.EnvDevnet
@@ -570,7 +574,9 @@ func run() error {
 		GeoIPResolver: geoIPResolver,
 
 		// Serviceability configuration
-		ServiceabilityRPC: serviceabilityClient,
+		ServiceabilityRPC:       serviceabilityClient,
+		ServiceabilityProgramID: networkConfig.ServiceabilityProgramID,
+		PermissionEventsRPC:     permissionEventsRawRPC,
 
 		// Geolocation configuration
 		GeolocationRPC: geolocationClient,
@@ -672,22 +678,23 @@ func run() error {
 		dzIngestErrCh = make(chan error, 1)
 		go func() {
 			err := dzingest.Start(ctx, dzingest.Config{
-				Log:            log.With("component", "dz-ingest"),
-				IngestionLog:   ingestionLogWriter,
-				Network:        *dzEnvFlag,
-				Serviceability: idx.Serviceability(),
-				Geolocation:    idx.Geolocation(),
-				Shreds:         idx.Shreds(),
-				EscrowEvents:   idx.EscrowEvents(),
-				TelemLatency:   idx.TelemLatency(),
-				TelemUsage:     idx.TelemUsage(),
-				GraphStore:     idx.GraphStore(),
-				ISISSource:     idx.ISISSource(),
-				ISISStore:      idx.ISISStore(),
-				MrouteSource:   idx.MrouteSource(),
-				MrouteStore:    idx.MrouteStore(),
-				MSDPSource:     idx.MSDPSource(),
-				MSDPStore:      idx.MSDPStore(),
+				Log:              log.With("component", "dz-ingest"),
+				IngestionLog:     ingestionLogWriter,
+				Network:          *dzEnvFlag,
+				Serviceability:   idx.Serviceability(),
+				Geolocation:      idx.Geolocation(),
+				Shreds:           idx.Shreds(),
+				EscrowEvents:     idx.EscrowEvents(),
+				PermissionEvents: idx.PermissionEvents(),
+				TelemLatency:     idx.TelemLatency(),
+				TelemUsage:       idx.TelemUsage(),
+				GraphStore:       idx.GraphStore(),
+				ISISSource:       idx.ISISSource(),
+				ISISStore:        idx.ISISStore(),
+				MrouteSource:     idx.MrouteSource(),
+				MrouteStore:      idx.MrouteStore(),
+				MSDPSource:       idx.MSDPSource(),
+				MSDPStore:        idx.MSDPStore(),
 			})
 			if err != nil {
 				dzIngestErrCh <- err
@@ -995,6 +1002,9 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
 	geolocationClient := geolocsdk.New(log, dzRPCClient, networkConfig.GeolocationProgramID)
 
+	// Raw Solana RPC on the DZ ledger for the permission-events audit indexer.
+	permissionEventsRawRPC := solanarpc.New(networkConfig.LedgerPublicRPCURL)
+
 	// Shreds subscription client (testnet only, not devnet).
 	var shredsClient *shreds.Client
 	var secondaryShredsRawRPC *solanarpc.Client
@@ -1032,15 +1042,17 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 			Password: cfg.clickhousePassword,
 			Secure:   cfg.clickhouseSecure,
 		},
-		RefreshInterval:        cfg.refreshInterval,
-		MaxConcurrency:         cfg.maxConcurrency,
-		ServiceabilityRPC:      serviceabilityClient,
-		GeolocationRPC:         geolocationClient,
-		TelemetryRPC:           telemetryClient,
-		DZEpochRPC:             dzRPCClient,
-		InternetLatencyAgentPK: networkConfig.InternetLatencyCollectorPK,
-		InternetDataProviders:  telemetryconfig.InternetTelemetryDataProviders,
-		SkipReadyWait:          cfg.skipReadyWait,
+		RefreshInterval:         cfg.refreshInterval,
+		MaxConcurrency:          cfg.maxConcurrency,
+		ServiceabilityRPC:       serviceabilityClient,
+		ServiceabilityProgramID: networkConfig.ServiceabilityProgramID,
+		PermissionEventsRPC:     permissionEventsRawRPC,
+		GeolocationRPC:          geolocationClient,
+		TelemetryRPC:            telemetryClient,
+		DZEpochRPC:              dzRPCClient,
+		InternetLatencyAgentPK:  networkConfig.InternetLatencyCollectorPK,
+		InternetDataProviders:   telemetryconfig.InternetTelemetryDataProviders,
+		SkipReadyWait:           cfg.skipReadyWait,
 
 		// Device usage configuration.
 		DeviceUsageInfluxClient:      influxDBClient,
@@ -1095,22 +1107,23 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 
 	// Start DZ ingest worker (blocks until ctx cancelled or error).
 	dzErr := dzingest.Start(ctx, dzingest.Config{
-		Log:            log.With("component", "dz-ingest"),
-		IngestionLog:   secondaryIngestionLog,
-		Network:        env,
-		Serviceability: idx.Serviceability(),
-		Geolocation:    idx.Geolocation(),
-		Shreds:         idx.Shreds(),
-		EscrowEvents:   idx.EscrowEvents(),
-		TelemLatency:   idx.TelemLatency(),
-		TelemUsage:     idx.TelemUsage(),
-		GraphStore:     idx.GraphStore(),
-		ISISSource:     idx.ISISSource(),
-		ISISStore:      idx.ISISStore(),
-		MrouteSource:   idx.MrouteSource(),
-		MrouteStore:    idx.MrouteStore(),
-		MSDPSource:     idx.MSDPSource(),
-		MSDPStore:      idx.MSDPStore(),
+		Log:              log.With("component", "dz-ingest"),
+		IngestionLog:     secondaryIngestionLog,
+		Network:          env,
+		Serviceability:   idx.Serviceability(),
+		Geolocation:      idx.Geolocation(),
+		Shreds:           idx.Shreds(),
+		EscrowEvents:     idx.EscrowEvents(),
+		PermissionEvents: idx.PermissionEvents(),
+		TelemLatency:     idx.TelemLatency(),
+		TelemUsage:       idx.TelemUsage(),
+		GraphStore:       idx.GraphStore(),
+		ISISSource:       idx.ISISSource(),
+		ISISStore:        idx.ISISStore(),
+		MrouteSource:     idx.MrouteSource(),
+		MrouteStore:      idx.MrouteStore(),
+		MSDPSource:       idx.MSDPSource(),
+		MSDPStore:        idx.MSDPStore(),
 	})
 
 	select {

--- a/indexer/db/clickhouse/migrations/20260617000001_fact_dz_permission_events.sql
+++ b/indexer/db/clickhouse/migrations/20260617000001_fact_dz_permission_events.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+
+-- Append-only audit trail of serviceability Permission-management instructions
+-- (grant / change / suspend / resume / revoke). One row per decoded instruction.
+-- Column order must match permissionevents.permissionEventSchema.ToRow().
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS fact_dz_permission_events
+(
+    event_ts                 DateTime64(3),
+    ingested_at              DateTime64(3),
+    tx_signature             String,
+    slot                     UInt64,
+    instruction_index        UInt16,
+    signer                   String DEFAULT '',
+    permission_pk            String,
+    target_pubkey            String DEFAULT '',
+    event_type               String,
+    permissions_added        String DEFAULT '',
+    permissions_removed      String DEFAULT '',
+    permissions_added_mask   String DEFAULT '',
+    permissions_removed_mask String DEFAULT '',
+    success                  UInt8 DEFAULT 1
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(event_ts)
+ORDER BY (permission_pk, slot, tx_signature, instruction_index);
+-- +goose StatementEnd
+
+-- Scan cursor for the program-wide signature sweep. The fact table only holds
+-- permission events, so it cannot serve as the resume cursor for a program-wide scan
+-- (rare permission events among many serviceability txs). This tracks the newest
+-- signature already scanned per watched program, so each signature is fetched once.
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dz_permission_events_scan_cursor
+(
+    program_pk        String,
+    last_tx_signature String,
+    last_slot         UInt64,
+    updated_at        DateTime64(3)
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (program_pk);
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS fact_dz_permission_events;
+DROP TABLE IF EXISTS dz_permission_events_scan_cursor;

--- a/indexer/pkg/dz/serviceability/permissionevents/decode.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/decode.go
@@ -1,0 +1,185 @@
+// Package permissionevents indexes DoubleZero serviceability Permission-management
+// transactions (grant / change / suspend / resume / revoke) into an append-only
+// ClickHouse audit trail.
+//
+// The on-chain program keeps no audit trail: Permission accounts store only current
+// state and the permission processors emit no logs/events. So — unlike escrowevents,
+// which parses program log messages — this source decodes the *instruction data bytes*
+// (leading variant byte + Borsh args) fetched via getTransaction.
+//
+// The decode contract below is reimplemented from the Rust source of truth (kept in
+// sync manually; there is no Go SDK decoder). See:
+//   - smartcontract/programs/doublezero-serviceability/src/instructions.rs (variants 97-101)
+//   - smartcontract/programs/doublezero-serviceability/src/processors/permission/{create,update}.rs (args)
+//   - smartcontract/programs/doublezero-serviceability/src/state/permission.rs (flag bits)
+//   - smartcontract/cli/src/permission/flags.rs (bitmask -> role names + emit order)
+package permissionevents
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// Serviceability instruction variant tags for the Permission-management instructions.
+// These are the first byte of the instruction data (instructions.rs:228-232 / 372-376).
+const (
+	variantCreatePermission  uint8 = 97
+	variantUpdatePermission  uint8 = 98
+	variantSuspendPermission uint8 = 99
+	variantResumePermission  uint8 = 100
+	variantDeletePermission  uint8 = 101
+)
+
+// Event type labels stored in the fact table.
+const (
+	EventCreate  = "Create"
+	EventUpdate  = "Update"
+	EventSuspend = "Suspend"
+	EventResume  = "Resume"
+	EventDelete  = "Delete"
+)
+
+// u128 is a 128-bit little-endian unsigned integer split into low/high 64-bit halves,
+// mirroring how the Go SDK stores the Permission account bitmask (PermissionsLo/Hi).
+// The permission flags only occupy bits 0-17 today (all in Lo), but we decode the full
+// 16 bytes so a future flag in the high word is preserved rather than truncated.
+type u128 struct {
+	Lo uint64
+	Hi uint64
+}
+
+// readU128LE decodes a little-endian u128 from the first 16 bytes of b.
+func readU128LE(b []byte) u128 {
+	return u128{
+		Lo: binary.LittleEndian.Uint64(b[0:8]),
+		Hi: binary.LittleEndian.Uint64(b[8:16]),
+	}
+}
+
+// IsZero reports whether the mask has no bits set.
+func (m u128) IsZero() bool { return m.Lo == 0 && m.Hi == 0 }
+
+// Hex renders the mask as a canonical 0x-prefixed hex string.
+func (m u128) Hex() string {
+	if m.Hi == 0 {
+		return fmt.Sprintf("0x%x", m.Lo)
+	}
+	return fmt.Sprintf("0x%x%016x", m.Hi, m.Lo)
+}
+
+// flagName pairs a bit mask with its role name. Ordered to match the Rust
+// bitmask_to_names() emit order (flags.rs:117-136) so audit output is identical.
+var flagNames = []struct {
+	bit  uint64
+	name string
+}{
+	{1 << 0, "foundation"},
+	{1 << 1, "permission-admin"},
+	{1 << 13, "globalstate-admin"},
+	{1 << 14, "contributor-admin"},
+	{1 << 2, "infra-admin"},
+	{1 << 3, "network-admin"},
+	{1 << 4, "tenant-admin"},
+	{1 << 5, "multicast-admin"},
+	{1 << 6, "feed-authority"},
+	{1 << 7, "activator"},
+	{1 << 8, "sentinel"},
+	{1 << 9, "user-admin"},
+	{1 << 10, "access-pass-admin"},
+	{1 << 11, "health-oracle"},
+	{1 << 12, "qa"},
+	{1 << 15, "topology-admin"},
+	{1 << 16, "resource-admin"},
+	{1 << 17, "index-admin"},
+}
+
+// FlagNames returns the comma-separated role names set in the mask, in the same order
+// as the Rust CLI. Known flags all live in the low 64 bits; if any unknown high bits are
+// set they are surfaced as "unknown-hi:0x..." so the audit never silently drops a grant.
+func FlagNames(m u128) string {
+	var out []string
+	for _, f := range flagNames {
+		if m.Lo&f.bit != 0 {
+			out = append(out, f.name)
+		}
+	}
+	// Surface any bits we don't have a name for (future flags) rather than hiding them.
+	known := uint64(0)
+	for _, f := range flagNames {
+		known |= f.bit
+	}
+	if unknownLo := m.Lo &^ known; unknownLo != 0 {
+		out = append(out, fmt.Sprintf("unknown-lo:0x%x", unknownLo))
+	}
+	if m.Hi != 0 {
+		out = append(out, fmt.Sprintf("unknown-hi:0x%x", m.Hi))
+	}
+	return strings.Join(out, ", ")
+}
+
+// DecodedPermissionIx is a decoded Permission-management instruction.
+type DecodedPermissionIx struct {
+	Variant   uint8
+	EventType string
+
+	// TargetUserPayer is the grantee, base58-encoded. Only CreatePermission carries it
+	// in its args; for the other variants it is empty and must be resolved by the caller
+	// (from the Permission PDA account, or by joining the indexed create row).
+	TargetUserPayer string
+
+	// Added/Removed are the permission bitmask deltas. For Create, Added is the granted
+	// mask and Removed is zero. For Update, both apply. For Suspend/Resume/Delete both
+	// are zero (they only change status / close the account).
+	Added   u128
+	Removed u128
+}
+
+// DecodePermissionInstruction decodes a single serviceability instruction's data bytes.
+// It returns (decoded, true, nil) for a Permission-management instruction, (nil, false, nil)
+// for any other (non-permission) instruction, and (nil, false, err) when a permission
+// variant is recognized but its argument payload is malformed.
+func DecodePermissionInstruction(data []byte) (*DecodedPermissionIx, bool, error) {
+	if len(data) == 0 {
+		return nil, false, nil
+	}
+
+	switch data[0] {
+	case variantCreatePermission:
+		// PermissionCreateArgs { user_payer: Pubkey(32), permissions: u128(16) }
+		const want = 1 + 32 + 16
+		if len(data) < want {
+			return nil, false, fmt.Errorf("CreatePermission: data too short: got %d want >= %d", len(data), want)
+		}
+		return &DecodedPermissionIx{
+			Variant:         data[0],
+			EventType:       EventCreate,
+			TargetUserPayer: solana.PublicKeyFromBytes(data[1:33]).String(),
+			Added:           readU128LE(data[33:49]),
+		}, true, nil
+
+	case variantUpdatePermission:
+		// PermissionUpdateArgs { add: u128(16), remove: u128(16) }
+		const want = 1 + 16 + 16
+		if len(data) < want {
+			return nil, false, fmt.Errorf("UpdatePermission: data too short: got %d want >= %d", len(data), want)
+		}
+		return &DecodedPermissionIx{
+			Variant:   data[0],
+			EventType: EventUpdate,
+			Added:     readU128LE(data[1:17]),
+			Removed:   readU128LE(data[17:33]),
+		}, true, nil
+
+	case variantSuspendPermission:
+		return &DecodedPermissionIx{Variant: data[0], EventType: EventSuspend}, true, nil
+	case variantResumePermission:
+		return &DecodedPermissionIx{Variant: data[0], EventType: EventResume}, true, nil
+	case variantDeletePermission:
+		return &DecodedPermissionIx{Variant: data[0], EventType: EventDelete}, true, nil
+	}
+
+	return nil, false, nil
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/decode.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/decode.go
@@ -96,6 +96,16 @@ var flagNames = []struct {
 	{1 << 17, "index-admin"},
 }
 
+// knownFlagBits is the union of all named flag bits (all in the low 64 bits). Computed
+// once from flagNames so FlagNames doesn't recompute the constant on every call.
+var knownFlagBits = func() uint64 {
+	var known uint64
+	for _, f := range flagNames {
+		known |= f.bit
+	}
+	return known
+}()
+
 // FlagNames returns the comma-separated role names set in the mask, in the same order
 // as the Rust CLI. Known flags all live in the low 64 bits; if any unknown high bits are
 // set they are surfaced as "unknown-hi:0x..." so the audit never silently drops a grant.
@@ -107,11 +117,7 @@ func FlagNames(m u128) string {
 		}
 	}
 	// Surface any bits we don't have a name for (future flags) rather than hiding them.
-	known := uint64(0)
-	for _, f := range flagNames {
-		known |= f.bit
-	}
-	if unknownLo := m.Lo &^ known; unknownLo != 0 {
+	if unknownLo := m.Lo &^ knownFlagBits; unknownLo != 0 {
 		out = append(out, fmt.Sprintf("unknown-lo:0x%x", unknownLo))
 	}
 	if m.Hi != 0 {

--- a/indexer/pkg/dz/serviceability/permissionevents/decode_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/decode_test.go
@@ -1,0 +1,130 @@
+package permissionevents
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// Permission flag bit values, mirrored from the on-chain program for test fixtures.
+const (
+	flagPermissionAdmin uint64 = 1 << 1
+	flagNetworkAdmin    uint64 = 1 << 3
+	flagActivator       uint64 = 1 << 7
+	flagSentinel        uint64 = 1 << 8
+	flagUserAdmin       uint64 = 1 << 9
+	flagQA              uint64 = 1 << 12
+)
+
+// u128LE encodes a low/high pair into 16 little-endian bytes.
+func u128LE(lo, hi uint64) []byte {
+	b := make([]byte, 16)
+	binary.LittleEndian.PutUint64(b[0:8], lo)
+	binary.LittleEndian.PutUint64(b[8:16], hi)
+	return b
+}
+
+func TestLake_PermissionEvents_Decode_Create(t *testing.T) {
+	target := solana.PublicKeyFromBytes([]byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+	})
+
+	data := []byte{variantCreatePermission}
+	data = append(data, target.Bytes()...)
+	data = append(data, u128LE(flagNetworkAdmin|flagActivator, 0)...)
+
+	ix, ok, err := DecodePermissionInstruction(data)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, EventCreate, ix.EventType)
+	require.Equal(t, target.String(), ix.TargetUserPayer)
+	require.Equal(t, flagNetworkAdmin|flagActivator, ix.Added.Lo)
+	require.Equal(t, uint64(0), ix.Added.Hi)
+	require.True(t, ix.Removed.IsZero())
+	require.Equal(t, "network-admin, activator", FlagNames(ix.Added))
+}
+
+func TestLake_PermissionEvents_Decode_Update(t *testing.T) {
+	data := []byte{variantUpdatePermission}
+	data = append(data, u128LE(flagUserAdmin, 0)...) // add
+	data = append(data, u128LE(flagQA, 0)...)        // remove
+
+	ix, ok, err := DecodePermissionInstruction(data)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, EventUpdate, ix.EventType)
+	require.Empty(t, ix.TargetUserPayer)
+	require.Equal(t, flagUserAdmin, ix.Added.Lo)
+	require.Equal(t, flagQA, ix.Removed.Lo)
+	require.Equal(t, "user-admin", FlagNames(ix.Added))
+	require.Equal(t, "qa", FlagNames(ix.Removed))
+}
+
+func TestLake_PermissionEvents_Decode_StatusVariants(t *testing.T) {
+	cases := []struct {
+		variant uint8
+		want    string
+	}{
+		{variantSuspendPermission, EventSuspend},
+		{variantResumePermission, EventResume},
+		{variantDeletePermission, EventDelete},
+	}
+	for _, c := range cases {
+		ix, ok, err := DecodePermissionInstruction([]byte{c.variant})
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, c.want, ix.EventType)
+		require.True(t, ix.Added.IsZero())
+		require.True(t, ix.Removed.IsZero())
+	}
+}
+
+func TestLake_PermissionEvents_Decode_NotAPermissionInstruction(t *testing.T) {
+	// Variant 36 = CreateUser — must be ignored, not misdecoded.
+	ix, ok, err := DecodePermissionInstruction([]byte{36, 0, 0, 0})
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, ix)
+
+	// Empty data.
+	ix, ok, err = DecodePermissionInstruction(nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, ix)
+}
+
+func TestLake_PermissionEvents_Decode_MalformedArgsError(t *testing.T) {
+	// Recognized as CreatePermission but the arg payload is truncated.
+	_, ok, err := DecodePermissionInstruction([]byte{variantCreatePermission, 1, 2, 3})
+	require.Error(t, err)
+	require.False(t, ok)
+
+	_, ok, err = DecodePermissionInstruction([]byte{variantUpdatePermission, 1, 2, 3})
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+func TestLake_PermissionEvents_FlagNames_OrderAndEmpty(t *testing.T) {
+	// Mirrors the Rust bitmask_to_names roundtrip test: activator, sentinel, qa.
+	require.Equal(t, "activator, sentinel, qa",
+		FlagNames(u128{Lo: flagActivator | flagSentinel | flagQA}))
+	require.Equal(t, "", FlagNames(u128{}))
+	require.Equal(t, "permission-admin", FlagNames(u128{Lo: flagPermissionAdmin}))
+}
+
+func TestLake_PermissionEvents_FlagNames_UnknownBitsSurfaced(t *testing.T) {
+	// A bit with no known name must not be silently dropped.
+	names := FlagNames(u128{Lo: flagNetworkAdmin | (1 << 40), Hi: 1})
+	require.Contains(t, names, "network-admin")
+	require.Contains(t, names, "unknown-lo:")
+	require.Contains(t, names, "unknown-hi:")
+}
+
+func TestLake_PermissionEvents_Mask_Hex(t *testing.T) {
+	require.Equal(t, "0x0", u128{}.Hex())
+	require.Equal(t, "0x88", u128{Lo: 0x88}.Hex())
+	require.Equal(t, "0x10000000000000001", u128{Lo: 1, Hi: 1}.Hex())
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/rpc.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/rpc.go
@@ -1,0 +1,18 @@
+package permissionevents
+
+import (
+	"context"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+// SolanaRPC abstracts the Solana RPC methods needed for fetching serviceability
+// transaction history. Satisfied by *rpc.Client (gagliardetto solana-go).
+type SolanaRPC interface {
+	GetSignaturesForAddressWithOpts(ctx context.Context, account solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error)
+	GetTransaction(ctx context.Context, txSig solana.Signature, opts *rpc.GetTransactionOpts) (*rpc.GetTransactionResult, error)
+}
+
+// Compile-time check that *rpc.Client satisfies SolanaRPC.
+var _ SolanaRPC = (*rpc.Client)(nil)

--- a/indexer/pkg/dz/serviceability/permissionevents/rpc.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/rpc.go
@@ -1,8 +1,20 @@
 package permissionevents
 
-import "github.com/malbeclabs/lake/indexer/pkg/sol"
+import (
+	"context"
 
-// SolanaRPC abstracts the Solana RPC methods needed for fetching serviceability
-// transaction history. It aliases the shared sol.TxHistoryRPC so the escrowevents
-// and permissionevents indexers stay on one interface. Satisfied by *rpc.Client.
-type SolanaRPC = sol.TxHistoryRPC
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/lake/indexer/pkg/sol"
+)
+
+// SolanaRPC is the RPC surface the permission-events indexer needs: the shared tx-history
+// methods (getSignaturesForAddress + getTransaction, via sol.TxHistoryRPC) plus
+// getProgramAccounts for discovering Permission PDAs to watch. Satisfied by *rpc.Client.
+type SolanaRPC interface {
+	sol.TxHistoryRPC
+	GetProgramAccountsWithOpts(ctx context.Context, program solana.PublicKey, opts *rpc.GetProgramAccountsOpts) (rpc.GetProgramAccountsResult, error)
+}
+
+// Compile-time check that *rpc.Client satisfies SolanaRPC.
+var _ SolanaRPC = (*rpc.Client)(nil)

--- a/indexer/pkg/dz/serviceability/permissionevents/rpc.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/rpc.go
@@ -1,18 +1,8 @@
 package permissionevents
 
-import (
-	"context"
-
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
-)
+import "github.com/malbeclabs/lake/indexer/pkg/sol"
 
 // SolanaRPC abstracts the Solana RPC methods needed for fetching serviceability
-// transaction history. Satisfied by *rpc.Client (gagliardetto solana-go).
-type SolanaRPC interface {
-	GetSignaturesForAddressWithOpts(ctx context.Context, account solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error)
-	GetTransaction(ctx context.Context, txSig solana.Signature, opts *rpc.GetTransactionOpts) (*rpc.GetTransactionResult, error)
-}
-
-// Compile-time check that *rpc.Client satisfies SolanaRPC.
-var _ SolanaRPC = (*rpc.Client)(nil)
+// transaction history. It aliases the shared sol.TxHistoryRPC so the escrowevents
+// and permissionevents indexers stay on one interface. Satisfied by *rpc.Client.
+type SolanaRPC = sol.TxHistoryRPC

--- a/indexer/pkg/dz/serviceability/permissionevents/schema.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/schema.go
@@ -1,0 +1,84 @@
+package permissionevents
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
+)
+
+// PermissionEventRow is a single decoded Permission-management instruction — one row
+// in the append-only audit trail. Column order in ToRow must match the migration DDL
+// (event_ts first, as the TimeColumn).
+type PermissionEventRow struct {
+	EventTS                time.Time
+	IngestedAt             time.Time
+	TxSignature            string
+	Slot                   uint64
+	InstructionIndex       uint16
+	Signer                 string // acting admin = transaction fee-payer
+	PermissionPK           string // instruction account[0] = the Permission PDA
+	TargetPubkey           string // grantee (user_payer); set for Create, resolved best-effort otherwise
+	EventType              string // Create | Update | Suspend | Resume | Delete
+	PermissionsAdded       string // decoded role names, comma-separated
+	PermissionsRemoved     string // decoded role names, comma-separated
+	PermissionsAddedMask   string // raw bitmask, hex (no truncation)
+	PermissionsRemovedMask string // raw bitmask, hex
+	Success                uint8  // 1 if the transaction succeeded, 0 if it failed on-chain
+}
+
+type permissionEventSchema struct{}
+
+func (s *permissionEventSchema) Name() string { return "dz_permission_events" }
+
+func (s *permissionEventSchema) UniqueKeyColumns() []string {
+	return []string{"permission_pk", "slot", "tx_signature", "instruction_index"}
+}
+
+func (s *permissionEventSchema) Columns() []string {
+	return []string{
+		"ingested_at:TIMESTAMP",
+		"tx_signature:VARCHAR",
+		"slot:BIGINT",
+		"instruction_index:INTEGER",
+		"signer:VARCHAR",
+		"permission_pk:VARCHAR",
+		"target_pubkey:VARCHAR",
+		"event_type:VARCHAR",
+		"permissions_added:VARCHAR",
+		"permissions_removed:VARCHAR",
+		"permissions_added_mask:VARCHAR",
+		"permissions_removed_mask:VARCHAR",
+		"success:INTEGER",
+	}
+}
+
+func (s *permissionEventSchema) TimeColumn() string           { return "event_ts" }
+func (s *permissionEventSchema) PartitionByTime() bool        { return true }
+func (s *permissionEventSchema) DedupMode() dataset.DedupMode { return dataset.DedupReplacing }
+func (s *permissionEventSchema) DedupVersionColumn() string   { return "ingested_at" }
+
+func (s *permissionEventSchema) ToRow(row PermissionEventRow) []any {
+	return []any{
+		row.EventTS.UTC(),          // event_ts
+		row.IngestedAt,             // ingested_at
+		row.TxSignature,            // tx_signature
+		row.Slot,                   // slot
+		row.InstructionIndex,       // instruction_index
+		row.Signer,                 // signer
+		row.PermissionPK,           // permission_pk
+		row.TargetPubkey,           // target_pubkey
+		row.EventType,              // event_type
+		row.PermissionsAdded,       // permissions_added
+		row.PermissionsRemoved,     // permissions_removed
+		row.PermissionsAddedMask,   // permissions_added_mask
+		row.PermissionsRemovedMask, // permissions_removed_mask
+		row.Success,                // success
+	}
+}
+
+var schema = &permissionEventSchema{}
+
+func newDataset(log *slog.Logger) (*dataset.FactDataset, error) {
+	return dataset.NewFactDataset(log, schema)
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/store.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/store.go
@@ -13,7 +13,15 @@ import (
 
 // ScanCursor is the newest signature already scanned for a watched program. Empty when
 // nothing has been scanned yet (first run / after truncate), which triggers a full sweep.
+// Used only by the full-program backfill scan.
 type ScanCursor struct {
+	TxSignature string
+	Slot        uint64
+}
+
+// HighWaterMark is the newest signature/slot already indexed for a single Permission PDA.
+// Used by the steady-state per-account watch to resume incrementally.
+type HighWaterMark struct {
 	TxSignature string
 	Slot        uint64
 }
@@ -99,6 +107,49 @@ func (s *Store) SetScanCursor(ctx context.Context, programPK string, cur ScanCur
 		return fmt.Errorf("failed to write scan cursor: %w", err)
 	}
 	return nil
+}
+
+// GetHighWaterMarks returns the newest indexed signature/slot per Permission PDA, derived
+// from the fact table. Every permission event for a PDA lands in the fact table, so
+// max(slot) per permission_pk is where the per-account watch resumes.
+func (s *Store) GetHighWaterMarks(ctx context.Context) (map[string]HighWaterMark, error) {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+
+	const query = `
+		SELECT permission_pk, tx_signature, slot
+		FROM fact_dz_permission_events
+		WHERE (permission_pk, slot) IN (
+			SELECT permission_pk, max(slot)
+			FROM fact_dz_permission_events
+			GROUP BY permission_pk
+		)
+		ORDER BY permission_pk, slot DESC, tx_signature DESC
+	`
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query high water marks: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]HighWaterMark)
+	for rows.Next() {
+		var pk, txSig string
+		var slot uint64
+		if err := rows.Scan(&pk, &txSig, &slot); err != nil {
+			return nil, fmt.Errorf("failed to scan high water mark row: %w", err)
+		}
+		// Keep the first (newest, by ORDER BY) row per PDA.
+		if _, ok := result[pk]; !ok {
+			result[pk] = HighWaterMark{TxSignature: txSig, Slot: slot}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating high water marks: %w", err)
+	}
+	return result, nil
 }
 
 // InsertEvents writes permission event rows to ClickHouse.

--- a/indexer/pkg/dz/serviceability/permissionevents/store.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
 )
 
 // ScanCursor is the newest signature already scanned for a watched program. Empty when
@@ -35,13 +36,18 @@ func (cfg *StoreConfig) Validate() error {
 type Store struct {
 	log *slog.Logger
 	cfg StoreConfig
+	ds  *dataset.FactDataset
 }
 
 func NewStore(cfg StoreConfig) (*Store, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return &Store{log: cfg.Logger, cfg: cfg}, nil
+	ds, err := newDataset(cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset: %w", err)
+	}
+	return &Store{log: cfg.Logger, cfg: cfg, ds: ds}, nil
 }
 
 // GetScanCursor returns the newest signature/slot already scanned for the given program.
@@ -101,18 +107,13 @@ func (s *Store) InsertEvents(ctx context.Context, events []PermissionEventRow) e
 		return nil
 	}
 
-	ds, err := newDataset(s.log)
-	if err != nil {
-		return fmt.Errorf("failed to create dataset: %w", err)
-	}
-
 	conn, err := s.cfg.ClickHouse.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
 	}
 
 	ingestedAt := time.Now().UTC()
-	if err := ds.WriteBatch(ctx, conn, len(events), func(i int) ([]any, error) {
+	if err := s.ds.WriteBatch(ctx, conn, len(events), func(i int) ([]any, error) {
 		row := events[i]
 		row.IngestedAt = ingestedAt
 		return schema.ToRow(row), nil

--- a/indexer/pkg/dz/serviceability/permissionevents/store.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/store.go
@@ -1,0 +1,125 @@
+package permissionevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+)
+
+// ScanCursor is the newest signature already scanned for a watched program. Empty when
+// nothing has been scanned yet (first run / after truncate), which triggers a full sweep.
+type ScanCursor struct {
+	TxSignature string
+	Slot        uint64
+}
+
+type StoreConfig struct {
+	Logger     *slog.Logger
+	ClickHouse clickhouse.Client
+}
+
+func (cfg *StoreConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	return nil
+}
+
+type Store struct {
+	log *slog.Logger
+	cfg StoreConfig
+}
+
+func NewStore(cfg StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Store{log: cfg.Logger, cfg: cfg}, nil
+}
+
+// GetScanCursor returns the newest signature/slot already scanned for the given program.
+// Returns an empty cursor (no error) when none has been recorded yet.
+func (s *Store) GetScanCursor(ctx context.Context, programPK string) (ScanCursor, error) {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return ScanCursor{}, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+
+	// ReplacingMergeTree: the highest updated_at row is the current cursor.
+	const query = `
+		SELECT last_tx_signature, last_slot
+		FROM dz_permission_events_scan_cursor
+		WHERE program_pk = ?
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`
+	rows, err := conn.Query(ctx, query, programPK)
+	if err != nil {
+		return ScanCursor{}, fmt.Errorf("failed to query scan cursor: %w", err)
+	}
+	defer rows.Close()
+
+	var cur ScanCursor
+	if rows.Next() {
+		if err := rows.Scan(&cur.TxSignature, &cur.Slot); err != nil {
+			return ScanCursor{}, fmt.Errorf("failed to scan cursor row: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return ScanCursor{}, fmt.Errorf("error iterating scan cursor: %w", err)
+	}
+	return cur, nil
+}
+
+// SetScanCursor records the newest scanned signature/slot for the given program.
+func (s *Store) SetScanCursor(ctx context.Context, programPK string, cur ScanCursor) error {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	const query = `
+		INSERT INTO dz_permission_events_scan_cursor
+			(program_pk, last_tx_signature, last_slot, updated_at)
+		VALUES (?, ?, ?, ?)
+	`
+	if err := conn.Exec(ctx, query, programPK, cur.TxSignature, cur.Slot, time.Now().UTC()); err != nil {
+		return fmt.Errorf("failed to write scan cursor: %w", err)
+	}
+	return nil
+}
+
+// InsertEvents writes permission event rows to ClickHouse.
+func (s *Store) InsertEvents(ctx context.Context, events []PermissionEventRow) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	ds, err := newDataset(s.log)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset: %w", err)
+	}
+
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+
+	ingestedAt := time.Now().UTC()
+	if err := ds.WriteBatch(ctx, conn, len(events), func(i int) ([]any, error) {
+		row := events[i]
+		row.IngestedAt = ingestedAt
+		return schema.ToRow(row), nil
+	}); err != nil {
+		return fmt.Errorf("failed to write permission events: %w", err)
+	}
+
+	s.log.Info("serviceability/permission-events: inserted events", "count", len(events))
+	return nil
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 	"time"
 
@@ -23,6 +22,12 @@ const (
 	maxConcurrentFetches = 10
 	// maxSignaturesPerRequest is the Solana RPC page limit.
 	maxSignaturesPerRequest = 1000
+	// scanChunkSize is how many signatures are fetched, decoded, and durably written
+	// before the scan cursor is advanced. Chunking (oldest-first) bounds how much work
+	// is lost if the refresh is cancelled — e.g. a first-run full-history sweep that
+	// exceeds the Temporal activity timeout resumes from the last completed chunk instead
+	// of restarting from scratch.
+	scanChunkSize = 200
 	// metricSource labels this view's refresh metrics.
 	metricSource = "serviceability_permission_events"
 )
@@ -142,6 +147,25 @@ func (v *View) safeRefresh(ctx context.Context) {
 }
 
 func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	return v.refresh(ctx, v.cfg.SkipHighWaterMarks)
+}
+
+// BackfillRefresh runs a full re-scan ignoring the stored cursor. Existing events are
+// safely overwritten via ReplacingMergeTree dedup.
+func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	return v.refresh(ctx, true)
+}
+
+// refresh scans the program's transaction history and writes any permission events.
+// ignoreCursor forces a full re-scan (backfill); otherwise it resumes from the stored
+// scan cursor.
+//
+// The scan is processed oldest-first in chunks, and the cursor is advanced only after
+// each chunk is durably written. This means (a) a cancelled/timed-out refresh resumes
+// from the last completed chunk rather than restarting, and (b) a transient fetch/decode
+// failure fails the refresh without advancing past the un-indexed signatures, so the
+// events are retried on the next run rather than silently dropped from the audit trail.
+func (v *View) refresh(ctx context.Context, ignoreCursor bool) (ingestionlog.RefreshResult, error) {
 	v.refreshMu.Lock()
 	defer v.refreshMu.Unlock()
 
@@ -159,7 +183,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 
 	// Resolve where to resume from (unless backfilling).
 	var cursor ScanCursor
-	if !v.cfg.SkipHighWaterMarks {
+	if !ignoreCursor {
 		var err error
 		cursor, err = v.store.GetScanCursor(ctx, programPK)
 		if err != nil {
@@ -169,6 +193,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 	}
 
 	// Fetch all new signatures for the program, paginating backward to the cursor.
+	// Results are newest-first.
 	sigs, err := v.fetchNewSignatures(ctx, cursor)
 	if err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
@@ -180,23 +205,78 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		return result, nil
 	}
 
-	// The newest signature (first, since results are newest-first) becomes the new cursor.
-	newCursor := ScanCursor{TxSignature: sigs[0].Signature.String(), Slot: sigs[0].Slot}
+	// Reverse to oldest-first so the cursor advances monotonically as we checkpoint each
+	// chunk; a partial scan then leaves the cursor at the newest fully-indexed signature.
+	for i, j := 0, len(sigs)-1; i < j; i, j = i+1, j-1 {
+		sigs[i], sigs[j] = sigs[j], sigs[i]
+	}
 
-	// Fetch and decode each transaction concurrently.
+	var totalEvents int64
+	for start := 0; start < len(sigs); start += scanChunkSize {
+		end := start + scanChunkSize
+		if end > len(sigs) {
+			end = len(sigs)
+		}
+		chunk := sigs[start:end]
+
+		events, decodeErr := v.decodeChunk(ctx, chunk)
+
+		// Persist whatever decoded cleanly (idempotent via ReplacingMergeTree) before
+		// deciding whether to advance the cursor.
+		if err := v.store.InsertEvents(ctx, events); err != nil {
+			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+			return result, fmt.Errorf("insert permission events: %w", err)
+		}
+		totalEvents += int64(len(events))
+
+		// A transient fetch/decode error must not advance the cursor past the affected
+		// signatures — fail the refresh so Temporal retries and the events are re-scanned.
+		if decodeErr != nil {
+			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+			return result, fmt.Errorf("decode transactions: %w", decodeErr)
+		}
+
+		// Chunk is oldest-first, so its last element is the newest signature indexed so far.
+		newest := chunk[len(chunk)-1]
+		newCursor := ScanCursor{TxSignature: newest.Signature.String(), Slot: newest.Slot}
+		if err := v.store.SetScanCursor(ctx, programPK, newCursor); err != nil {
+			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+			return result, fmt.Errorf("set scan cursor: %w", err)
+		}
+	}
+
+	result.RowsAffected = totalEvents
+	fetchedAt := time.Now().UTC()
+	result.SourceMaxEventTS = &fetchedAt
+
+	v.markReady()
+	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+
+	if totalEvents > 0 {
+		v.log.Info("serviceability/permission-events: indexed new events",
+			"count", totalEvents, "scanned_signatures", len(sigs))
+	}
+	return result, nil
+}
+
+// decodeChunk fetches and decodes a batch of transactions concurrently. It returns the
+// events that decoded cleanly along with the first fetch/decode error encountered, if any.
+// All transactions are attempted even when one fails (no early cancellation) so a single
+// transient error doesn't discard the rest of the chunk's successfully decoded events.
+func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature) ([]PermissionEventRow, error) {
 	var (
 		mu        sync.Mutex
 		allEvents []PermissionEventRow
 	)
-	g, gctx := errgroup.WithContext(ctx)
+	var g errgroup.Group
 	g.SetLimit(maxConcurrentFetches)
 	for _, sig := range sigs {
 		g.Go(func() error {
-			events, err := v.decodeTransaction(gctx, sig)
+			events, err := v.decodeTransaction(ctx, sig)
 			if err != nil {
 				v.log.Warn("serviceability/permission-events: failed to decode transaction",
 					"signature", sig.Signature.String(), "error", err)
-				return nil // one bad tx shouldn't fail the whole refresh
+				return err
 			}
 			if len(events) > 0 {
 				mu.Lock()
@@ -206,44 +286,8 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-		return result, fmt.Errorf("decode transactions: %w", err)
-	}
-
-	if err := v.store.InsertEvents(ctx, allEvents); err != nil {
-		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-		return result, fmt.Errorf("insert permission events: %w", err)
-	}
-
-	// Advance the cursor only after events are durably written, so a crash mid-refresh
-	// re-scans (idempotent via ReplacingMergeTree) rather than skipping.
-	if err := v.store.SetScanCursor(ctx, programPK, newCursor); err != nil {
-		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-		return result, fmt.Errorf("set scan cursor: %w", err)
-	}
-
-	result.RowsAffected = int64(len(allEvents))
-	fetchedAt := time.Now().UTC()
-	result.SourceMaxEventTS = &fetchedAt
-
-	v.markReady()
-	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
-
-	if len(allEvents) > 0 {
-		v.log.Info("serviceability/permission-events: indexed new events",
-			"count", len(allEvents), "scanned_signatures", len(sigs))
-	}
-	return result, nil
-}
-
-// BackfillRefresh runs a full re-scan ignoring the stored cursor. Existing events are
-// safely overwritten via ReplacingMergeTree dedup.
-func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
-	orig := v.cfg.SkipHighWaterMarks
-	v.cfg.SkipHighWaterMarks = true
-	defer func() { v.cfg.SkipHighWaterMarks = orig }()
-	return v.Refresh(ctx)
+	err := g.Wait()
+	return allEvents, err
 }
 
 // ClickHouse returns the ClickHouse client for direct operations (e.g. truncate).
@@ -269,10 +313,18 @@ func (v *View) fetchNewSignatures(ctx context.Context, cursor ScanCursor) ([]*rp
 		}
 	}
 
+	// Paginate backward (via Before) until an empty page. We terminate only on an empty
+	// page rather than on a short page: a provider/gateway may cap pages below our
+	// requested limit, and stopping on the first short page would skip older history and
+	// advance the cursor past it permanently.
+	limit := maxSignaturesPerRequest
 	var allSigs []*rpc.TransactionSignature
 	var beforeSig solana.Signature
 	for {
-		opts := &rpc.GetSignaturesForAddressOpts{Commitment: rpc.CommitmentFinalized}
+		opts := &rpc.GetSignaturesForAddressOpts{
+			Commitment: rpc.CommitmentFinalized,
+			Limit:      &limit,
+		}
 		if !untilSig.IsZero() {
 			opts.Until = untilSig
 		}
@@ -284,17 +336,24 @@ func (v *View) fetchNewSignatures(ctx context.Context, cursor ScanCursor) ([]*rp
 		if err != nil {
 			return nil, fmt.Errorf("get signatures: %w", err)
 		}
-		allSigs = append(allSigs, page...)
-		if len(page) < maxSignaturesPerRequest {
+		if len(page) == 0 {
 			break
 		}
+		allSigs = append(allSigs, page...)
 		beforeSig = page[len(page)-1].Signature
 	}
 	return allSigs, nil
 }
 
 // decodeTransaction fetches one transaction and decodes any permission-management
-// instructions it contains into audit rows.
+// instructions it contains into audit rows. Both top-level and CPI (inner) instructions
+// are scanned, since permission ops invoked via a multisig/governance program appear only
+// in the transaction's inner instructions.
+//
+// Signer is the transaction fee-payer (accountKeys[0]). For the common case — an admin
+// signing and paying for their own permission tx — this is the acting authority. When a
+// relayer or multisig pays fees, the fee-payer is not the acting admin; the true signer
+// set is not recorded here.
 func (v *View) decodeTransaction(ctx context.Context, sig *rpc.TransactionSignature) ([]PermissionEventRow, error) {
 	maxVersion := uint64(0)
 	txResult, err := v.cfg.RPC.GetTransaction(ctx, sig.Signature, &rpc.GetTransactionOpts{
@@ -316,12 +375,25 @@ func (v *View) decodeTransaction(ctx context.Context, sig *rpc.TransactionSignat
 		return nil, nil
 	}
 
+	// Resolve the full account key list. For v0 transactions the instruction account
+	// indices also reference address-lookup-table entries, which the RPC returns in
+	// Meta.LoadedAddresses (writable first, then read-only). Without merging them, a
+	// looked-up Permission PDA would resolve to an empty pubkey.
 	accountKeys := tx.Message.AccountKeys
+	if txResult.Meta != nil {
+		accountKeys = append(accountKeys, txResult.Meta.LoadedAddresses.Writable...)
+		accountKeys = append(accountKeys, txResult.Meta.LoadedAddresses.ReadOnly...)
+	}
 	feePayer := accountKeys[0].String()
 
+	// Prefer the signature's block time; fall back to the transaction result's block time
+	// (either may be nil on some RPC states). event_ts may still be zero in the rare case
+	// both are absent — the API sorts by slot first so such rows remain visible.
 	var blockTime time.Time
 	if sig.BlockTime != nil {
 		blockTime = sig.BlockTime.Time().UTC()
+	} else if txResult.BlockTime != nil {
+		blockTime = txResult.BlockTime.Time().UTC()
 	}
 	success := uint8(1)
 	if sig.Err != nil {
@@ -329,35 +401,43 @@ func (v *View) decodeTransaction(ctx context.Context, sig *rpc.TransactionSignat
 	}
 
 	var rows []PermissionEventRow
-	for idx, ci := range tx.Message.Instructions {
-		if int(ci.ProgramIDIndex) >= len(accountKeys) {
-			continue
+	// seq assigns a stable, unique index to each permission row within the tx (top-level
+	// instructions in order, then inner instructions). It backs the (permission_pk, slot,
+	// tx_signature, instruction_index) dedup key, so two permission instructions in one tx
+	// stay distinct rows.
+	// decodeInto decodes a single (top-level or inner) instruction. Top-level and inner
+	// instructions are distinct Go types (solana.CompiledInstruction vs
+	// rpc.CompiledInstruction) with the same shape, so it takes the fields directly.
+	var seq uint16
+	decodeInto := func(programIDIndex uint16, accounts []uint16, data []byte) {
+		if int(programIDIndex) >= len(accountKeys) {
+			return
 		}
-		if !accountKeys[ci.ProgramIDIndex].Equals(v.cfg.ProgramID) {
-			continue
+		if !accountKeys[programIDIndex].Equals(v.cfg.ProgramID) {
+			return
 		}
 
-		decoded, ok, err := DecodePermissionInstruction(ci.Data)
+		decoded, ok, err := DecodePermissionInstruction(data)
 		if err != nil {
 			v.log.Warn("serviceability/permission-events: malformed permission instruction",
-				"signature", sig.Signature.String(), "instruction_index", idx, "error", err)
-			continue
+				"signature", sig.Signature.String(), "instruction_index", seq, "error", err)
+			return
 		}
 		if !ok {
-			continue
+			return
 		}
 
 		// account[0] is the target Permission PDA.
 		var permissionPK string
-		if len(ci.Accounts) > 0 && int(ci.Accounts[0]) < len(accountKeys) {
-			permissionPK = accountKeys[ci.Accounts[0]].String()
+		if len(accounts) > 0 && int(accounts[0]) < len(accountKeys) {
+			permissionPK = accountKeys[accounts[0]].String()
 		}
 
 		rows = append(rows, PermissionEventRow{
 			EventTS:                blockTime,
 			TxSignature:            sig.Signature.String(),
 			Slot:                   sig.Slot,
-			InstructionIndex:       uint16(idx),
+			InstructionIndex:       seq,
 			Signer:                 feePayer,
 			PermissionPK:           permissionPK,
 			TargetPubkey:           decoded.TargetUserPayer,
@@ -368,9 +448,19 @@ func (v *View) decodeTransaction(ctx context.Context, sig *rpc.TransactionSignat
 			PermissionsRemovedMask: decoded.Removed.Hex(),
 			Success:                success,
 		})
+		seq++
 	}
 
-	// Deterministic order within a tx (stable across concurrent refreshes).
-	sort.SliceStable(rows, func(i, j int) bool { return rows[i].InstructionIndex < rows[j].InstructionIndex })
+	for _, ci := range tx.Message.Instructions {
+		decodeInto(ci.ProgramIDIndex, ci.Accounts, ci.Data)
+	}
+	if txResult.Meta != nil {
+		for _, inner := range txResult.Meta.InnerInstructions {
+			for _, ci := range inner.Instructions {
+				decodeInto(ci.ProgramIDIndex, ci.Accounts, ci.Data)
+			}
+		}
+	}
+
 	return rows, nil
 }

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -22,12 +22,16 @@ const (
 	maxConcurrentFetches = 10
 	// maxSignaturesPerRequest is the Solana RPC page limit.
 	maxSignaturesPerRequest = 1000
-	// scanChunkSize is how many signatures are fetched, decoded, and durably written
-	// before the scan cursor is advanced. Chunking (oldest-first) bounds how much work
-	// is lost if the refresh is cancelled — e.g. a first-run full-history sweep that
-	// exceeds the Temporal activity timeout resumes from the last completed chunk instead
-	// of restarting from scratch.
+	// scanChunkSize is how many signatures the full-program backfill scan fetches,
+	// decodes, and durably writes before advancing the program scan cursor. Chunking
+	// (oldest-first) bounds how much work is lost if the backfill is cancelled — a
+	// full-history sweep that exceeds the Temporal activity timeout resumes from the last
+	// completed chunk instead of restarting from scratch.
 	scanChunkSize = 200
+	// permissionAccountType is the serviceability account_type discriminator (first byte
+	// of account data) for Permission accounts — AccountType::Permission = 15 in
+	// state/permission.rs. Used to enumerate Permission PDAs via getProgramAccounts.
+	permissionAccountType byte = 15
 	// metricSource labels this view's refresh metrics.
 	metricSource = "serviceability_permission_events"
 )
@@ -39,10 +43,6 @@ type ViewConfig struct {
 	ProgramID       solana.PublicKey // the serviceability program id
 	RefreshInterval time.Duration
 	ClickHouse      clickhouse.Client
-	// SkipHighWaterMarks ignores the stored scan cursor, forcing a full re-scan of all
-	// history. Used by the backfill command. Existing rows are safely overwritten via
-	// ReplacingMergeTree dedup.
-	SkipHighWaterMarks bool
 }
 
 func (cfg *ViewConfig) Validate() error {
@@ -146,26 +146,22 @@ func (v *View) safeRefresh(ctx context.Context) {
 	}
 }
 
-func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
-	return v.refresh(ctx, v.cfg.SkipHighWaterMarks)
-}
-
-// BackfillRefresh runs a full re-scan ignoring the stored cursor. Existing events are
-// safely overwritten via ReplacingMergeTree dedup.
-func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
-	return v.refresh(ctx, true)
-}
-
-// refresh scans the program's transaction history and writes any permission events.
-// ignoreCursor forces a full re-scan (backfill); otherwise it resumes from the stored
-// scan cursor.
+// Refresh is the steady-state refresh. Permission-management instructions are sporadic
+// among a high volume of other serviceability transactions, so instead of fetching every
+// program transaction just to check its variant byte, it watches each Permission account
+// directly:
 //
-// The scan is processed oldest-first in chunks, and the cursor is advanced only after
-// each chunk is durably written. This means (a) a cancelled/timed-out refresh resumes
-// from the last completed chunk rather than restarting, and (b) a transient fetch/decode
-// failure fails the refresh without advancing past the un-indexed signatures, so the
-// events are retried on the next run rather than silently dropped from the audit trail.
-func (v *View) refresh(ctx context.Context, ignoreCursor bool) (ingestionlog.RefreshResult, error) {
+//  1. discover the current Permission PDAs via getProgramAccounts (one cheap call), then
+//  2. per PDA, getSignaturesForAddress since that account's high-water mark and decode only
+//     those transactions.
+//
+// Because a Permission PDA is only ever referenced by permission instructions, this fetches
+// only permission transactions rather than the whole program's history. New grants are
+// picked up once the PDA is discovered (its create tx references the account). The only gap
+// is an account created and deleted between two discovery polls (a deleted account no longer
+// appears in getProgramAccounts) — BackfillRefresh's full-history program scan is the
+// completeness backstop for that.
+func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
 	v.refreshMu.Lock()
 	defer v.refreshMu.Unlock()
 
@@ -179,17 +175,107 @@ func (v *View) refresh(ctx context.Context, ignoreCursor bool) (ingestionlog.Ref
 		metrics.ViewRefreshDuration.WithLabelValues(metricSource).Observe(duration.Seconds())
 	}()
 
+	// Discover the Permission accounts to watch.
+	pdas, err := v.discoverPermissionAccounts(ctx)
+	if err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("discover permission accounts: %w", err)
+	}
+	if len(pdas) == 0 {
+		v.markReady()
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+		return result, nil
+	}
+
+	// Resume each account from the newest slot already indexed for it. The fact table holds
+	// every permission event for a given PDA, so max(slot) per permission_pk is a sound
+	// per-account cursor (unlike a program-wide scan, which the fact table can't anchor).
+	hwms, err := v.store.GetHighWaterMarks(ctx)
+	if err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("get high water marks: %w", err)
+	}
+
+	var (
+		mu        sync.Mutex
+		allEvents []PermissionEventRow
+	)
+	var g errgroup.Group
+	g.SetLimit(maxConcurrentFetches)
+	for _, pda := range pdas {
+		g.Go(func() error {
+			events, err := v.fetchAccountEvents(ctx, pda, hwms[pda.String()])
+			if len(events) > 0 {
+				mu.Lock()
+				allEvents = append(allEvents, events...)
+				mu.Unlock()
+			}
+			if err != nil {
+				v.log.Warn("serviceability/permission-events: failed to fetch account",
+					"permission_pk", pda.String(), "error", err)
+				return err
+			}
+			return nil
+		})
+	}
+	fetchErr := g.Wait()
+
+	// Persist whatever decoded cleanly (idempotent via ReplacingMergeTree). Because the
+	// per-account cursor is derived from the fact table, a failed account simply isn't
+	// advanced — it is re-fetched next refresh rather than leaving a silent gap.
+	if err := v.store.InsertEvents(ctx, allEvents); err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("insert permission events: %w", err)
+	}
+	if fetchErr != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("fetch account events: %w", fetchErr)
+	}
+
+	result.RowsAffected = int64(len(allEvents))
+	fetchedAt := time.Now().UTC()
+	result.SourceMaxEventTS = &fetchedAt
+
+	v.markReady()
+	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+
+	if len(allEvents) > 0 {
+		v.log.Info("serviceability/permission-events: indexed new events",
+			"count", len(allEvents), "watched_accounts", len(pdas))
+	}
+	return result, nil
+}
+
+// BackfillRefresh scans the serviceability program's entire transaction history for
+// permission instructions, ignoring the per-account cursors. This is the completeness
+// path: it catches historical events and permission accounts that were created and later
+// deleted (which the steady-state per-account watch can't discover). Existing rows are
+// safely overwritten via ReplacingMergeTree dedup.
+//
+// The scan is processed oldest-first in chunks, advancing a program scan cursor after each
+// chunk is durably written. So (a) a cancelled/timed-out backfill resumes from the last
+// completed chunk rather than restarting, and (b) a transient fetch/decode failure fails
+// the run without advancing past the un-indexed signatures.
+func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	v.refreshMu.Lock()
+	defer v.refreshMu.Unlock()
+
+	var result ingestionlog.RefreshResult
+
+	refreshStart := time.Now()
+	v.log.Debug("serviceability/permission-events: backfill started")
+	defer func() {
+		duration := time.Since(refreshStart)
+		v.log.Info("serviceability/permission-events: backfill completed", "duration", duration.String())
+		metrics.ViewRefreshDuration.WithLabelValues(metricSource).Observe(duration.Seconds())
+	}()
+
 	programPK := v.cfg.ProgramID.String()
 
-	// Resolve where to resume from (unless backfilling).
-	var cursor ScanCursor
-	if !ignoreCursor {
-		var err error
-		cursor, err = v.store.GetScanCursor(ctx, programPK)
-		if err != nil {
-			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-			return result, fmt.Errorf("get scan cursor: %w", err)
-		}
+	cursor, err := v.store.GetScanCursor(ctx, programPK)
+	if err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("get scan cursor: %w", err)
 	}
 
 	// Fetch all new signatures for the program, paginating backward to the cursor.
@@ -257,6 +343,84 @@ func (v *View) refresh(ctx context.Context, ignoreCursor bool) (ingestionlog.Ref
 			"count", totalEvents, "scanned_signatures", len(sigs))
 	}
 	return result, nil
+}
+
+// discoverPermissionAccounts returns the current Permission PDAs owned by the serviceability
+// program, via a single getProgramAccounts filtered on the account_type discriminator. The
+// data slice is zero-length: we only need the pubkeys, not the account contents.
+func (v *View) discoverPermissionAccounts(ctx context.Context) ([]solana.PublicKey, error) {
+	zero := uint64(0)
+	res, err := v.cfg.RPC.GetProgramAccountsWithOpts(ctx, v.cfg.ProgramID, &rpc.GetProgramAccountsOpts{
+		Commitment: rpc.CommitmentFinalized,
+		Encoding:   solana.EncodingBase64,
+		DataSlice:  &rpc.DataSlice{Offset: &zero, Length: &zero},
+		Filters: []rpc.RPCFilter{{
+			Memcmp: &rpc.RPCFilterMemcmp{Offset: 0, Bytes: solana.Base58{permissionAccountType}},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get program accounts: %w", err)
+	}
+	pdas := make([]solana.PublicKey, 0, len(res))
+	for _, acc := range res {
+		if acc != nil {
+			pdas = append(pdas, acc.Pubkey)
+		}
+	}
+	return pdas, nil
+}
+
+// fetchAccountEvents fetches all transactions touching a single Permission PDA newer than
+// its high-water mark and decodes their permission instructions. A Permission PDA is only
+// referenced by permission instructions, so every signature here yields audit rows.
+func (v *View) fetchAccountEvents(ctx context.Context, pda solana.PublicKey, hwm HighWaterMark) ([]PermissionEventRow, error) {
+	var untilSig solana.Signature
+	if hwm.TxSignature != "" {
+		var err error
+		untilSig, err = solana.SignatureFromBase58(hwm.TxSignature)
+		if err != nil {
+			return nil, fmt.Errorf("invalid high water mark signature %q: %w", hwm.TxSignature, err)
+		}
+	}
+
+	// Paginate backward (via Before) until an empty page — robust to gateways that cap
+	// pages below the requested limit (a short page would otherwise end pagination early).
+	limit := maxSignaturesPerRequest
+	var allSigs []*rpc.TransactionSignature
+	var beforeSig solana.Signature
+	for {
+		opts := &rpc.GetSignaturesForAddressOpts{Commitment: rpc.CommitmentFinalized, Limit: &limit}
+		if !untilSig.IsZero() {
+			opts.Until = untilSig
+		}
+		if !beforeSig.IsZero() {
+			opts.Before = beforeSig
+		}
+		page, err := v.cfg.RPC.GetSignaturesForAddressWithOpts(ctx, pda, opts)
+		if err != nil {
+			return nil, fmt.Errorf("get signatures: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		allSigs = append(allSigs, page...)
+		beforeSig = page[len(page)-1].Signature
+	}
+	if len(allSigs) == 0 {
+		return nil, nil
+	}
+
+	var events []PermissionEventRow
+	for _, sig := range allSigs {
+		decoded, err := v.decodeTransaction(ctx, sig)
+		if err != nil {
+			// Fail the account so it is retried (cursor is derived from the fact table and
+			// therefore not advanced) rather than silently dropping the event.
+			return events, fmt.Errorf("decode transaction %s: %w", sig.Signature.String(), err)
+		}
+		events = append(events, decoded...)
+	}
+	return events, nil
 }
 
 // decodeChunk fetches and decodes a batch of transactions concurrently. It returns the

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -1,0 +1,376 @@
+package permissionevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/jonboulle/clockwork"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// maxConcurrentFetches limits parallel getTransaction calls per refresh.
+	maxConcurrentFetches = 10
+	// maxSignaturesPerRequest is the Solana RPC page limit.
+	maxSignaturesPerRequest = 1000
+	// metricSource labels this view's refresh metrics.
+	metricSource = "serviceability_permission_events"
+)
+
+type ViewConfig struct {
+	Logger          *slog.Logger
+	Clock           clockwork.Clock
+	RPC             SolanaRPC
+	ProgramID       solana.PublicKey // the serviceability program id
+	RefreshInterval time.Duration
+	ClickHouse      clickhouse.Client
+	// SkipHighWaterMarks ignores the stored scan cursor, forcing a full re-scan of all
+	// history. Used by the backfill command. Existing rows are safely overwritten via
+	// ReplacingMergeTree dedup.
+	SkipHighWaterMarks bool
+}
+
+func (cfg *ViewConfig) Validate() error {
+	if cfg.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if cfg.RPC == nil {
+		return errors.New("rpc is required")
+	}
+	if cfg.ProgramID.IsZero() {
+		return errors.New("program id is required")
+	}
+	if cfg.ClickHouse == nil {
+		return errors.New("clickhouse connection is required")
+	}
+	if cfg.RefreshInterval <= 0 {
+		return errors.New("refresh interval must be greater than 0")
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+type View struct {
+	log       *slog.Logger
+	cfg       ViewConfig
+	store     *Store
+	refreshMu sync.Mutex
+
+	readyOnce sync.Once
+	readyCh   chan struct{}
+}
+
+func NewView(cfg ViewConfig) (*View, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	store, err := NewStore(StoreConfig{Logger: cfg.Logger, ClickHouse: cfg.ClickHouse})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create store: %w", err)
+	}
+	return &View{
+		log:     cfg.Logger,
+		cfg:     cfg,
+		store:   store,
+		readyCh: make(chan struct{}),
+	}, nil
+}
+
+func (v *View) Ready() bool {
+	select {
+	case <-v.readyCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v *View) WaitReady(ctx context.Context) error {
+	select {
+	case <-v.readyCh:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context cancelled while waiting for permission events view: %w", ctx.Err())
+	}
+}
+
+func (v *View) Start(ctx context.Context) {
+	go func() {
+		v.log.Info("serviceability/permission-events: starting refresh loop", "interval", v.cfg.RefreshInterval)
+
+		v.safeRefresh(ctx)
+
+		ticker := v.cfg.Clock.NewTicker(v.cfg.RefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.Chan():
+				v.safeRefresh(ctx)
+			}
+		}
+	}()
+}
+
+func (v *View) safeRefresh(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			v.log.Error("serviceability/permission-events: refresh panicked", "panic", r)
+			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "panic").Inc()
+		}
+	}()
+
+	if _, err := v.Refresh(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		v.log.Error("serviceability/permission-events: refresh failed", "error", err)
+	}
+}
+
+func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	v.refreshMu.Lock()
+	defer v.refreshMu.Unlock()
+
+	var result ingestionlog.RefreshResult
+
+	refreshStart := time.Now()
+	v.log.Debug("serviceability/permission-events: refresh started")
+	defer func() {
+		duration := time.Since(refreshStart)
+		v.log.Info("serviceability/permission-events: refresh completed", "duration", duration.String())
+		metrics.ViewRefreshDuration.WithLabelValues(metricSource).Observe(duration.Seconds())
+	}()
+
+	programPK := v.cfg.ProgramID.String()
+
+	// Resolve where to resume from (unless backfilling).
+	var cursor ScanCursor
+	if !v.cfg.SkipHighWaterMarks {
+		var err error
+		cursor, err = v.store.GetScanCursor(ctx, programPK)
+		if err != nil {
+			metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+			return result, fmt.Errorf("get scan cursor: %w", err)
+		}
+	}
+
+	// Fetch all new signatures for the program, paginating backward to the cursor.
+	sigs, err := v.fetchNewSignatures(ctx, cursor)
+	if err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("fetch signatures: %w", err)
+	}
+	if len(sigs) == 0 {
+		v.markReady()
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+		return result, nil
+	}
+
+	// The newest signature (first, since results are newest-first) becomes the new cursor.
+	newCursor := ScanCursor{TxSignature: sigs[0].Signature.String(), Slot: sigs[0].Slot}
+
+	// Fetch and decode each transaction concurrently.
+	var (
+		mu        sync.Mutex
+		allEvents []PermissionEventRow
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentFetches)
+	for _, sig := range sigs {
+		g.Go(func() error {
+			events, err := v.decodeTransaction(gctx, sig)
+			if err != nil {
+				v.log.Warn("serviceability/permission-events: failed to decode transaction",
+					"signature", sig.Signature.String(), "error", err)
+				return nil // one bad tx shouldn't fail the whole refresh
+			}
+			if len(events) > 0 {
+				mu.Lock()
+				allEvents = append(allEvents, events...)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("decode transactions: %w", err)
+	}
+
+	if err := v.store.InsertEvents(ctx, allEvents); err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("insert permission events: %w", err)
+	}
+
+	// Advance the cursor only after events are durably written, so a crash mid-refresh
+	// re-scans (idempotent via ReplacingMergeTree) rather than skipping.
+	if err := v.store.SetScanCursor(ctx, programPK, newCursor); err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("set scan cursor: %w", err)
+	}
+
+	result.RowsAffected = int64(len(allEvents))
+	fetchedAt := time.Now().UTC()
+	result.SourceMaxEventTS = &fetchedAt
+
+	v.markReady()
+	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+
+	if len(allEvents) > 0 {
+		v.log.Info("serviceability/permission-events: indexed new events",
+			"count", len(allEvents), "scanned_signatures", len(sigs))
+	}
+	return result, nil
+}
+
+// BackfillRefresh runs a full re-scan ignoring the stored cursor. Existing events are
+// safely overwritten via ReplacingMergeTree dedup.
+func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	orig := v.cfg.SkipHighWaterMarks
+	v.cfg.SkipHighWaterMarks = true
+	defer func() { v.cfg.SkipHighWaterMarks = orig }()
+	return v.Refresh(ctx)
+}
+
+// ClickHouse returns the ClickHouse client for direct operations (e.g. truncate).
+func (v *View) ClickHouse() clickhouse.Client {
+	return v.cfg.ClickHouse
+}
+
+func (v *View) markReady() {
+	v.readyOnce.Do(func() {
+		close(v.readyCh)
+		v.log.Info("serviceability/permission-events: view is now ready")
+	})
+}
+
+// fetchNewSignatures returns all program signatures newer than the cursor, newest-first.
+func (v *View) fetchNewSignatures(ctx context.Context, cursor ScanCursor) ([]*rpc.TransactionSignature, error) {
+	var untilSig solana.Signature
+	if cursor.TxSignature != "" {
+		var err error
+		untilSig, err = solana.SignatureFromBase58(cursor.TxSignature)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor signature %q: %w", cursor.TxSignature, err)
+		}
+	}
+
+	var allSigs []*rpc.TransactionSignature
+	var beforeSig solana.Signature
+	for {
+		opts := &rpc.GetSignaturesForAddressOpts{Commitment: rpc.CommitmentFinalized}
+		if !untilSig.IsZero() {
+			opts.Until = untilSig
+		}
+		if !beforeSig.IsZero() {
+			opts.Before = beforeSig
+		}
+
+		page, err := v.cfg.RPC.GetSignaturesForAddressWithOpts(ctx, v.cfg.ProgramID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("get signatures: %w", err)
+		}
+		allSigs = append(allSigs, page...)
+		if len(page) < maxSignaturesPerRequest {
+			break
+		}
+		beforeSig = page[len(page)-1].Signature
+	}
+	return allSigs, nil
+}
+
+// decodeTransaction fetches one transaction and decodes any permission-management
+// instructions it contains into audit rows.
+func (v *View) decodeTransaction(ctx context.Context, sig *rpc.TransactionSignature) ([]PermissionEventRow, error) {
+	maxVersion := uint64(0)
+	txResult, err := v.cfg.RPC.GetTransaction(ctx, sig.Signature, &rpc.GetTransactionOpts{
+		Encoding:                       solana.EncodingBase64,
+		Commitment:                     rpc.CommitmentFinalized,
+		MaxSupportedTransactionVersion: &maxVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get transaction: %w", err)
+	}
+	if txResult == nil || txResult.Transaction == nil {
+		return nil, nil
+	}
+	tx, err := txResult.Transaction.GetTransaction()
+	if err != nil {
+		return nil, fmt.Errorf("parse transaction: %w", err)
+	}
+	if tx == nil || len(tx.Message.AccountKeys) == 0 {
+		return nil, nil
+	}
+
+	accountKeys := tx.Message.AccountKeys
+	feePayer := accountKeys[0].String()
+
+	var blockTime time.Time
+	if sig.BlockTime != nil {
+		blockTime = sig.BlockTime.Time().UTC()
+	}
+	success := uint8(1)
+	if sig.Err != nil {
+		success = 0
+	}
+
+	var rows []PermissionEventRow
+	for idx, ci := range tx.Message.Instructions {
+		if int(ci.ProgramIDIndex) >= len(accountKeys) {
+			continue
+		}
+		if !accountKeys[ci.ProgramIDIndex].Equals(v.cfg.ProgramID) {
+			continue
+		}
+
+		decoded, ok, err := DecodePermissionInstruction(ci.Data)
+		if err != nil {
+			v.log.Warn("serviceability/permission-events: malformed permission instruction",
+				"signature", sig.Signature.String(), "instruction_index", idx, "error", err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		// account[0] is the target Permission PDA.
+		var permissionPK string
+		if len(ci.Accounts) > 0 && int(ci.Accounts[0]) < len(accountKeys) {
+			permissionPK = accountKeys[ci.Accounts[0]].String()
+		}
+
+		rows = append(rows, PermissionEventRow{
+			EventTS:                blockTime,
+			TxSignature:            sig.Signature.String(),
+			Slot:                   sig.Slot,
+			InstructionIndex:       uint16(idx),
+			Signer:                 feePayer,
+			PermissionPK:           permissionPK,
+			TargetPubkey:           decoded.TargetUserPayer,
+			EventType:              decoded.EventType,
+			PermissionsAdded:       FlagNames(decoded.Added),
+			PermissionsRemoved:     FlagNames(decoded.Removed),
+			PermissionsAddedMask:   decoded.Added.Hex(),
+			PermissionsRemovedMask: decoded.Removed.Hex(),
+			Success:                success,
+		})
+	}
+
+	// Deterministic order within a tx (stable across concurrent refreshes).
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].InstructionIndex < rows[j].InstructionIndex })
+	return rows, nil
+}

--- a/indexer/pkg/dz/shreds/escrowevents/rpc.go
+++ b/indexer/pkg/dz/shreds/escrowevents/rpc.go
@@ -1,18 +1,8 @@
 package escrowevents
 
-import (
-	"context"
-
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
-)
+import "github.com/malbeclabs/lake/indexer/pkg/sol"
 
 // SolanaRPC abstracts the Solana RPC methods needed for fetching escrow
-// transaction history.
-type SolanaRPC interface {
-	GetSignaturesForAddressWithOpts(ctx context.Context, account solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error)
-	GetTransaction(ctx context.Context, txSig solana.Signature, opts *rpc.GetTransactionOpts) (*rpc.GetTransactionResult, error)
-}
-
-// Compile-time check that *rpc.Client satisfies SolanaRPC.
-var _ SolanaRPC = (*rpc.Client)(nil)
+// transaction history. It aliases the shared sol.TxHistoryRPC so the escrowevents
+// and permissionevents indexers stay on one interface. Satisfied by *rpc.Client.
+type SolanaRPC = sol.TxHistoryRPC

--- a/indexer/pkg/dz/shreds/escrowevents/view.go
+++ b/indexer/pkg/dz/shreds/escrowevents/view.go
@@ -148,6 +148,10 @@ func (v *View) safeRefresh(ctx context.Context) {
 }
 
 func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
+	return v.refresh(ctx, v.cfg.SkipHighWaterMarks)
+}
+
+func (v *View) refresh(ctx context.Context, ignoreCursor bool) (ingestionlog.RefreshResult, error) {
 	v.refreshMu.Lock()
 	defer v.refreshMu.Unlock()
 
@@ -172,7 +176,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 
 	// Get high water marks to know where to resume (unless skipping for backfill).
 	var hwms map[string]HighWaterMark
-	if v.cfg.SkipHighWaterMarks {
+	if ignoreCursor {
 		hwms = make(map[string]HighWaterMark)
 	} else {
 		var err error
@@ -246,10 +250,7 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 // BackfillRefresh runs a full refresh ignoring high-water marks. Existing events
 // are safely overwritten via ReplacingMergeTree deduplication.
 func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult, error) {
-	orig := v.cfg.SkipHighWaterMarks
-	v.cfg.SkipHighWaterMarks = true
-	defer func() { v.cfg.SkipHighWaterMarks = orig }()
-	return v.Refresh(ctx)
+	return v.refresh(ctx, true)
 }
 
 // ClickHouse returns the ClickHouse client for direct operations (e.g. truncate).
@@ -285,9 +286,14 @@ func (v *View) fetchEscrowEvents(ctx context.Context, escrow EscrowInfo, hwm Hig
 	var allSigs []*rpc.TransactionSignature
 	var beforeSig solana.Signature
 
+	// Paginate backward (via Before) until an empty page. Terminating on an empty page
+	// rather than a short page is robust to providers/gateways that cap pages below the
+	// requested limit — stopping on the first short page would skip older history.
+	limit := maxSignaturesPerRequest
 	for {
 		opts := &rpc.GetSignaturesForAddressOpts{
 			Commitment: rpc.CommitmentFinalized,
+			Limit:      &limit,
 		}
 		if !untilSig.IsZero() {
 			opts.Until = untilSig
@@ -300,13 +306,11 @@ func (v *View) fetchEscrowEvents(ctx context.Context, escrow EscrowInfo, hwm Hig
 		if err != nil {
 			return nil, fmt.Errorf("get signatures: %w", err)
 		}
-
-		allSigs = append(allSigs, sigs...)
-
-		// If we got fewer than the max, we've reached the end.
-		if len(sigs) < maxSignaturesPerRequest {
+		if len(sigs) == 0 {
 			break
 		}
+
+		allSigs = append(allSigs, sigs...)
 
 		// Paginate: set before to the last (oldest) signature.
 		beforeSig = sigs[len(sigs)-1].Signature

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -13,6 +13,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
@@ -31,22 +32,23 @@ const errorAfterFailures = 3
 
 // Activities holds dependencies for DZ ingest activities.
 type Activities struct {
-	Log            *slog.Logger
-	IngestionLog   *ingestionlog.Writer
-	Network        string
-	Serviceability *dzsvc.View
-	Geolocation    *dzgeoloc.View     // nil when geolocation is not configured
-	Shreds         *dzshreds.View     // nil when shreds is not configured
-	EscrowEvents   *escrowevents.View // nil when shreds is not configured
-	TelemLatency   *dztelemlatency.View
-	TelemUsage     *dztelemusage.View // nil when InfluxDB is not configured
-	GraphStore     *dzgraph.Store     // nil when Neo4j is not configured
-	ISISSource     isis.Source        // nil when ISIS is not enabled
-	ISISStore      *isis.Store        // nil when ISIS is not enabled
-	MrouteSource   mroute.Source      // nil when mroute ingest is not enabled
-	MrouteStore    *mroute.Store      // nil when mroute ingest is not enabled
-	MSDPSource     msdp.Source        // nil when MSDP ingest is not enabled
-	MSDPStore      *msdp.Store        // nil when MSDP ingest is not enabled
+	Log              *slog.Logger
+	IngestionLog     *ingestionlog.Writer
+	Network          string
+	Serviceability   *dzsvc.View
+	Geolocation      *dzgeoloc.View         // nil when geolocation is not configured
+	Shreds           *dzshreds.View         // nil when shreds is not configured
+	EscrowEvents     *escrowevents.View     // nil when shreds is not configured
+	PermissionEvents *permissionevents.View // nil when permission events indexing is not configured
+	TelemLatency     *dztelemlatency.View
+	TelemUsage       *dztelemusage.View // nil when InfluxDB is not configured
+	GraphStore       *dzgraph.Store     // nil when Neo4j is not configured
+	ISISSource       isis.Source        // nil when ISIS is not enabled
+	ISISStore        *isis.Store        // nil when ISIS is not enabled
+	MrouteSource     mroute.Source      // nil when mroute ingest is not enabled
+	MrouteStore      *mroute.Store      // nil when mroute ingest is not enabled
+	MSDPSource       msdp.Source        // nil when MSDP ingest is not enabled
+	MSDPStore        *msdp.Store        // nil when MSDP ingest is not enabled
 
 	// failures tracks consecutive-failure counts per activity name.
 	// map[string]*atomic.Int32; populated lazily.
@@ -212,6 +214,23 @@ func (a *Activities) RefreshShredEscrowEvents(ctx context.Context) error {
 		result, err := a.EscrowEvents.Refresh(ctx)
 		if err != nil {
 			return result, fmt.Errorf("escrow events refresh: %w", err)
+		}
+		return result, nil
+	})
+}
+
+// RefreshPermissionEvents scans serviceability transaction history for Permission-
+// management instructions and writes the decoded audit rows to ClickHouse. No-op if
+// permission events indexing is not configured.
+func (a *Activities) RefreshPermissionEvents(ctx context.Context) error {
+	if a.PermissionEvents == nil {
+		a.IngestionLog.WrapSkipped(ctx, "dzingest", "RefreshPermissionEvents", a.Network)
+		return nil
+	}
+	return a.refresh(ctx, "RefreshPermissionEvents", func() (ingestionlog.RefreshResult, error) {
+		result, err := a.PermissionEvents.Refresh(ctx)
+		if err != nil {
+			return result, fmt.Errorf("permission events refresh: %w", err)
 		}
 		return result, nil
 	})

--- a/indexer/pkg/dzingest/backfill_permission_events.go
+++ b/indexer/pkg/dzingest/backfill_permission_events.go
@@ -1,0 +1,77 @@
+package dzingest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	temporalworkflow "go.temporal.io/sdk/workflow"
+)
+
+// BackfillPermissionEventsInput configures the permission events backfill.
+type BackfillPermissionEventsInput struct {
+	Truncate bool // If true, truncate the fact table + scan cursor before backfilling.
+}
+
+// BackfillPermissionEventsWorkflow re-scans all serviceability transaction history
+// for Permission-management instructions, ignoring the stored scan cursor. Events are
+// upserted via ReplacingMergeTree so re-ingesting is safe.
+func BackfillPermissionEventsWorkflow(ctx temporalworkflow.Context, input BackfillPermissionEventsInput) error {
+	logger := temporalworkflow.GetLogger(ctx)
+
+	actOpts := temporalworkflow.ActivityOptions{
+		// Backfill sweeps the program's full signature history, which can be large.
+		StartToCloseTimeout: 60 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 2,
+		},
+	}
+	ctx = temporalworkflow.WithActivityOptions(ctx, actOpts)
+
+	if input.Truncate {
+		logger.Info("truncating permission events table")
+		if err := temporalworkflow.ExecuteActivity(ctx, (*Activities).TruncatePermissionEvents).Get(ctx, nil); err != nil {
+			return fmt.Errorf("truncate permission events: %w", err)
+		}
+	}
+
+	logger.Info("backfilling permission events")
+	if err := temporalworkflow.ExecuteActivity(ctx, (*Activities).BackfillPermissionEvents).Get(ctx, nil); err != nil {
+		return fmt.Errorf("backfill permission events: %w", err)
+	}
+
+	logger.Info("permission events backfill complete")
+	return nil
+}
+
+// TruncatePermissionEvents truncates the permission events fact table and its scan cursor.
+func (a *Activities) TruncatePermissionEvents(ctx context.Context) error {
+	if a.PermissionEvents == nil {
+		return fmt.Errorf("permission events view not configured")
+	}
+	conn, err := a.PermissionEvents.ClickHouse().Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("get ClickHouse connection: %w", err)
+	}
+	if err := conn.Exec(ctx, "TRUNCATE TABLE fact_dz_permission_events"); err != nil {
+		return fmt.Errorf("truncate fact_dz_permission_events: %w", err)
+	}
+	if err := conn.Exec(ctx, "TRUNCATE TABLE dz_permission_events_scan_cursor"); err != nil {
+		return fmt.Errorf("truncate dz_permission_events_scan_cursor: %w", err)
+	}
+	return nil
+}
+
+// BackfillPermissionEvents runs a full permission events re-scan, ignoring the cursor.
+func (a *Activities) BackfillPermissionEvents(ctx context.Context) error {
+	if a.PermissionEvents == nil {
+		return fmt.Errorf("permission events view not configured")
+	}
+	result, err := a.PermissionEvents.BackfillRefresh(ctx)
+	if err != nil {
+		return fmt.Errorf("permission events backfill: %w", err)
+	}
+	a.Log.Info("permission events backfill complete", "events_inserted", result.RowsAffected)
+	return nil
+}

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -21,6 +21,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
@@ -38,19 +39,20 @@ type Config struct {
 	Network string
 
 	// Views and stores for activity execution.
-	Serviceability *dzsvc.View
-	Geolocation    *dzgeoloc.View     // optional
-	Shreds         *dzshreds.View     // optional
-	EscrowEvents   *escrowevents.View // optional
-	TelemLatency   *dztelemlatency.View
-	TelemUsage     *dztelemusage.View // optional
-	GraphStore     *dzgraph.Store     // optional
-	ISISSource     isis.Source        // optional
-	ISISStore      *isis.Store        // optional
-	MrouteSource   mroute.Source      // optional
-	MrouteStore    *mroute.Store      // optional
-	MSDPSource     msdp.Source        // optional
-	MSDPStore      *msdp.Store        // optional
+	Serviceability   *dzsvc.View
+	Geolocation      *dzgeoloc.View         // optional
+	Shreds           *dzshreds.View         // optional
+	EscrowEvents     *escrowevents.View     // optional
+	PermissionEvents *permissionevents.View // optional
+	TelemLatency     *dztelemlatency.View
+	TelemUsage       *dztelemusage.View // optional
+	GraphStore       *dzgraph.Store     // optional
+	ISISSource       isis.Source        // optional
+	ISISStore        *isis.Store        // optional
+	MrouteSource     mroute.Source      // optional
+	MrouteStore      *mroute.Store      // optional
+	MSDPSource       msdp.Source        // optional
+	MSDPStore        *msdp.Store        // optional
 }
 
 // TaskQueue returns the Temporal task queue name for the given network.
@@ -84,22 +86,23 @@ func Start(ctx context.Context, cfg Config) error {
 	wfID := workflowID(cfg.Network)
 
 	activities := &Activities{
-		Log:            log.With("component", "dz-ingest"),
-		IngestionLog:   cfg.IngestionLog,
-		Network:        cfg.Network,
-		Serviceability: cfg.Serviceability,
-		Geolocation:    cfg.Geolocation,
-		Shreds:         cfg.Shreds,
-		EscrowEvents:   cfg.EscrowEvents,
-		TelemLatency:   cfg.TelemLatency,
-		TelemUsage:     cfg.TelemUsage,
-		GraphStore:     cfg.GraphStore,
-		ISISSource:     cfg.ISISSource,
-		ISISStore:      cfg.ISISStore,
-		MrouteSource:   cfg.MrouteSource,
-		MrouteStore:    cfg.MrouteStore,
-		MSDPSource:     cfg.MSDPSource,
-		MSDPStore:      cfg.MSDPStore,
+		Log:              log.With("component", "dz-ingest"),
+		IngestionLog:     cfg.IngestionLog,
+		Network:          cfg.Network,
+		Serviceability:   cfg.Serviceability,
+		Geolocation:      cfg.Geolocation,
+		Shreds:           cfg.Shreds,
+		EscrowEvents:     cfg.EscrowEvents,
+		PermissionEvents: cfg.PermissionEvents,
+		TelemLatency:     cfg.TelemLatency,
+		TelemUsage:       cfg.TelemUsage,
+		GraphStore:       cfg.GraphStore,
+		ISISSource:       cfg.ISISSource,
+		ISISStore:        cfg.ISISStore,
+		MrouteSource:     cfg.MrouteSource,
+		MrouteStore:      cfg.MrouteStore,
+		MSDPSource:       cfg.MSDPSource,
+		MSDPStore:        cfg.MSDPStore,
 	}
 
 	w := worker.New(tc, tq, worker.Options{})

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -26,6 +26,7 @@ const (
 func RegisterWorkflows(w worker.Worker) {
 	w.RegisterWorkflow(DZIngestWorkflow)
 	w.RegisterWorkflow(BackfillEscrowEventsWorkflow)
+	w.RegisterWorkflow(BackfillPermissionEventsWorkflow)
 }
 
 // DZIngestWorkflow is a long-running workflow that refreshes DZ mainnet data
@@ -59,6 +60,7 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		geolocationFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshGeolocation)
 		shredsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShreds)
 		escrowEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShredEscrowEvents)
+		permissionEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshPermissionEvents)
 		isisSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncISIS)
 		mrouteSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncIPMroute)
 		msdpSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncMSDP)
@@ -93,6 +95,12 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 				return ctx.Err()
 			}
 			logger.Error("escrow events refresh failed", "error", err)
+		}
+		if err := permissionEventsFuture.Get(ctx, nil); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			logger.Error("permission events refresh failed", "error", err)
 		}
 		if err := isisSyncFuture.Get(ctx, nil); err != nil {
 			if ctx.Err() != nil {

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -20,6 +20,12 @@ const (
 	// At 60s base interval, 1 iteration = ~1 minute. Source data is reported
 	// at ~2s resolution so indexing every minute keeps data reasonably fresh.
 	telemUsageEveryN = 1
+
+	// permissionEventsEveryN controls how often the permission audit refresh runs.
+	// Serviceability permission changes are sporadic, so at the 60s base interval this
+	// runs every ~5 minutes — enough freshness for an audit page while avoiding a
+	// per-minute getProgramAccounts poll.
+	permissionEventsEveryN = 5
 )
 
 // RegisterWorkflows registers all DZ ingest workflows with the given worker.
@@ -60,7 +66,6 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		geolocationFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshGeolocation)
 		shredsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShreds)
 		escrowEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshShredEscrowEvents)
-		permissionEventsFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshPermissionEvents)
 		isisSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncISIS)
 		mrouteSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncIPMroute)
 		msdpSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncMSDP)
@@ -70,6 +75,12 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		var telemUsageFuture temporalworkflow.Future
 		if iteration%telemUsageEveryN == 0 {
 			telemUsageFuture = temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshTelemetryUsage)
+		}
+
+		// Permission audit events run less frequently (~5 minutes); changes are sporadic.
+		var permissionEventsFuture temporalworkflow.Future
+		if iteration%permissionEventsEveryN == 0 {
+			permissionEventsFuture = temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshPermissionEvents)
 		}
 
 		if err := telemLatencyFuture.Get(ctx, nil); err != nil {
@@ -95,12 +106,6 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 				return ctx.Err()
 			}
 			logger.Error("escrow events refresh failed", "error", err)
-		}
-		if err := permissionEventsFuture.Get(ctx, nil); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			logger.Error("permission events refresh failed", "error", err)
 		}
 		if err := isisSyncFuture.Get(ctx, nil); err != nil {
 			if ctx.Err() != nil {
@@ -132,6 +137,14 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 					return ctx.Err()
 				}
 				logger.Error("telemetry usage refresh failed", "error", err)
+			}
+		}
+		if permissionEventsFuture != nil {
+			if err := permissionEventsFuture.Get(ctx, nil); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				logger.Error("permission events refresh failed", "error", err)
 			}
 		}
 

--- a/indexer/pkg/indexer/config.go
+++ b/indexer/pkg/indexer/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
@@ -40,6 +41,12 @@ type Config struct {
 
 	// Serviceability RPC configuration.
 	ServiceabilityRPC dzsvc.ServiceabilityRPC
+
+	// Serviceability program id and a raw Solana RPC for the permission-events audit
+	// indexer (optional). PermissionEventsRPC watches the serviceability program's
+	// transaction history for Permission-management instructions.
+	ServiceabilityProgramID solana.PublicKey
+	PermissionEventsRPC     permissionevents.SolanaRPC
 
 	// Geolocation RPC configuration (optional).
 	GeolocationRPC dzgeoloc.GeolocationRPC

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/dz/mroute"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/msdp"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
 	dzshreds "github.com/malbeclabs/lake/indexer/pkg/dz/shreds"
 	"github.com/malbeclabs/lake/indexer/pkg/dz/shreds/escrowevents"
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
@@ -27,22 +28,23 @@ type Indexer struct {
 	log *slog.Logger
 	cfg Config
 
-	svc           *dzsvc.View
-	geoloc        *dzgeoloc.View
-	shreds        *dzshreds.View
-	escrowEvents  *escrowevents.View
-	graphStore    *dzgraph.Store
-	telemLatency  *dztelemlatency.View
-	telemUsage    *dztelemusage.View
-	sol           *sol.View
-	geoip         *mcpgeoip.View
-	isisSource    isis.Source
-	isisStore     *isis.Store
-	mrouteSource  mroute.Source
-	mrouteStore   *mroute.Store
-	msdpSource    msdp.Source
-	msdpStore     *msdp.Store
-	validatorsApp *validatorsapp.View
+	svc              *dzsvc.View
+	geoloc           *dzgeoloc.View
+	shreds           *dzshreds.View
+	escrowEvents     *escrowevents.View
+	permissionEvents *permissionevents.View
+	graphStore       *dzgraph.Store
+	telemLatency     *dztelemlatency.View
+	telemUsage       *dztelemusage.View
+	sol              *sol.View
+	geoip            *mcpgeoip.View
+	isisSource       isis.Source
+	isisStore        *isis.Store
+	mrouteSource     mroute.Source
+	mrouteStore      *mroute.Store
+	msdpSource       msdp.Source
+	msdpStore        *msdp.Store
+	validatorsApp    *validatorsapp.View
 }
 
 func New(ctx context.Context, cfg Config) (*Indexer, error) {
@@ -137,6 +139,23 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create escrow events view: %w", err)
+		}
+	}
+
+	// Initialize permission events audit view (optional, requires the serviceability
+	// program id + a raw Solana RPC on the DZ ledger).
+	var permissionEventsView *permissionevents.View
+	if cfg.PermissionEventsRPC != nil && !cfg.ServiceabilityProgramID.IsZero() {
+		permissionEventsView, err = permissionevents.NewView(permissionevents.ViewConfig{
+			Logger:          cfg.Logger,
+			Clock:           cfg.Clock,
+			RPC:             cfg.PermissionEventsRPC,
+			ProgramID:       cfg.ServiceabilityProgramID,
+			RefreshInterval: cfg.RefreshInterval,
+			ClickHouse:      cfg.ClickHouse,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create permission events view: %w", err)
 		}
 	}
 
@@ -324,22 +343,23 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 		log: cfg.Logger,
 		cfg: cfg,
 
-		svc:           svcView,
-		geoloc:        geolocView,
-		shreds:        shredsView,
-		escrowEvents:  escrowEventsView,
-		graphStore:    graphStore,
-		telemLatency:  telemView,
-		telemUsage:    telemetryUsageView,
-		sol:           solanaView,
-		geoip:         geoipView,
-		isisSource:    isisSource,
-		isisStore:     isisStore,
-		mrouteSource:  mrouteSource,
-		mrouteStore:   mrouteStore,
-		msdpSource:    msdpSource,
-		msdpStore:     msdpStore,
-		validatorsApp: validatorsAppView,
+		svc:              svcView,
+		geoloc:           geolocView,
+		shreds:           shredsView,
+		escrowEvents:     escrowEventsView,
+		permissionEvents: permissionEventsView,
+		graphStore:       graphStore,
+		telemLatency:     telemView,
+		telemUsage:       telemetryUsageView,
+		sol:              solanaView,
+		geoip:            geoipView,
+		isisSource:       isisSource,
+		isisStore:        isisStore,
+		mrouteSource:     mrouteSource,
+		mrouteStore:      mrouteStore,
+		msdpSource:       msdpSource,
+		msdpStore:        msdpStore,
+		validatorsApp:    validatorsAppView,
 	}
 
 	return i, nil
@@ -459,6 +479,11 @@ func (i *Indexer) Shreds() *dzshreds.View {
 // EscrowEvents returns the escrow events view, or nil if not configured.
 func (i *Indexer) EscrowEvents() *escrowevents.View {
 	return i.escrowEvents
+}
+
+// PermissionEvents returns the permission events audit view, or nil if not configured.
+func (i *Indexer) PermissionEvents() *permissionevents.View {
+	return i.permissionEvents
 }
 
 // ValidatorsApp returns the validators.app view, or nil if not configured.

--- a/indexer/pkg/sol/txhistory.go
+++ b/indexer/pkg/sol/txhistory.go
@@ -1,0 +1,23 @@
+package sol
+
+import (
+	"context"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+)
+
+// TxHistoryRPC abstracts the Solana RPC methods needed to fetch and decode an
+// account/program's transaction history (getSignaturesForAddress + getTransaction).
+// It is shared by the escrowevents and permissionevents audit indexers, which both
+// scan serviceability/escrow transaction history.
+//
+// Satisfied by *solanarpc.Client (gagliardetto solana-go), including the retrying
+// client returned by doublezero's rpc.NewWithRetries.
+type TxHistoryRPC interface {
+	GetSignaturesForAddressWithOpts(ctx context.Context, account solana.PublicKey, opts *solanarpc.GetSignaturesForAddressOpts) ([]*solanarpc.TransactionSignature, error)
+	GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
+}
+
+// Compile-time check that *solanarpc.Client satisfies TxHistoryRPC.
+var _ TxHistoryRPC = (*solanarpc.Client)(nil)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import { ShredsRewardsDetailPage } from '@/components/shreds-rewards-detail-page
 import { PublisherCheckPage } from './components/publisher-check-page'
 import { EdgeScoreboardPage } from './components/edge-scoreboard-page'
 import { HyperliquidScoreboardPage } from './components/hyperliquid-scoreboard-page'
+import { PermissionAuditPage } from './components/permission-audit-page'
 import { MulticastGroupDetailPage } from '@/components/multicast-group-detail-page'
 import { AccessPassesPage } from '@/components/access-passes-page'
 import { AccessPassDetailPage } from '@/components/access-pass-detail-page'
@@ -738,6 +739,7 @@ function AppContent() {
             <Route path="/dz/edge/scoreboard" element={<Navigate to="/dz/shreds/scoreboard" replace />} />
             <Route path="/dz/hyperliquid" element={<Navigate to="/dz/hyperliquid/scoreboard" replace />} />
             <Route path="/dz/hyperliquid/scoreboard" element={<HyperliquidScoreboardPage />} />
+            <Route path="/dz/permission-audit" element={<PermissionAuditPage />} />
 
             {/* Geolocation routes */}
             <Route path="/dz/geoloc/probes" element={<GeolocProbesPage />} />

--- a/web/src/components/permission-audit-page.tsx
+++ b/web/src/components/permission-audit-page.tsx
@@ -2,7 +2,22 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, ShieldCheck, AlertCircle } from 'lucide-react'
 import { fetchPermissionAudit, type PermissionAuditEvent } from '@/lib/api'
 import { useDocumentTitle } from '@/hooks/use-document-title'
+import { useEnv } from '@/contexts/EnvContext'
 import { CopyableText } from '@/components/copyable-text'
+
+// Permission events live on the DoubleZero ledger (a Solana-fork sidechain), not
+// Solana mainnet — so solscan can't resolve them. Point the Solana Explorer at the
+// per-env ledger RPC via its custom-cluster support.
+const LEDGER_RPC_URL_BY_ENV: Record<string, string> = {
+  'mainnet-beta': 'https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab',
+  testnet: 'https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16',
+  devnet: 'https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16',
+}
+
+function txExplorerUrl(txSignature: string, env: string): string {
+  const rpcUrl = LEDGER_RPC_URL_BY_ENV[env] ?? LEDGER_RPC_URL_BY_ENV['mainnet-beta']
+  return `https://explorer.solana.com/tx/${txSignature}?cluster=custom&customUrl=${encodeURIComponent(rpcUrl)}`
+}
 
 function shortPubkey(pk: string): string {
   if (!pk) return '—'
@@ -59,6 +74,7 @@ function FlagList({ names, tone }: { names: string; tone: 'add' | 'remove' }) {
 
 export function PermissionAuditPage() {
   useDocumentTitle('Permission Audit')
+  const { env } = useEnv()
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['permission-audit'],
@@ -139,7 +155,7 @@ export function PermissionAuditPage() {
                   <td className="px-4 py-2.5"><FlagList names={e.permissionsRemoved} tone="remove" /></td>
                   <td className="px-4 py-2.5 text-sm font-mono">
                     <a
-                      href={`https://solscan.io/tx/${e.txSignature}`}
+                      href={txExplorerUrl(e.txSignature, env)}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-purple-500 hover:underline"

--- a/web/src/components/permission-audit-page.tsx
+++ b/web/src/components/permission-audit-page.tsx
@@ -1,0 +1,164 @@
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, ShieldCheck, AlertCircle } from 'lucide-react'
+import { fetchPermissionAudit, type PermissionAuditEvent } from '@/lib/api'
+import { useDocumentTitle } from '@/hooks/use-document-title'
+import { CopyableText } from '@/components/copyable-text'
+
+function shortPubkey(pk: string): string {
+  if (!pk) return '—'
+  return `${pk.slice(0, 6)}…${pk.slice(-4)}`
+}
+
+function eventTypeClasses(eventType: string): string {
+  switch (eventType) {
+    case 'Create':
+      return 'bg-green-500/15 text-green-600 dark:text-green-400'
+    case 'Update':
+      return 'bg-blue-500/15 text-blue-600 dark:text-blue-400'
+    case 'Suspend':
+      return 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+    case 'Resume':
+      return 'bg-teal-500/15 text-teal-600 dark:text-teal-400'
+    case 'Delete':
+      return 'bg-red-500/15 text-red-600 dark:text-red-400'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+function formatTs(ts: string): string {
+  const d = new Date(ts)
+  if (isNaN(d.getTime())) return ts
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+function FlagList({ names, tone }: { names: string; tone: 'add' | 'remove' }) {
+  if (!names) return <span className="text-muted-foreground">—</span>
+  const cls =
+    tone === 'add'
+      ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+      : 'bg-red-500/10 text-red-600 dark:text-red-400'
+  return (
+    <div className="flex flex-wrap gap-1">
+      {names.split(', ').map((n) => (
+        <span key={n} className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${cls}`}>
+          {tone === 'remove' ? `−${n}` : n}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function PermissionAuditPage() {
+  useDocumentTitle('Permission Audit')
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['permission-audit'],
+    queryFn: () => fetchPermissionAudit(500),
+    staleTime: 30_000,
+  })
+
+  const events: PermissionAuditEvent[] = data?.events ?? []
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center">
+          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <div className="text-lg font-medium">Failed to load permission audit</div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-[1400px] mx-auto px-4 sm:px-8 py-8">
+        <div className="flex items-center gap-3 mb-2">
+          <ShieldCheck className="h-6 w-6 text-purple-500" />
+          <h1 className="text-2xl font-bold">Permission Audit</h1>
+        </div>
+        <p className="text-sm text-muted-foreground mb-8">
+          Onchain history of serviceability permission grants, changes, suspensions and revocations —
+          who did what, to whom, and when.
+        </p>
+
+        <div className="border border-border rounded-lg overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="text-left text-sm text-muted-foreground border-b border-border bg-muted/30">
+                <th className="px-4 py-2.5 font-medium">Time (UTC local)</th>
+                <th className="px-4 py-2.5 font-medium">Event</th>
+                <th className="px-4 py-2.5 font-medium">Admin (signer)</th>
+                <th className="px-4 py-2.5 font-medium">Grantee</th>
+                <th className="px-4 py-2.5 font-medium">Added</th>
+                <th className="px-4 py-2.5 font-medium">Removed</th>
+                <th className="px-4 py-2.5 font-medium">Tx</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e) => (
+                <tr
+                  key={`${e.txSignature}-${e.permissionPk}-${e.eventType}-${e.slot}`}
+                  className="border-b border-border last:border-b-0 hover:bg-muted/50 transition-colors"
+                >
+                  <td className="px-4 py-2.5 text-sm whitespace-nowrap tabular-nums">{formatTs(e.eventTs)}</td>
+                  <td className="px-4 py-2.5">
+                    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${eventTypeClasses(e.eventType)}`}>
+                      {e.eventType}
+                    </span>
+                    {!e.success && (
+                      <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-500/15 text-red-600 dark:text-red-400">
+                        failed
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 text-sm font-mono">
+                    {e.signer ? <CopyableText text={e.signer}>{shortPubkey(e.signer)}</CopyableText> : '—'}
+                  </td>
+                  <td className="px-4 py-2.5 text-sm font-mono">
+                    {e.targetPubkey ? <CopyableText text={e.targetPubkey}>{shortPubkey(e.targetPubkey)}</CopyableText> : '—'}
+                  </td>
+                  <td className="px-4 py-2.5"><FlagList names={e.permissionsAdded} tone="add" /></td>
+                  <td className="px-4 py-2.5"><FlagList names={e.permissionsRemoved} tone="remove" /></td>
+                  <td className="px-4 py-2.5 text-sm font-mono">
+                    <a
+                      href={`https://solscan.io/tx/${e.txSignature}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-purple-500 hover:underline"
+                    >
+                      {shortPubkey(e.txSignature)}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+              {events.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                    No permission events found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/permission-audit-page.tsx
+++ b/web/src/components/permission-audit-page.tsx
@@ -36,6 +36,7 @@ function formatTs(ts: string): string {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
+    timeZone: 'UTC',
   })
 }
 
@@ -102,7 +103,7 @@ export function PermissionAuditPage() {
           <table className="w-full">
             <thead>
               <tr className="text-left text-sm text-muted-foreground border-b border-border bg-muted/30">
-                <th className="px-4 py-2.5 font-medium">Time (UTC local)</th>
+                <th className="px-4 py-2.5 font-medium">Time (UTC)</th>
                 <th className="px-4 py-2.5 font-medium">Event</th>
                 <th className="px-4 py-2.5 font-medium">Admin (signer)</th>
                 <th className="px-4 py-2.5 font-medium">Grantee</th>
@@ -114,7 +115,7 @@ export function PermissionAuditPage() {
             <tbody>
               {events.map((e) => (
                 <tr
-                  key={`${e.txSignature}-${e.permissionPk}-${e.eventType}-${e.slot}`}
+                  key={`${e.txSignature}-${e.permissionPk}-${e.slot}-${e.instructionIndex}`}
                   className="border-b border-border last:border-b-0 hover:bg-muted/50 transition-colors"
                 >
                   <td className="px-4 py-2.5 text-sm whitespace-nowrap tabular-nums">{formatTs(e.eventTs)}</td>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -602,12 +602,6 @@ const { resolvedTheme, setTheme } = useTheme()
                 )}
               </>
             )}
-            {showPermissionAudit && (
-              <Link to="/dz/permission-audit" className={navItemClass(isPermissionAuditRoute)}>
-                <Shield className="h-4 w-4" />
-                Permission Audit
-              </Link>
-            )}
           </div>
         </div>
 
@@ -659,6 +653,12 @@ const { resolvedTheme, setTheme } = useTheme()
               <KeyRound className="h-4 w-4" />
               Access Passes
             </Link>
+            {showPermissionAudit && (
+              <Link to="/dz/permission-audit" className={navItemClass(isPermissionAuditRoute)}>
+                <Shield className="h-4 w-4" />
+                Permission Audit
+              </Link>
+            )}
           </div>
         </div>
 

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -61,6 +61,7 @@ export function Sidebar() {
   const showGeoloc = user?.is_internal_user === true
   // Internal only (unannounced venue) — gated to allowed-domain Google users.
   const showHyperliquid = user?.is_internal_user === true
+  const showPermissionAudit = user?.is_internal_user === true
 const { resolvedTheme, setTheme } = useTheme()
   const { updateAvailable, reload } = useVersionCheck()
 
@@ -119,6 +120,7 @@ const { resolvedTheme, setTheme } = useTheme()
     location.pathname.startsWith('/dz/shreds/rewards/')
   const isShredsRoute = location.pathname.startsWith('/dz/shreds') || isShredsPublishersRoute
   const isHyperliquidScoreboardRoute = location.pathname === '/dz/hyperliquid/scoreboard'
+  const isPermissionAuditRoute = location.pathname === '/dz/permission-audit'
   const isHyperliquidRoute = location.pathname.startsWith('/dz/hyperliquid')
   const isEdgeRoute = isShredsRoute || isHyperliquidRoute
   const isGeolocRoute = location.pathname.startsWith('/dz/geoloc/')
@@ -599,6 +601,12 @@ const { resolvedTheme, setTheme } = useTheme()
                   </>
                 )}
               </>
+            )}
+            {showPermissionAudit && (
+              <Link to="/dz/permission-audit" className={navItemClass(isPermissionAuditRoute)}>
+                <Shield className="h-4 w-4" />
+                Permission Audit
+              </Link>
             )}
           </div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6924,3 +6924,29 @@ export async function fetchHyperliquidScoreboard(
   }
   return res.json()
 }
+
+// Serviceability permission audit trail (internal only).
+export interface PermissionAuditEvent {
+  eventTs: string
+  txSignature: string
+  slot: number
+  signer: string
+  permissionPk: string
+  targetPubkey: string
+  eventType: string
+  permissionsAdded: string
+  permissionsRemoved: string
+  success: boolean
+}
+
+export interface PermissionAuditResponse {
+  events: PermissionAuditEvent[]
+}
+
+export async function fetchPermissionAudit(limit = 200): Promise<PermissionAuditResponse> {
+  const res = await apiFetch(`/api/dz/permission-audit?limit=${limit}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch permission audit')
+  }
+  return res.json()
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6930,6 +6930,7 @@ export interface PermissionAuditEvent {
   eventTs: string
   txSignature: string
   slot: number
+  instructionIndex: number
   signer: string
   permissionPk: string
   targetPubkey: string


### PR DESCRIPTION
## Summary

- Adds an onchain **audit trail** for serviceability Permission-management instructions (grant / change / suspend / resume / revoke). The program keeps no audit trail — Permission accounts store only current state and the permission processors emit no logs — so this decodes the **instruction data bytes** (variants 97–101 + Borsh args) from transaction history.
- New `permissionevents` indexer source that **watches each Permission account** (not the whole program) and writes an append-only `fact_dz_permission_events` table capturing the acting admin (tx fee-payer), grantee, flag deltas (role names + raw mask), event type, and success.
- New internal-only **Permission Audit** page (under the DoubleZero sidebar section), gated to `@malbeclabs.com` / allowed-domain users via `RequireInternalDomain`.

## Why

After the serviceability permission migration, there was no way to answer *who granted / changed / revoked which permission flag, to whom, and when* — the data only exists in raw transaction history. This surfaces it as a queryable, viewable audit trail without any onchain/program changes.

## Details

**Indexer** (`indexer/pkg/dz/serviceability/permissionevents/`)

Permission changes are sporadic among a high volume of other serviceability transactions, so the steady-state refresh **watches Permission accounts directly** rather than scanning every program transaction:

- **Discover** the current Permission PDAs via `getProgramAccounts` filtered on the `account_type` discriminator (one cheap call), then **per PDA** `getSignaturesForAddress` since that account's high-water mark and decode only those transactions. A Permission PDA is only referenced by permission instructions, so this fetches only permission txs — not the whole program's history. New grants are picked up once the PDA is discovered (its create tx references the account).
- **Per-account high-water marks** are derived from the fact table (`max(slot)` per `permission_pk`), mirroring `escrowevents`. A failed account is simply not advanced and re-fetched next refresh, so a transient RPC error never leaves a silent gap.
- **`BackfillRefresh`** is a full-history **program scan** (chunked oldest-first, resumable via a program scan cursor) — the completeness backstop for accounts created and deleted between discovery polls, and for initial history seeding. Triggerable via `admin --dz-env <env> --backfill-permission-events[ --backfill-permission-events-truncate]`.
- Decoding scans both top-level and **CPI (inner) instructions** and merges `Meta.LoadedAddresses` so v0/ALT-resolved and multisig-invoked permission ops are captured. `Signer` is the tx fee-payer (documented; may differ from the acting admin for relayer/multisig-paid txs).
- Instruction decoding is reimplemented in Go (the doublezero Go SDK only decodes account state); the decode contract is documented against the Rust source of truth and covered by fixture tests (u128 decoded without truncation; flag→name order cross-checked against `flags.rs`).
- A retrying RPC client (`rpc.NewWithRetries`) is used so a transient `getTransaction` error doesn't drop an event.
- Refresh cadence: the permission refresh runs every ~5 minutes (sporadic changes don't need per-minute polling).

**API** — `GET /api/dz/permission-audit` (internal-domain gated). Newest-first by slot (so events with a missing block time stay visible), with `instruction_index` as a tiebreak. Grantee is only carried by `CreatePermission`, so it is backfilled for the other event types via a self-join to each PDA's create row.

**Web** — Permission Audit table page (time in UTC, event, admin, grantee, flags added/removed, tx→solscan), sidebar link (end of the DoubleZero section) gated on `is_internal_user`.

## Testing Verification

- Fixture-based unit tests for the instruction decoder cover each variant (97–101), including u128 decode without truncation, fee-payer attribution, and flag→name mapping cross-checked against the Rust `flags.rs` order.
- Verified on the DZ mainnet-beta ledger that the per-account discovery + watch correctly surfaces the single existing Permission account (`foundation`) — its `Create` event is indexed on the first steady-state refresh with no manual backfill.
- `go build`, `go vet`, `golangci-lint` (0 issues), and `go test -race` pass on the changed packages.

## Note for reviewers

The indexer architecture changed materially from the first-reviewed revision. The original design scanned the **whole serviceability program** and `getTransaction`'d every tx to find the rare permission instructions, which hammered the RPC. It now **watches Permission accounts individually** (discover-then-watch), fetching only permission transactions; the full program scan is retained only for the backfill. The earlier review comments about the program-wide scan (cursor gaps, first-run timeout, CPI coverage) are addressed by this model and the inline fixes.
