### PR TITLE
indexer: ingest onchain BGP status into dz_users_current

### DIFF
--- a/indexer/db/clickhouse/migrations/20260708000001_users_bgp_status.sql
+++ b/indexer/db/clickhouse/migrations/20260708000001_users_bgp_status.sql
@@ -1,25 +1,35 @@
 -- +goose Up
-
--- Add onchain BGP session state (User account: bgp_status, last_bgp_up_at,
--- last_bgp_reported_at) to the users dimension so consumers can distinguish a
--- user that is not connected (BGP down) from a multicast forwarding fault.
+--
+-- Add the onchain BGP session status (User account) to the users dimension so
+-- consumers can distinguish a user that is not connected (BGP down) from a
+-- multicast forwarding fault.
+--
+-- Only bgp_status is ingested. The onchain last_bgp_up_at / last_bgp_reported_at
+-- slots are deliberately NOT ingested: last_bgp_reported_at is rewritten by a
+-- ~6-hourly onchain keepalive, and since attrs_hash covers every payload column
+-- it would churn a new dim_dz_users_history row per user ~4x/day forever. If a
+-- freshness signal is needed later, add it as a non-hashed column.
+--
+-- Column values: 'up' | 'down' | 'unknown' (agent never reported). DEFAULT
+-- 'unknown' means "not yet reported"; consumers treat anything != 'down' as
+-- fail-open (old behavior), so an unreported user is never masked.
+--
+-- NOTE: the AFTER placement is load-bearing. loadSnapshotIntoStaging appends a
+-- positional batch with no column list, so the physical column order MUST match
+-- UserSchema.PayloadColumns() order (bgp_status last, after subscribers).
 
 -- +goose StatementBegin
 ALTER TABLE dim_dz_users_history
-    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT '' AFTER subscribers,
-    ADD COLUMN IF NOT EXISTS last_bgp_up_at UInt64 DEFAULT 0 AFTER bgp_status,
-    ADD COLUMN IF NOT EXISTS last_bgp_reported_at UInt64 DEFAULT 0 AFTER last_bgp_up_at;
+    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT 'unknown' AFTER subscribers;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
 ALTER TABLE stg_dim_dz_users_snapshot
