### PR TITLE
multicast-health: drop rate reconciliation, add path root-cause rollup

### DIFF
--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -99,6 +99,11 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+// multicastHealthRootCauseLimit bounds the returned root causes; after a
+// whole-group event every endpoint can be a fault, so the panel shows the
+// top-N by blast radius while Total still reports the true distinct count.
+const multicastHealthRootCauseLimit = 100
+
 // GetMulticastGroupHealthPathRootCauses returns the unhealthy per-path fan-out
 // collapsed to the faulting endpoint (publisher or subscriber), with a count of
 // how many (publisher, subscriber) pairs each one drags down. This is the
@@ -123,7 +128,7 @@ func (a *API) GetMulticastGroupHealthPathRootCauses(w http.ResponseWriter, r *ht
 		return
 	}
 
-	items, err := a.queryMulticastHealthPathRootCauses(ctx, group.PK)
+	items, total, err := a.queryMulticastHealthPathRootCauses(ctx, group.PK)
 	if err != nil {
 		logError("multicast group health/path-root-causes query error", "error", err, "pk", group.PK)
 		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
@@ -134,81 +139,106 @@ func (a *API) GetMulticastGroupHealthPathRootCauses(w http.ResponseWriter, r *ht
 		Group:       group,
 		GeneratedAt: formatMulticastTime(time.Now().UTC()),
 		Items:       items,
-		Total:       len(items),
+		Total:       total,
 	})
 }
 
 // queryMulticastHealthPathRootCauses attributes every non-healthy path to a
-// single primary faulting endpoint. A BGP-down endpoint has no session, so no
-// (S,G)/OIF, so its *_endpoint_observed is false — meaning the not-observed
-// filter catches both 'unhealthy' (endpoint present but not forwarding) and
-// 'disconnected' (BGP down). endpoint_status reports the endpoint's own
-// condition (disconnected if its BGP is down, else unhealthy).
+// single primary faulting endpoint and rolls the fan-out up per endpoint.
 //
