### PR TITLE
web: show real topology membership in map/globe/graph link drawers

### DIFF
--- a/web/src/components/shared/link-info-converters.test.ts
+++ b/web/src/components/shared/link-info-converters.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { topologyLinkToLinkInfo, topologyLinkToInfo } from './link-info-converters'
+import type { TopologyLink } from '@/lib/api'
+
+const makeTopologyLink = (overrides: Partial<TopologyLink> = {}): TopologyLink => ({
+  pk: 'link-pk',
+  code: 'mrs001-dz002:sin001-dz002',
+  status: 'activated',
+  link_type: 'WAN',
+  bandwidth_bps: 10_000_000_000,
+  side_a_pk: 'device-a-pk',
+  side_a_code: 'mrs001-dz002',
+  side_a_iface_name: 'Port-Channel1000.2030',
+  side_a_ip: '172.16.0.226',
+  side_z_pk: 'device-z-pk',
+  side_z_code: 'sin001-dz002',
+  side_z_iface_name: 'Port-Channel1000.2030',
+  side_z_ip: '172.16.0.227',
+  contributor_pk: 'contributor-pk',
+  contributor_code: 'jump_',
+  side_a_contributor_pk: '',
+  side_a_contributor_code: '',
+  side_z_contributor_pk: '',
+  side_z_contributor_code: '',
+  latency_us: 138_480,
+  jitter_us: 24,
+  latency_a_to_z_us: 138_480,
+  jitter_a_to_z_us: 24,
+  latency_z_to_a_us: 138_500,
+  jitter_z_to_a_us: 29,
+  loss_percent: 0,
+  sample_count: 100,
+  in_bps: 0,
+  out_bps: 0,
+  committed_rtt_ns: 138_500_000,
+  isis_delay_override_ns: 0,
+  ...overrides,
+})
+
+describe('topologyLinkToLinkInfo', () => {
+  it('preserves topology membership and drain state', () => {
+    const info = topologyLinkToLinkInfo(
+      makeTopologyLink({ link_topologies: ['unicast-default'], unicast_drained: true })
+    )
+    expect(info.linkTopologies).toEqual(['unicast-default'])
+    expect(info.unicastDrained).toBe(true)
+  })
+
+  it('maps core fields from the topology API shape', () => {
+    const info = topologyLinkToLinkInfo(makeTopologyLink())
+    expect(info.pk).toBe('link-pk')
+    expect(info.code).toBe('mrs001-dz002:sin001-dz002')
+    expect(info.linkType).toBe('WAN')
+    expect(info.bandwidthBps).toBe(10_000_000_000)
+    expect(info.deviceACode).toBe('mrs001-dz002')
+    expect(info.deviceZCode).toBe('sin001-dz002')
+    expect(info.interfaceAIP).toBe('172.16.0.226')
+    expect(info.interfaceZIP).toBe('172.16.0.227')
+    expect(info.latencyAtoZUs).toBe(138_480)
+    expect(info.latencyZtoAUs).toBe(138_500)
+    expect(info.committedRttNs).toBe(138_500_000)
+    expect(info.health).toBeUndefined()
+  })
+
+  it('attaches health when provided', () => {
+    const info = topologyLinkToLinkInfo(makeTopologyLink(), {
+      status: 'healthy',
+      committedRttNs: 138_500_000,
+      slaRatio: 0.98,
+      lossPct: 0,
+    })
+    expect(info.health).toEqual({
+      status: 'healthy',
+      committedRttNs: 138_500_000,
+      slaRatio: 0.98,
+      lossPct: 0,
+    })
+  })
+
+  it('falls back to device codes when the link code is empty', () => {
+    const info = topologyLinkToLinkInfo(makeTopologyLink({ code: '' }))
+    expect(info.code).toBe('mrs001-dz002 — sin001-dz002')
+  })
+
+  // Regression: the map/globe/graph drawers showed a hardcoded "default"
+  // topology chip because each view's inline builder dropped link_topologies
+  // on the way to LinkInfoContent.
+  it('keeps topology membership through the drawer conversion chain', () => {
+    const data = topologyLinkToInfo(
+      topologyLinkToLinkInfo(makeTopologyLink({ link_topologies: ['unicast-default'] }))
+    )
+    expect(data.linkTopologies).toEqual(['unicast-default'])
+  })
+})