-    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT '' AFTER subscribers,
-    ADD COLUMN IF NOT EXISTS last_bgp_up_at UInt64 DEFAULT 0 AFTER bgp_status,
-    ADD COLUMN IF NOT EXISTS last_bgp_reported_at UInt64 DEFAULT 0 AFTER last_bgp_up_at;
+    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT 'unknown' AFTER subscribers;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
--- Recreate dz_users_current to expose the BGP columns.
+-- Recreate dz_users_current to expose bgp_status.
 CREATE OR REPLACE VIEW dz_users_current
 AS
 WITH ranked AS (
@@ -45,9 +55,7 @@ SELECT
     tunnel_id,
     publishers,
     subscribers,
-    bgp_status,
-    last_bgp_up_at,
-    last_bgp_reported_at
+    bgp_status
 FROM ranked
 WHERE rn = 1 AND is_deleted = 0;
 -- +goose StatementEnd
@@ -55,7 +63,7 @@ WHERE rn = 1 AND is_deleted = 0;
 -- +goose Down
 
 -- +goose StatementBegin
--- Restore dz_users_current without the BGP columns.
+-- Restore dz_users_current without bgp_status.
 CREATE OR REPLACE VIEW dz_users_current
 AS
 WITH ranked AS (
@@ -87,14 +95,10 @@ WHERE rn = 1 AND is_deleted = 0;
 
 -- +goose StatementBegin
 ALTER TABLE dim_dz_users_history
-    DROP COLUMN IF EXISTS bgp_status,
-    DROP COLUMN IF EXISTS last_bgp_up_at,
-    DROP COLUMN IF EXISTS last_bgp_reported_at;
+    DROP COLUMN IF EXISTS bgp_status;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
 ALTER TABLE stg_dim_dz_users_snapshot
-    DROP COLUMN IF EXISTS bgp_status,
-    DROP COLUMN IF EXISTS last_bgp_up_at,
-    DROP COLUMN IF EXISTS last_bgp_reported_at;
+    DROP COLUMN IF EXISTS bgp_status;
 -- +goose StatementEnd

--- a/indexer/db/clickhouse/migrations/20260708000001_users_bgp_status.sql
+++ b/indexer/db/clickhouse/migrations/20260708000001_users_bgp_status.sql
@@ -1,0 +1,100 @@
+-- +goose Up
+
+-- Add onchain BGP session state (User account: bgp_status, last_bgp_up_at,
+-- last_bgp_reported_at) to the users dimension so consumers can distinguish a
+-- user that is not connected (BGP down) from a multicast forwarding fault.
+
+-- +goose StatementBegin
+ALTER TABLE dim_dz_users_history
+    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT '' AFTER subscribers,
+    ADD COLUMN IF NOT EXISTS last_bgp_up_at UInt64 DEFAULT 0 AFTER bgp_status,
+    ADD COLUMN IF NOT EXISTS last_bgp_reported_at UInt64 DEFAULT 0 AFTER last_bgp_up_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE stg_dim_dz_users_snapshot
+    ADD COLUMN IF NOT EXISTS bgp_status String DEFAULT '' AFTER subscribers,
+    ADD COLUMN IF NOT EXISTS last_bgp_up_at UInt64 DEFAULT 0 AFTER bgp_status,
+    ADD COLUMN IF NOT EXISTS last_bgp_reported_at UInt64 DEFAULT 0 AFTER last_bgp_up_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Recreate dz_users_current to expose the BGP columns.
+CREATE OR REPLACE VIEW dz_users_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_users_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner_pubkey,
+    status,
+    kind,
+    client_ip,
+    dz_ip,
+    device_pk,
+    tenant_pk,
+    tunnel_id,
+    publishers,
+    subscribers,
+    bgp_status,
+    last_bgp_up_at,
+    last_bgp_reported_at
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+-- Restore dz_users_current without the BGP columns.
+CREATE OR REPLACE VIEW dz_users_current
+AS
+WITH ranked AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY entity_id ORDER BY snapshot_ts DESC, ingested_at DESC, op_id DESC) AS rn
+    FROM dim_dz_users_history
+)
+SELECT
+    entity_id,
+    snapshot_ts,
+    ingested_at,
+    op_id,
+    attrs_hash,
+    pk,
+    owner_pubkey,
+    status,
+    kind,
+    client_ip,
+    dz_ip,
+    device_pk,
+    tenant_pk,
+    tunnel_id,
+    publishers,
+    subscribers
+FROM ranked
+WHERE rn = 1 AND is_deleted = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dim_dz_users_history
+    DROP COLUMN IF EXISTS bgp_status,
+    DROP COLUMN IF EXISTS last_bgp_up_at,
+    DROP COLUMN IF EXISTS last_bgp_reported_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE stg_dim_dz_users_snapshot
+    DROP COLUMN IF EXISTS bgp_status,
+    DROP COLUMN IF EXISTS last_bgp_up_at,
+    DROP COLUMN IF EXISTS last_bgp_reported_at;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/serviceability/schema.go
+++ b/indexer/pkg/dz/serviceability/schema.go
@@ -164,8 +164,6 @@ func (s *UserSchema) PayloadColumns() []string {
 		"publishers:VARCHAR",
 		"subscribers:VARCHAR",
 		"bgp_status:VARCHAR",
-		"last_bgp_up_at:BIGINT",
-		"last_bgp_reported_at:BIGINT",
 	}
 }
 