-// The subscriber branch additionally requires publisher_endpoint_observed = 1:
-// when a publisher is itself unobserved (e.g. BGP down) there is no (S,G) for
-// that source anywhere, so every one of its subscribers is trivially
-// unobserved too. Attributing those subscribers would re-create the exact
-// fan-out this rollup exists to collapse (1 down publisher → N false
-// subscriber root causes). The fault is upstream, so the pair is attributed
-// to the publisher alone.
-func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK string) ([]MulticastHealthPathRootCause, error) {
+// A single scan of the (expensive, non-materialized) path view feeds an
+// ARRAY JOIN over two candidate endpoint tuples per pair, each gated by the
+// observed flags — replacing a UNION ALL that scanned the view twice.
+// Candidates:
+//   - publisher, when publisher_endpoint_observed = 0
+//   - subscriber, when subscriber_endpoint_observed = 0 AND publisher is
+//     observed
+//
+// The publisher gate on the subscriber candidate makes each pair attribute to
+// a single primary endpoint: when a publisher is itself unobserved (e.g. BGP
+// down) there is no (S,G) for that source, so every one of its subscribers is
+// trivially unobserved too — the fault is upstream and the pair belongs to the
+// publisher alone. Without this a down publisher with N subscribers would
+// re-create the exact fan-out this rollup exists to collapse.
+//
+// A BGP-down endpoint has no session, so no (S,G)/OIF, so its *_endpoint_observed
+// is false — the not-observed gate therefore catches both 'unhealthy' (present
+// but not forwarding) and 'disconnected' (BGP down). endpoint_status reports the
+// endpoint's own condition via dz_users_current (the path view only exposes the
+// pair-level verdict, not which side is down). Grouping is by endpoint alone so
+// a P+S user broken on both sides is one row with a combined role label.
+//
+// Returns the top-N rows by blast radius plus the true distinct-endpoint total.
+func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK string) ([]MulticastHealthPathRootCause, int, error) {
 	query := `
 		WITH faults AS (
 			SELECT
-				'publisher' AS faulting_role,
-				publisher_user_pk AS endpoint_user_pk,
-				publisher_owner_pubkey AS endpoint_owner_pubkey,
-				publisher_dz_ip AS endpoint_dz_ip,
-				publisher_tunnel_id AS endpoint_tunnel_id,
-				publisher_device_pk AS endpoint_device_pk,
-				publisher_device_code AS endpoint_device_code
+				c.1 AS faulting_role,
+				c.2 AS endpoint_user_pk,
+				c.3 AS endpoint_owner_pubkey,
+				c.4 AS endpoint_dz_ip,
+				c.5 AS endpoint_tunnel_id,
+				c.6 AS endpoint_device_pk,
+				c.7 AS endpoint_device_code
 			FROM health_publisher_subscriber_path
+			ARRAY JOIN [
+				if(publisher_endpoint_observed = 0,
+					('publisher', publisher_user_pk, publisher_owner_pubkey, publisher_dz_ip,
+					 CAST(publisher_tunnel_id AS Int32), publisher_device_pk, publisher_device_code),
+					('', '', '', '', CAST(0 AS Int32), '', '')),
+				if(subscriber_endpoint_observed = 0 AND publisher_endpoint_observed = 1,
+					('subscriber', subscriber_user_pk, subscriber_owner_pubkey, subscriber_dz_ip,
+					 CAST(subscriber_tunnel_id AS Int32), subscriber_device_pk, subscriber_device_code),
+					('', '', '', '', CAST(0 AS Int32), '', ''))
+			] AS c
 			WHERE multicast_group_pk = ?
 			  AND health_status != 'healthy'
-			  AND publisher_endpoint_observed = 0
-			UNION ALL
+		),
+		grouped AS (
 			SELECT
-				'subscriber' AS faulting_role,
-				subscriber_user_pk AS endpoint_user_pk,
-				subscriber_owner_pubkey AS endpoint_owner_pubkey,
-				subscriber_dz_ip AS endpoint_dz_ip,
-				subscriber_tunnel_id AS endpoint_tunnel_id,
-				subscriber_device_pk AS endpoint_device_pk,
-				subscriber_device_code AS endpoint_device_code
-			FROM health_publisher_subscriber_path
-			WHERE multicast_group_pk = ?
-			  AND health_status != 'healthy'
-			  AND subscriber_endpoint_observed = 0
-			  AND publisher_endpoint_observed = 1
+				arrayStringConcat(arraySort(groupUniqArray(f.faulting_role)), '+') AS faulting_role,
+				f.endpoint_user_pk AS endpoint_user_pk,
+				any(f.endpoint_owner_pubkey) AS endpoint_owner_pubkey,
+				any(f.endpoint_dz_ip) AS endpoint_dz_ip,
+				any(f.endpoint_tunnel_id) AS endpoint_tunnel_id,
+				any(f.endpoint_device_pk) AS endpoint_device_pk,
+				any(f.endpoint_device_code) AS endpoint_device_code,
+				if(any(u.bgp_status) = 'down', 'disconnected', 'unhealthy') AS endpoint_status,
+				toInt32(count()) AS affected_pairs
+			FROM faults f
+			LEFT ANY JOIN dz_users_current u ON f.endpoint_user_pk = u.pk
+			WHERE f.faulting_role != ''
+			GROUP BY f.endpoint_user_pk
 		)
 		SELECT
-			f.faulting_role,
-			f.endpoint_user_pk,
-			any(f.endpoint_owner_pubkey),
-			any(f.endpoint_dz_ip),
-			any(f.endpoint_tunnel_id),
-			any(f.endpoint_device_pk),
-			any(f.endpoint_device_code),
-			if(any(u.bgp_status) = 'down', 'disconnected', 'unhealthy') AS endpoint_status,
-			toInt32(count()) AS affected_pairs
-		FROM faults f
-		LEFT ANY JOIN dz_users_current u ON f.endpoint_user_pk = u.pk
-		GROUP BY f.faulting_role, f.endpoint_user_pk
-		ORDER BY affected_pairs DESC, endpoint_status, f.endpoint_user_pk
+			faulting_role,
+			endpoint_user_pk,
+			endpoint_owner_pubkey,
+			endpoint_dz_ip,
+			endpoint_tunnel_id,
+			endpoint_device_pk,
+			endpoint_device_code,
+			endpoint_status,
+			affected_pairs,
+			toInt32(count() OVER ()) AS total_endpoints
+		FROM grouped
+		ORDER BY affected_pairs DESC, endpoint_status, endpoint_user_pk
+		LIMIT ?
 		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
 	`
 	start := time.Now()
-	rows, err := a.envDB(ctx).Query(ctx, query, groupPK, groupPK)
+	rows, err := a.envDB(ctx).Query(ctx, query, groupPK, multicastHealthRootCauseLimit)
 	metrics.RecordClickHouseQuery("multicast_health_path_root_causes", time.Since(start), err)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
 	items := []MulticastHealthPathRootCause{}
+	total := 0
 	for rows.Next() {
 		var it MulticastHealthPathRootCause
+		var rowTotal int32
 		if err := rows.Scan(
 			&it.FaultingRole,
 			&it.UserPK,
@@ -219,15 +249,17 @@ func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK st
 			&it.DeviceCode,
 			&it.EndpointStatus,
 			&it.AffectedPairs,
+			&rowTotal,
 		); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		total = int(rowTotal)
 		items = append(items, it)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return items, nil
+	return items, total, nil
 }
 
 // readMulticastHealthPathsCache returns the cached first-page paths response

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -99,6 +99,128 @@ func (a *API) GetMulticastGroupHealthPaths(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+// GetMulticastGroupHealthPathRootCauses returns the unhealthy per-path fan-out
+// collapsed to the faulting endpoint (publisher or subscriber), with a count of
+// how many (publisher, subscriber) pairs each one drags down. This is the
+// actionable summary behind the raw per-path table.
+func (a *API) GetMulticastGroupHealthPathRootCauses(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	pkOrCode := chi.URLParam(r, "pk")
+	if pkOrCode == "" {
+		http.Error(w, "missing multicast group pk", http.StatusBadRequest)
+		return
+	}
+	group, err := a.queryMulticastDeliveryGroup(ctx, pkOrCode)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "multicast group not found", http.StatusNotFound)
+			return
+		}
+		logError("multicast group health/path-root-causes group query error", "error", err, "pk", pkOrCode)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	items, err := a.queryMulticastHealthPathRootCauses(ctx, group.PK)
+	if err != nil {
+		logError("multicast group health/path-root-causes query error", "error", err, "pk", group.PK)
+		http.Error(w, dberror.UserMessage(err), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, MulticastHealthPathRootCausesResponse{
+		Group:       group,
+		GeneratedAt: formatMulticastTime(time.Now().UTC()),
+		Items:       items,
+		Total:       len(items),
+	})
+}
+
+// queryMulticastHealthPathRootCauses attributes every non-healthy path to the
+// endpoint(s) that are not observed. A BGP-down endpoint has no session, so no
+// (S,G)/OIF, so its *_endpoint_observed is false — meaning this single filter
+// catches both 'unhealthy' (endpoint present but not forwarding) and
+// 'disconnected' (BGP down) attributions. endpoint_status reports the
+// endpoint's own condition (disconnected if its BGP is down, else unhealthy).
+func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK string) ([]MulticastHealthPathRootCause, error) {
+	query := `
+		WITH faults AS (
+			SELECT
+				'publisher' AS faulting_role,
+				publisher_user_pk AS endpoint_user_pk,
+				publisher_owner_pubkey AS endpoint_owner_pubkey,
+				publisher_dz_ip AS endpoint_dz_ip,
+				publisher_tunnel_id AS endpoint_tunnel_id,
+				publisher_device_pk AS endpoint_device_pk,
+				publisher_device_code AS endpoint_device_code
+			FROM health_publisher_subscriber_path
+			WHERE multicast_group_pk = ?
+			  AND health_status != 'healthy'
+			  AND publisher_endpoint_observed = 0
+			UNION ALL
+			SELECT
+				'subscriber' AS faulting_role,
+				subscriber_user_pk AS endpoint_user_pk,
+				subscriber_owner_pubkey AS endpoint_owner_pubkey,
+				subscriber_dz_ip AS endpoint_dz_ip,
+				subscriber_tunnel_id AS endpoint_tunnel_id,
+				subscriber_device_pk AS endpoint_device_pk,
+				subscriber_device_code AS endpoint_device_code
+			FROM health_publisher_subscriber_path
+			WHERE multicast_group_pk = ?
+			  AND health_status != 'healthy'
+			  AND subscriber_endpoint_observed = 0
+		)
+		SELECT
+			f.faulting_role,
+			f.endpoint_user_pk,
+			any(f.endpoint_owner_pubkey),
+			any(f.endpoint_dz_ip),
+			any(f.endpoint_tunnel_id),
+			any(f.endpoint_device_pk),
+			any(f.endpoint_device_code),
+			if(any(u.bgp_status) = 'down', 'disconnected', 'unhealthy') AS endpoint_status,
+			toInt32(count()) AS affected_pairs
+		FROM faults f
+		LEFT ANY JOIN dz_users_current u ON f.endpoint_user_pk = u.pk
+		GROUP BY f.faulting_role, f.endpoint_user_pk
+		ORDER BY affected_pairs DESC, endpoint_status, f.endpoint_user_pk
+		SETTINGS max_execution_time = 30, timeout_before_checking_execution_speed = 0
+	`
+	start := time.Now()
+	rows, err := a.envDB(ctx).Query(ctx, query, groupPK, groupPK)
+	metrics.RecordClickHouseQuery("multicast_health_path_root_causes", time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []MulticastHealthPathRootCause{}
+	for rows.Next() {
+		var it MulticastHealthPathRootCause
+		if err := rows.Scan(
+			&it.FaultingRole,
+			&it.UserPK,
+			&it.OwnerPubkey,
+			&it.DZIP,
+			&it.TunnelID,
+			&it.DevicePK,
+			&it.DeviceCode,
+			&it.EndpointStatus,
+			&it.AffectedPairs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 // readMulticastHealthPathsCache returns the cached first-page paths response
 // for the given group pk if the worker has written it. Missing entry or
 // decode failure → cache miss, caller falls through to live query.

--- a/api/handlers/multicast_health_paths.go
+++ b/api/handlers/multicast_health_paths.go
@@ -138,12 +138,20 @@ func (a *API) GetMulticastGroupHealthPathRootCauses(w http.ResponseWriter, r *ht
 	})
 }
 
-// queryMulticastHealthPathRootCauses attributes every non-healthy path to the
-// endpoint(s) that are not observed. A BGP-down endpoint has no session, so no
-// (S,G)/OIF, so its *_endpoint_observed is false — meaning this single filter
-// catches both 'unhealthy' (endpoint present but not forwarding) and
-// 'disconnected' (BGP down) attributions. endpoint_status reports the
-// endpoint's own condition (disconnected if its BGP is down, else unhealthy).
+// queryMulticastHealthPathRootCauses attributes every non-healthy path to a
+// single primary faulting endpoint. A BGP-down endpoint has no session, so no
+// (S,G)/OIF, so its *_endpoint_observed is false — meaning the not-observed
+// filter catches both 'unhealthy' (endpoint present but not forwarding) and
+// 'disconnected' (BGP down). endpoint_status reports the endpoint's own
+// condition (disconnected if its BGP is down, else unhealthy).
+//
+// The subscriber branch additionally requires publisher_endpoint_observed = 1:
+// when a publisher is itself unobserved (e.g. BGP down) there is no (S,G) for
+// that source anywhere, so every one of its subscribers is trivially
+// unobserved too. Attributing those subscribers would re-create the exact
+// fan-out this rollup exists to collapse (1 down publisher → N false
+// subscriber root causes). The fault is upstream, so the pair is attributed
+// to the publisher alone.
 func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK string) ([]MulticastHealthPathRootCause, error) {
 	query := `
 		WITH faults AS (
@@ -172,6 +180,7 @@ func (a *API) queryMulticastHealthPathRootCauses(ctx context.Context, groupPK st
 			WHERE multicast_group_pk = ?
 			  AND health_status != 'healthy'
 			  AND subscriber_endpoint_observed = 0
+			  AND publisher_endpoint_observed = 1
 		)
 		SELECT
 			f.faulting_role,

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -77,6 +77,8 @@ func executeRequest(api *handlers.API, req *http.Request, path string) (*httptes
 		api.GetMulticastGroupHealthUsers(rr, req)
 	case "/api/dz/multicast-groups/" + chi.URLParam(req, "pk") + "/health/paths":
 		api.GetMulticastGroupHealthPaths(rr, req)
+	case "/api/dz/multicast-groups/" + chi.URLParam(req, "pk") + "/health/path-root-causes":
+		api.GetMulticastGroupHealthPathRootCauses(rr, req)
 	case "/user-health":
 		api.GetUserHealth(rr, req)
 	}
@@ -189,16 +191,18 @@ func TestGetMulticastGroupHealth_Users(t *testing.T) {
 	require.Len(t, resp.Items, 2)
 	assert.EqualValues(t, 2, resp.Total)
 
-	// Both items should be reconciled on both dimensions.
+	// Rate is presence-only now: both endpoints transmit non-zero, so both are
+	// 'active' and healthy. expected_bps_5m is always nil (reconciliation removed).
 	var pub, sub *handlers.MulticastHealthUserItem
 	for i := range resp.Items {
 		it := &resp.Items[i]
 		assert.True(t, it.Reconciled, "user %s expected reconciled", it.UserPK)
 		assert.Equal(t, "healthy", it.ControlPlaneStatus, "user %s expected CP healthy", it.UserPK)
-		assert.Equal(t, "reconciled", it.RateStatus, "user %s expected rate reconciled", it.UserPK)
+		assert.Equal(t, "active", it.RateStatus, "user %s expected rate active", it.UserPK)
 		assert.Equal(t, "healthy", it.HealthStatus, "user %s expected combined healthy", it.UserPK)
 		assert.NotNil(t, it.ObservedBps5m, "user %s missing observed rate", it.UserPK)
 		assert.NotNil(t, it.RateBucketTS, "user %s missing rate bucket ts", it.UserPK)
+		assert.Nil(t, it.ExpectedBps5m, "user %s expected_bps should be nil (reconciliation removed)", it.UserPK)
 		switch it.Mode {
 		case "P":
 			pub = it
@@ -206,14 +210,11 @@ func TestGetMulticastGroupHealth_Users(t *testing.T) {
 			sub = it
 		}
 	}
-	// Publisher's rate reason is 'active' (transmitting). Subscriber's is 'reconciled'
-	// (TX matches sum of publishers).
+	// Both endpoints are transmitting → both read 'active'.
 	require.NotNil(t, pub)
 	require.NotNil(t, sub)
 	assert.Equal(t, "active", pub.RateStatusReason)
-	assert.Equal(t, "reconciled", sub.RateStatusReason)
-	require.NotNil(t, sub.ExpectedBps5m)
-	assert.InDelta(t, 10_000_000, *sub.ExpectedBps5m, 1)
+	assert.Equal(t, "active", sub.RateStatusReason)
 	assert.InDelta(t, 10_000_000, *sub.ObservedBps5m, 1)
 }
 
@@ -255,6 +256,62 @@ func TestGetMulticastGroupHealth_Paths(t *testing.T) {
 	assert.True(t, resp.Items[0].EndpointsReconciled)
 	assert.Equal(t, "healthy", resp.Items[0].HealthStatus)
 	assert.Equal(t, "endpoints_only", resp.Items[0].VerificationMethod)
+}
+
+// TestGetMulticastGroupHealth_PathRootCauses verifies the fan-out rollup:
+// two extra subscribers of group-1 whose OIF is never observed each make their
+// (user-pub → sub) path non-healthy, and the endpoint should surface each one
+// as a root cause with affected_pairs=1 — user-sub2 as 'unhealthy' (BGP up,
+// just not forwarding) and user-sub3 as 'disconnected' (BGP down). The healthy
+// user-pub → user-sub path contributes no root cause.
+func TestGetMulticastGroupHealth_PathRootCauses(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertMulticastTestData(t, api)
+	insertMulticastHealthFixtures(t, api)
+
+	// Two more subscribers of group-1 on nyc, neither observed in any OIF.
+	// user-sub3's BGP is down → 'disconnected'; user-sub2's is up → 'unhealthy'.
+	require.NoError(t, api.DB.Exec(t.Context(), `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tunnel_id, publishers, subscribers, bgp_status)
+		VALUES
+			('user-sub2', now(), now(), generateUUIDv4(), 0, 1, 'user-sub2', 'pubkey-sub2', 'activated', 'multicast', '10.0.0.3', '10.0.0.3', 'dev-nyc1', 503, '[]', '["group-1"]', 'up'),
+			('user-sub3', now(), now(), generateUUIDv4(), 0, 1, 'user-sub3', 'pubkey-sub3', 'activated', 'multicast', '10.0.0.4', '10.0.0.4', 'dev-nyc1', 504, '[]', '["group-1"]', 'down')`))
+
+	rr, body := makeGroupHealthRequest(api, "test-group", "/health/path-root-causes")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+
+	var resp handlers.MulticastHealthPathRootCausesResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	assert.Equal(t, "test-group", resp.Group.Code)
+	require.Len(t, resp.Items, 2, "body: %s", string(body))
+	assert.EqualValues(t, 2, resp.Total)
+
+	byUser := map[string]handlers.MulticastHealthPathRootCause{}
+	for _, it := range resp.Items {
+		byUser[it.UserPK] = it
+	}
+
+	sub2, ok := byUser["user-sub2"]
+	require.True(t, ok, "expected user-sub2 root cause, body: %s", string(body))
+	assert.Equal(t, "subscriber", sub2.FaultingRole)
+	assert.Equal(t, "unhealthy", sub2.EndpointStatus)
+	assert.EqualValues(t, 1, sub2.AffectedPairs)
+	assert.Equal(t, "nyc001-dz001", sub2.DeviceCode)
+	assert.EqualValues(t, 503, sub2.TunnelID)
+
+	sub3, ok := byUser["user-sub3"]
+	require.True(t, ok, "expected user-sub3 root cause, body: %s", string(body))
+	assert.Equal(t, "subscriber", sub3.FaultingRole)
+	assert.Equal(t, "disconnected", sub3.EndpointStatus)
+	assert.EqualValues(t, 1, sub3.AffectedPairs)
+
+	// The healthy user-pub → user-sub path must not surface a root cause, and
+	// the observed publisher (user-pub) is never at fault.
+	_, hasPub := byUser["user-pub"]
+	assert.False(t, hasPub, "observed publisher should not be a root cause")
 }
 
 func TestGetUserHealth_PerGroupRows(t *testing.T) {

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -351,11 +351,50 @@ func TestGetMulticastGroupHealth_PathRootCauses_DownPublisherNoSubscriberFanout(
 	// Exactly one root cause: the down publisher, owning all 3 pairs. No
 	// per-subscriber fan-out.
 	require.Len(t, resp.Items, 1, "body: %s", string(body))
+	assert.EqualValues(t, 1, resp.Total)
 	rc := resp.Items[0]
 	assert.Equal(t, "user-pub-down", rc.UserPK)
 	assert.Equal(t, "publisher", rc.FaultingRole)
 	assert.Equal(t, "disconnected", rc.EndpointStatus)
 	assert.EqualValues(t, 3, rc.AffectedPairs)
+}
+
+// TestGetMulticastGroupHealth_PathRootCauses_PlusSubscriberSingleRow verifies
+// that a P+S user broken on both its publisher and subscriber sides collapses
+// to a single root-cause row with a combined role label (grouped by endpoint,
+// not by (role, endpoint)), rather than appearing twice.
+func TestGetMulticastGroupHealth_PathRootCauses_PlusSubscriberSingleRow(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertMulticastTestData(t, api)
+	insertMulticastHealthFixtures(t, api) // user-pub IIF + user-sub OIF observed
+
+	// user-ps both publishes and subscribes group-1; its Tunnel505 is neither
+	// an observed IIF nor OIF, so it is unobserved on both sides. It pairs as
+	// publisher with user-sub (→ publisher fault) and as subscriber behind the
+	// observed user-pub (→ subscriber fault) = 2 pairs, one endpoint.
+	require.NoError(t, api.DB.Exec(t.Context(), `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tunnel_id, publishers, subscribers, bgp_status)
+		VALUES ('user-ps', now(), now(), generateUUIDv4(), 0, 1, 'user-ps', 'pubkey-ps', 'activated', 'multicast', '10.0.0.9', '10.0.0.9', 'dev-nyc1', 505, '["group-1"]', '["group-1"]', 'up')`))
+
+	rr, body := makeGroupHealthRequest(api, "test-group", "/health/path-root-causes")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+
+	var resp handlers.MulticastHealthPathRootCausesResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+
+	psRows := make([]handlers.MulticastHealthPathRootCause, 0)
+	for _, it := range resp.Items {
+		if it.UserPK == "user-ps" {
+			psRows = append(psRows, it)
+		}
+	}
+	require.Len(t, psRows, 1, "P+S user must be a single row, body: %s", string(body))
+	assert.Equal(t, "publisher+subscriber", psRows[0].FaultingRole)
+	assert.EqualValues(t, 2, psRows[0].AffectedPairs)
+	assert.Equal(t, "unhealthy", psRows[0].EndpointStatus)
 }
 
 func TestGetUserHealth_PerGroupRows(t *testing.T) {

--- a/api/handlers/multicast_health_test.go
+++ b/api/handlers/multicast_health_test.go
@@ -314,6 +314,50 @@ func TestGetMulticastGroupHealth_PathRootCauses(t *testing.T) {
 	assert.False(t, hasPub, "observed publisher should not be a root cause")
 }
 
+// TestGetMulticastGroupHealth_PathRootCauses_DownPublisherNoSubscriberFanout
+// pins the primary-endpoint attribution: when a publisher's BGP is down, there
+// is no (S,G) for its source, so every one of its subscribers is trivially
+// unobserved too. The rollup must attribute all those pairs to the publisher
+// alone (1 'disconnected' root cause, affects N) and must NOT emit a false
+// 'unhealthy' root cause per healthy subscriber — otherwise it re-creates the
+// fan-out it exists to collapse.
+func TestGetMulticastGroupHealth_PathRootCauses_DownPublisherNoSubscriberFanout(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPI(t, testChDB)
+	insertMulticastTestData(t, api)
+
+	// Fresh group-2 with a BGP-down publisher and three BGP-up subscribers.
+	// No mroute fixtures for its address → nothing observed for the group.
+	require.NoError(t, api.DB.Exec(t.Context(), `
+		INSERT INTO dim_dz_multicast_groups_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
+		VALUES ('group-2', now(), now(), generateUUIDv4(), 0, 1, 'group-2', '', 'test-group-2', '233.0.0.2', 100000000, 'activated', 0, 0)`))
+	require.NoError(t, api.DB.Exec(t.Context(), `
+		INSERT INTO dim_dz_users_history
+			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
+			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tunnel_id, publishers, subscribers, bgp_status)
+		VALUES
+			('user-pub-down', now(), now(), generateUUIDv4(), 0, 1, 'user-pub-down', 'pubkey-pd', 'activated', 'multicast', '10.0.1.1', '10.0.1.1', 'dev-ams1', 601, '["group-2"]', '[]', 'down'),
+			('user-subA', now(), now(), generateUUIDv4(), 0, 1, 'user-subA', 'pubkey-sa', 'activated', 'multicast', '10.0.1.2', '10.0.1.2', 'dev-nyc1', 602, '[]', '["group-2"]', 'up'),
+			('user-subB', now(), now(), generateUUIDv4(), 0, 1, 'user-subB', 'pubkey-sb', 'activated', 'multicast', '10.0.1.3', '10.0.1.3', 'dev-nyc1', 603, '[]', '["group-2"]', 'up'),
+			('user-subC', now(), now(), generateUUIDv4(), 0, 1, 'user-subC', 'pubkey-sc', 'activated', 'multicast', '10.0.1.4', '10.0.1.4', 'dev-nyc1', 604, '[]', '["group-2"]', 'up')`))
+
+	rr, body := makeGroupHealthRequest(api, "test-group-2", "/health/path-root-causes")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", string(body))
+
+	var resp handlers.MulticastHealthPathRootCausesResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	// Exactly one root cause: the down publisher, owning all 3 pairs. No
+	// per-subscriber fan-out.
+	require.Len(t, resp.Items, 1, "body: %s", string(body))
+	rc := resp.Items[0]
+	assert.Equal(t, "user-pub-down", rc.UserPK)
+	assert.Equal(t, "publisher", rc.FaultingRole)
+	assert.Equal(t, "disconnected", rc.EndpointStatus)
+	assert.EqualValues(t, 3, rc.AffectedPairs)
+}
+
 func TestGetUserHealth_PerGroupRows(t *testing.T) {
 	t.Parallel()
 	api := apitesting.NewTestAPI(t, testChDB)

--- a/api/handlers/multicast_health_types.go
+++ b/api/handlers/multicast_health_types.go
@@ -116,3 +116,28 @@ type MulticastHealthGroupPathsResponse struct {
 	Limit       int                       `json:"limit"`
 	Offset      int                       `json:"offset"`
 }
+
+// MulticastHealthPathRootCause collapses the per-(publisher, subscriber) path
+// fan-out to the endpoint that is actually at fault. One faulty endpoint drags
+// down every pair it participates in (a publisher → all its subscribers, a
+// subscriber → all its publishers), so listing endpoints with an affected-pair
+// count is far more actionable than N raw rows.
+type MulticastHealthPathRootCause struct {
+	// FaultingRole is "publisher" or "subscriber".
+	FaultingRole   string `json:"faulting_role"`
+	UserPK         string `json:"user_pk"`
+	OwnerPubkey    string `json:"owner_pubkey"`
+	DZIP           string `json:"dz_ip"`
+	TunnelID       int32  `json:"tunnel_id"`
+	DevicePK       string `json:"device_pk"`
+	DeviceCode     string `json:"device_code"`
+	EndpointStatus string `json:"endpoint_status"` // disconnected | unhealthy
+	AffectedPairs  int32  `json:"affected_pairs"`
+}
+
+type MulticastHealthPathRootCausesResponse struct {
+	Group       MulticastDeliveryGroup         `json:"group"`
+	GeneratedAt string                         `json:"generated_at"`
+	Items       []MulticastHealthPathRootCause `json:"items"`
+	Total       int                            `json:"total"`
+}

--- a/api/main.go
+++ b/api/main.go
@@ -600,6 +600,7 @@ func main() {
 		r.Get("/api/dz/multicast-groups/{pk}/health", api.GetMulticastGroupHealth)
 		r.Get("/api/dz/multicast-groups/{pk}/health/users", api.GetMulticastGroupHealthUsers)
 		r.Get("/api/dz/multicast-groups/{pk}/health/paths", api.GetMulticastGroupHealthPaths)
+		r.Get("/api/dz/multicast-groups/{pk}/health/path-root-causes", api.GetMulticastGroupHealthPathRootCauses)
 		r.Get("/api/dz/users/{pk}/health", api.GetUserHealth)
 		r.Get("/api/dz/access-passes", api.GetAccessPasses)
 		r.Get("/api/dz/access-passes/{pk}", api.GetAccessPass)

--- a/indexer/db/clickhouse/migrations/20260709000003_health_rate_presence_only.sql
+++ b/indexer/db/clickhouse/migrations/20260709000003_health_rate_presence_only.sql
@@ -3,6 +3,12 @@
 -- Drop rate reconciliation from the multicast health verdict. See the view
 -- header for the rationale (per-group rate attribution is impossible from
 -- per-tunnel counters when users span multiple groups).
+--
+-- ROLLBACK COUPLING: the Down body restores the reconciled/mismatch/
+-- monitoring_gap/group_idle rate vocabulary, but this PR's web bundle removes
+-- those keys from the badge/reason maps and narrows the TS unions. Roll this
+-- migration back together with the web deploy — a DB-only rollback would leave
+-- unstyled badges and blank reasons. (Same coupling documented in 20260708000003.)
 
 -- +goose StatementBegin
 CREATE OR REPLACE VIEW health_multicast_user_rate
@@ -56,12 +62,9 @@ SELECT
             OR (h.mode IN ('S', 'P+S') AND ur.ur_max_out_bps > 0), 'active',
         'idle'
     ) AS rate_status_reason,
-    multiIf(
-        ur.ur_present = 0, 'unknown',
-        (h.mode = 'P' AND ur.ur_max_in_bps > 0)
-            OR (h.mode IN ('S', 'P+S') AND ur.ur_max_out_bps > 0), 'active',
-        'idle'
-    ) AS rate_status,
+    -- Derived from the reason so the two can't drift; the only difference is
+    -- that 'no_data' surfaces as 'unknown' in the status.
+    if(rate_status_reason = 'no_data', 'unknown', rate_status_reason) AS rate_status,
     -- Verdict = control-plane + disconnected. Rate never downgrades it.
     h.health_status AS health_status
 FROM health_multicast_user h

--- a/indexer/db/clickhouse/migrations/20260709000003_health_rate_presence_only.sql
+++ b/indexer/db/clickhouse/migrations/20260709000003_health_rate_presence_only.sql
@@ -1,0 +1,199 @@
+-- +goose Up
+--
+-- Drop rate reconciliation from the multicast health verdict. See the view
+-- header for the rationale (per-group rate attribution is impossible from
+-- per-tunnel counters when users span multiple groups).
+
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+-- Rate reconciliation against sum-of-publishers has been removed. A user's
+-- device_interface_rollup_5m counter is per-tunnel and aggregates every group
+-- that user publishes/subscribes to, so a per-group expected rate cannot be
+-- attributed when a user participates in more than one group — which is the
+-- common case. In practice 100% of the "degraded" verdicts this produced were
+-- multi-group attribution artifacts, not delivery problems, so the reconciliation
+-- was pure noise.
+--
+-- The verdict is now the control-plane verdict (health_multicast_user, which
+-- already includes 'disconnected' for BGP-down users). Rate is kept only as an
+-- informational presence signal (active / idle / no_data) plus the observed
+-- bps; expected_bps_5m is retained as NULL for output-schema stability. The UI
+-- links out to the per-tunnel traffic charts for the actual rates.
+WITH
+user_rates AS (
+    SELECT
+        device_pk AS ur_device_pk,
+        user_tunnel_id AS ur_user_tunnel_id,
+        user_pk AS ur_user_pk,
+        max(bucket_ts) AS ur_bucket_ts,
+        argMax(max_in_bps, bucket_ts) AS ur_max_in_bps,
+        argMax(max_out_bps, bucket_ts) AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+      AND user_pk != ''
+    GROUP BY ur_device_pk, ur_user_tunnel_id, ur_user_pk
+)
+SELECT
+    h.* EXCEPT (health_status),
+    h.health_status AS control_plane_status,
+    if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+    multiIf(
+        ur.ur_present = 0, NULL,
+        h.mode = 'P',   toNullable(ur.ur_max_in_bps),
+        h.mode = 'S',   toNullable(ur.ur_max_out_bps),
+        h.mode = 'P+S', toNullable(ur.ur_max_out_bps),
+        NULL
+    ) AS observed_bps_5m,
+    -- Retained as NULL: reconciliation removed (see header).
+    CAST(NULL AS Nullable(Float64)) AS expected_bps_5m,
+    -- Presence-only signal; does NOT gate health_status.
+    multiIf(
+        ur.ur_present = 0, 'no_data',
+        (h.mode = 'P' AND ur.ur_max_in_bps > 0)
+            OR (h.mode IN ('S', 'P+S') AND ur.ur_max_out_bps > 0), 'active',
+        'idle'
+    ) AS rate_status_reason,
+    multiIf(
+        ur.ur_present = 0, 'unknown',
+        (h.mode = 'P' AND ur.ur_max_in_bps > 0)
+            OR (h.mode IN ('S', 'P+S') AND ur.ur_max_out_bps > 0), 'active',
+        'idle'
+    ) AS rate_status,
+    -- Verdict = control-plane + disconnected. Rate never downgrades it.
+    h.health_status AS health_status
+FROM health_multicast_user h
+LEFT JOIN user_rates ur
+    ON ur.ur_device_pk = h.user_device_pk
+   AND ur.ur_user_tunnel_id = h.user_tunnel_id
+   AND ur.ur_user_pk = h.user_pk;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE VIEW health_multicast_user_rate
+AS
+WITH
+-- Aggregating + argMax collapses two sources of duplication into one CTE:
+--   1. Multiple buckets per (device, tunnel, user) → keep max(bucket_ts).
+--   2. ReplacingMergeTree part-row duplicates within that bucket → argMax
+--      picks one (values are identical by RMT contract, so tie-break safe).
+-- ur_present = 1 lets the outer LEFT JOIN distinguish "no row" (default
+-- 0) from "row exists with rate 0" (sentinel 1).
+user_rates AS (
+    SELECT
+        device_pk AS ur_device_pk,
+        user_tunnel_id AS ur_user_tunnel_id,
+        user_pk AS ur_user_pk,
+        max(bucket_ts) AS ur_bucket_ts,
+        argMax(max_in_bps, bucket_ts) AS ur_max_in_bps,
+        argMax(max_out_bps, bucket_ts) AS ur_max_out_bps,
+        1 AS ur_present
+    FROM device_interface_rollup_5m
+    WHERE bucket_ts >= now() - INTERVAL 15 MINUTE
+      AND user_tunnel_id IS NOT NULL
+      AND user_pk != ''
+    GROUP BY ur_device_pk, ur_user_tunnel_id, ur_user_pk
+),
+-- Per-group publisher RX total + missing-publisher count so subscribers
+-- (and P+S users on the subscriber side) can reconcile their TX against
+-- expected sum-of-publishers. gpt_missing_publisher_count > 0 means at
+-- least one publisher in the group has no counter row, which forces
+-- subscribers to 'monitoring_gap' (we refuse to reconcile against a
+-- deflated expected).
+group_publisher_total AS (
+    SELECT
+        h.multicast_group_pk AS gpt_multicast_group_pk,
+        sumIf(ur.ur_max_in_bps, ur.ur_present = 1) AS gpt_total_publisher_rx_bps,
+        countIf(ur.ur_present = 0) AS gpt_missing_publisher_count,
+        count() AS gpt_publisher_count
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    -- Exclude BGP-down (disconnected) publishers: no counter row, so counting them
+    -- forces subscribers to monitoring_gap/unknown (the masking this feature removes).
+    -- Mirrors health_mroute (000005).
+    WHERE h.mode IN ('P', 'P+S') AND h.health_status != 'disconnected'
+    GROUP BY gpt_multicast_group_pk
+),
+-- Inner layer: compute rate_status_reason / observed_bps_5m / expected_bps_5m
+-- / control_plane_status. The outer SELECT rolls these into the three-value
+-- rate_status and the combined health_status.
+with_rate AS (
+    SELECT
+        h.* EXCEPT (health_status),
+        h.health_status AS control_plane_status,
+        if(ur.ur_present = 1, ur.ur_bucket_ts, NULL) AS rate_bucket_ts,
+        multiIf(
+            ur.ur_present = 0, NULL,
+            h.mode = 'P',   toNullable(ur.ur_max_in_bps),
+            h.mode = 'S',   toNullable(ur.ur_max_out_bps),
+            h.mode = 'P+S', toNullable(ur.ur_max_out_bps),
+            NULL
+        ) AS observed_bps_5m,
+        multiIf(
+            -- S: expected is the full group_total (only set when no missing publishers).
+            h.mode = 'S' AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps),
+            -- P+S: expected excludes self's contribution (PIM-SM RPF: source does
+            -- not receive its own multicast back via the tree).
+            h.mode = 'P+S' AND ur.ur_present = 1 AND gpt.gpt_missing_publisher_count = 0,
+                toNullable(gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps),
+            NULL
+        ) AS expected_bps_5m,
+        multiIf(
+            ur.ur_present = 0, 'no_data',
+
+            -- Pure publisher: just observe activity.
+            h.mode = 'P' AND ur.ur_max_in_bps > 0, 'active',
+            h.mode = 'P', 'idle',
+
+            -- Subscriber-side reconciliation (S and P+S).
+            h.mode IN ('S', 'P+S') AND gpt.gpt_missing_publisher_count > 0, 'monitoring_gap',
+            h.mode = 'P+S' AND (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps) = 0, 'group_idle',
+            h.mode = 'S'   AND gpt.gpt_total_publisher_rx_bps = 0, 'group_idle',
+
+            h.mode = 'P+S' AND abs(ur.ur_max_out_bps - (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps))
+                                <= greatest(0.05 * (gpt.gpt_total_publisher_rx_bps - ur.ur_max_in_bps), 1000000.0),
+                'reconciled',
+            h.mode = 'S'   AND abs(ur.ur_max_out_bps - gpt.gpt_total_publisher_rx_bps)
+                                <= greatest(0.05 * gpt.gpt_total_publisher_rx_bps, 1000000.0),
+                'reconciled',
+            h.mode IN ('S', 'P+S'), 'mismatch',
+            'no_data'
+        ) AS rate_status_reason
+    FROM health_multicast_user h
+    LEFT JOIN user_rates ur
+        ON ur.ur_device_pk = h.user_device_pk
+       AND ur.ur_user_tunnel_id = h.user_tunnel_id
+       AND ur.ur_user_pk = h.user_pk
+    LEFT JOIN group_publisher_total gpt
+        ON gpt.gpt_multicast_group_pk = h.multicast_group_pk
+)
+SELECT
+    w.*,
+    -- Roll rate_status_reason up into the three-value rate_status.
+    if(rate_status_reason IN ('active', 'reconciled'), 'reconciled',
+        if(rate_status_reason = 'mismatch', 'mismatch', 'unknown')
+    ) AS rate_status,
+    -- Combined verdict per the matrix.
+    --                | rate=reconciled | rate=mismatch | rate=unknown
+    --  CP=healthy    | healthy         | degraded      | unknown
+    --  CP=degraded   | degraded        | unhealthy     | degraded
+    --  CP=unhealthy  | unhealthy       | unhealthy     | unhealthy
+    multiIf(
+        control_plane_status = 'disconnected', 'disconnected',
+        control_plane_status = 'unhealthy', 'unhealthy',
+        control_plane_status = 'degraded' AND rate_status_reason = 'mismatch', 'unhealthy',
+        control_plane_status = 'degraded', 'degraded',
+        control_plane_status = 'healthy' AND rate_status_reason IN ('active', 'reconciled'), 'healthy',
+        control_plane_status = 'healthy' AND rate_status_reason = 'mismatch', 'degraded',
+        control_plane_status = 'healthy', 'unknown',
+        'unknown'
+    ) AS health_status
+FROM with_rate w;
+-- +goose StatementEnd

--- a/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
+++ b/indexer/pkg/dz/mroute/health_multicast_user_rate_test.go
@@ -8,19 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestHealthMulticastUserRate exercises the rate-reconciliation view across
-// the three publisher rate states (active / idle / no_data) and the four
-// subscriber reasons (reconciled / mismatch / monitoring_gap / group_idle).
-// Three groups are set up:
-//
-//	grp-rate-clean — full counter data; one active publisher, one matched
-//	  subscriber, one mismatched subscriber.
-//	grp-rate-gap — publisher has no counter row in the freshness window;
-//	  subscriber's rate goes to unknown via monitoring_gap.
-//	grp-rate-idle — publisher transmits zero; subscriber's rate goes to
-//	  unknown via group_idle.
-//
-// The combined health_status column is verified against the rollup matrix.
+// TestHealthMulticastUserRate exercises the presence-only rate signal across
+// the three states (active / idle / no_data) and confirms rate never downgrades
+// the control-plane verdict. Every user here has a healthy control plane, so
+// all stay healthy regardless of observed rate; expected_bps_5m is always NULL.
 func TestHealthMulticastUserRate(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
@@ -146,63 +137,67 @@ func TestHealthMulticastUserRate(t *testing.T) {
 		byKey[r.userPK] = r
 	}
 
-	// grp-rate-clean: u-pub-active is transmitting → active → reconciled.
+	// Rate is now a presence-only signal and never downgrades the verdict:
+	// every user here has a healthy control plane, so all are 'healthy'
+	// regardless of observed rate. expected_bps_5m is always NULL (no
+	// reconciliation). See migration 20260709000003.
+
+	// u-pub-active: transmitting → active.
 	pub := byKey["u-pub-active"]
 	assert.Equal(t, "healthy", pub.cp, "publisher CP healthy")
 	assert.Equal(t, "active", pub.reason)
-	assert.Equal(t, "reconciled", pub.rate)
+	assert.Equal(t, "active", pub.rate)
 	require.NotNil(t, pub.observedBps)
 	assert.InDelta(t, 10000000, *pub.observedBps, 1)
+	assert.Nil(t, pub.expectedBps, "expected_bps is no longer computed")
 	assert.Equal(t, "healthy", pub.combined)
 
-	// u-sub-recon: 10 Mbps matches sum-of-publishers = 10 Mbps → reconciled.
+	// u-sub-recon: transmitting → active, healthy.
 	subR := byKey["u-sub-recon"]
-	assert.Equal(t, "reconciled", subR.rate)
-	assert.Equal(t, "reconciled", subR.reason)
+	assert.Equal(t, "active", subR.rate)
+	assert.Equal(t, "active", subR.reason)
 	require.NotNil(t, subR.observedBps)
-	require.NotNil(t, subR.expectedBps)
 	assert.InDelta(t, 10000000, *subR.observedBps, 1)
-	assert.InDelta(t, 10000000, *subR.expectedBps, 1)
+	assert.Nil(t, subR.expectedBps)
 	assert.Equal(t, "healthy", subR.combined)
 
-	// u-sub-mis: 50 Mbps vs expected 10 Mbps → mismatch.
+	// u-sub-mis: high TX (50 Mbps) no longer matters — presence-only, so it is
+	// 'active' and stays healthy (previously this was a false 'degraded').
 	subM := byKey["u-sub-mis"]
-	assert.Equal(t, "mismatch", subM.rate)
-	assert.Equal(t, "mismatch", subM.reason)
+	assert.Equal(t, "active", subM.rate)
+	assert.Equal(t, "active", subM.reason)
 	require.NotNil(t, subM.observedBps)
 	assert.InDelta(t, 50000000, *subM.observedBps, 1)
-	// CP healthy + rate mismatch → combined degraded.
-	assert.Equal(t, "degraded", subM.combined)
+	assert.Equal(t, "healthy", subM.combined, "rate divergence must not downgrade the verdict")
 
-	// grp-rate-gap: publisher has no rate row.
+	// grp-rate-gap: publisher has no counter row → no_data, but CP is healthy.
 	pubNoData := byKey["u-pub-nodata"]
 	assert.Equal(t, "no_data", pubNoData.reason)
 	assert.Equal(t, "unknown", pubNoData.rate)
 	assert.Nil(t, pubNoData.observedBps, "no observed rate when no counter row")
-	assert.Equal(t, "unknown", pubNoData.combined)
+	assert.Equal(t, "healthy", pubNoData.combined)
 
-	// u-sub-gap: subscriber has data but expected is NULL (one+ publisher no_data) → monitoring_gap.
+	// u-sub-gap: subscriber has TX → active; healthy (no more monitoring_gap).
 	subGap := byKey["u-sub-gap"]
-	assert.Equal(t, "monitoring_gap", subGap.reason)
-	assert.Equal(t, "unknown", subGap.rate)
-	assert.Nil(t, subGap.expectedBps, "expected NULL when group has no_data publishers")
-	assert.Equal(t, "unknown", subGap.combined)
+	assert.Equal(t, "active", subGap.reason)
+	assert.Equal(t, "active", subGap.rate)
+	assert.Nil(t, subGap.expectedBps)
+	assert.Equal(t, "healthy", subGap.combined)
 
-	// grp-rate-idle: publisher RX = 0 → idle.
+	// grp-rate-idle: publisher RX = 0 → idle; CP healthy so still healthy.
 	pubIdle := byKey["u-pub-idle"]
 	assert.Equal(t, "idle", pubIdle.reason)
-	assert.Equal(t, "unknown", pubIdle.rate)
+	assert.Equal(t, "idle", pubIdle.rate)
 	require.NotNil(t, pubIdle.observedBps)
 	assert.InDelta(t, 0, *pubIdle.observedBps, 1)
-	assert.Equal(t, "unknown", pubIdle.combined)
+	assert.Equal(t, "healthy", pubIdle.combined)
 
-	// u-sub-idle: expected = 0 (publisher present but transmitting 0) → group_idle.
+	// u-sub-idle: subscriber TX = 0 → idle; CP healthy so still healthy.
 	subIdle := byKey["u-sub-idle"]
-	assert.Equal(t, "group_idle", subIdle.reason)
-	assert.Equal(t, "unknown", subIdle.rate)
-	require.NotNil(t, subIdle.expectedBps)
-	assert.InDelta(t, 0, *subIdle.expectedBps, 1)
-	assert.Equal(t, "unknown", subIdle.combined)
+	assert.Equal(t, "idle", subIdle.reason)
+	assert.Equal(t, "idle", subIdle.rate)
+	assert.Nil(t, subIdle.expectedBps)
+	assert.Equal(t, "healthy", subIdle.combined)
 }
 
 // TestHealthMulticastUserRate_PlusSubscriber covers a dual-role (P+S) user.
@@ -283,13 +278,14 @@ func TestHealthMulticastUserRate_PlusSubscriber(t *testing.T) {
 	require.NoError(t, rows.Err())
 
 	assert.Equal(t, "P+S", mode)
-	assert.Equal(t, "reconciled", reason, "P+S subscriber side reconciles against group_total minus self")
-	assert.Equal(t, "reconciled", rate)
+	// Presence-only: a P+S user transmitting on its tunnel is 'active'; no
+	// reconciliation, so expected_bps is NULL.
+	assert.Equal(t, "active", reason)
+	assert.Equal(t, "active", rate)
 	require.NotNil(t, observed)
-	require.NotNil(t, expected)
-	// Observed = max_out_bps = 5 Mbps; expected = group_total (10M) - self.max_in_bps (5M) = 5M.
+	// Observed = max_out_bps = 5 Mbps.
 	assert.InDelta(t, 5000000, *observed, 1)
-	assert.InDelta(t, 5000000, *expected, 1)
+	assert.Nil(t, expected, "expected_bps is no longer computed")
 }
 
 // TestHealthMulticastUserRate_TunnelReuse verifies the user_pk component
@@ -372,15 +368,13 @@ func TestHealthMulticastUserRate_TunnelReuse(t *testing.T) {
 	assert.InDelta(t, 99000000, observed["u-B"], 1, "u-B keeps its own 99 Mbps")
 }
 
-// TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded verifies
-// that when one (device, tunnel, user) tuple subscribes to multiple multicast
-// groups — so its per-tunnel TX is a cross-group aggregate — every rate row
-// for that user gets the standard tolerance check applied. The TX includes
-// other groups' traffic, so observed (10 Mbps) exceeds expected (5 Mbps
-// per-group) beyond tolerance and the view flags mismatch → degraded.
-// Operators read this as "user tunnel deviates, investigate" rather than
-// the previous silent fall-through to unknown.
-func TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded(t *testing.T) {
+// TestHealthMulticastUserRate_MultiGroupSubscriberStaysHealthy verifies that a
+// subscriber whose (device, tunnel, user) tuple joins multiple multicast groups
+// — so its per-tunnel TX is a cross-group aggregate that cannot be attributed
+// per group — stays healthy. Rate reconciliation used to flag this as a false
+// 'mismatch'/'degraded'; presence-only rate reports it as 'active' and lets the
+// control-plane verdict stand.
+func TestHealthMulticastUserRate_MultiGroupSubscriberStaysHealthy(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
 	require.NoError(t, err)
@@ -462,104 +456,17 @@ func TestHealthMulticastUserRate_MultiGroupSubscriberFlaggedDegraded(t *testing.
 	require.Len(t, got, 2, "subscriber should produce one row per group")
 
 	for _, row := range got {
-		// Observed = subscriber tunnel TX (10 Mbps, cross-group aggregate).
-		// Expected = single-group publisher RX (5 Mbps). |10M - 5M| = 5M > 1M tolerance.
-		assert.Equal(t, "mismatch", row.rate, "TX/expected divergence must surface as mismatch (group=%s)", row.group)
-		assert.Equal(t, "mismatch", row.reason, "group=%s", row.group)
+		// The subscriber's tunnel TX (10 Mbps) is a cross-group aggregate that
+		// cannot be attributed per group. Reconciliation used to flag this as a
+		// false 'mismatch'/'degraded'; with presence-only rate it is simply
+		// 'active' and stays healthy (its control plane is fine). No expected_bps.
+		assert.Equal(t, "active", row.rate, "group=%s", row.group)
+		assert.Equal(t, "active", row.reason, "group=%s", row.group)
 		require.NotNil(t, row.observed)
-		require.NotNil(t, row.expected)
 		assert.InDelta(t, 10000000, *row.observed, 1)
-		assert.InDelta(t, 5000000, *row.expected, 1)
-		assert.Equal(t, "degraded", row.combined, "CP healthy + rate mismatch → combined degraded (group=%s)", row.group)
+		assert.Nil(t, row.expected, "group=%s", row.group)
+		assert.Equal(t, "healthy", row.combined, "multi-group aggregate must not degrade the verdict (group=%s)", row.group)
 	}
-}
-
-// TestHealthMulticastUserRate_AmbiguousPublisherFlaggedDegraded verifies
-// that when a group's publisher is multi-group (its per-tunnel RX is a
-// cross-group aggregate that inflates gpt_total_publisher_rx_bps), every
-// single-group subscriber in that group sees observed (their honest
-// per-group TX) < expected (the inflated total) and the standard
-// tolerance check flags mismatch → degraded. This replaces the previous
-// silent fall-through to unknown.
-func TestHealthMulticastUserRate_AmbiguousPublisherFlaggedDegraded(t *testing.T) {
-	info := laketesting.NewClientWithInfo(t, sharedDB)
-	conn, err := info.Client.Conn(t.Context())
-	require.NoError(t, err)
-	defer conn.Close()
-	ctx := t.Context()
-
-	require.NoError(t, conn.Exec(ctx, `
-		INSERT INTO dim_dz_devices_history
-			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
-			 pk, status, device_type, code, public_ip, contributor_pk, metro_pk, max_users, interfaces)
-		VALUES
-			('d-ap-fhr', now(), now(), generateUUIDv4(), 0, 1, 'd-ap-fhr', 'activated', 'edge', 'ap-fhr-dz1', '', '', '', 0, '[]'),
-			('d-ap-lhr', now(), now(), generateUUIDv4(), 0, 2, 'd-ap-lhr', 'activated', 'edge', 'ap-lhr-dz1', '', '', '', 0, '[]')`))
-
-	require.NoError(t, conn.Exec(ctx, `
-		INSERT INTO dim_dz_multicast_groups_history
-			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
-			 pk, owner_pubkey, code, multicast_ip, max_bandwidth, status, publisher_count, subscriber_count)
-		VALUES
-			('grp-ap-X', now(), now(), generateUUIDv4(), 0, 1, 'grp-ap-X', 'o', 'ap-X', '233.99.5.1', 100000000, 'activated', 1, 1),
-			('grp-ap-Y', now(), now(), generateUUIDv4(), 0, 2, 'grp-ap-Y', 'o', 'ap-Y', '233.99.5.2', 100000000, 'activated', 1, 0)`))
-
-	// u-ap-pub publishes to BOTH grp-ap-X and grp-ap-Y over the same tunnel
-	// — its RX is a cross-group aggregate. u-ap-sub is a single-group
-	// subscriber on grp-ap-X only.
-	require.NoError(t, conn.Exec(ctx, `
-		INSERT INTO dim_dz_users_history
-			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
-			 pk, owner_pubkey, status, kind, client_ip, dz_ip, device_pk, tenant_pk, tunnel_id, publishers, subscribers)
-		VALUES
-			('u-ap-pub', now(), now(), generateUUIDv4(), 0, 1, 'u-ap-pub', 'o', 'activated', 'multicast', '203.0.117.1', '10.99.5.1', 'd-ap-fhr', 't1', 960, '["grp-ap-X","grp-ap-Y"]', '[]'),
-			('u-ap-sub', now(), now(), generateUUIDv4(), 0, 2, 'u-ap-sub', 'o', 'activated', 'multicast', '203.0.117.2', '10.99.5.2', 'd-ap-lhr', 't1', 961, '[]', '["grp-ap-X"]')`))
-
-	require.NoError(t, conn.Exec(ctx, `
-		INSERT INTO dim_dz_ip_mroute_entries_history
-			(entity_id, snapshot_ts, ingested_at, op_id, is_deleted, attrs_hash,
-			 device_pubkey, vrf, mode, group_address, source_address,
-			 route_flags, register_in_oif_list, rpf_interface, rpf_rib, rpf_prefix,
-			 rpf_preference, rpf_metric, rpf_neighbor, rpf_attached, rpf_has_block,
-			 oif_list, oif_count, creation_time)
-		VALUES
-			('mr-ap-fhr-X', now(), now(), generateUUIDv4(), 0, 1, 'd-ap-fhr', 'default', 'sparse', '233.99.5.1', '10.99.5.1', 'SBNP', 0, 'Tunnel960', '', '', 0, 0, '', 0, 0, '', 0, now()),
-			('mr-ap-fhr-Y', now(), now(), generateUUIDv4(), 0, 2, 'd-ap-fhr', 'default', 'sparse', '233.99.5.2', '10.99.5.1', 'SBNP', 0, 'Tunnel960', '', '', 0, 0, '', 0, 0, '', 0, now()),
-			('mr-ap-lhr-X', now(), now(), generateUUIDv4(), 0, 3, 'd-ap-lhr', 'default', 'sparse', '233.99.5.1', '10.99.5.1', 'SMP',  0, 'Port-Channel1', '', '', 0, 0, '', 0, 0, '["Tunnel961"]', 1, now())`))
-
-	// Publisher's tunnel reports 10 Mbps (aggregate of X+Y).
-	// Single-group subscriber tunnel reports 5 Mbps.
-	require.NoError(t, conn.Exec(ctx, `
-		INSERT INTO device_interface_rollup_5m
-			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
-		VALUES
-			(now() - INTERVAL 1 MINUTE, 'd-ap-fhr', 'Tunnel960', 960, 'u-ap-pub', 10000000, 0,       now()),
-			(now() - INTERVAL 1 MINUTE, 'd-ap-lhr', 'Tunnel961', 961, 'u-ap-sub', 0,        5000000, now())`))
-
-	require.NoError(t, conn.Exec(ctx, `SYSTEM REFRESH VIEW dz_device_interface_ips`))
-	require.NoError(t, conn.Exec(ctx, `SYSTEM WAIT VIEW dz_device_interface_ips`))
-
-	rows2, err := conn.Query(ctx, `
-		SELECT rate_status, rate_status_reason, observed_bps_5m, expected_bps_5m, health_status
-		FROM health_multicast_user_rate
-		WHERE user_pk = 'u-ap-sub' AND multicast_group_pk = 'grp-ap-X'`)
-	require.NoError(t, err)
-	defer rows2.Close()
-	require.True(t, rows2.Next(), "expected one row for u-ap-sub on grp-ap-X")
-
-	var rate, reason, combined string
-	var observed, expected *float64
-	require.NoError(t, rows2.Scan(&rate, &reason, &observed, &expected, &combined))
-	require.NoError(t, rows2.Err())
-	// Observed = honest single-group subscriber TX (5 Mbps).
-	// Expected = publisher's contaminated cross-group RX (10 Mbps). |5M - 10M| = 5M > 1M tolerance.
-	assert.Equal(t, "mismatch", rate, "TX/expected divergence must surface as mismatch")
-	assert.Equal(t, "mismatch", reason)
-	require.NotNil(t, observed)
-	require.NotNil(t, expected)
-	assert.InDelta(t, 5000000, *observed, 1)
-	assert.InDelta(t, 10000000, *expected, 1)
-	assert.Equal(t, "degraded", combined, "CP healthy + rate mismatch → combined degraded")
 }
 
 // TestHealthMulticastUserRate_RollupDedup guards against the
@@ -610,10 +517,8 @@ func TestHealthMulticastUserRate_RollupDedup(t *testing.T) {
 
 	// Insert THREE identical part-row copies for each rollup bucket — emulates
 	// what ReplacingMergeTree leaves on disk before background merges run.
-	// Without dedup in the view, the publisher fan-out would multiply
-	// gpt_total_publisher_rx_bps by 3 (30 Mbps), and the subscriber's
-	// observed (10 Mbps) would be flagged mismatch against the inflated
-	// expected. With dedup, expected == observed == 10 Mbps → reconciled.
+	// Without the argMax dedup in the view, the duplicates would both fan out
+	// into multiple view rows per (user, group, mode) and inflate observed_bps.
 	require.NoError(t, conn.Exec(ctx, `
 		INSERT INTO device_interface_rollup_5m
 			(bucket_ts, device_pk, intf, user_tunnel_id, user_pk, max_in_bps, max_out_bps, ingested_at)
