### PR TITLE
api: make page-cache refresh interval + concurrency env-configurable

### DIFF
--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -29,17 +29,16 @@ func Start(ctx context.Context, cfg Config) error {
 		log = slog.Default()
 	}
 
-	// Load-shaping knobs (see workflow.go), overridable per-environment. Staging
-	// runs gentler values (lower concurrency, longer interval) to spread page-cache
-	// load across its smaller self-hosted ClickHouse rather than scaling it up.
-	// Read once here, before the worker/workflow start, so both are in effect.
-	if d := envDuration("PAGE_CACHE_REFRESH_INTERVAL", 0); d > 0 {
-		refreshInterval = d
-	}
-	if n := envInt("PAGE_CACHE_REFRESH_CONCURRENCY", 0); n > 0 {
-		pageCacheRefreshConcurrency = n
-	}
-	log.Info("page-cache: refresh config", "interval", refreshInterval, "concurrency", pageCacheRefreshConcurrency)
+	// Load-shaping knobs (see PageCacheParams / loadRefreshConfig), overridable
+	// per-environment. Staging runs gentler values (lower concurrency, longer
+	// interval) to spread page-cache load across its smaller self-hosted
+	// ClickHouse rather than scaling it up. Read once here; the interval/timeout
+	// go into the workflow as arguments (replay-deterministic) and concurrency
+	// onto the activity struct.
+	params, concurrency := loadRefreshConfig(log)
+	log.Info("page-cache: refresh config",
+		"interval", params.RefreshInterval, "concurrency", concurrency,
+		"activity_timeout", params.ActivityTimeout, "continue_as_new_after", params.ContinueAsNewThreshold)
 
 	// Connect to Temporal
 	temporalHost := envOrDefault("TEMPORAL_HOST_PORT", "localhost:7233")
@@ -57,8 +56,9 @@ func Start(ctx context.Context, cfg Config) error {
 
 	// Register workflows and activities
 	activities := &Activities{
-		Log: log.With("component", "page-cache"),
-		API: cfg.API,
+		Log:                log.With("component", "page-cache"),
+		API:                cfg.API,
+		RefreshConcurrency: concurrency,
 	}
 
 	w := worker.New(tc, TaskQueue, worker.Options{})
@@ -70,7 +70,7 @@ func Start(ctx context.Context, cfg Config) error {
 	run, err := tc.ExecuteWorkflow(ctx, temporalclient.StartWorkflowOptions{
 		ID:        WorkflowID,
 		TaskQueue: TaskQueue,
-	}, PageCacheWorkflow, 0)
+	}, PageCacheWorkflow, 0, params)
 	if err != nil {
 		return fmt.Errorf("page-cache: failed to start workflow: %w", err)
 	}
@@ -161,23 +161,71 @@ func envOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-// envDuration returns the env var parsed as a Go duration (e.g. "90s"), or def
-// if unset/invalid.
-func envDuration(key string, def time.Duration) time.Duration {
-	if v := os.Getenv(key); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			return d
-		}
-	}
-	return def
+// loadRefreshConfig reads the page-cache load-shaping knobs from the environment,
+// clamping to sane bounds and warning on anything set-but-invalid/out-of-range so
+// a typo (e.g. PAGE_CACHE_REFRESH_INTERVAL=90 with no unit) is visible rather than
+// silently falling back to prod defaults. Returns the workflow params (interval,
+// activity timeout, derived continue-as-new threshold) and the activity-side
+// concurrency. Pure and side-effect-free (aside from logging) so it's unit-testable
+// without a Temporal connection.
+func loadRefreshConfig(log *slog.Logger) (PageCacheParams, int) {
+	interval := durationEnv(log, "PAGE_CACHE_REFRESH_INTERVAL", defaultRefreshInterval, minRefreshInterval, maxRefreshInterval)
+	concurrency := intEnv(log, "PAGE_CACHE_REFRESH_CONCURRENCY", defaultRefreshConcurrency, minRefreshConcurrency, maxRefreshConcurrency)
+	timeout := durationEnv(log, "PAGE_CACHE_REFRESH_TIMEOUT", defaultActivityTimeout, minActivityTimeout, maxActivityTimeout)
+
+	// Continue-as-new after roughly continueAsNewTargetWindow of wall-clock so a
+	// longer interval can't inflate per-run history toward Temporal's limits.
+	threshold := max(int(continueAsNewTargetWindow/interval), 1)
+	return PageCacheParams{
+		RefreshInterval:        interval,
+		ActivityTimeout:        timeout,
+		ContinueAsNewThreshold: threshold,
+	}, concurrency
 }
 
-// envInt returns the env var parsed as an int, or def if unset/invalid.
-func envInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
+// durationEnv parses key as a Go duration (e.g. "90s"), clamped to [min,max].
+// Unset → def; set-but-unparseable → def with a warn; out-of-range → clamped with
+// a warn (so an operator sees their value was adjusted).
+func durationEnv(log *slog.Logger, key string, def, min, max time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
 	}
-	return def
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Warn("ignoring invalid duration env var; using default", "var", key, "value", raw, "default", def)
+		return def
+	}
+	if d < min {
+		log.Warn("duration env var below minimum; clamping", "var", key, "value", d.String(), "min", min.String())
+		return min
+	}
+	if d > max {
+		log.Warn("duration env var above maximum; clamping", "var", key, "value", d.String(), "max", max.String())
+		return max
+	}
+	return d
+}
+
+// intEnv parses key as an int, clamped to [min,max]. Unset → def;
+// set-but-unparseable → def with a warn; out-of-range → clamped with a warn.
+func intEnv(log *slog.Logger, key string, def, min, max int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Warn("ignoring invalid int env var; using default", "var", key, "value", raw, "default", def)
+		return def
+	}
+	if n < min {
+		log.Warn("int env var below minimum; clamping", "var", key, "value", n, "min", min)
+		return min
+	}
+	if n > max {
+		log.Warn("int env var above maximum; clamping", "var", key, "value", n, "max", max)
+		return max
+	}
+	return n
 }