@@ -185,8 +183,6 @@ func (s *UserSchema) ToRow(u User) []any {
 		string(publishersJSON),
 		string(subscribersJSON),
 		u.BgpStatus,
-		u.LastBgpUpAt,
-		u.LastBgpReportedAt,
 	}
 }
 

--- a/indexer/pkg/dz/serviceability/schema.go
+++ b/indexer/pkg/dz/serviceability/schema.go
@@ -163,6 +163,9 @@ func (s *UserSchema) PayloadColumns() []string {
 		"tunnel_id:INTEGER",
 		"publishers:VARCHAR",
 		"subscribers:VARCHAR",
+		"bgp_status:VARCHAR",
+		"last_bgp_up_at:BIGINT",
+		"last_bgp_reported_at:BIGINT",
 	}
 }
 
@@ -181,6 +184,9 @@ func (s *UserSchema) ToRow(u User) []any {
 		u.TunnelID,
 		string(publishersJSON),
 		string(subscribersJSON),
+		u.BgpStatus,
+		u.LastBgpUpAt,
+		u.LastBgpReportedAt,
 	}
 }
 

--- a/indexer/pkg/dz/serviceability/store_test.go
+++ b/indexer/pkg/dz/serviceability/store_test.go
@@ -347,17 +347,15 @@ func TestLake_Serviceability_Store_ReplaceUsers(t *testing.T) {
 
 		users := []User{
 			{
-				PK:                userPK,
-				OwnerPubkey:       testPK(11),
-				Status:            "activated",
-				Kind:              "multicast",
-				ClientIP:          net.IP{10, 0, 0, 1},
-				DZIP:              net.IP{10, 0, 0, 2},
-				DevicePK:          testPK(12),
-				TunnelID:          505,
-				BgpStatus:         "down",
-				LastBgpUpAt:       12345,
-				LastBgpReportedAt: 67890,
+				PK:          userPK,
+				OwnerPubkey: testPK(11),
+				Status:      "activated",
+				Kind:        "multicast",
+				ClientIP:    net.IP{10, 0, 0, 1},
+				DZIP:        net.IP{10, 0, 0, 2},
+				DevicePK:    testPK(12),
+				TunnelID:    505,
+				BgpStatus:   "down",
 			},
 		}
 
@@ -368,24 +366,64 @@ func TestLake_Serviceability_Store_ReplaceUsers(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		// The dz_users_current view (recreated by the migration) must expose the
-		// BGP columns.
+		// The dz_users_current view (recreated by the migration) must expose bgp_status.
 		rows, err := conn.Query(ctx,
-			"SELECT bgp_status, last_bgp_up_at, last_bgp_reported_at FROM dz_users_current WHERE pk = ?",
-			userPK)
+			"SELECT bgp_status FROM dz_users_current WHERE pk = ?", userPK)
 		require.NoError(t, err)
 		defer rows.Close()
 
 		require.True(t, rows.Next(), "expected a dz_users_current row for the user")
-		var (
-			bgpStatus         string
-			lastBgpUpAt       uint64
-			lastBgpReportedAt uint64
-		)
-		require.NoError(t, rows.Scan(&bgpStatus, &lastBgpUpAt, &lastBgpReportedAt))
+		var bgpStatus string
+		require.NoError(t, rows.Scan(&bgpStatus))
 		require.Equal(t, "down", bgpStatus)
-		require.Equal(t, uint64(12345), lastBgpUpAt)
-		require.Equal(t, uint64(67890), lastBgpReportedAt)
+	})
+
+	// Guards against the SCD-churn concern from review: only bgp_status is
+	// ingested (not the ~6-hourly last_bgp_reported_at keepalive slot), so a
+	// re-ingest with unchanged BGP state must NOT write a new history row. A
+	// real bgp_status transition must.
+	t.Run("bgp_status change detection does not churn history", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		ctx := t.Context()
+
+		store, err := NewStore(StoreConfig{Logger: laketesting.NewLogger(), ClickHouse: db})
+		require.NoError(t, err)
+
+		userPK := testPK(20)
+		mk := func(bgp string) []User {
+			return []User{{
+				PK: userPK, OwnerPubkey: testPK(21), Status: "activated", Kind: "multicast",
+				ClientIP: net.IP{10, 0, 1, 1}, DZIP: net.IP{10, 0, 1, 2}, DevicePK: testPK(22),
+				TunnelID: 506, BgpStatus: bgp,
+			}}
+		}
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		entityID := dataset.NewNaturalKey(userPK).ToSurrogate()
+		historyRows := func() uint64 {
+			r, err := conn.Query(ctx, "SELECT count() FROM dim_dz_users_history WHERE entity_id = ?", entityID)
+			require.NoError(t, err)
+			defer r.Close()
+			require.True(t, r.Next())
+			var n uint64
+			require.NoError(t, r.Scan(&n))
+			return n
+		}
+
+		require.NoError(t, store.ReplaceUsers(ctx, mk("up")))
+		require.EqualValues(t, 1, historyRows())
+
+		// Same BGP state re-ingested → no new row (attrs_hash unchanged).
+		require.NoError(t, store.ReplaceUsers(ctx, mk("up")))
+		require.EqualValues(t, 1, historyRows(), "unchanged bgp_status must not churn a new history row")
+
+		// Real transition → exactly one new row.
+		require.NoError(t, store.ReplaceUsers(ctx, mk("down")))
+		require.EqualValues(t, 2, historyRows(), "bgp_status transition must write one new history row")
 	})
 }
 

