### PR TITLE
web: default tiredsolid scoreboard to 24h view

### DIFF
--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -129,7 +129,7 @@ function relAge(tsMs: number, nowMs: number): string {
 }
 
 export function HyperliquidScoreboardPage() {
-  const [timeWindow, setTimeWindow] = useState<(typeof WINDOWS)[number]>('1h')
+  const [timeWindow, setTimeWindow] = useState<(typeof WINDOWS)[number]>('24h')
   const [data, setData] = useState<HyperliquidScoreboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())


### PR DESCRIPTION
## Summary
- Change the tiredsolid scoreboard (`/dz/tiredsolid/scoreboard`) to default to the 24h time window instead of 1h.

Single-line change to the initial `timeWindow` state; `24h` is already a valid option in `WINDOWS`, so the toggle buttons and data fetch key off the same state with no other edits needed.