@@ -639,38 +544,32 @@ func TestHealthMulticastUserRate_RollupDedup(t *testing.T) {
 	assert.Equal(t, uint64(2), rowCount,
 		"expected 2 rows (publisher + subscriber); got %d means part-row duplicates fanned out", rowCount)
 
-	// 2. Subscriber's expected_bps_5m must reflect the deduped publisher RX
-	//    (10 Mbps), not the inflated 30 Mbps — so the verdict is healthy,
-	//    not the spurious 'mismatch' the original bug would produce.
+	// 2. The subscriber's observed_bps_5m must be the deduped tunnel TX
+	//    (10 Mbps), not 3× inflated by the part-row copies — argMax collapses them.
 	rows, err := conn.Query(ctx, `
-		SELECT mode, observed_bps_5m, expected_bps_5m, rate_status, health_status
+		SELECT mode, observed_bps_5m, rate_status, health_status
 		FROM health_multicast_user_rate
 		WHERE multicast_group_pk = 'grp-dd' AND user_pk = 'u-dd-sub'`)
 	require.NoError(t, err)
 	defer rows.Close()
 	require.True(t, rows.Next())
 	var mode, rate, combined string
-	var observed, expected *float64
-	require.NoError(t, rows.Scan(&mode, &observed, &expected, &rate, &combined))
+	var observed *float64
+	require.NoError(t, rows.Scan(&mode, &observed, &rate, &combined))
 	require.NoError(t, rows.Err())
 	assert.Equal(t, "S", mode)
 	require.NotNil(t, observed)
-	require.NotNil(t, expected)
-	assert.InDelta(t, 10000000, *observed, 1)
-	assert.InDelta(t, 10000000, *expected, 1, "expected must equal deduped publisher RX, not 3× inflated")
-	assert.Equal(t, "reconciled", rate)
+	assert.InDelta(t, 10000000, *observed, 1, "observed must be the deduped TX, not 3× inflated")
+	assert.Equal(t, "active", rate)
 	assert.Equal(t, "healthy", combined)
 }
 
