### PR TITLE
api: log transient errors at WARN centrally in logError/internalError

### DIFF
--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 
+	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/utils/pkg/redact"
 )
 
@@ -32,9 +33,20 @@ func isClientDisconnect(err error) bool {
 		strings.Contains(msg, "context deadline exceeded")
 }
 
-// logError logs at ERROR level, silently skipping client disconnects.
+// logError logs a handler error, silently skipping client disconnects.
+//
+// Transient (self-healing) causes — upstream connection blips, timeouts, and
+// rate limits (see dberror.IsTransient) — are logged at WARN rather than ERROR
+// so a momentary ClickHouse/RPC hiccup on the request path doesn't page on-call.
+// Genuine failures (query/syntax/auth errors, nil-derived, anything else) still
+// log at ERROR. Sustained outages are caught elsewhere (the page-cache
+// consecutive-failure threshold and the lake-api-down/crash-loop alerts).
 func logError(msg string, args ...any) {
 	if hasClientDisconnect(args) {
+		return
+	}
+	if err := errorFromArgs(args); err != nil && dberror.IsTransient(err) {
+		slog.Warn(msg, args...)
 		return
 	}
 	slog.Error(msg, args...)
@@ -48,17 +60,24 @@ func logWarn(msg string, args ...any) {
 	slog.Warn(msg, args...)
 }
 
-// hasClientDisconnect reports whether args contains an "error" key whose
-// value is a client-disconnect error (context cancellation, broken pipe, etc.).
-func hasClientDisconnect(args []any) bool {
+// errorFromArgs returns the value of the first "error" key in a slog-style
+// args slice, or nil if none is present.
+func errorFromArgs(args []any) error {
 	for i := 0; i+1 < len(args); i += 2 {
 		if args[i] == "error" {
-			if err, ok := args[i+1].(error); ok && isClientDisconnect(err) {
-				return true
+			if err, ok := args[i+1].(error); ok {
+				return err
 			}
 		}
 	}
-	return false
+	return nil
+}
+
+// hasClientDisconnect reports whether args contains an "error" key whose
+// value is a client-disconnect error (context cancellation, broken pipe, etc.).
+func hasClientDisconnect(args []any) bool {
+	err := errorFromArgs(args)
+	return err != nil && isClientDisconnect(err)
 }
 
 // internalError logs the full error internally and returns a user-safe message.
@@ -66,6 +85,13 @@ func hasClientDisconnect(args []any) bool {
 // hostnames, or query details.
 func internalError(operation string, err error) string {
 	if isClientDisconnect(err) {
+		return operation
+	}
+
+	// Transient (self-healing) causes aren't actionable — log at WARN and skip
+	// the Sentry capture so a momentary hiccup neither pages nor opens an issue.
+	if dberror.IsTransient(err) {
+		slog.Warn(operation, "error", err)
 		return operation
 	}
 

--- a/api/handlers/errors_transient_test.go
+++ b/api/handlers/errors_transient_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// levelRecorder is a slog.Handler that records the level of each emitted record.
+type levelRecorder struct{ records *[]slog.Record }
+
+func (h levelRecorder) Enabled(context.Context, slog.Level) bool { return true }
+func (h levelRecorder) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h levelRecorder) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h levelRecorder) WithGroup(string) slog.Handler      { return h }
+
+// Not parallel: swaps the global slog default. Go runs non-parallel tests to
+// completion before parallel tests resume, so the swap window is isolated.
+func TestLogError_DowngradesTransientToWarn(t *testing.T) {
+	var recs []slog.Record
+	prev := slog.Default()
+	slog.SetDefault(slog.New(levelRecorder{&recs}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	tests := []struct {
+		name       string
+		err        error
+		wantLogged bool
+		wantLevel  slog.Level
+	}{
+		// The actual transient prod errors → WARN (self-healing, not actionable).
+		{"ch connection reset", errors.New("query processing: failed to read packet from 54.166.56.105:9440 (conn_id=2819): read: connection reset by peer"), true, slog.LevelWarn},
+		{"ch io timeout", errors.New("failed to read packet from x:9440: read: i/o timeout"), true, slog.LevelWarn},
+		{"upstream rate limit", errors.New("rate limited (status 429)"), true, slog.LevelWarn},
+		// Genuine failures still escalate to ERROR (still page).
+		{"syntax error", errors.New("Code: 62. DB::Exception: Syntax error"), true, slog.LevelError},
+		{"generic error", errors.New("boom"), true, slog.LevelError},
+		// Client disconnects are dropped entirely (not logged).
+		{"client cancel", context.Canceled, false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recs = nil
+			logError("op failed", "error", tt.err)
+			if !tt.wantLogged {
+				require.Empty(t, recs)
+				return
+			}
+			require.Len(t, recs, 1)
+			require.Equal(t, tt.wantLevel, recs[0].Level)
+		})
+	}
+}
+
+func TestInternalError_DowngradesTransientToWarn(t *testing.T) {
+	var recs []slog.Record
+	prev := slog.Default()
+	slog.SetDefault(slog.New(levelRecorder{&recs}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	recs = nil
+	internalError("fetch failed", errors.New("failed to read packet from x:9440: read: connection reset by peer"))
+	require.Len(t, recs, 1)
+	require.Equal(t, slog.LevelWarn, recs[0].Level, "transient → WARN")
+
+	recs = nil
+	internalError("fetch failed", errors.New("unexpected boom"))
+	require.Len(t, recs, 1)
+	require.Equal(t, slog.LevelError, recs[0].Level, "genuine → ERROR")
+}

--- a/api/handlers/multicast_delivery_entity.go
+++ b/api/handlers/multicast_delivery_entity.go
@@ -374,12 +374,6 @@ func writeMulticastDeliveryEntityError(w http.ResponseWriter, err error, msg, en
 		http.Error(w, entityKind+" not found", http.StatusNotFound)
 		return
 	}
-	// Transient CH connection blips are self-healing — log at WARN so they don't
-	// page on-call; reserve ERROR for real (non-transient) query failures.
-	if dberror.IsTransient(err) {
-		logWarn(msg, "error", err, "pk", pkOrCode)
-	} else {
-		logError(msg, "error", err, "pk", pkOrCode)
-	}
+	logError(msg, "error", err, "pk", pkOrCode)
 	http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
 }

--- a/api/handlers/validators.go
+++ b/api/handlers/validators.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/malbeclabs/lake/api/handlers/dberror"
 	"github.com/malbeclabs/lake/api/metrics"
 )
 
@@ -267,13 +266,7 @@ func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rows.Err(); err != nil {
-		// A transient CH connection drop mid-iteration is self-healing — log at
-		// WARN so it doesn't page on-call; reserve ERROR for real failures.
-		if dberror.IsTransient(err) {
-			logWarn("validators rows iteration failed", "error", err)
-		} else {
-			logError("validators rows iteration failed", "error", err)
-		}
+		logError("validators rows iteration failed", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary

Follow-up to #681 (which fixed two handlers and the page-cache): prod `lake-api` was still paging `#alerts` for self-healing errors from *other* query handlers (e.g. `gossip node query failed`, `validator query failed` — single transient ClickHouse connection drops logged at ERROR).

Rather than patch handlers one at a time, this makes the two central error-logging helpers transient-aware, so **all ~456 handler error sites** get the treatment at once:

- **`logError`** and **`internalError`** now log at **WARN** when the error is transient/self-healing (`dberror.IsTransient` — connection blips, timeouts, upstream 429s), and **ERROR** otherwise. `internalError` also skips the Sentry capture for transient causes.
- Genuine failures (query/syntax/auth errors, anything non-transient) still log at ERROR and page. Sustained outages are still caught elsewhere — the page-cache consecutive-failure threshold (#681) and the `lake-api-down`/crash-loop alerts — so a real ClickHouse outage isn't silenced.
- All handler error logging already funnels through these two helpers (verified: 0 direct `slog.Error`/`.Log.Error` in `api/handlers`), so this is a complete sweep.
- Removed the now-redundant per-handler `IsTransient` checks added in #681 (multicast helper, validators) — the central helper supersedes them.

## Testing Verification

- New internal test drives `logError`/`internalError` with the **actual transient prod error strings** (`read packet from …:9440` reset / i/o timeout, `rate limited (status 429)`) and asserts they emit at WARN; syntax/generic errors emit at ERROR; client-cancel is dropped entirely.
- Confirmed the whole `api/...` tree builds and the handlers test binary compiles.