--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -36,6 +36,7 @@ func Start(ctx context.Context, cfg Config) error {
 	// go into the workflow as arguments (replay-deterministic) and concurrency
 	// onto the activity struct.
 	params, concurrency := loadRefreshConfig(log)
+	params = params.withDefaults() // derive ContinueAsNewThreshold (single source) for the log + workflow arg
 	log.Info("page-cache: refresh config",
 		"interval", params.RefreshInterval, "concurrency", concurrency,
 		"activity_timeout", params.ActivityTimeout, "continue_as_new_after", params.ContinueAsNewThreshold)
@@ -165,21 +166,17 @@ func envOrDefault(key, defaultValue string) string {
 // clamping to sane bounds and warning on anything set-but-invalid/out-of-range so
 // a typo (e.g. PAGE_CACHE_REFRESH_INTERVAL=90 with no unit) is visible rather than
 // silently falling back to prod defaults. Returns the workflow params (interval,
-// activity timeout, derived continue-as-new threshold) and the activity-side
-// concurrency. Pure and side-effect-free (aside from logging) so it's unit-testable
-// without a Temporal connection.
+// activity timeout) and the activity-side concurrency. ContinueAsNewThreshold is
+// left zero and derived by PageCacheParams.withDefaults (the single source, so
+// the derivation isn't duplicated). Pure and side-effect-free (aside from logging)
+// so it's unit-testable without a Temporal connection.
 func loadRefreshConfig(log *slog.Logger) (PageCacheParams, int) {
 	interval := durationEnv(log, "PAGE_CACHE_REFRESH_INTERVAL", defaultRefreshInterval, minRefreshInterval, maxRefreshInterval)
 	concurrency := intEnv(log, "PAGE_CACHE_REFRESH_CONCURRENCY", defaultRefreshConcurrency, minRefreshConcurrency, maxRefreshConcurrency)
 	timeout := durationEnv(log, "PAGE_CACHE_REFRESH_TIMEOUT", defaultActivityTimeout, minActivityTimeout, maxActivityTimeout)
-
-	// Continue-as-new after roughly continueAsNewTargetWindow of wall-clock so a
-	// longer interval can't inflate per-run history toward Temporal's limits.
-	threshold := max(int(continueAsNewTargetWindow/interval), 1)
 	return PageCacheParams{
-		RefreshInterval:        interval,
-		ActivityTimeout:        timeout,
-		ContinueAsNewThreshold: threshold,
+		RefreshInterval: interval,
+		ActivityTimeout: timeout,
 	}, concurrency
 }
 

--- a/api/worker/pagecache.go
+++ b/api/worker/pagecache.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
@@ -26,6 +28,18 @@ func Start(ctx context.Context, cfg Config) error {
 	if log == nil {
 		log = slog.Default()
 	}
+
+	// Load-shaping knobs (see workflow.go), overridable per-environment. Staging
+	// runs gentler values (lower concurrency, longer interval) to spread page-cache
+	// load across its smaller self-hosted ClickHouse rather than scaling it up.
+	// Read once here, before the worker/workflow start, so both are in effect.
+	if d := envDuration("PAGE_CACHE_REFRESH_INTERVAL", 0); d > 0 {
+		refreshInterval = d
+	}
+	if n := envInt("PAGE_CACHE_REFRESH_CONCURRENCY", 0); n > 0 {
+		pageCacheRefreshConcurrency = n
+	}
+	log.Info("page-cache: refresh config", "interval", refreshInterval, "concurrency", pageCacheRefreshConcurrency)
 
 	// Connect to Temporal
 	temporalHost := envOrDefault("TEMPORAL_HOST_PORT", "localhost:7233")
@@ -145,4 +159,25 @@ func envOrDefault(key, defaultValue string) string {
 		return v
 	}
 	return defaultValue
+}
+
+// envDuration returns the env var parsed as a Go duration (e.g. "90s"), or def
+// if unset/invalid.
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+// envInt returns the env var parsed as an int, or def if unset/invalid.
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
 }

--- a/api/worker/pagecache_test.go
+++ b/api/worker/pagecache_test.go
@@ -25,10 +25,10 @@ func capLogger() (*slog.Logger, *[]slog.Record) {
 	return slog.New(capHandler{&recs}), &recs
 }
 
-func warnCount(recs []slog.Record) int {
+func countLevel(recs []slog.Record, lvl slog.Level) int {
 	n := 0
 	for _, r := range recs {
-		if r.Level == slog.LevelWarn {
+		if r.Level == lvl {
 			n++
 		}
 	}
@@ -41,31 +41,31 @@ func TestDurationEnv(t *testing.T) {
 	t.Run("unset uses default, no warn", func(t *testing.T) {
 		log, recs := capLogger()
 		require.Equal(t, def, durationEnv(log, "PC_DUR_UNSET", def, lo, hi))
-		require.Zero(t, warnCount(*recs))
+		require.Zero(t, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("valid override", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_DUR", "90s")
 		require.Equal(t, 90*time.Second, durationEnv(log, "PC_DUR", def, lo, hi))
-		require.Zero(t, warnCount(*recs))
+		require.Zero(t, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("invalid (missing unit) keeps default + warns", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_DUR_BAD", "90") // no unit → ParseDuration fails
 		require.Equal(t, def, durationEnv(log, "PC_DUR_BAD", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("below min clamps + warns", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_DUR_LOW", "1ms")
 		require.Equal(t, lo, durationEnv(log, "PC_DUR_LOW", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("above max clamps + warns", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_DUR_HIGH", "1h")
 		require.Equal(t, hi, durationEnv(log, "PC_DUR_HIGH", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
 }
 
@@ -75,7 +75,7 @@ func TestIntEnv(t *testing.T) {
 	t.Run("unset uses default", func(t *testing.T) {
 		log, recs := capLogger()
 		require.Equal(t, def, intEnv(log, "PC_INT_UNSET", def, lo, hi))
-		require.Zero(t, warnCount(*recs))
+		require.Zero(t, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("valid override", func(t *testing.T) {
 		log, _ := capLogger()
@@ -86,41 +86,110 @@ func TestIntEnv(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_INT_BAD", "three")
 		require.Equal(t, def, intEnv(log, "PC_INT_BAD", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("non-positive clamps to min + warns", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_INT_ZERO", "0")
 		require.Equal(t, lo, intEnv(log, "PC_INT_ZERO", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
 	t.Run("above max clamps + warns", func(t *testing.T) {
 		log, recs := capLogger()
 		t.Setenv("PC_INT_HIGH", "1000")
 		require.Equal(t, hi, intEnv(log, "PC_INT_HIGH", def, lo, hi))
-		require.Equal(t, 1, warnCount(*recs))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn))
 	})
+}
+
+// clearRefreshEnv makes the test hermetic against an ambient PAGE_CACHE_* env
+// (durationEnv/intEnv treat empty as unset).
+func clearRefreshEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("PAGE_CACHE_REFRESH_INTERVAL", "")
+	t.Setenv("PAGE_CACHE_REFRESH_CONCURRENCY", "")
+	t.Setenv("PAGE_CACHE_REFRESH_TIMEOUT", "")
 }
 
 func TestLoadRefreshConfig(t *testing.T) {
 	log, _ := capLogger()
 
-	t.Run("unset → prod defaults, threshold derived for 30s", func(t *testing.T) {
+	t.Run("unset → prod defaults; threshold left to withDefaults", func(t *testing.T) {
+		clearRefreshEnv(t)
 		p, conc := loadRefreshConfig(log)
 		require.Equal(t, defaultRefreshInterval, p.RefreshInterval)
 		require.Equal(t, defaultActivityTimeout, p.ActivityTimeout)
 		require.Equal(t, defaultRefreshConcurrency, conc)
-		// 30min / 30s = 60 iterations.
-		require.Equal(t, 60, p.ContinueAsNewThreshold)
+		require.Zero(t, p.ContinueAsNewThreshold, "derivation is withDefaults' job")
 	})
 
-	t.Run("staging overrides → gentler values, threshold scales down", func(t *testing.T) {
+	t.Run("staging overrides → gentler values", func(t *testing.T) {
+		clearRefreshEnv(t)
 		t.Setenv("PAGE_CACHE_REFRESH_INTERVAL", "90s")
 		t.Setenv("PAGE_CACHE_REFRESH_CONCURRENCY", "3")
 		p, conc := loadRefreshConfig(log)
 		require.Equal(t, 90*time.Second, p.RefreshInterval)
 		require.Equal(t, 3, conc)
-		// 30min / 90s = 20 iterations → history stays bounded despite the longer interval.
+	})
+}
+
+func TestPageCacheParamsWithDefaults(t *testing.T) {
+	t.Run("zero params → all defaults (pre-change history compat path)", func(t *testing.T) {
+		p := PageCacheParams{}.withDefaults()
+		require.Equal(t, defaultRefreshInterval, p.RefreshInterval)
+		require.Equal(t, defaultActivityTimeout, p.ActivityTimeout)
+		// 30min / 30s = 60.
+		require.Equal(t, 60, p.ContinueAsNewThreshold)
+	})
+
+	t.Run("longer interval scales threshold down to bound history", func(t *testing.T) {
+		p := PageCacheParams{RefreshInterval: 90 * time.Second}.withDefaults()
+		require.Equal(t, 90*time.Second, p.RefreshInterval)
+		require.Equal(t, defaultActivityTimeout, p.ActivityTimeout)
+		// 30min / 90s = 20.
 		require.Equal(t, 20, p.ContinueAsNewThreshold)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		once := PageCacheParams{RefreshInterval: 90 * time.Second}.withDefaults()
+		require.Equal(t, once, once.withDefaults())
+	})
+}
+
+// TestInterruptedEscalation pins the fix for the fast-loop regression: a
+// deadline-cut fast-cadence entry must escalate at the transient threshold (WARN
+// well past 3), while the slow batch escalates strictly at errorAfterFailures.
+func TestInterruptedEscalation(t *testing.T) {
+	notStopping := func() bool { return false }
+
+	// n calls, chosen to sit above the strict threshold but below the transient one.
+	const n = errorAfterFailures + 1 // 4: > errorAfterFailures(3), < transientErrorAfterFailures(10)
+
+	t.Run("fast loop deadline stays WARN below transient threshold", func(t *testing.T) {
+		log, recs := capLogger()
+		a := &Activities{Log: log}
+		for range n {
+			a.interrupted("edge scoreboard (latest)", "fastkey", context.DeadlineExceeded, notStopping, errFastRefreshDeadline)
+		}
+		require.Zero(t, countLevel(*recs, slog.LevelError), "fast-loop blips must not page below the transient threshold")
+		require.Equal(t, n, countLevel(*recs, slog.LevelWarn))
+	})
+
+	t.Run("slow batch deadline escalates to ERROR at the strict threshold", func(t *testing.T) {
+		log, recs := capLogger()
+		a := &Activities{Log: log}
+		for range n {
+			a.interrupted("geo concentration", "slowkey", nil, notStopping, errBatchDeadline)
+		}
+		require.NotZero(t, countLevel(*recs, slog.LevelError), "starvation should escalate at the strict threshold")
+	})
+
+	t.Run("worker shutdown is benign (not counted)", func(t *testing.T) {
+		log, recs := capLogger()
+		a := &Activities{Log: log}
+		stopping := func() bool { return true }
+		a.interrupted("geo concentration", "k", context.Canceled, stopping, errBatchDeadline)
+		require.Zero(t, countLevel(*recs, slog.LevelError))
+		require.Equal(t, 1, countLevel(*recs, slog.LevelWarn)) // "interrupted (shutdown)"
 	})
 }

--- a/api/worker/pagecache_test.go
+++ b/api/worker/pagecache_test.go
@@ -1,28 +1,126 @@
 package worker
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnvDuration(t *testing.T) {
-	require.Equal(t, 30*time.Second, envDuration("PC_TEST_DUR_UNSET", 30*time.Second), "unset → default")
+// capHandler records emitted records so tests can assert on log level.
+type capHandler struct{ records *[]slog.Record }
 
-	t.Setenv("PC_TEST_DUR", "90s")
-	require.Equal(t, 90*time.Second, envDuration("PC_TEST_DUR", 30*time.Second), "valid → parsed")
+func (h capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h capHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h capHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h capHandler) WithGroup(string) slog.Handler      { return h }
 
-	t.Setenv("PC_TEST_DUR_BAD", "not-a-duration")
-	require.Equal(t, 30*time.Second, envDuration("PC_TEST_DUR_BAD", 30*time.Second), "invalid → default")
+func capLogger() (*slog.Logger, *[]slog.Record) {
+	var recs []slog.Record
+	return slog.New(capHandler{&recs}), &recs
 }
 
-func TestEnvInt(t *testing.T) {
-	require.Equal(t, 8, envInt("PC_TEST_INT_UNSET", 8), "unset → default")
+func warnCount(recs []slog.Record) int {
+	n := 0
+	for _, r := range recs {
+		if r.Level == slog.LevelWarn {
+			n++
+		}
+	}
+	return n
+}
 
-	t.Setenv("PC_TEST_INT", "3")
-	require.Equal(t, 3, envInt("PC_TEST_INT", 8), "valid → parsed")
+func TestDurationEnv(t *testing.T) {
+	const def, lo, hi = 30 * time.Second, 5 * time.Second, 10 * time.Minute
 
-	t.Setenv("PC_TEST_INT_BAD", "x")
-	require.Equal(t, 8, envInt("PC_TEST_INT_BAD", 8), "invalid → default")
+	t.Run("unset uses default, no warn", func(t *testing.T) {
+		log, recs := capLogger()
+		require.Equal(t, def, durationEnv(log, "PC_DUR_UNSET", def, lo, hi))
+		require.Zero(t, warnCount(*recs))
+	})
+	t.Run("valid override", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_DUR", "90s")
+		require.Equal(t, 90*time.Second, durationEnv(log, "PC_DUR", def, lo, hi))
+		require.Zero(t, warnCount(*recs))
+	})
+	t.Run("invalid (missing unit) keeps default + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_DUR_BAD", "90") // no unit → ParseDuration fails
+		require.Equal(t, def, durationEnv(log, "PC_DUR_BAD", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+	t.Run("below min clamps + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_DUR_LOW", "1ms")
+		require.Equal(t, lo, durationEnv(log, "PC_DUR_LOW", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+	t.Run("above max clamps + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_DUR_HIGH", "1h")
+		require.Equal(t, hi, durationEnv(log, "PC_DUR_HIGH", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+}
+
+func TestIntEnv(t *testing.T) {
+	const def, lo, hi = 8, 1, 32
+
+	t.Run("unset uses default", func(t *testing.T) {
+		log, recs := capLogger()
+		require.Equal(t, def, intEnv(log, "PC_INT_UNSET", def, lo, hi))
+		require.Zero(t, warnCount(*recs))
+	})
+	t.Run("valid override", func(t *testing.T) {
+		log, _ := capLogger()
+		t.Setenv("PC_INT", "3")
+		require.Equal(t, 3, intEnv(log, "PC_INT", def, lo, hi))
+	})
+	t.Run("invalid keeps default + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_INT_BAD", "three")
+		require.Equal(t, def, intEnv(log, "PC_INT_BAD", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+	t.Run("non-positive clamps to min + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_INT_ZERO", "0")
+		require.Equal(t, lo, intEnv(log, "PC_INT_ZERO", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+	t.Run("above max clamps + warns", func(t *testing.T) {
+		log, recs := capLogger()
+		t.Setenv("PC_INT_HIGH", "1000")
+		require.Equal(t, hi, intEnv(log, "PC_INT_HIGH", def, lo, hi))
+		require.Equal(t, 1, warnCount(*recs))
+	})
+}
+
+func TestLoadRefreshConfig(t *testing.T) {
+	log, _ := capLogger()
+
+	t.Run("unset → prod defaults, threshold derived for 30s", func(t *testing.T) {
+		p, conc := loadRefreshConfig(log)
+		require.Equal(t, defaultRefreshInterval, p.RefreshInterval)
+		require.Equal(t, defaultActivityTimeout, p.ActivityTimeout)
+		require.Equal(t, defaultRefreshConcurrency, conc)
+		// 30min / 30s = 60 iterations.
+		require.Equal(t, 60, p.ContinueAsNewThreshold)
+	})
+
+	t.Run("staging overrides → gentler values, threshold scales down", func(t *testing.T) {
+		t.Setenv("PAGE_CACHE_REFRESH_INTERVAL", "90s")
+		t.Setenv("PAGE_CACHE_REFRESH_CONCURRENCY", "3")
+		p, conc := loadRefreshConfig(log)
+		require.Equal(t, 90*time.Second, p.RefreshInterval)
+		require.Equal(t, 3, conc)
+		// 30min / 90s = 20 iterations → history stays bounded despite the longer interval.
+		require.Equal(t, 20, p.ContinueAsNewThreshold)
+	})
 }

--- a/api/worker/pagecache_test.go
+++ b/api/worker/pagecache_test.go
@@ -1,0 +1,28 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvDuration(t *testing.T) {
+	require.Equal(t, 30*time.Second, envDuration("PC_TEST_DUR_UNSET", 30*time.Second), "unset → default")
+
+	t.Setenv("PC_TEST_DUR", "90s")
+	require.Equal(t, 90*time.Second, envDuration("PC_TEST_DUR", 30*time.Second), "valid → parsed")
+
+	t.Setenv("PC_TEST_DUR_BAD", "not-a-duration")
+	require.Equal(t, 30*time.Second, envDuration("PC_TEST_DUR_BAD", 30*time.Second), "invalid → default")
+}
+
+func TestEnvInt(t *testing.T) {
+	require.Equal(t, 8, envInt("PC_TEST_INT_UNSET", 8), "unset → default")
+
+	t.Setenv("PC_TEST_INT", "3")
+	require.Equal(t, 3, envInt("PC_TEST_INT", 8), "valid → parsed")
+
+	t.Setenv("PC_TEST_INT_BAD", "x")
+	require.Equal(t, 8, envInt("PC_TEST_INT_BAD", 8), "invalid → default")
+}

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -18,7 +18,6 @@ const (
 	TaskQueue  = "api-page-cache"
 	WorkflowID = "api-page-cache"
 
-	refreshInterval        = 30 * time.Second
 	fastRefreshInterval    = 3 * time.Second
 	continueAsNewThreshold = 60 // ~30 min at 30s intervals
 	errorAfterFailures     = 3  // log WARN for transient failures, ERROR after this many consecutive failures
@@ -164,13 +163,26 @@ type refreshError struct{ msg string }
 
 func (e *refreshError) Error() string { return e.msg }
 
-// pageCacheRefreshConcurrency bounds how many cache entries refresh at once.
-// 2-wide was too slow (each entry refreshed only every few minutes), but fully
-// unbounded (~28 entries) oversubscribed ClickHouse — ~55 concurrent queries
-// pegged an 8-core node, so even trivial queries hit their timeouts and the
-// per-entry retry amplified the storm. A bounded limit keeps in-flight queries
-// near what ClickHouse can run while still refreshing the batch within the cycle.
-const pageCacheRefreshConcurrency = 8
+// refreshInterval (how often the full page-cache batch refreshes) and
+// pageCacheRefreshConcurrency (how many entries refresh at once) are the two
+// load-shaping knobs. They default to prod-appropriate values and are overridden
+// per-environment from env in Start (PAGE_CACHE_REFRESH_INTERVAL,
+// PAGE_CACHE_REFRESH_CONCURRENCY) — staging runs gentler values to spread load
+// across its smaller self-hosted ClickHouse instead of scaling it up.
+//
+// Concurrency history: 2-wide was too slow (each entry refreshed only every few
+// minutes); fully unbounded (~28 entries) oversubscribed ClickHouse (~55
+// concurrent queries pegged the node, timeouts + per-entry retries amplified the
+// storm). A bounded limit keeps in-flight queries near what ClickHouse can run
+// while still refreshing the batch within the cycle.
+//
+// These are read once at startup (Start) and then treated as constant for the
+// life of the worker, so the workflow's use of refreshInterval stays
+// deterministic across replay/continue-as-new within a deployment.
+var (
+	refreshInterval             = 30 * time.Second
+	pageCacheRefreshConcurrency = 8
+)
 
 // RefreshCaches refreshes all page cache entries, writing results to Postgres.
 func (a *Activities) RefreshCaches(ctx context.Context) error {

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -2,10 +2,12 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
 
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	temporalworkflow "go.temporal.io/sdk/workflow"
 	"golang.org/x/sync/errgroup"
@@ -18,16 +20,14 @@ const (
 	TaskQueue  = "api-page-cache"
 	WorkflowID = "api-page-cache"
 
-	fastRefreshInterval    = 3 * time.Second
-	continueAsNewThreshold = 60 // ~30 min at 30s intervals
-	errorAfterFailures     = 3  // log WARN for transient failures, ERROR after this many consecutive failures
+	fastRefreshInterval = 3 * time.Second
+	errorAfterFailures  = 3 // log WARN for transient failures, ERROR after this many consecutive failures
 
 	// transientErrorAfterFailures is the ERROR-escalation threshold for transient
 	// causes (upstream connection blips, timeouts, rate limits). It's higher than
 	// errorAfterFailures because a brief transient failure is self-healing and not
-	// actionable — only a sustained one (this many × refreshInterval ≈ 5 min) is
-	// worth paging on. Keeps single/short blips (e.g. a CH connection drop or an
-	// external RPC 429) at WARN so they don't page on-call.
+	// actionable — only a sustained run is worth paging on. Keeps single/short
+	// blips (e.g. a CH connection drop or an external RPC 429) at WARN.
 	transientErrorAfterFailures = 10
 
 	// slowRefreshThreshold surfaces per-entry duration at INFO when a single
@@ -35,7 +35,65 @@ const (
 	// finish in well under a second; anything above this is worth flagging
 	// when the activity is running close to its StartToCloseTimeout budget.
 	slowRefreshThreshold = 10 * time.Second
+
+	// Defaults for the per-environment load-shaping knobs (see loadRefreshConfig).
+	// Prod runs these against ClickHouse Cloud; staging overrides them lower/longer
+	// to spread load across its smaller self-hosted ClickHouse.
+	defaultRefreshInterval    = 30 * time.Second
+	defaultRefreshConcurrency = 8
+	defaultActivityTimeout    = 3 * time.Minute
+
+	// continueAsNewTargetWindow bounds workflow history: PageCacheWorkflow
+	// continues-as-new after roughly this much wall-clock regardless of the
+	// refresh interval, so a longer interval can't inflate per-run history toward
+	// Temporal's ~10k-event soft / ~51k hard limits.
+	continueAsNewTargetWindow = 30 * time.Minute
+
+	// Sane bounds for the knobs; out-of-range env values are clamped (with a warn).
+	minRefreshInterval    = 5 * time.Second
+	maxRefreshInterval    = 10 * time.Minute
+	minRefreshConcurrency = 1
+	maxRefreshConcurrency = 32
+	minActivityTimeout    = 30 * time.Second
+	maxActivityTimeout    = 10 * time.Minute
 )
+
+// PageCacheParams carries the load-shaping config into PageCacheWorkflow as an
+// argument, so the values are recorded in workflow history and replay is
+// deterministic by construction. This matters because the workflow's fast-refresh
+// loop emits a command count that depends on RefreshInterval: reading it from a
+// mutable package var would let a rolling deploy that changed the value replay an
+// in-flight run with a different value → history divergence → the workflow task
+// fails forever and the page cache silently freezes. As an argument, a config
+// change instead starts a fresh run (Start terminates + restarts) with the new
+// value, and any in-flight replay uses the value from its own history.
+type PageCacheParams struct {
+	RefreshInterval        time.Duration
+	ActivityTimeout        time.Duration
+	ContinueAsNewThreshold int
+}
+
+// withDefaults normalizes zero/nonsensical values to defaults. Applied at the top
+// of the workflow so it stays deterministic even if started without params.
+func (p PageCacheParams) withDefaults() PageCacheParams {
+	if p.RefreshInterval <= 0 {
+		p.RefreshInterval = defaultRefreshInterval
+	}
+	if p.ActivityTimeout <= 0 {
+		p.ActivityTimeout = defaultActivityTimeout
+	}
+	if p.ContinueAsNewThreshold <= 0 {
+		p.ContinueAsNewThreshold = max(int(continueAsNewTargetWindow/p.RefreshInterval), 1)
+	}
+	return p
+}
+
+// errBatchDeadline marks an entry that never ran (or was cut off) because the
+// RefreshCaches activity ran out of its StartToCloseTimeout budget — i.e. the
+// batch is starving tail entries. Phrased to avoid dberror's transient keywords
+// so it escalates at errorAfterFailures (making starvation visible), not the
+// higher transient threshold.
+var errBatchDeadline = errors.New("page-cache batch budget exhausted before refresh completed")
 
 // cacheEntry defines a single cache key to refresh.
 type cacheEntry struct {
@@ -46,10 +104,15 @@ type cacheEntry struct {
 
 // Activities holds the logger and API deps for the refresh activity.
 type Activities struct {
-	Log      *slog.Logger
-	API      *handlers.API
-	failures sync.Map   // map[string]int: consecutive failure count per cache key
-	writeMu  sync.Mutex // serializes WritePageCache calls to avoid Postgres OOM from concurrent large JSONB upserts
+	Log *slog.Logger
+	API *handlers.API
+	// RefreshConcurrency bounds how many cache entries refresh at once. Set from
+	// config in Start; 0 falls back to defaultRefreshConcurrency. Activity-side
+	// only (no replay concern), so it stays a plain field rather than a workflow
+	// argument.
+	RefreshConcurrency int
+	failures           sync.Map   // map[string]int: consecutive failure count per cache key
+	writeMu            sync.Mutex // serializes WritePageCache calls to avoid Postgres OOM from concurrent large JSONB upserts
 }
 
 func (a *Activities) entries() []cacheEntry {
@@ -163,36 +226,30 @@ type refreshError struct{ msg string }
 
 func (e *refreshError) Error() string { return e.msg }
 
-// refreshInterval (how often the full page-cache batch refreshes) and
-// pageCacheRefreshConcurrency (how many entries refresh at once) are the two
-// load-shaping knobs. They default to prod-appropriate values and are overridden
-// per-environment from env in Start (PAGE_CACHE_REFRESH_INTERVAL,
-// PAGE_CACHE_REFRESH_CONCURRENCY) — staging runs gentler values to spread load
-// across its smaller self-hosted ClickHouse instead of scaling it up.
+// RefreshCaches refreshes all page cache entries, writing results to Postgres.
 //
 // Concurrency history: 2-wide was too slow (each entry refreshed only every few
 // minutes); fully unbounded (~28 entries) oversubscribed ClickHouse (~55
 // concurrent queries pegged the node, timeouts + per-entry retries amplified the
 // storm). A bounded limit keeps in-flight queries near what ClickHouse can run
 // while still refreshing the batch within the cycle.
-//
-// These are read once at startup (Start) and then treated as constant for the
-// life of the worker, so the workflow's use of refreshInterval stays
-// deterministic across replay/continue-as-new within a deployment.
-var (
-	refreshInterval             = 30 * time.Second
-	pageCacheRefreshConcurrency = 8
-)
-
-// RefreshCaches refreshes all page cache entries, writing results to Postgres.
 func (a *Activities) RefreshCaches(ctx context.Context) error {
 	start := time.Now()
+	limit := a.RefreshConcurrency
+	if limit <= 0 {
+		limit = defaultRefreshConcurrency
+	}
+	// Distinguish a real worker shutdown (deploy) from an activity-deadline
+	// cancellation so tail-entry starvation under the StartToCloseTimeout is
+	// counted rather than silently swallowed as "shutdown".
+	shuttingDown := workerStopping(ctx)
+
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(pageCacheRefreshConcurrency)
+	g.SetLimit(limit)
 
 	for _, entry := range a.entries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown)
 			return nil
 		})
 	}
@@ -202,7 +259,7 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 		g.Go(func() error {
 			a.refresh(gctx, "metro path latency:"+strategy, "metro_path_latency:"+strategy, func(ctx context.Context) (any, error) {
 				return a.API.FetchMetroPathLatencyData(ctx, strategy)
-			})
+			}, shuttingDown)
 			return nil
 		})
 	}
@@ -210,6 +267,21 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 	_ = g.Wait()
 	a.Log.Info("page cache refresh complete", "duration", time.Since(start).Round(time.Millisecond))
 	return nil
+}
+
+// workerStopping returns a predicate reporting whether the Temporal worker is
+// shutting down (deploy/stop). Used to tell a benign shutdown cancellation from
+// an activity-deadline cancellation. Must be called with an activity context.
+func workerStopping(ctx context.Context) func() bool {
+	stop := activity.GetWorkerStopChannel(ctx)
+	return func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
 }
 
 // latestEntries are refreshed on the fast cadence (see fastRefreshInterval). They back
@@ -229,10 +301,11 @@ func (a *Activities) latestEntries() []cacheEntry {
 
 // RefreshLatestCaches refreshes just the fast-cadence entries (latest slots slice).
 func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
+	shuttingDown := workerStopping(ctx)
 	g, gctx := errgroup.WithContext(ctx)
 	for _, entry := range a.latestEntries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown)
 			return nil
 		})
 	}
@@ -240,14 +313,15 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 	return nil
 }
 
-func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error)) {
+func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error), shuttingDown func() bool) {
 	start := time.Now()
 	var queryDuration, writeDuration time.Duration
 
 	const maxAttempts = 2
 	for attempt := range maxAttempts {
 		if parentCtx.Err() != nil {
-			a.Log.Warn("cache refresh interrupted (shutdown)", "cache", name)
+			// Batch context already done before this entry ran.
+			a.interrupted(name, key, nil, shuttingDown)
 			return
 		}
 
@@ -259,8 +333,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 
 		if err != nil {
 			if parentCtx.Err() != nil {
-				// Temporal is shutting down — not a query failure, don't count it.
-				a.Log.Warn("cache refresh interrupted (shutdown)", "cache", name, "error", err)
+				a.interrupted(name, key, err, shuttingDown)
 				return
 			}
 			// Query error or timeout. Retry once before counting as a failure.
@@ -268,19 +341,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 				a.Log.Warn("cache refresh failed, retrying", "cache", name, "attempt", attempt+1, "error", err)
 				continue
 			}
-			n := a.incFailures(key)
-			// Transient causes (connection blips, timeouts, upstream 429s) are
-			// self-healing, so only escalate to ERROR once they persist — a brief
-			// blip stays at WARN and doesn't page on-call.
-			threshold := errorAfterFailures
-			if dberror.IsTransient(err) {
-				threshold = transientErrorAfterFailures
-			}
-			if n >= threshold {
-				a.Log.Error("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
-			} else {
-				a.Log.Warn("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
-			}
+			a.recordFailure(name, key, err)
 			return
 		}
 
@@ -328,12 +389,47 @@ func (a *Activities) incFailures(key string) int {
 	}
 }
 
-// PageCacheWorkflow is a long-running workflow that refreshes all page caches
-// every 30s. It uses continue-as-new after 60 iterations (~30 min) to keep
-// workflow history bounded.
-func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
+// interrupted handles a refresh cut short because the batch's parent context was
+// cancelled. A genuine worker shutdown (deploy) is benign and not counted;
+// otherwise the RefreshCaches activity ran out of its StartToCloseTimeout budget
+// and this entry is being starved — count it (as errBatchDeadline) so persistent
+// starvation of tail entries surfaces and escalates rather than hiding as
+// "shutdown". cause is the underlying fn error if any (nil if the entry never ran).
+func (a *Activities) interrupted(name, key string, cause error, shuttingDown func() bool) {
+	if shuttingDown == nil || shuttingDown() {
+		a.Log.Warn("cache refresh interrupted (shutdown)", "cache", name, "error", cause)
+		return
+	}
+	a.recordFailure(name, key, errBatchDeadline)
+}
+
+// recordFailure increments the consecutive-failure counter for key and logs at
+// WARN below the escalation threshold, ERROR at/above it. Transient causes
+// (connection blips, timeouts, upstream 429s) get a higher threshold since they
+// self-heal; a brief blip stays at WARN and doesn't page on-call.
+func (a *Activities) recordFailure(name, key string, err error) {
+	n := a.incFailures(key)
+	threshold := errorAfterFailures
+	if dberror.IsTransient(err) {
+		threshold = transientErrorAfterFailures
+	}
+	if n >= threshold {
+		a.Log.Error("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
+	} else {
+		a.Log.Warn("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
+	}
+}
+
+// PageCacheWorkflow is a long-running workflow that refreshes all page caches on
+// p.RefreshInterval. It continues-as-new after p.ContinueAsNewThreshold iterations
+// (derived to bound wall-clock ≈ continueAsNewTargetWindow) to keep workflow
+// history bounded. p is passed as an argument (not read from package state) so
+// replay is deterministic across a config change — see PageCacheParams.
+func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int, p PageCacheParams) error {
+	p = p.withDefaults()
+
 	actOpts := temporalworkflow.ActivityOptions{
-		StartToCloseTimeout: 3 * time.Minute,
+		StartToCloseTimeout: p.ActivityTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},
@@ -353,14 +449,14 @@ func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	}
 	fastCtx := temporalworkflow.WithActivityOptions(ctx, fastActOpts)
 
-	for iteration < continueAsNewThreshold {
+	for iteration < p.ContinueAsNewThreshold {
 		_ = temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshCaches).Get(ctx, nil)
 
 		iteration++
-		if iteration < continueAsNewThreshold {
+		if iteration < p.ContinueAsNewThreshold {
 			// Tick the fast-cadence refresh repeatedly during the outer sleep window
 			// so latest-slots caches stay fresh for live-tail clients.
-			deadline := temporalworkflow.Now(ctx).Add(refreshInterval)
+			deadline := temporalworkflow.Now(ctx).Add(p.RefreshInterval)
 			for temporalworkflow.Now(ctx).Before(deadline) {
 				_ = temporalworkflow.ExecuteActivity(fastCtx, (*Activities).RefreshLatestCaches).Get(fastCtx, nil)
 				remaining := deadline.Sub(temporalworkflow.Now(ctx))
@@ -378,5 +474,5 @@ func PageCacheWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		}
 	}
 
-	return temporalworkflow.NewContinueAsNewError(ctx, PageCacheWorkflow, 0)
+	return temporalworkflow.NewContinueAsNewError(ctx, PageCacheWorkflow, 0, p)
 }

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -88,12 +88,21 @@ func (p PageCacheParams) withDefaults() PageCacheParams {
 	return p
 }
 
-// errBatchDeadline marks an entry that never ran (or was cut off) because the
-// RefreshCaches activity ran out of its StartToCloseTimeout budget — i.e. the
-// batch is starving tail entries. Phrased to avoid dberror's transient keywords
-// so it escalates at errorAfterFailures (making starvation visible), not the
-// higher transient threshold.
-var errBatchDeadline = errors.New("page-cache batch budget exhausted before refresh completed")
+// Sentinels recorded when a refresh is cut short by its activity's deadline (not
+// a worker shutdown). They differ by cadence so escalation matches the cause:
+var (
+	// errBatchDeadline: the full RefreshCaches batch ran out of its
+	// StartToCloseTimeout before this entry ran — deterministic tail starvation.
+	// Phrased to avoid dberror's transient keywords so it escalates at
+	// errorAfterFailures, making starvation visible.
+	errBatchDeadline = errors.New("page-cache batch budget exhausted before refresh completed")
+
+	// errFastRefreshDeadline: a fast-cadence (RefreshLatestCaches) entry hit the
+	// fast activity's StartToCloseTimeout — ordinary, self-healing ClickHouse
+	// contention. Phrased as a timeout so dberror classifies it transient and it
+	// escalates only at transientErrorAfterFailures (a blip shouldn't page).
+	errFastRefreshDeadline = errors.New("page-cache fast refresh deadline exceeded")
+)
 
 // cacheEntry defines a single cache key to refresh.
 type cacheEntry struct {
@@ -249,7 +258,7 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 
 	for _, entry := range a.entries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown, errBatchDeadline)
 			return nil
 		})
 	}
@@ -259,7 +268,7 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 		g.Go(func() error {
 			a.refresh(gctx, "metro path latency:"+strategy, "metro_path_latency:"+strategy, func(ctx context.Context) (any, error) {
 				return a.API.FetchMetroPathLatencyData(ctx, strategy)
-			}, shuttingDown)
+			}, shuttingDown, errBatchDeadline)
 			return nil
 		})
 	}
@@ -305,7 +314,7 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	for _, entry := range a.latestEntries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown, errFastRefreshDeadline)
 			return nil
 		})
 	}
@@ -313,7 +322,11 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 	return nil
 }
 
-func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error), shuttingDown func() bool) {
+// deadlineErr is the sentinel recorded when the parent (activity) context is
+// cancelled by its own deadline rather than a worker shutdown — it selects the
+// escalation cadence (errBatchDeadline for the slow batch, errFastRefreshDeadline
+// for the fast loop).
+func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error), shuttingDown func() bool, deadlineErr error) {
 	start := time.Now()
 	var queryDuration, writeDuration time.Duration
 
@@ -321,7 +334,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 	for attempt := range maxAttempts {
 		if parentCtx.Err() != nil {
 			// Batch context already done before this entry ran.
-			a.interrupted(name, key, nil, shuttingDown)
+			a.interrupted(name, key, nil, shuttingDown, deadlineErr)
 			return
 		}
 
@@ -333,7 +346,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 
 		if err != nil {
 			if parentCtx.Err() != nil {
-				a.interrupted(name, key, err, shuttingDown)
+				a.interrupted(name, key, err, shuttingDown, deadlineErr)
 				return
 			}
 			// Query error or timeout. Retry once before counting as a failure.
@@ -389,34 +402,42 @@ func (a *Activities) incFailures(key string) int {
 	}
 }
 
-// interrupted handles a refresh cut short because the batch's parent context was
+// interrupted handles a refresh cut short because its parent context was
 // cancelled. A genuine worker shutdown (deploy) is benign and not counted;
-// otherwise the RefreshCaches activity ran out of its StartToCloseTimeout budget
-// and this entry is being starved — count it (as errBatchDeadline) so persistent
-// starvation of tail entries surfaces and escalates rather than hiding as
-// "shutdown". cause is the underlying fn error if any (nil if the entry never ran).
-func (a *Activities) interrupted(name, key string, cause error, shuttingDown func() bool) {
+// otherwise the activity ran out of its StartToCloseTimeout and this entry is
+// being starved — count it (as deadlineErr) so it surfaces/escalates rather than
+// hiding as "shutdown". deadlineErr selects the escalation cadence per cadence
+// (errBatchDeadline: strict, for the slow batch; errFastRefreshDeadline: transient,
+// for the self-healing fast loop). cause is the underlying fn error, if any, and
+// is attached as a log attribute only (not wrapped into the classification error).
+func (a *Activities) interrupted(name, key string, cause error, shuttingDown func() bool, deadlineErr error) {
 	if shuttingDown == nil || shuttingDown() {
 		a.Log.Warn("cache refresh interrupted (shutdown)", "cache", name, "error", cause)
 		return
 	}
-	a.recordFailure(name, key, errBatchDeadline)
+	if cause != nil {
+		a.recordFailure(name, key, deadlineErr, "cause", cause)
+	} else {
+		a.recordFailure(name, key, deadlineErr)
+	}
 }
 
 // recordFailure increments the consecutive-failure counter for key and logs at
 // WARN below the escalation threshold, ERROR at/above it. Transient causes
 // (connection blips, timeouts, upstream 429s) get a higher threshold since they
-// self-heal; a brief blip stays at WARN and doesn't page on-call.
-func (a *Activities) recordFailure(name, key string, err error) {
+// self-heal; a brief blip stays at WARN and doesn't page on-call. extra key/value
+// pairs are appended to the log line (e.g. the underlying cause).
+func (a *Activities) recordFailure(name, key string, err error, extra ...any) {
 	n := a.incFailures(key)
 	threshold := errorAfterFailures
 	if dberror.IsTransient(err) {
 		threshold = transientErrorAfterFailures
 	}
+	args := append([]any{"cache", name, "consecutive_failures", n, "error", err}, extra...)
 	if n >= threshold {
-		a.Log.Error("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
+		a.Log.Error("cache refresh failed", args...)
 	} else {
-		a.Log.Warn("cache refresh failed", "cache", name, "consecutive_failures", n, "error", err)
+		a.Log.Warn("cache refresh failed", args...)
 	}
 }
 


### PR DESCRIPTION
## Summary

Staging's page-cache errors (`geo concentration` cache hitting its deadline) come from the refresh burst — ~28 entries, up to 8 concurrent, every 30s — oversubscribing staging's smaller self-hosted ClickHouse. Rather than grow that instance, this lets us **spread the load over time** per-environment.

- `refreshInterval` (30s) and `pageCacheRefreshConcurrency` (8) become env-overridable via **`PAGE_CACHE_REFRESH_INTERVAL`** and **`PAGE_CACHE_REFRESH_CONCURRENCY`**, read once in `worker.Start` before the worker/workflow start.
- **Prod defaults are unchanged** (30s / 8) — CH Cloud handles that fine. Staging will set gentler values (lower concurrency, longer interval) via k8s env to flatten the peak.
- Both are read once at startup and then constant for the worker's life, so the workflow's use of `refreshInterval` stays deterministic across replay/continue-as-new within a deployment (no per-decision env reads).

## Testing Verification

- Unit tests for the env parsing (`envDuration`/`envInt`): unset/invalid → default, valid → parsed.

## Rollout (two-phase, to avoid a one-time replay wedge)

`PageCacheWorkflow` is now 3-arg (`PageCacheParams`). During the migration deploy's rolling overlap, an old pre-PR 2-arg worker can pick up a new run and ignore the params payload, recording 30s-constant-shaped history for it. That's harmless **only if the env vars are unset** in that deploy (old and new code produce command-identical histories; the zero-params path normalizes via `withDefaults`). If a non-default `PAGE_CACHE_REFRESH_INTERVAL` shipped in the *same* deploy, the old worker's history would diverge from the new worker's replay once — until the next deploy.

So ship it in two phases:
1. **Merge/deploy this PR with the env vars unset** (prod stays at 30s/8 defaults, no behavior change).
2. **Then set staging's values in a follow-up deploy** (infra#1905) once every worker is on the 3-arg code.

(Reverse direction is safe — zero-params histories normalize via `withDefaults`.)