--- a/web/src/components/shared/link-info-converters.ts
+++ b/web/src/components/shared/link-info-converters.ts
@@ -1,4 +1,5 @@
-import type { LinkDetail } from '@/lib/api'
+import type { LinkDetail, TopologyLink } from '@/lib/api'
+import type { LinkInfo } from '@/components/topology/types'
 import type { LinkInfoData } from './LinkInfoContent'
 
 /**
@@ -44,6 +45,60 @@ export function linkDetailToInfo(link: LinkDetail): LinkInfoData {
     isisDelayOverrideNs: link.isis_delay_override_ns,
     linkTopologies: link.link_topologies ?? [],
     unicastDrained: link.unicast_drained ?? false,
+  }
+}
+
+/**
+ * Convert TopologyLink (from /api/topology) to the shared LinkInfo consumed
+ * by the map/globe/graph link drawers. Single mapping point so API fields
+ * (e.g. link_topologies) reach every view.
+ */
+export function topologyLinkToLinkInfo(
+  link: TopologyLink,
+  health?: { status: string; committedRttNs: number; slaRatio: number; lossPct: number }
+): LinkInfo {
+  return {
+    pk: link.pk,
+    code: link.code || `${link.side_a_code || 'Unknown'} — ${link.side_z_code || 'Unknown'}`,
+    status: link.status,
+    linkType: link.link_type || 'unknown',
+    bandwidthBps: link.bandwidth_bps ?? 0,
+    latencyUs: link.latency_us ?? 0,
+    jitterUs: link.jitter_us ?? 0,
+    latencyAtoZUs: link.latency_a_to_z_us ?? 0,
+    jitterAtoZUs: link.jitter_a_to_z_us ?? 0,
+    latencyZtoAUs: link.latency_z_to_a_us ?? 0,
+    jitterZtoAUs: link.jitter_z_to_a_us ?? 0,
+    lossPercent: link.loss_percent ?? 0,
+    inBps: link.in_bps ?? 0,
+    outBps: link.out_bps ?? 0,
+    deviceAPk: link.side_a_pk || '',
+    deviceACode: link.side_a_code || 'Unknown',
+    interfaceAName: link.side_a_iface_name || '',
+    interfaceAIP: link.side_a_ip || '',
+    deviceZPk: link.side_z_pk || '',
+    deviceZCode: link.side_z_code || 'Unknown',
+    interfaceZName: link.side_z_iface_name || '',
+    interfaceZIP: link.side_z_ip || '',
+    contributorPk: link.contributor_pk || '',
+    contributorCode: link.contributor_code || '',
+    sideAContributorPk: link.side_a_contributor_pk || '',
+    sideAContributorCode: link.side_a_contributor_code || '',
+    sideZContributorPk: link.side_z_contributor_pk || '',
+    sideZContributorCode: link.side_z_contributor_code || '',
+    sampleCount: link.sample_count ?? 0,
+    committedRttNs: link.committed_rtt_ns ?? 0,
+    isisDelayOverrideNs: link.isis_delay_override_ns ?? 0,
+    linkTopologies: link.link_topologies,
+    unicastDrained: link.unicast_drained,
+    health: health
+      ? {
+          status: health.status,
+          committedRttNs: health.committedRttNs,
+          slaRatio: health.slaRatio,
+          lossPct: health.lossPct,
+        }
+      : undefined,
   }
 }
 