--- a/indexer/pkg/dz/serviceability/store_test.go
+++ b/indexer/pkg/dz/serviceability/store_test.go
@@ -329,6 +329,64 @@ func TestLake_Serviceability_Store_ReplaceUsers(t *testing.T) {
 		require.Equal(t, "10.0.0.2", current["dz_ip"])
 		require.Equal(t, devicePK, current["device_pk"])
 	})
+
+	t.Run("persists onchain BGP status through to dz_users_current", func(t *testing.T) {
+		t.Parallel()
+
+		db := testClient(t)
+		log := laketesting.NewLogger()
+		ctx := t.Context()
+
+		store, err := NewStore(StoreConfig{
+			Logger:     log,
+			ClickHouse: db,
+		})
+		require.NoError(t, err)
+
+		userPK := testPK(10)
+
+		users := []User{
+			{
+				PK:                userPK,
+				OwnerPubkey:       testPK(11),
+				Status:            "activated",
+				Kind:              "multicast",
+				ClientIP:          net.IP{10, 0, 0, 1},
+				DZIP:              net.IP{10, 0, 0, 2},
+				DevicePK:          testPK(12),
+				TunnelID:          505,
+				BgpStatus:         "down",
+				LastBgpUpAt:       12345,
+				LastBgpReportedAt: 67890,
+			},
+		}
+
+		err = store.ReplaceUsers(ctx, users)
+		require.NoError(t, err)
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// The dz_users_current view (recreated by the migration) must expose the
+		// BGP columns.
+		rows, err := conn.Query(ctx,
+			"SELECT bgp_status, last_bgp_up_at, last_bgp_reported_at FROM dz_users_current WHERE pk = ?",
+			userPK)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		require.True(t, rows.Next(), "expected a dz_users_current row for the user")
+		var (
+			bgpStatus         string
+			lastBgpUpAt       uint64
+			lastBgpReportedAt uint64
+		)
+		require.NoError(t, rows.Scan(&bgpStatus, &lastBgpUpAt, &lastBgpReportedAt))
+		require.Equal(t, "down", bgpStatus)
+		require.Equal(t, uint64(12345), lastBgpUpAt)
+		require.Equal(t, uint64(67890), lastBgpReportedAt)
+	})
 }
 
 func TestLake_Serviceability_Store_ReplaceLinks(t *testing.T) {

--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -137,6 +137,10 @@ type User struct {
 	TunnelID    uint16
 	Publishers  []string // multicast group PKs this user publishes to
 	Subscribers []string // multicast group PKs this user subscribes to
+	// BGP session state as last reported by the device agent (onchain).
+	BgpStatus         string // "up" | "down" | "unknown"
+	LastBgpUpAt       uint64 // ledger slot of the most recent BGP up event
+	LastBgpReportedAt uint64 // ledger slot of the most recent BGP status report
 }
 
 type MulticastGroup struct {
@@ -542,17 +546,20 @@ func convertUsers(onchain []serviceability.User) []User {
 		}
 
 		result[i] = User{
-			PK:          solana.PublicKeyFromBytes(user.PubKey[:]).String(),
-			OwnerPubkey: solana.PublicKeyFromBytes(user.Owner[:]).String(),
-			Status:      statusString(user.Status),
-			Kind:        user.UserType.String(),
-			ClientIP:    net.IP(user.ClientIp[:]),
-			DZIP:        net.IP(user.DzIp[:]),
-			DevicePK:    solana.PublicKeyFromBytes(user.DevicePubKey[:]).String(),
-			TenantPK:    solana.PublicKeyFromBytes(user.TenantPubKey[:]).String(),
-			TunnelID:    user.TunnelId,
-			Publishers:  publishers,
-			Subscribers: subscribers,
+			PK:                solana.PublicKeyFromBytes(user.PubKey[:]).String(),
+			OwnerPubkey:       solana.PublicKeyFromBytes(user.Owner[:]).String(),
+			Status:            statusString(user.Status),
+			Kind:              user.UserType.String(),
+			ClientIP:          net.IP(user.ClientIp[:]),
+			DZIP:              net.IP(user.DzIp[:]),
+			DevicePK:          solana.PublicKeyFromBytes(user.DevicePubKey[:]).String(),
+			TenantPK:          solana.PublicKeyFromBytes(user.TenantPubKey[:]).String(),
+			TunnelID:          user.TunnelId,
+			Publishers:        publishers,
+			Subscribers:       subscribers,
+			BgpStatus:         serviceability.BGPStatus(user.BgpStatus).String(),
+			LastBgpUpAt:       user.LastBgpUpAt,
+			LastBgpReportedAt: user.LastBgpReportedAt,
 		}
 	}
 	return result

--- a/indexer/pkg/dz/serviceability/view.go
+++ b/indexer/pkg/dz/serviceability/view.go
@@ -137,10 +137,9 @@ type User struct {
 	TunnelID    uint16
 	Publishers  []string // multicast group PKs this user publishes to
 	Subscribers []string // multicast group PKs this user subscribes to
-	// BGP session state as last reported by the device agent (onchain).
-	BgpStatus         string // "up" | "down" | "unknown"
-	LastBgpUpAt       uint64 // ledger slot of the most recent BGP up event
-	LastBgpReportedAt uint64 // ledger slot of the most recent BGP status report
+	// BgpStatus is the onchain BGP session status as last reported by the
+	// device agent: always one of "up" | "down" | "unknown".
+	BgpStatus string
 }
 
 type MulticastGroup struct {
@@ -546,23 +545,36 @@ func convertUsers(onchain []serviceability.User) []User {
 		}
 
 		result[i] = User{
-			PK:                solana.PublicKeyFromBytes(user.PubKey[:]).String(),
-			OwnerPubkey:       solana.PublicKeyFromBytes(user.Owner[:]).String(),
-			Status:            statusString(user.Status),
-			Kind:              user.UserType.String(),
-			ClientIP:          net.IP(user.ClientIp[:]),
-			DZIP:              net.IP(user.DzIp[:]),
-			DevicePK:          solana.PublicKeyFromBytes(user.DevicePubKey[:]).String(),
-			TenantPK:          solana.PublicKeyFromBytes(user.TenantPubKey[:]).String(),
-			TunnelID:          user.TunnelId,
-			Publishers:        publishers,
-			Subscribers:       subscribers,
-			BgpStatus:         serviceability.BGPStatus(user.BgpStatus).String(),
-			LastBgpUpAt:       user.LastBgpUpAt,
-			LastBgpReportedAt: user.LastBgpReportedAt,
+			PK:          solana.PublicKeyFromBytes(user.PubKey[:]).String(),
+			OwnerPubkey: solana.PublicKeyFromBytes(user.Owner[:]).String(),
+			Status:      statusString(user.Status),
+			Kind:        user.UserType.String(),
+			ClientIP:    net.IP(user.ClientIp[:]),
+			DZIP:        net.IP(user.DzIp[:]),
+			DevicePK:    solana.PublicKeyFromBytes(user.DevicePubKey[:]).String(),
+			TenantPK:    solana.PublicKeyFromBytes(user.TenantPubKey[:]).String(),
+			TunnelID:    user.TunnelId,
+			Publishers:  publishers,
+			Subscribers: subscribers,
+			BgpStatus:   bgpStatusString(user.BgpStatus),
 		}
 	}
 	return result
+}
+
+// bgpStatusString maps the onchain BGP status enum to the documented
+// "up" | "down" | "unknown" vocabulary. Any value outside the known enum (a
+// future onchain variant) normalizes to "unknown" so consumers never see an
+// out-of-vocabulary string like "BGPStatus(3)".
+func bgpStatusString(status uint8) string {
+	switch serviceability.BGPStatus(status) {
+	case serviceability.BGPStatusUp:
+		return "up"
+	case serviceability.BGPStatusDown:
+		return "down"
+	default:
+		return "unknown"
+	}
 }
 
 func convertLinks(onchain []serviceability.Link, devices []serviceability.Device, topologies []serviceability.TopologyInfo) []Link {

--- a/indexer/pkg/dz/serviceability/view_test.go
+++ b/indexer/pkg/dz/serviceability/view_test.go
@@ -236,6 +236,35 @@ func TestLake_Serviceability_View_ConvertUsers(t *testing.T) {
 		require.Equal(t, "activated", result[0].Status)
 		require.Equal(t, "ibrl", result[0].Kind)
 	})
