### PR TITLE
status: don't report links with live telemetry as down

### DIFF
--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -1314,6 +1314,11 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 		// Find when each adjacency was last seen to compute accurate "since" time.
 		// The last snapshot where is_deleted=0 is when the adjacency was still up.
 		lastSeen := make(map[string]string) // link_pk -> ISO timestamp
+		// A missing ISIS adjacency does not by itself mean the link is down: the data
+		// plane can keep forwarding traffic while the adjacency is absent. Track which
+		// of these links are still producing telemetry so we don't report them as
+		// "down" when they are only missing an adjacency.
+		hasRecentTelemetry := make(map[string]bool) // link_pk -> has samples in last 15m
 		if len(missing) > 0 {
 			linkPKs := make([]string, len(missing))
 			for i, m := range missing {
@@ -1338,6 +1343,24 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 					}
 				}
 			}
+
+			telemetryQuery := `
+				SELECT DISTINCT link_pk
+				FROM link_rollup_5m
+				WHERE link_pk IN ?
+				  AND bucket_ts >= now() - INTERVAL 15 MINUTE
+				  AND (a_samples + z_samples) > 0
+			`
+			telemetryRows, telemetryErr := a.envDB(ctx).Query(ctx, telemetryQuery, linkPKs)
+			if telemetryErr == nil {
+				defer telemetryRows.Close()
+				for telemetryRows.Next() {
+					var pk string
+					if err := telemetryRows.Scan(&pk); err == nil {
+						hasRecentTelemetry[pk] = true
+					}
+				}
+			}
 		}
 
 		for _, m := range missing {
@@ -1350,8 +1373,9 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 				SideAMetro:       m.sideAMetro,
 				SideZMetro:       m.sideZMetro,
 				Since:            lastSeen[m.linkPK],
-				IsDown:           true,
-				BandwidthBps:     m.bandwidthBps,
+				// Only a link whose data plane is also dark counts as down.
+				IsDown:       !hasRecentTelemetry[m.linkPK],
+				BandwidthBps: m.bandwidthBps,
 			})
 		}
 		return nil