-// TestHealthMulticastUserRate_DisconnectedPublisherNotCountedAsMissing pins the
-// two review fixes on the rate view:
-//  1. A BGP-down (disconnected) publisher — which has no counter row — is
-//     excluded from group_publisher_total, so a co-group subscriber that
-//     matches the live publisher's rate stays 'healthy' instead of being
-//     dragged to monitoring_gap → 'unknown'.
-//  2. The disconnected control-plane verdict propagates through the combined
-//     rate verdict (control_plane_status='disconnected' → health_status='disconnected').
-func TestHealthMulticastUserRate_DisconnectedPublisherNotCountedAsMissing(t *testing.T) {
+// TestHealthMulticastUserRate_DisconnectedPublisherPropagates verifies that a
+// BGP-down publisher's 'disconnected' control-plane verdict propagates through
+// the rate view (health_status='disconnected'), and that a live co-group
+// subscriber is unaffected (stays 'active'/healthy) — trivially true now that
+// rate is presence-only with no cross-publisher reconciliation.
+func TestHealthMulticastUserRate_DisconnectedPublisherPropagates(t *testing.T) {
 	info := laketesting.NewClientWithInfo(t, sharedDB)
 	conn, err := info.Client.Conn(t.Context())
 	require.NoError(t, err)
@@ -748,9 +647,10 @@ func TestHealthMulticastUserRate_DisconnectedPublisherNotCountedAsMissing(t *tes
 	assert.Equal(t, "disconnected", got["u-pub-down"].cp)
 	assert.Equal(t, "disconnected", got["u-pub-down"].combined)
 
-	// The subscriber reconciles against the live publisher only: the disconnected
-	// publisher must NOT force monitoring_gap/unknown.
+	// The subscriber is transmitting and its control plane is healthy, so it is
+	// 'active' and healthy — a disconnected co-group publisher has no effect
+	// (presence-only rate; no cross-publisher reconciliation).
 	require.Contains(t, got, "u-sub-rb")
-	assert.Equal(t, "reconciled", got["u-sub-rb"].reason, "disconnected publisher must not create a monitoring gap")
+	assert.Equal(t, "active", got["u-sub-rb"].reason)
 	assert.Equal(t, "healthy", got["u-sub-rb"].combined)
 }

--- a/web/src/components/multicast-delivery-panel.tsx
+++ b/web/src/components/multicast-delivery-panel.tsx
@@ -36,19 +36,15 @@ const STATUS_BADGE: Record<MulticastHealthStatus, string> = {
 }
 
 const RATE_STATUS_BADGE: Record<MulticastRateStatus, string> = {
-  reconciled: 'bg-emerald-500/15 text-emerald-500',
-  mismatch: 'bg-red-500/15 text-red-500',
+  active: 'bg-emerald-500/15 text-emerald-500',
+  idle: 'bg-amber-500/15 text-amber-500',
   unknown: 'bg-muted text-muted-foreground',
 }
 
 const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
-  active: 'transmitting',
-  idle: 'idle, registered but sending zero',
+  active: 'non-zero traffic on tunnel',
+  idle: 'registered, transmitting 0',
   no_data: 'no counter data in 15 min',
-  reconciled: 'TX matches sum of publishers',
-  mismatch: 'TX deviates from sum of publishers',
-  monitoring_gap: 'a publisher in this group has no counter data',
-  group_idle: 'all publishers are idle, nothing to verify',
 }
 
 function compactNumber(value: number): string {
@@ -298,14 +294,14 @@ function HealthTooltip({ item }: { item: MulticastHealthUserItem }) {
       <div><span className="font-medium">Control plane:</span> {item.control_plane_status}</div>
       <div><span className="font-medium">Rate:</span> {item.rate_status}, {RATE_REASON_HUMAN[item.rate_status_reason] ?? item.rate_status_reason}</div>
       <div className="text-muted-foreground">Observed: {formatBps(item.observed_bps_5m)}</div>
-      {item.expected_bps_5m !== undefined && <div className="text-muted-foreground">Expected: {formatBps(item.expected_bps_5m)}</div>}
+      <div className="text-muted-foreground">Presence only — does not affect health.</div>
     </div>
   )
 }
 
 function rowReason(item: MulticastHealthUserItem): string {
   if (item.mismatch_reason) return item.mismatch_reason
-  if (item.rate_status_reason === 'active' || item.rate_status_reason === 'reconciled') return EMPTY
+  if (item.rate_status_reason === 'active') return EMPTY
   return RATE_REASON_HUMAN[item.rate_status_reason] ?? item.rate_status_reason
 }
 

--- a/web/src/components/multicast-delivery-panel.tsx
+++ b/web/src/components/multicast-delivery-panel.tsx
@@ -275,7 +275,7 @@ function UserHealthTable({ items }: { items: MulticastHealthUserItem[] }) {
               <td className="px-3 py-2"><HealthBadge status={item.control_plane_status} /></td>
               <td className="px-3 py-2 whitespace-nowrap">
                 <span className="font-mono tabular-nums">{formatBps(item.observed_bps_5m)}</span>
-                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${RATE_STATUS_BADGE[item.rate_status]}`}>{item.rate_status}</span>
+                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${RATE_STATUS_BADGE[item.rate_status] ?? RATE_STATUS_BADGE.unknown}`}>{item.rate_status}</span>
               </td>
               <td className="px-3 py-2"><FocusHealthBadge status={item.health_status} label={<HealthTooltip item={item} />} /></td>
               <td className="px-3 py-2 text-muted-foreground">{rowReason(item)}</td>

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -256,17 +256,13 @@ function rowReason(item: MulticastHealthUserItem): string {
 // the combined-verdict hover-card on the Status column.
 const DIM_BADGE_CLASS: Record<string, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',
-  reconciled: 'bg-emerald-500/15 text-emerald-500',
   active: 'bg-emerald-500/15 text-emerald-500',
   degraded: 'bg-amber-500/15 text-amber-500',
-  mismatch: 'bg-red-500/15 text-red-500',
+  idle: 'bg-amber-500/15 text-amber-500',
   unhealthy: 'bg-red-500/15 text-red-500',
   disconnected: 'bg-sky-500/15 text-sky-500',
   unknown: 'bg-muted text-muted-foreground',
-  idle: 'bg-muted text-muted-foreground',
   no_data: 'bg-muted text-muted-foreground',
-  monitoring_gap: 'bg-muted text-muted-foreground',
-  group_idle: 'bg-muted text-muted-foreground',
 }
 
 function DimBadge({ value }: { value: string }) {

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -420,11 +420,15 @@ function TableStateRow({
 function RootCausePanel({
   items,
   isLoading,
+  isError,
   faultCount,
+  total,
 }: {
   items: MulticastHealthPathRootCause[]
   isLoading: boolean
+  isError: boolean
   faultCount: number
+  total: number
 }) {
   return (
     <div className="px-4 py-3 border-b border-border bg-muted/30">
@@ -432,18 +436,20 @@ function RootCausePanel({
         <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Root causes</h4>
         {isLoading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
       </div>
-      {isLoading && items.length === 0 ? (
+      {isError ? (
+        <div className="text-xs text-red-500">Failed to load root causes.</div>
+      ) : isLoading && items.length === 0 ? (
         <div className="text-xs text-muted-foreground">Loading…</div>
       ) : items.length === 0 ? (
         <div className="text-xs text-muted-foreground">
-          {faultCount.toLocaleString()} unhealthy pairs, but no single endpoint could be attributed.
+          {faultCount.toLocaleString()} faulting pairs, but none could be attributed to a single endpoint.
         </div>
       ) : (
         <>
           <div className="text-xs text-muted-foreground mb-2">
-            {faultCount.toLocaleString()} unhealthy publisher → subscriber pairs trace back to{' '}
-            <span className="font-medium text-foreground">{items.length}</span>{' '}
-            {items.length === 1 ? 'endpoint' : 'endpoints'}:
+            <span className="font-medium text-foreground">{total.toLocaleString()}</span>{' '}
+            {total === 1 ? 'endpoint accounts' : 'endpoints account'} for the faulting publisher → subscriber
+            pairs in this group{items.length < total ? ` (showing top ${items.length})` : ''}:
           </div>
           <ul className="space-y-1">
             {items.map((rc) => (
@@ -747,7 +753,9 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
           <RootCausePanel
             items={rootCausesQuery.data?.items ?? []}
             isLoading={rootCausesQuery.isLoading}
+            isError={rootCausesQuery.isError}
             faultCount={pathFaultCount}
+            total={rootCausesQuery.data?.total ?? 0}
           />
         )}
         {!showPathDetails ? (

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -175,22 +175,22 @@ const STATUS_DOT: Record<MulticastHealthStatus, string> = {
 }
 
 const STATUS_DEFINITIONS: Array<{ status: MulticastHealthStatus; short: string }> = [
-  { status: 'healthy', short: 'control plane reconciles AND subscriber TX matches sum of publishers (±5% / 1 Mbps)' },
-  { status: 'degraded', short: 'control plane reconciles but rates diverge, or partial control plane reconciliation' },
-  { status: 'unhealthy', short: 'no (S,G) mroute, or rates diverge under a degraded control plane' },
+  { status: 'healthy', short: 'control plane reconciles — publisher Tunnel is the (S,G) IIF, and/or subscriber Tunnel is in the OIF list for every source' },
+  { status: 'degraded', short: 'partial reconciliation — some but not all sources/endpoints reconcile (e.g. subscriber sees some publishers but not all)' },
+  { status: 'unhealthy', short: 'no (S,G) mroute — the expected publisher IIF or subscriber OIF is not observed at the device' },
   { status: 'disconnected', short: "user's onchain BGP session is down — not connected, so no (S,G)/OIF is expected (not a forwarding fault)" },
-  { status: 'unknown', short: 'no counter data, or no traffic flowing in the 5-min window' },
+  { status: 'unknown', short: 'not enough collected state to classify' },
 ]
 
 const SECTION_HELP = {
   summary:
-    'Per-status totals across three view granularities. The combined verdict requires control-plane reconciliation (mroute matches onchain) AND data-plane reconciliation (subscriber TX matches sum of publishers within tolerance).',
+    'Per-status totals across three view granularities. The verdict is the control-plane reconciliation — onchain membership matched against the (S,G) IIF/OIF state observed at each device. A user whose onchain BGP session is down is "disconnected". The 5-min rate is a presence signal only and does not affect the verdict.',
   users:
-    'Each row pairs one onchain user with the mroute and 5-min rate observed at their device. ' +
-    'Publishers expect their Tunnel<N> as the IIF of (S,G) and to be transmitting; ' +
-    'subscribers expect their Tunnel<N> in the OIF list and to receive at the same rate publishers send. ' +
-    'A user in P+S mode contributes one row (mode = "P+S") that reconciles subscriber-side ' +
-    'against (sum of publishers − self).',
+    'Each row pairs one onchain user with the mroute state observed at their device. ' +
+    'Publishers expect their Tunnel<N> as the IIF of (S,G); ' +
+    'subscribers expect their Tunnel<N> in the OIF list for every source. ' +
+    'A user in P+S mode contributes one row (mode = "P+S") reconciled on both sides. ' +
+    'The observed 5-min rate is shown as a presence signal (active / idle) only.',
   paths:
     'Each row is a (publisher, subscriber) pair belonging to the group. ' +
     'Endpoints-only verification: both endpoints must be reconciled. ' +
@@ -599,7 +599,7 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
       <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-100">
         <div className="font-medium">This view is under development.</div>
         <div className="mt-1 text-amber-700 dark:text-amber-200/90">
-          Health verdicts and the rate dimension are work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> (or <span className="font-mono">disconnected</span> when its onchain BGP session is down) even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
+          Health verdicts are a work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> (or <span className="font-mono">disconnected</span> when its onchain BGP session is down) even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
         </div>
       </div>
 

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -590,17 +590,9 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
 
   return (
     <div className="p-4 space-y-6">
-      {/* Under-development notice. The reconciliation logic and rate dimension
-          here surface real data, but the verdicts assume state-collect covers
-          every device — today only jump devices are collected, so non-jump
-          publishers/subscribers can falsely render as unhealthy. Wording is
-          deliberately concrete so operators read it as caveat, not "do not
-          trust this page". */}
+      {/* Under-development notice. */}
       <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-100">
         <div className="font-medium">This view is under development.</div>
-        <div className="mt-1 text-amber-700 dark:text-amber-200/90">
-          Health verdicts are a work in progress. State-collect runs only on jump devices today, so any user, publisher, or subscriber on a non-jump device will appear as <span className="font-mono">unhealthy</span> (or <span className="font-mono">disconnected</span> when its onchain BGP session is down) even when it is functioning normally. Treat verdicts as a starting point, not ground truth.
-        </div>
       </div>
 
       {/* Summary counts */}

--- a/web/src/components/multicast-group-health-tab.tsx
+++ b/web/src/components/multicast-group-health-tab.tsx
@@ -9,9 +9,11 @@ import {
   fetchMulticastGroupHealth,
   fetchMulticastGroupHealthUsers,
   fetchMulticastGroupHealthPaths,
+  fetchMulticastGroupHealthPathRootCauses,
   type MulticastHealthStatus,
   type MulticastHealthStatusCounts,
   type MulticastHealthUserItem,
+  type MulticastHealthPathRootCause,
   type MulticastRateStatus,
   type MulticastRateStatusReason,
 } from '@/lib/api'
@@ -60,19 +62,15 @@ function formatBps(bps?: number): string {
 }
 
 const RATE_STATUS_BADGE: Record<MulticastRateStatus, string> = {
-  reconciled: 'bg-emerald-500/15 text-emerald-500',
-  mismatch: 'bg-red-500/15 text-red-500',
+  active: 'bg-emerald-500/15 text-emerald-500',
+  idle: 'bg-amber-500/15 text-amber-500',
   unknown: 'bg-muted text-muted-foreground',
 }
 
 const RATE_REASON_HUMAN: Record<MulticastRateStatusReason, string> = {
-  active: 'transmitting',
-  idle: 'idle (registered, transmitting 0)',
+  active: 'non-zero traffic on tunnel',
+  idle: 'registered, transmitting 0',
   no_data: 'no counter data in 15 min',
-  reconciled: 'TX matches sum of publishers',
-  mismatch: 'TX deviates from sum of publishers',
-  monitoring_gap: 'a publisher in this group has no counter data',
-  group_idle: 'all publishers transmitting 0 — nothing to verify against',
 }
 
 // 25 keeps the per-page Radix Tooltip.Root count (~2 per row × N rows) below
@@ -216,34 +214,41 @@ function RateCell({ item }: { item: MulticastHealthUserItem }) {
         <span className="font-medium">{item.rate_status_reason}</span> — {RATE_REASON_HUMAN[item.rate_status_reason] ?? ''}
       </div>
       <div className="text-muted-foreground">Observed: {formatBps(item.observed_bps_5m)}</div>
-      {item.expected_bps_5m !== undefined && item.expected_bps_5m !== null && (
-        <div className="text-muted-foreground">Expected: {formatBps(item.expected_bps_5m)} (sum of publishers' RX)</div>
-      )}
       {item.rate_bucket_ts && (
         <div className="text-muted-foreground">5-min bucket: {new Date(item.rate_bucket_ts).toLocaleTimeString()}</div>
       )}
+      <div className="text-muted-foreground">Presence only — does not affect health.</div>
     </div>
   )
   return (
-    <Tooltip content={tooltip}>
-      <span
-        tabIndex={0}
-        aria-label={`Rate ${item.rate_status}: ${item.rate_status_reason}`}
-        className="inline-flex items-center gap-1.5 cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
-      >
-        <span className="tabular-nums font-mono text-xs">{formatBps(item.observed_bps_5m)}</span>
-        <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
-          {item.rate_status}
+    <span className="inline-flex items-center gap-1.5">
+      <Tooltip content={tooltip}>
+        <span
+          tabIndex={0}
+          aria-label={`Rate ${item.rate_status}: ${item.rate_status_reason}`}
+          className="inline-flex items-center gap-1.5 cursor-help focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-full"
+        >
+          <span className="tabular-nums font-mono text-xs">{formatBps(item.observed_bps_5m)}</span>
+          <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium ${cls}`}>
+            {item.rate_status}
+          </span>
         </span>
-      </span>
-    </Tooltip>
+      </Tooltip>
+      <Link
+        to={`/dz/users/${item.user_pk}#traffic`}
+        className="text-[10px] text-primary hover:underline whitespace-nowrap"
+        title="View this tunnel's traffic history"
+      >
+        traffic<NavLinkArrow />
+      </Link>
+    </span>
   )
 }
 
 function rowReason(item: MulticastHealthUserItem): string {
   if (item.mismatch_reason) return item.mismatch_reason
-  // No CP reason → surface the rate reason (or nothing if rate is healthy/active/reconciled).
-  if (['active', 'reconciled'].includes(item.rate_status_reason)) return '—'
+  // No CP reason → surface the rate reason (nothing if the tunnel is active).
+  if (item.rate_status_reason === 'active') return '—'
   return RATE_REASON_HUMAN[item.rate_status_reason] ?? '—'
 }
 
@@ -412,6 +417,76 @@ function TableStateRow({
   return null
 }
 
+// RootCausePanel collapses the unhealthy per-path fan-out to the handful of
+// endpoints actually at fault. A single broken publisher drags down every one
+// of its subscriber pairs (and vice-versa), so N unhealthy rows usually trace
+// back to just a few endpoints — this shows them, ranked by blast radius.
+function RootCausePanel({
+  items,
+  isLoading,
+  faultCount,
+}: {
+  items: MulticastHealthPathRootCause[]
+  isLoading: boolean
+  faultCount: number
+}) {
+  return (
+    <div className="px-4 py-3 border-b border-border bg-muted/30">
+      <div className="flex items-center gap-1.5 mb-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Root causes</h4>
+        {isLoading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+      </div>
+      {isLoading && items.length === 0 ? (
+        <div className="text-xs text-muted-foreground">Loading…</div>
+      ) : items.length === 0 ? (
+        <div className="text-xs text-muted-foreground">
+          {faultCount.toLocaleString()} unhealthy pairs, but no single endpoint could be attributed.
+        </div>
+      ) : (
+        <>
+          <div className="text-xs text-muted-foreground mb-2">
+            {faultCount.toLocaleString()} unhealthy publisher → subscriber pairs trace back to{' '}
+            <span className="font-medium text-foreground">{items.length}</span>{' '}
+            {items.length === 1 ? 'endpoint' : 'endpoints'}:
+          </div>
+          <ul className="space-y-1">
+            {items.map((rc) => (
+              <li key={`${rc.faulting_role}-${rc.user_pk}`} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground uppercase">
+                  {rc.faulting_role}
+                </span>
+                <HealthBadge status={rc.endpoint_status} />
+                <Link
+                  to={`/dz/users/${rc.user_pk}`}
+                  className="group font-mono text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                  title={rc.owner_pubkey ? `account ${rc.user_pk}\nowner ${rc.owner_pubkey}` : rc.user_pk}
+                >
+                  {rc.dz_ip || rc.user_pk.slice(0, 8)}
+                  {rc.tunnel_id > 0 && <span className="ml-1 text-muted-foreground">·T{rc.tunnel_id}</span>}
+                  <NavLinkArrow />
+                </Link>
+                {rc.device_pk && (
+                  <Link
+                    to={`/dz/devices/${rc.device_pk}`}
+                    className="group text-xs font-mono text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center"
+                  >
+                    {rc.device_code || rc.device_pk.slice(0, 8)}
+                    <NavLinkArrow />
+                  </Link>
+                )}
+                <span className="text-muted-foreground text-xs">
+                  affects <span className="tabular-nums font-medium text-foreground">{rc.affected_pairs.toLocaleString()}</span>{' '}
+                  {rc.affected_pairs === 1 ? 'pair' : 'pairs'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
 export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: string }) {
   const [searchParams] = useSearchParams()
   const [usersOffset, setUsersOffset] = useState(0)
@@ -474,6 +549,19 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
     queryKey: ['multicast-group-health-paths', groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch],
     queryFn: () => fetchMulticastGroupHealthPaths(groupPkOrCode, HEALTH_PAGE_SIZE, pathsOffset, pathsSearch || undefined),
     enabled: !!groupPkOrCode && showPathDetails,
+    refetchInterval: 60_000,
+    placeholderData: keepPreviousData,
+  })
+
+  // Root-cause rollup of the unhealthy per-path fan-out. Only fetched when the
+  // group actually has faulting paths (cheap aggregation, always shown when
+  // present — independent of the raw-row details toggle).
+  const pathFaultCount =
+    (summaryQuery.data?.counts.paths.unhealthy ?? 0) + (summaryQuery.data?.counts.paths.disconnected ?? 0)
+  const rootCausesQuery = useQuery({
+    queryKey: ['multicast-group-health-path-root-causes', groupPkOrCode],
+    queryFn: () => fetchMulticastGroupHealthPathRootCauses(groupPkOrCode),
+    enabled: !!groupPkOrCode && pathFaultCount > 0,
     refetchInterval: 60_000,
     placeholderData: keepPreviousData,
   })
@@ -667,6 +755,13 @@ export function MulticastGroupHealthTab({ groupPkOrCode }: { groupPkOrCode: stri
             />
           )}
         </div>
+        {pathFaultCount > 0 && (
+          <RootCausePanel
+            items={rootCausesQuery.data?.items ?? []}
+            isLoading={rootCausesQuery.isLoading}
+            faultCount={pathFaultCount}
+          />
+        )}
         {!showPathDetails ? (
           <div className="px-4 py-6 text-sm text-muted-foreground flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div>

--- a/web/src/components/user-detail-page.tsx
+++ b/web/src/components/user-detail-page.tsx
@@ -30,17 +30,13 @@ const HEALTH_BADGE_CLASS: Record<MulticastHealthStatus, string> = {
 
 const DIM_BADGE_CLASS: Record<string, string> = {
   healthy: 'bg-emerald-500/15 text-emerald-500',
-  reconciled: 'bg-emerald-500/15 text-emerald-500',
   active: 'bg-emerald-500/15 text-emerald-500',
   degraded: 'bg-amber-500/15 text-amber-500',
-  mismatch: 'bg-red-500/15 text-red-500',
+  idle: 'bg-amber-500/15 text-amber-500',
   unhealthy: 'bg-red-500/15 text-red-500',
   disconnected: 'bg-sky-500/15 text-sky-500',
   unknown: 'bg-muted text-muted-foreground',
-  idle: 'bg-muted text-muted-foreground',
   no_data: 'bg-muted text-muted-foreground',
-  monitoring_gap: 'bg-muted text-muted-foreground',
-  group_idle: 'bg-muted text-muted-foreground',
 }
 
 function DimBadge({ value }: { value: string }) {
@@ -213,6 +209,14 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
   const [bucket, setBucket] = useState<string>('auto')
   const [agg, setAgg] = useState<AggMethod>('max')
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
+
+  // Scroll into view when linked to with #traffic (e.g. from a multicast
+  // health tab's "traffic" link). Client-side nav doesn't honor the hash.
+  useEffect(() => {
+    if (window.location.hash === '#traffic') {
+      document.getElementById('traffic')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [])
 
   const effectiveBucket = bucket === 'auto' ? resolveAutoBucket(timeRange) : bucket
   const autoBucketLabel = BUCKET_LABELS[resolveAutoBucket(timeRange)] || '5m'
@@ -387,7 +391,7 @@ function UserTrafficChart({ userPk }: { userPk: string }) {
   }, [uplotData, hoveredIdx])
 
   return (
-    <div className="border border-border rounded-lg p-4 bg-card col-span-full group/chart">
+    <div id="traffic" className="border border-border rounded-lg p-4 bg-card col-span-full group/chart scroll-mt-20">
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium text-muted-foreground">Traffic History</h3>
@@ -793,7 +797,7 @@ export function UserDetailPage() {
             <div className="border border-border rounded-lg p-4 bg-card">
               <h3 className="text-sm font-medium text-muted-foreground mb-1">Multicast Groups</h3>
               <p className="text-xs text-muted-foreground mb-3">
-                Healthy = control plane reconciled with onchain expectation AND data-plane rate matches expected. Hover a badge for the CP × Rate breakdown.
+                Health reflects the control plane reconciled against the onchain expectation. Rate is a presence-only signal (active/idle) and does not affect health. Hover a badge for the breakdown.
               </p>
               <div className="space-y-2">
                 {multicastGroups.map((g) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2234,16 +2234,13 @@ export interface MulticastHealthGroupSummary {
   counts: MulticastHealthCounts
 }
 
-export type MulticastRateStatus = 'reconciled' | 'mismatch' | 'unknown'
+// Rate is a presence-only signal now (see the health_rate_presence_only
+// migration): 'active' = non-zero traffic observed on the tunnel, 'idle' =
+// registered but 0 bps, 'unknown' = no counter data. It never gates
+// health_status — that comes from the control plane.
+export type MulticastRateStatus = 'active' | 'idle' | 'unknown'
 
-export type MulticastRateStatusReason =
-  | 'active'
-  | 'idle'
-  | 'no_data'
-  | 'reconciled'
-  | 'mismatch'
-  | 'monitoring_gap'
-  | 'group_idle'
+export type MulticastRateStatusReason = 'active' | 'idle' | 'no_data'
 
 export interface MulticastHealthUserItem {
   user_pk: string
@@ -2325,6 +2322,27 @@ export interface MulticastHealthGroupPathsResponse {
   offset: number
 }
 
+// One faulting endpoint behind the unhealthy per-path fan-out. affected_pairs
+// is how many (publisher, subscriber) pairs this endpoint drags down.
+export interface MulticastHealthPathRootCause {
+  faulting_role: 'publisher' | 'subscriber' | string
+  user_pk: string
+  owner_pubkey: string
+  dz_ip: string
+  tunnel_id: number
+  device_pk: string
+  device_code: string
+  endpoint_status: MulticastHealthStatus
+  affected_pairs: number
+}
+
+export interface MulticastHealthPathRootCausesResponse {
+  group: MulticastHealthGroupRef
+  generated_at: string
+  items: MulticastHealthPathRootCause[]
+  total: number
+}
+
 export async function fetchMulticastGroupHealth(pkOrCode: string): Promise<MulticastHealthGroupSummary> {
   const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health`)
   if (!res.ok) {
@@ -2365,6 +2383,16 @@ export async function fetchMulticastGroupHealthPaths(
   const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/paths${qs ? `?${qs}` : ''}`)
   if (!res.ok) {
     throw new Error('Failed to fetch multicast group health paths')
+  }
+  return res.json()
+}
+
+export async function fetchMulticastGroupHealthPathRootCauses(
+  pkOrCode: string,
+): Promise<MulticastHealthPathRootCausesResponse> {
+  const res = await apiFetch(`/api/dz/multicast-groups/${encodeURIComponent(pkOrCode)}/health/path-root-causes`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch multicast group path root causes')
   }
   return res.json()
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2323,16 +2323,18 @@ export interface MulticastHealthGroupPathsResponse {
 }
 
 // One faulting endpoint behind the unhealthy per-path fan-out. affected_pairs
-// is how many (publisher, subscriber) pairs this endpoint drags down.
+// is how many (publisher, subscriber) pairs this endpoint drags down. A user
+// broken as both publisher and subscriber of the group reports the combined
+// 'publisher+subscriber' role.
 export interface MulticastHealthPathRootCause {
-  faulting_role: 'publisher' | 'subscriber' | string
+  faulting_role: 'publisher' | 'subscriber' | 'publisher+subscriber'
   user_pk: string
   owner_pubkey: string
   dz_ip: string
   tunnel_id: number
   device_pk: string
   device_code: string
-  endpoint_status: MulticastHealthStatus
+  endpoint_status: 'disconnected' | 'unhealthy'
   affected_pairs: number
 }
 


### PR DESCRIPTION
## Summary

- **Drop rate reconciliation from the multicast health verdict.** A user's `device_interface_rollup_5m` counter is per-tunnel and aggregates every group that user publishes/subscribes to, so a per-group "expected" rate (sum of the group's publishers' RX) can't be attributed once a user is in more than one group — which is the common case. In practice 100% of the "degraded" verdicts this check produced were multi-group aggregation artifacts, not delivery problems. The rate dimension is now **presence-only** (`active` / `idle` / `no_data`) and never gates `health_status`. Health is the control-plane verdict, which already includes `disconnected` for BGP-down users.
- **Keep observed bps + link to the traffic charts.** Each rate cell still shows the observed 5-min rate and now links to the tunnel's Traffic History on the user page, so operators can eyeball the actual rates without the (impossible) per-group reconciliation.
- **Add a "Root causes" rollup for the per-path fan-out.** One broken publisher drags down every one of its subscriber pairs (and vice-versa), so a handful of faulty endpoints can produce hundreds of unhealthy `(publisher, subscriber)` rows. A new `GET /api/dz/multicast-groups/{pk}/health/path-root-causes` endpoint collapses the unhealthy fan-out to the faulting endpoint(s) with an affected-pair count, rendered as a "Root causes" panel above the per-path table.

## Why

The group Health tab flagged large numbers of publishers/paths as unhealthy or degraded for reasons that weren't real delivery faults — degraded from an un-attributable rate mismatch, and a raw per-path table where 3 bad endpoints read as 450 bad rows. This removes the noise source and replaces the fan-out with an actionable root-cause view.

## Changes

- New migration `20260709000003_health_rate_presence_only.sql` recreates `health_multicast_user_rate`: drops `group_publisher_total` and the sum-reconciliation, verdict = control-plane `health_status`, rate reduced to a presence signal. `expected_bps_5m` retained as `NULL` for output-schema stability.
- New `path-root-causes` endpoint + query attributing each non-healthy path to the endpoint(s) not observed (a BGP-down endpoint has no session → not observed, so one filter catches both `unhealthy` and `disconnected` attributions).
- Web: rate badges → `active`/`idle`/`unknown`; removed expected/mismatch rendering; "traffic" deep-link to the user Traffic History section; `RootCausePanel` in the group Health tab.

## Testing Verification

- `TestHealthMulticastUserRate*` (mroute) rewritten to presence-only semantics — multi-group subscriber that previously flagged `degraded` now stays `active`/`healthy`; observed-rate dedup preserved; disconnected propagation still asserted.
- New `TestGetMulticastGroupHealth_PathRootCauses`: two unobserved subscribers of the same group surface as distinct root causes — one `unhealthy` (BGP up), one `disconnected` (BGP down) — each `affects 1 pair`; the observed publisher and the healthy pair contribute no root cause.
- `TestGetMulticastGroupHealth_Users` updated for presence-only (both endpoints transmitting → `active`, `expected_bps_5m` nil).
- Full `-run Multicast` API handler suite green.

## Related

Follows #685 (ingest onchain `bgp_status`) and #686 (reclassify BGP-down as `disconnected`).