+
+	t.Run("maps onchain BGP session state", func(t *testing.T) {
+		t.Parallel()
+
+		onchain := []serviceability.User{
+			{
+				PubKey:            [32]byte{1},
+				Status:            serviceability.UserStatusActivated,
+				UserType:          serviceability.UserTypeMulticast,
+				BgpStatus:         uint8(serviceability.BGPStatusDown),
+				LastBgpUpAt:       12345,
+				LastBgpReportedAt: 67890,
+			},
+			{
+				PubKey:    [32]byte{2},
+				Status:    serviceability.UserStatusActivated,
+				UserType:  serviceability.UserTypeMulticast,
+				BgpStatus: uint8(serviceability.BGPStatusUp),
+			},
+		}
+
+		result := convertUsers(onchain)
+
+		require.Len(t, result, 2)
+		require.Equal(t, "down", result[0].BgpStatus)
+		require.Equal(t, uint64(12345), result[0].LastBgpUpAt)
+		require.Equal(t, uint64(67890), result[0].LastBgpReportedAt)
+		require.Equal(t, "up", result[1].BgpStatus)
+	})
 }
 
 func TestLake_Serviceability_View_ConvertMetros(t *testing.T) {

--- a/indexer/pkg/dz/serviceability/view_test.go
+++ b/indexer/pkg/dz/serviceability/view_test.go
@@ -242,12 +242,10 @@ func TestLake_Serviceability_View_ConvertUsers(t *testing.T) {
 
 		onchain := []serviceability.User{
 			{
-				PubKey:            [32]byte{1},
-				Status:            serviceability.UserStatusActivated,
-				UserType:          serviceability.UserTypeMulticast,
-				BgpStatus:         uint8(serviceability.BGPStatusDown),
-				LastBgpUpAt:       12345,
-				LastBgpReportedAt: 67890,
+				PubKey:    [32]byte{1},
+				Status:    serviceability.UserStatusActivated,
+				UserType:  serviceability.UserTypeMulticast,
+				BgpStatus: uint8(serviceability.BGPStatusDown),
 			},
 			{
 				PubKey:    [32]byte{2},
@@ -255,15 +253,22 @@ func TestLake_Serviceability_View_ConvertUsers(t *testing.T) {
 				UserType:  serviceability.UserTypeMulticast,
 				BgpStatus: uint8(serviceability.BGPStatusUp),
 			},
+			{
+				// Value outside the known enum (a future onchain variant)
+				// normalizes to "unknown", never a raw "BGPStatus(N)" string.
+				PubKey:    [32]byte{3},
+				Status:    serviceability.UserStatusActivated,
+				UserType:  serviceability.UserTypeMulticast,
+				BgpStatus: 99,
+			},
 		}
 
 		result := convertUsers(onchain)
 
-		require.Len(t, result, 2)
+		require.Len(t, result, 3)
 		require.Equal(t, "down", result[0].BgpStatus)
-		require.Equal(t, uint64(12345), result[0].LastBgpUpAt)
-		require.Equal(t, uint64(67890), result[0].LastBgpReportedAt)
 		require.Equal(t, "up", result[1].BgpStatus)
+		require.Equal(t, "unknown", result[2].BgpStatus)
 	})
 }
 