--- a/web/src/components/topology-globe.tsx
+++ b/web/src/components/topology-globe.tsx
@@ -9,6 +9,7 @@ import { fetchISISPaths, fetchISISTopology, fetchCriticalLinks, fetchSimulateLin
 import { useTopology, useMulticastState, TopologyControlBar, TopologyPanel, DeviceDetails, LinkDetails, MetroDetails, ValidatorDetails, EntityLink as TopologyEntityLink, PathModePanel, MetroPathModePanel, CriticalityPanel, WhatIfRemovalPanel, WhatIfAdditionPanel, ImpactPanel, ComparePanel, StakeOverlayPanel, LinkHealthOverlayPanel, TrafficFlowOverlayPanel, MetroClusteringOverlayPanel, ContributorsOverlayPanel, ValidatorsOverlayPanel, DeviceTypeOverlayPanel, LinkTypeOverlayPanel, MulticastTreesOverlayPanel, LINK_TYPE_COLORS, MULTICAST_PUBLISHER_COLORS, type DeviceOption, type MetroOption } from '@/components/topology'
 import type { LinkInfo, SelectedItemData } from '@/components/topology'
 import { formatBandwidth, formatTrafficRate } from '@/components/topology'
+import { topologyLinkToLinkInfo } from '@/components/shared/link-info-converters'
 
 // Path colors for multi-path visualization
 const PATH_COLORS = [
@@ -783,27 +784,10 @@ export function TopologyGlobe({ metros, devices, links, validators }: TopologyGl
   }, [selection, selectedItem])
 
   // Build link info for panel/hover
-  const buildLinkInfo = useCallback((link: TopologyLink): LinkInfo => {
-    const healthInfo = linkSlaStatus.get(link.pk)
-    return {
-      pk: link.pk, code: link.code, status: link.status, linkType: link.link_type,
-      bandwidthBps: link.bandwidth_bps, latencyUs: link.latency_us,
-      jitterUs: link.jitter_us ?? 0, latencyAtoZUs: link.latency_a_to_z_us,
-      jitterAtoZUs: link.jitter_a_to_z_us ?? 0, latencyZtoAUs: link.latency_z_to_a_us,
-      jitterZtoAUs: link.jitter_z_to_a_us ?? 0, lossPercent: link.loss_percent ?? 0,
-      inBps: link.in_bps, outBps: link.out_bps,
-      deviceAPk: link.side_a_pk, deviceACode: link.side_a_code || 'Unknown',
-      interfaceAName: link.side_a_iface_name || '', interfaceAIP: link.side_a_ip || '',
-      deviceZPk: link.side_z_pk, deviceZCode: link.side_z_code || 'Unknown',
-      interfaceZName: link.side_z_iface_name || '', interfaceZIP: link.side_z_ip || '',
-      contributorPk: link.contributor_pk, contributorCode: link.contributor_code,
-      sideAContributorPk: link.side_a_contributor_pk || '', sideAContributorCode: link.side_a_contributor_code || '',
-      sideZContributorPk: link.side_z_contributor_pk || '', sideZContributorCode: link.side_z_contributor_code || '',
-      sampleCount: link.sample_count ?? 0, committedRttNs: link.committed_rtt_ns,
-      isisDelayOverrideNs: link.isis_delay_override_ns,
-      health: healthInfo ? { status: healthInfo.status, committedRttNs: healthInfo.committedRttNs, slaRatio: healthInfo.slaRatio, lossPct: healthInfo.lossPct } : undefined,
-    }
-  }, [linkSlaStatus])
+  const buildLinkInfo = useCallback(
+    (link: TopologyLink): LinkInfo => topologyLinkToLinkInfo(link, linkSlaStatus.get(link.pk)),
+    [linkSlaStatus]
+  )
 
   // ─── Dimension tracking ──────────────────────────────────────────────
 

--- a/web/src/components/topology-graph.tsx
+++ b/web/src/components/topology-graph.tsx
@@ -7,6 +7,7 @@ import { fetchISISTopology, fetchISISPaths, fetchTopologyCompare, fetchWhatIfRem
 import type { WhatIfRemovalResponse, MultiPathResponse, SimulateLinkRemovalResponse, SimulateLinkAdditionResponse, MetroDevicePathsResponse } from '@/lib/api'
 import { useTheme } from '@/hooks/use-theme'
 import { useTopology, useMulticastState, TopologyPanel, TopologyControlBar, DeviceDetails, LinkDetails, EntityLink, PathModePanel, MetroPathModePanel, CriticalityPanel, WhatIfRemovalPanel, WhatIfAdditionPanel, ImpactPanel, ComparePanel, StakeOverlayPanel, LinkHealthOverlayPanel, TrafficFlowOverlayPanel, MetroClusteringOverlayPanel, ContributorsOverlayPanel, DeviceTypeOverlayPanel, LinkTypeOverlayPanel, MulticastTreesOverlayPanel, LINK_TYPE_COLORS, MULTICAST_PUBLISHER_COLORS, type DeviceInfo, type LinkInfo, type DeviceOption, type MetroOption } from '@/components/topology'
+import { topologyLinkToLinkInfo } from '@/components/shared/link-info-converters'
 import { ErrorState } from '@/components/ui/error-state'
 
 // Device type colors (types from serviceability smart contract: hybrid, transit, edge)
@@ -421,39 +422,7 @@ export function TopologyGraph({
     const map = new Map<string, LinkInfo>()
     if (!topologyData?.links) return map
     for (const link of topologyData.links) {
-      map.set(link.pk, {
-        pk: link.pk,
-        code: link.code || `${link.side_a_code || 'Unknown'} — ${link.side_z_code || 'Unknown'}`,
-        status: link.status,
-        linkType: link.link_type || 'unknown',
-        bandwidthBps: link.bandwidth_bps ?? 0,
-        latencyUs: link.latency_us ?? 0,
-        jitterUs: link.jitter_us ?? 0,
-        latencyAtoZUs: link.latency_a_to_z_us ?? 0,
-        jitterAtoZUs: link.jitter_a_to_z_us ?? 0,
-        latencyZtoAUs: link.latency_z_to_a_us ?? 0,
-        jitterZtoAUs: link.jitter_z_to_a_us ?? 0,
-        lossPercent: link.loss_percent ?? 0,
-        inBps: link.in_bps ?? 0,
-        outBps: link.out_bps ?? 0,
-        deviceAPk: link.side_a_pk || '',
-        deviceACode: link.side_a_code || 'Unknown',
-        interfaceAName: link.side_a_iface_name || '',
-        interfaceAIP: link.side_a_ip || '',
-        deviceZPk: link.side_z_pk || '',
-        deviceZCode: link.side_z_code || 'Unknown',
-        interfaceZName: link.side_z_iface_name || '',
-        interfaceZIP: link.side_z_ip || '',
-        contributorPk: link.contributor_pk || '',
-        contributorCode: link.contributor_code || '',
-        sideAContributorPk: link.side_a_contributor_pk || '',
-        sideAContributorCode: link.side_a_contributor_code || '',
-        sideZContributorPk: link.side_z_contributor_pk || '',
-        sideZContributorCode: link.side_z_contributor_code || '',
-        sampleCount: link.sample_count ?? 0,
-        committedRttNs: link.committed_rtt_ns ?? 0,
-        isisDelayOverrideNs: link.isis_delay_override_ns ?? 0,
-      })
+      map.set(link.pk, topologyLinkToLinkInfo(link))
     }
     return map
   }, [topologyData])

--- a/web/src/components/topology-map.tsx
+++ b/web/src/components/topology-map.tsx
@@ -8,7 +8,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useTheme } from '@/hooks/use-theme'
 import type { TopologyMetro, TopologyDevice, TopologyLink, TopologyValidator, MultiPathResponse, SimulateLinkRemovalResponse, SimulateLinkAdditionResponse, WhatIfRemovalResponse, MetroDevicePathsResponse } from '@/lib/api'
 import { fetchISISPaths, fetchISISTopology, fetchCriticalLinks, fetchSimulateLinkRemoval, fetchSimulateLinkAddition, fetchWhatIfRemoval, fetchLinkHealth, fetchTopologyCompare, fetchMetroDevicePaths } from '@/lib/api'
-import { useTopology, useMulticastState, TopologyControlBar, TopologyPanel, DeviceDetails, LinkDetails, MetroDetails, ValidatorDetails, EntityLink as TopologyEntityLink, PathModePanel, MetroPathModePanel, CriticalityPanel, WhatIfRemovalPanel, WhatIfAdditionPanel, ImpactPanel, ComparePanel, StakeOverlayPanel, LinkHealthOverlayPanel, TrafficFlowOverlayPanel, MetroClusteringOverlayPanel, ContributorsOverlayPanel, ValidatorsOverlayPanel, DeviceTypeOverlayPanel, LinkTypeOverlayPanel, MulticastTreesOverlayPanel, FlexAlgoOverlayPanel, LINK_TYPE_COLORS, MULTICAST_PUBLISHER_COLORS, type DeviceOption, type MetroOption } from '@/components/topology'
+import { useTopology, useMulticastState, TopologyControlBar, TopologyPanel, DeviceDetails, LinkDetails, MetroDetails, ValidatorDetails, EntityLink as TopologyEntityLink, PathModePanel, MetroPathModePanel, CriticalityPanel, WhatIfRemovalPanel, WhatIfAdditionPanel, ImpactPanel, ComparePanel, StakeOverlayPanel, LinkHealthOverlayPanel, TrafficFlowOverlayPanel, MetroClusteringOverlayPanel, ContributorsOverlayPanel, ValidatorsOverlayPanel, DeviceTypeOverlayPanel, LinkTypeOverlayPanel, MulticastTreesOverlayPanel, FlexAlgoOverlayPanel, LINK_TYPE_COLORS, MULTICAST_PUBLISHER_COLORS, type LinkInfo, type DeviceOption, type MetroOption } from '@/components/topology'
+import { topologyLinkToLinkInfo } from '@/components/shared/link-info-converters'
 import { useActiveOpsTickets } from '@/hooks/use-ops-tickets'
 import { opsTicketUrl } from '@/lib/ops-api'
 import type { OpsTicket } from '@/lib/ops-api'
@@ -146,51 +147,6 @@ function getStakeColor(stakeShare: number): string {
   return `rgb(${r}, ${g}, ${b})`
 }
 
-// Hovered link info type
-interface HoveredLinkInfo {
-  pk: string
-  code: string
-  status: string
-  linkType: string
-  bandwidthBps: number
-  latencyUs: number
-  jitterUs: number
-  latencyAtoZUs: number
-  jitterAtoZUs: number
-  latencyZtoAUs: number
-  jitterZtoAUs: number
-  lossPercent: number
-  inBps: number
-  outBps: number
-  deviceAPk: string
-  deviceACode: string
-  interfaceAName: string
-  interfaceAIP: string
-  deviceZPk: string
-  deviceZCode: string
-  interfaceZName: string
-  interfaceZIP: string
-  contributorPk: string
-  contributorCode: string
-  sideAContributorPk: string
-  sideAContributorCode: string
-  sideZContributorPk: string
-  sideZContributorCode: string
-  sampleCount: number
-  committedRttNs: number
-  isisDelayOverrideNs: number
-  health?: {
-    status: string
-    committedRttNs: number
-    slaRatio: number
-    lossPct: number
-  }
-  // Inter-metro link properties
-  isInterMetro?: boolean
-  linkCount?: number
-  avgLatencyUs?: number
-}
-
 // Hovered device info type
 interface HoveredDeviceInfo {
   pk: string
@@ -247,7 +203,7 @@ interface HoveredValidatorInfo {
 
 // Selected item type for drawer
 type SelectedItem =
-  | { type: 'link'; data: HoveredLinkInfo }
+  | { type: 'link'; data: LinkInfo }
   | { type: 'device'; data: HoveredDeviceInfo }
   | { type: 'metro'; data: HoveredMetroInfo }
   | { type: 'validator'; data: HoveredValidatorInfo }
@@ -344,7 +300,7 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
   const [searchParams, setSearchParams] = useSearchParams()
-  const [hoveredLink, setHoveredLink] = useState<HoveredLinkInfo | null>(null)
+  const [hoveredLink, setHoveredLink] = useState<LinkInfo | null>(null)
   const [hoveredDevice, setHoveredDevice] = useState<HoveredDeviceInfo | null>(null)
   const [hoveredMetro, setHoveredMetro] = useState<HoveredMetroInfo | null>(null)
   const [hoveredValidator, setHoveredValidator] = useState<HoveredValidatorInfo | null>(null)
@@ -2288,48 +2244,10 @@ export function TopologyMap({ metros, devices, links, validators }: TopologyMapP
   const selectionColor = '#3b82f6' // blue - consistent with graph view
 
   // Build hover info for links
-  const buildLinkInfo = useCallback((link: TopologyLink): HoveredLinkInfo => {
-    const healthInfo = linkSlaStatus.get(link.pk)
-    return {
-      pk: link.pk,
-      code: link.code,
-      status: link.status,
-      linkType: link.link_type,
-      bandwidthBps: link.bandwidth_bps,
-      latencyUs: link.latency_us,
-      jitterUs: link.jitter_us ?? 0,
-      latencyAtoZUs: link.latency_a_to_z_us,
-      jitterAtoZUs: link.jitter_a_to_z_us ?? 0,
-      latencyZtoAUs: link.latency_z_to_a_us,
-      jitterZtoAUs: link.jitter_z_to_a_us ?? 0,
-      lossPercent: link.loss_percent ?? 0,
-      inBps: link.in_bps,
-      outBps: link.out_bps,
-      deviceAPk: link.side_a_pk,
-      deviceACode: link.side_a_code || 'Unknown',
-      interfaceAName: link.side_a_iface_name || '',
-      interfaceAIP: link.side_a_ip || '',
-      deviceZPk: link.side_z_pk,
-      deviceZCode: link.side_z_code || 'Unknown',
-      interfaceZName: link.side_z_iface_name || '',
-      interfaceZIP: link.side_z_ip || '',
-      contributorPk: link.contributor_pk,
-      contributorCode: link.contributor_code,
-      sideAContributorPk: link.side_a_contributor_pk || '',
-      sideAContributorCode: link.side_a_contributor_code || '',
-      sideZContributorPk: link.side_z_contributor_pk || '',
-      sideZContributorCode: link.side_z_contributor_code || '',
-      sampleCount: link.sample_count ?? 0,
-      committedRttNs: link.committed_rtt_ns,
-      isisDelayOverrideNs: link.isis_delay_override_ns,
-      health: healthInfo ? {
-        status: healthInfo.status,
-        committedRttNs: healthInfo.committedRttNs,
-        slaRatio: healthInfo.slaRatio,
-        lossPct: healthInfo.lossPct,
-      } : undefined,
-    }
-  }, [linkSlaStatus])
+  const buildLinkInfo = useCallback(
+    (link: TopologyLink): LinkInfo => topologyLinkToLinkInfo(link, linkSlaStatus.get(link.pk)),
+    [linkSlaStatus]
+  )
 
   // Handle map click to deselect or select links
   const handleMapClick = useCallback((e: MapLayerMouseEvent) => {


### PR DESCRIPTION
## Summary of Changes
- The link drawer on the map, globe, and graph topology views showed a hardcoded "default" topology chip for every link, while the link detail page showed the real membership (e.g. `UNICAST-DEFAULT`). Each view built its drawer data with its own inline mapping that dropped `link_topologies` and `unicast_drained` from the `/api/topology` response — and since both fields are optional on `LinkInfo`, the compiler couldn't catch it.
- Replace the three near-identical inline mappings with a single shared `topologyLinkToLinkInfo` converter in `link-info-converters.ts`, so topology API fields reach every view (and future fields can't be dropped by one view silently).
- Delete the map's local `HoveredLinkInfo` interface — a field-for-field copy of the shared `LinkInfo` type minus the two dropped fields — and use `LinkInfo` throughout.

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net   |
|--------------|-------|---------------|-------|
| Core logic   |     1 | +56 / -1      |  +55  |
| Scaffolding  |     3 | +15 / -144    | -129  |
| Tests        |     1 | +94 / -0      |  +94  |
| **Total**    |     5 | +165 / -145   |  +20  |

Net-negative product code: three duplicated drawer mappings collapse into one shared converter, plus new tests.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/shared/link-info-converters.ts` — new shared `topologyLinkToLinkInfo` converter (TopologyLink → LinkInfo), carrying `link_topologies`/`unicast_drained` and an optional SLA health projection
- `web/src/components/topology-map.tsx` — `buildLinkInfo` delegates to the shared converter; local `HoveredLinkInfo` type deleted in favor of shared `LinkInfo`
- `web/src/components/topology-graph.tsx` — `linkInfoMap` entries built by the shared converter
- `web/src/components/topology-globe.tsx` — `buildLinkInfo` delegates to the shared converter

</details>

## Testing Verification
- New unit tests for the converter, including a regression test asserting topology membership survives the full drawer conversion chain (`topologyLinkToLinkInfo` → `topologyLinkToInfo`) — the exact path that previously dropped it. Tests were written first and failed against the old code.
- Full web suite passes (185 tests).
- Not visually verified in a browser (local API/web services weren't running); the drawer renders via the same shared `LinkInfoContent` the detail page already uses, so with `linkTopologies` populated it shows the same badge.
