### PR TITLE
api: log transient CH/RPC errors at WARN so they don't page on-call

### DIFF
--- a/api/handlers/dberror/dberror.go
+++ b/api/handlers/dberror/dberror.go
@@ -23,6 +23,8 @@ const (
 	ErrorTypeAuth
 	// ErrorTypeQuery indicates a query/syntax error.
 	ErrorTypeQuery
+	// ErrorTypeRateLimit indicates the upstream throttled the request (e.g. HTTP 429).
+	ErrorTypeRateLimit
 )
 
 // IsTransient returns true if the error is likely transient and worth retrying.
@@ -38,7 +40,7 @@ func IsTransient(err error) bool {
 
 	errType := Classify(err)
 	switch errType {
-	case ErrorTypeConnectivity, ErrorTypeTimeout:
+	case ErrorTypeConnectivity, ErrorTypeTimeout, ErrorTypeRateLimit:
 		return true
 	default:
 		return false
@@ -104,6 +106,20 @@ func Classify(err error) ErrorType {
 		}
 	}
 
+	// Rate-limit patterns (upstream throttling, e.g. an external RPC returning 429).
+	// These are transient and self-healing — worth retrying, not worth paging on.
+	rateLimitPatterns := []string{
+		"rate limited",
+		"too many requests",
+		"status 429",
+	}
+
+	for _, pattern := range rateLimitPatterns {
+		if strings.Contains(errStr, pattern) {
+			return ErrorTypeRateLimit
+		}
+	}
+
 	// Auth patterns
 	authPatterns := []string{
 		"unauthorized",
@@ -149,6 +165,8 @@ func UserMessage(err error) string {
 		return "Database temporarily unavailable. Please try again in a moment."
 	case ErrorTypeTimeout:
 		return "Request timed out. Please try again."
+	case ErrorTypeRateLimit:
+		return "Upstream is rate limiting requests. Please try again in a moment."
 	case ErrorTypeAuth:
 		return "Database authentication error. Please contact support."
 	case ErrorTypeQuery:

--- a/api/handlers/dberror/dberror_test.go
+++ b/api/handlers/dberror/dberror_test.go
@@ -1,0 +1,44 @@
+package dberror_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/malbeclabs/lake/api/handlers/dberror"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyAndIsTransient(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantType  dberror.ErrorType
+		transient bool
+	}{
+		{"nil", nil, dberror.ErrorTypeUnknown, false},
+
+		// Rate limits (new): upstream 429 — transient, self-healing.
+		{"rpc rate limit message", errors.New("rate limited (status 429)"), dberror.ErrorTypeRateLimit, true},
+		{"too many requests", errors.New("upstream returned Too Many Requests"), dberror.ErrorTypeRateLimit, true},
+
+		// The actual prod CH-connection-drop errors we saw — must be transient.
+		{"ch read packet reset", errors.New("query processing: failed to read packet from 52.4.220.199:9440 (conn_id=492): read: connection reset by peer"), dberror.ErrorTypeConnectivity, true},
+		{"ch read packet io timeout", errors.New("failed to read packet from 54.166.56.105:9440: read: i/o timeout"), dberror.ErrorTypeConnectivity, true},
+
+		// Non-transient: real, actionable failures should still escalate to ERROR.
+		{"syntax error", errors.New("Code: 62. DB::Exception: Syntax error"), dberror.ErrorTypeQuery, false},
+		{"access denied", errors.New("access denied for user"), dberror.ErrorTypeAuth, false},
+		{"context canceled", context.Canceled, dberror.ErrorTypeUnknown, false},
+		{"deadline exceeded", context.DeadlineExceeded, dberror.ErrorTypeTimeout, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.transient, dberror.IsTransient(tt.err), "IsTransient")
+			if tt.err != nil {
+				require.Equal(t, tt.wantType, dberror.Classify(tt.err), "Classify")
+			}
+		})
+	}
+}

--- a/api/handlers/multicast_delivery_entity.go
+++ b/api/handlers/multicast_delivery_entity.go
@@ -374,6 +374,12 @@ func writeMulticastDeliveryEntityError(w http.ResponseWriter, err error, msg, en
 		http.Error(w, entityKind+" not found", http.StatusNotFound)
 		return
 	}