### PR DESCRIPTION
## Summary

Ingest the onchain BGP session status (`bgp_status`) into `dz_users_current` so multicast health can tell "client not connected (BGP down)" apart from a real forwarding fault.

The multicast Health tab flags any activated publisher/subscriber whose BGP session is down as **unhealthy** ("publisher TunnelN not seen as RPF interface"). Investigation of the `edge-solana-shreds` group found **100% of its 92 unhealthy publishers were onchain BGP-down** — the health views only knew onchain membership, not connectivity. `bgp_status` is onchain on the serviceability User account but lake's indexer dropped it. This PR extracts it; the follow-up (#686) consumes it as a distinct `disconnected` state.

- Add `bgp_status` to `dim_dz_users_history` / `stg_dim_dz_users_snapshot` and expose it on `dz_users_current` (migration mirrors the `tenant_pk` pattern).
- Map it from the Go serviceability SDK in `convertUsers`, normalizing to `up` | `down` | `unknown` (out-of-range enum values → `unknown`).
- `DEFAULT 'unknown'` on the new column; consumers treat anything `!= 'down'` as fail-open (pre-migration/unreported rows keep old behavior).

### Deliberately not ingested
The onchain `last_bgp_up_at` / `last_bgp_reported_at` slots are **not** ingested. `last_bgp_reported_at` is rewritten by a ~6-hourly onchain keepalive; since `attrs_hash` covers every payload column, ingesting it would write a new `dim_dz_users_history` row per user ~4×/day forever (contentless timeline events, growing `dz_users_current` scan). `bgp_status` changes only on real transitions, so there is no ongoing churn. If a freshness signal is needed later, it can be added as a non-hashed column.

### Local dev
The `lake.*` remote-proxy tables snapshot the remote schema at creation, so a local dev instance won't see `bgp_status` until the indexer restarts with `--setup-remote-tables` after this migration lands. Self-healing.

## Testing Verification

- `convertUsers` maps `bgp_status` and normalizes an out-of-range enum value to `unknown`.
- Change-detection guard: re-ingesting an unchanged `bgp_status` writes no new history row; a real transition writes exactly one (pins that there is no keepalive churn).
- Full write→`dz_users_current` round-trip through the migration (ClickHouse testcontainer).
