### PR TITLE
docs: point prod mcp url at data.doublezero.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ The API exposes an MCP (Model Context Protocol) server at `/api/mcp` for use wit
 
 1. Open Settings → Manage Connectors
 2. Click "Add Custom Connector"
-3. Enter URL: `https://data.malbeclabs.com/api/mcp`
+3. Enter URL: `https://data.doublezero.xyz/api/mcp`
 
 ### Claude Code / Cursor
 
@@ -300,7 +300,7 @@ Add a `.mcp.json` file to your project:
   "mcpServers": {
     "doublezero": {
       "type": "http",
-      "url": "https://data.malbeclabs.com/api/mcp"
+      "url": "https://data.doublezero.xyz/api/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Point the documented MCP connector URL at the new canonical prod domain `data.doublezero.xyz` (Claude Desktop connector + `.mcp.json` example)

Part of making `data.doublezero.xyz` the canonical production domain for DoubleZero Data. `data.malbeclabs.com` continues to work as an alias, so existing MCP connectors keep functioning.

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Docs     |     1 | +2 / -2     |  +0 |
| **Total** |    1 | +2 / -2     |  +0 |

Docs-only: two URL references in the MCP setup section.

## Testing Verification
- Docs-only change; `data.doublezero.xyz/api/mcp` resolves to the same prod backend as the existing domain once DNS/OAuth are in place (tracked in the infra PR).