-	logError(msg, "error", err, "pk", pkOrCode)
+	// Transient CH connection blips are self-healing — log at WARN so they don't
+	// page on-call; reserve ERROR for real (non-transient) query failures.
+	if dberror.IsTransient(err) {
+		logWarn(msg, "error", err, "pk", pkOrCode)
+	} else {
+		logError(msg, "error", err, "pk", pkOrCode)
+	}
 	http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 }

--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
@@ -266,7 +267,13 @@ func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rows.Err(); err != nil {
-		logError("validators rows iteration failed", "error", err)
+		// A transient CH connection drop mid-iteration is self-healing — log at
+		// WARN so it doesn't page on-call; reserve ERROR for real failures.
+		if dberror.IsTransient(err) {
+			logWarn("validators rows iteration failed", "error", err)
+		} else {
+			logError("validators rows iteration failed", "error", err)
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/malbeclabs/lake/api/handlers"
+	"github.com/malbeclabs/lake/api/handlers/dberror"
 )
 
 const (
@@ -21,6 +22,14 @@ const (
 	fastRefreshInterval    = 3 * time.Second
 	continueAsNewThreshold = 60 // ~30 min at 30s intervals
 	errorAfterFailures     = 3  // log WARN for transient failures, ERROR after this many consecutive failures
+
+	// transientErrorAfterFailures is the ERROR-escalation threshold for transient
+	// causes (upstream connection blips, timeouts, rate limits). It's higher than
+	// errorAfterFailures because a brief transient failure is self-healing and not
+	// actionable — only a sustained one (this many × refreshInterval ≈ 5 min) is
+	// worth paging on. Keeps single/short blips (e.g. a CH connection drop or an
+	// external RPC 429) at WARN so they don't page on-call.
+	transientErrorAfterFailures = 10
 
 	// slowRefreshThreshold surfaces per-entry duration at INFO when a single
 	// cache refresh (query + write) takes at least this long. Normal entries
@@ -248,7 +257,14 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 				continue
 			}
 			n := a.incFailures(key)
-			if n >= errorAfterFailures {
+			// Transient causes (connection blips, timeouts, upstream 429s) are
+			// self-healing, so only escalate to ERROR once they persist — a brief
+			// blip stays at WARN and doesn't page on-call.
+			threshold := errorAfterFailures
+			if dberror.IsTransient(err) {
+				threshold = transientErrorAfterFailures
+			}
+			if n >= threshold {
 				a.Log.Error("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
 			} else {
 				a.Log.Warn("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)


### PR DESCRIPTION
## Summary

Prod `lake-api` was paging `#alerts` for self-healing, non-actionable errors. This makes transient failures log at WARN (which doesn't alert) and reserves ERROR for genuinely actionable ones. Three observed false alarms, all now quieted:

- **Transient ClickHouse connection drops** (`multicast device endpoint health query error`, `validators rows iteration failed`) — a single `failed to read packet from …:9440` (connection reset / i/o timeout) logged ERROR immediately. These request-path handlers now log at WARN when the error is transient (`dberror.IsTransient`), ERROR otherwise.
- **External RPC rate-limiting** (`dz ledger` cache, `rate limited (status 429)`) — a brief Solana-RPC 429 burst reached the page-cache's 3-consecutive-failure ERROR threshold. `dberror` now classifies rate-limits (429) as transient, and the page-cache escalates transient causes at a higher threshold (`transientErrorAfterFailures = 10`, ~5 min) so a short blip stays WARN. A *sustained* failure still escalates to ERROR, so real outages (e.g. ClickHouse actually down) still page.

The principle: transient/self-healing conditions never page; sustained or genuinely-broken conditions still do.

## Testing Verification

- New `dberror` table test asserts the real prod error strings classify correctly: the two CH `read packet …:9440` messages (reset / i/o timeout) and the RPC `rate limited (status 429)` are transient; syntax/auth/context-cancel errors remain non-transient (still ERROR-worthy).
- Confirmed the page-cache escalation now branches on `IsTransient`: transient causes use the 10-failure threshold, everything else the existing 3.