@@ -1359,20 +1383,24 @@ func (a *API) FetchStatusData(ctx context.Context) *StatusResponse {
 
 	err := g.Wait()
 
-	// Merge missing adjacency issues after all goroutines complete (avoids race on resp.Links.Issues)
-	// Also update the Down count for links that weren't already counted during the latency scan.
-	existingIssueCodes := make(map[string]bool)
+	// Merge missing adjacency issues after all goroutines complete (avoids race on resp.Links.Issues).
+	// Only a link whose data plane is also dark (IsDown) counts toward Down. A link that is
+	// missing an adjacency but still carrying telemetry stays in the bucket the latency scan
+	// assigned it (e.g. degraded), so it is never counted as both degraded and down.
+	downCodes := make(map[string]bool)
 	for _, issue := range resp.Links.Issues {
 		if issue.IsDown {
-			existingIssueCodes[issue.Code] = true
+			downCodes[issue.Code] = true
 		}
 	}
 	for _, issue := range missingAdjIssues {
-		if !existingIssueCodes[issue.Code] {
+		if issue.IsDown && !downCodes[issue.Code] {
 			resp.Links.Down++
+			// A link with no telemetry was classified healthy by the latency scan.
 			if resp.Links.Healthy > 0 {
 				resp.Links.Healthy--
 			}
+			downCodes[issue.Code] = true
 		}
 	}
 	resp.Links.Issues = append(resp.Links.Issues, missingAdjIssues...)

--- a/web/src/components/status-page.tsx
+++ b/web/src/components/status-page.tsx
@@ -285,7 +285,9 @@ type IssueSeverity = "down" | "critical" | "degraded" | "no_data";
 
 function classifyIssueSeverity(issue: LinkIssue): IssueSeverity {
   if (issue.is_down) return "down";
-  if (issue.issue === "missing_adjacency") return "down";
+  // A missing ISIS adjacency while the data plane is still forwarding traffic
+  // (is_down=false) is a critical routing issue, not a full link-down.
+  if (issue.issue === "missing_adjacency") return "critical";
   if (issue.issue === "packet_loss") {
     if (issue.value >= 95) return "down";
     if (issue.value >= 10) return "critical";
@@ -379,19 +381,38 @@ function IssueDetails({
   onNonActivatedDeviceClick: (deviceCode: string) => void;
   onDeviceIssueClick: (devicePk: string) => void;
 }) {
-  const grouped = issues.reduce(
-    (acc, issue) => {
+  // Group all issues by link first, then assign each link to a single section based on
+  // its worst issue severity. This ensures a link with multiple issues (e.g. packet loss
+  // + missing adjacency) appears exactly once, not duplicated across severity sections.
+  const severityRank: Record<IssueSeverity, number> = {
+    down: 0,
+    critical: 1,
+    degraded: 2,
+    no_data: 3,
+  };
+  const issuesByLink = new Map<string, LinkIssue[]>();
+  for (const issue of issues) {
+    const existing = issuesByLink.get(issue.code) || [];
+    existing.push(issue);
+    issuesByLink.set(issue.code, existing);
+  }
+  const grouped: Record<
+    IssueSeverity,
+    { code: string; issues: LinkIssue[] }[]
+  > = {
+    down: [],
+    critical: [],
+    degraded: [],
+    no_data: [],
+  };
+  for (const [code, linkIssues] of issuesByLink) {
+    let worst = classifyIssueSeverity(linkIssues[0]);
+    for (const issue of linkIssues) {
       const severity = classifyIssueSeverity(issue);
-      acc[severity].push(issue);
-      return acc;
-    },
-    {
-      down: [] as LinkIssue[],
-      critical: [] as LinkIssue[],
-      degraded: [] as LinkIssue[],
-      no_data: [] as LinkIssue[],
-    },
-  );
+      if (severityRank[severity] < severityRank[worst]) worst = severity;
+    }
+    grouped[worst].push({ code, issues: linkIssues });
+  }
 
   const sections: {
     key: IssueSeverity;
@@ -463,16 +484,8 @@ function IssueDetails({
         Showing issues from the last hour
       </div>
       {sections.map(({ key, label, icon: Icon, iconColor, valueColor }) => {
-        const sectionIssues = grouped[key];
-        if (sectionIssues.length === 0) return null;
-
-        // Group issues by link code so the same link appears once with all its issues
-        const byLink = new Map<string, LinkIssue[]>();
-        for (const issue of sectionIssues) {
-          const existing = byLink.get(issue.code) || [];
-          existing.push(issue);
-          byLink.set(issue.code, existing);
-        }
+        const sectionLinks = grouped[key];
+        if (sectionLinks.length === 0) return null;
 
         return (
           <div key={key}>
@@ -480,7 +493,7 @@ function IssueDetails({
               {label}
             </div>
             <div className="space-y-2">
-              {[...byLink.entries()].map(([code, linkIssues]) => {
+              {sectionLinks.map(({ code, issues: linkIssues }) => {
                 const first = linkIssues[0];
                 // Use the most recent "since" across all issues for this link
                 const mostRecentSince = linkIssues.reduce((latest, i) => {


### PR DESCRIPTION
## Summary

- A WAN link on mainnet (`au1c-dz01:la2r-dz01`) was showing on the status page as both "Degraded Performance" **and** "Links Down (for 4d)" at the same time. The "down for 4d" was false: the link has carried continuous telemetry every day (full 288 five-minute buckets/day, 0% median loss) while its ISIS adjacency has merely been absent from `isis_adjacencies_current` for ~4.5 days.
- Root cause: the missing-ISIS-adjacency detector hardcoded `IsDown=true` for any activated link with a `tunnel_net` not present in `isis_adjacencies_current`, regardless of whether the data plane was still forwarding traffic. Nothing reconciled that "down" record against the link's separate "degraded" packet-loss record, so the same link was double-listed and the summary counts were inflated.

## Changes

**Backend (`api/handlers/status.go`)**
- Query `link_rollup_5m` for the missing-adjacency links and mark a `missing_adjacency` issue as `IsDown` only when the data plane is also dark (no samples in the last 15m).
- Fix the count merge so it only increments `Down` (and decrements `Healthy`) for genuinely dark links. A link the latency scan already counted as `degraded` is no longer double-counted as `down`, and the merge no longer wrongly decrements `Healthy` for a link that was counted as degraded.

**Frontend (`web/src/components/status-page.tsx`)**
- Classify a `missing_adjacency` issue whose data plane is up (`is_down=false`) as **critical** rather than unconditionally **down**.
- Group issues by link first, then assign each link to a single worst-severity section, so one link can never render in multiple sections simultaneously.

## Behavior after the fix

- A link carrying live telemetry is no longer reported as "down"; it appears once, under "Critical Issues", labeled "ISIS down · for Nd" (accurate: the adjacency has been missing, the link is not down).
- A genuinely dark link (missing adjacency **and** no telemetry) still appears under "Links Down" and counts toward `Down`, unchanged.

## Testing Verification

- Traced against live mainnet data: confirmed the affected link had 352 telemetry samples in the last 15 min and full daily bucket coverage with 0% median loss, while absent from `isis_adjacencies_current` since 2026-07-10; confirmed it was the sole driver of the mainnet "issues detected" banner.
- `go build ./api/...`, `gofmt`, and `go vet ./api/handlers/` pass; `status-page.tsx` typechecks clean.