### PR TITLE
network-health: add the Network Health Reporting page

### DIFF
--- a/api/handlers/network_health.go
+++ b/api/handlers/network_health.go
@@ -624,17 +624,21 @@ const nhGroupDeadline = 35 * time.Second
 // directly (bypassing these handlers) so it is excluded too.
 var nhLiveComputeSem = make(chan struct{}, 4)
 
-// nhAcquireLive tries to reserve a live-compute slot within a short timeout. On
-// success it returns a release func and true; on failure it returns false and the
-// caller must return 503 without launching a query. Release must be deferred.
+// nhAcquireLive reserves a live-compute slot, waiting for one to free rather
+// than shedding immediately. A scoped page load fires ~9 group requests at once
+// and every one computes live (scoped views are never precomputed); with only 4
+// slots, an immediate-shed policy 503'd the requests that lost the race, so the
+// UI showed "Couldn't load" on ~5 of 9 panels. Waiting for a slot instead lets
+// them queue and fill in progressively as the running queries finish. The wait
+// is bounded by ctx (the caller passes the group deadline), so a request still
+// sheds if its deadline expires while queued (genuine sustained overload) or if
+// the client disconnected. On success it returns a release func and true; on
+// failure it returns false and the caller must return 503 without launching a
+// query. Release must be deferred.
 func nhAcquireLive(ctx context.Context) (func(), bool) {
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
 	select {
 	case nhLiveComputeSem <- struct{}{}:
 		return func() { <-nhLiveComputeSem }, true
-	case <-timer.C:
-		return nil, false
 	case <-ctx.Done():
 		return nil, false
 	}
@@ -668,17 +672,21 @@ func (a *API) serveNHGroup(
 	)
 
 	writeLive := func(contrib string) {
-		// Bound concurrent live computes; shed load with 503 rather than piling on
-		// another ClickHouse query when the limit is saturated.
-		release, ok := nhAcquireLive(r.Context())
+		// One deadline covers the whole live operation: waiting for a slot plus
+		// the query. Concurrent ClickHouse queries are still bounded to 4, but
+		// waiters queue for a free slot instead of shedding on contention, so a
+		// single page load's ~9 concurrent group requests fill in progressively
+		// rather than 503-ing each other. Only a request whose deadline expires
+		// while queued (sustained overload) or whose client disconnected is shed.
+		ctx, cancel := context.WithTimeout(r.Context(), deadline)
+		defer cancel()
+		release, ok := nhAcquireLive(ctx)
 		if !ok {
 			nhWriteLiveUnavailable(w)
 			return
 		}
 		defer release()
 		w.Header().Set("X-Cache", "MISS")
-		ctx, cancel := context.WithTimeout(r.Context(), deadline)
-		defer cancel()
 		resp := fetch(ctx, start, end, contrib)
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/api/handlers/network_health.go
+++ b/api/handlers/network_health.go
@@ -1,0 +1,3453 @@
+package handlers
+
+// Network Health Reporting: a public, windowed report of how the DoubleZero
+// network performed over a time window (default: last 30 days), network-wide.
+//
+// Design notes (see plans/network-health-dashboard/SPEC.md):
+//   - Facts only. This endpoint returns raw measurements; it does not score,
+//     rank, or judge contributors. The frontend must present them neutrally.
+//     One deliberate exception: NHTickets.SelfReportedPct (the share of a
+//     contributor's own incidents that the contributor filed themselves) may be
+//     graded good/warn/bad on that contributor's OWN view. It is the
+//     contributor's own self-fact about their own incidents, shown only on their
+//     own page (never a cross-contributor leaderboard), so it does not judge one
+//     contributor against another.
+//   - Safety: every query carries an inline SETTINGS cap and the whole fetch
+//     runs under a context deadline. Time bounds are passed as bound parameters
+//     (time.Time), never string-interpolated. Rollup/percentile values are
+//     already clean rates, so no counter-wrap guard is needed there; the raw
+//     fact table (traffic bytes) keeps the out_octets_delta > 0 guard.
+//   - The default (30d) view is precomputed by the worker into page_cache and
+//     served on HIT; custom windows compute live under the deadline.
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// The Network Health page is split into independent data-source groups, each
+	// with its OWN page_cache key so it loads and caches on its own. Each suffix is
+	// bumped independently when that one group's payload shape changes, so a stale
+	// blob from an older shape is never served (it would crash the newer frontend).
+	// The bare route /api/network-health serves the Overview group (see
+	// GetNetworkHealth), so its key stands in for the old monolith key.
+	NetworkHealthOverviewCacheKey     = "network_health_overview_30d_v1"
+	NetworkHealthAvailabilityCacheKey = "network_health_availability_30d_v1"
+	NetworkHealthLatencyCacheKey      = "network_health_latency_30d_v1"
+	NetworkHealthCapacityCacheKey     = "network_health_capacity_30d_v1"
+	NetworkHealthOutagesCacheKey      = "network_health_outages_30d_v1"
+	NetworkHealthDrainCacheKey        = "network_health_drain_30d_v1"
+	NetworkHealthTicketsCacheKey      = "network_health_tickets_30d_v1"
+	NetworkHealthImpactfulCacheKey    = "network_health_impactful_30d_v1"
+	// NetworkHealthDeferredCacheKey is the page_cache key for the default 30d
+	// deferred payload (the slow undrain/recovery-health figures, split out of the
+	// main page so the main page loads without waiting on the heavy scan).
+	NetworkHealthDeferredCacheKey = "network_health_deferred_30d_v1"
+	// networkHealthContributorCacheKeyInfix separates a group's version suffix
+	// from the contributor code in a per-contributor cache key (see nhContribKey).
+	networkHealthContributorCacheKeyInfix = "_c_"
+	// NetworkHealthDefaultDays is the default (and cached) window length.
+	NetworkHealthDefaultDays = 30
+
+	networkHealthMaxDays = 92
+	// max_memory_usage caps each query at ~2 GiB so a single heavy query errors
+	// (and degrades to an empty panel via nhGo) instead of breaching the server
+	// total memory limit and taking down sibling queries. Public-page safety.
+	// max_bytes_before_external_group_by / max_bytes_before_external_sort let a
+	// big GROUP BY or ORDER BY spill to disk well before that cap, so a heavy
+	// 30d scan over device_interface_rollup_5m/link_rollup_5m (sorted by
+	// bucket_ts first, so a per-entity filter still scans the whole range)
+	// finishes slower instead of erroring with code 241 ("memory limit
+	// exceeded ... while reading column device_pk/link_pk").
+	// max_execution_time = 55 is chosen against two different callers of these
+	// queries: the page-cache worker's refresh() wraps each cache-refresh call
+	// in its own 60s context (api/worker/workflow.go), so 55s leaves headroom
+	// for the worker to finish every panel on one refresh instead of leaving it
+	// empty until a later tick; live requests (contributor scope, see
+	// GetNetworkHealth) are bounded by their own ~35s request context, which
+	// cancels the ClickHouse query client-side well before 55s, so raising this
+	// shared setting does not relax anything on that path.
+	networkHealthQuerySettings = " SETTINGS max_execution_time = 55, max_memory_usage = 2000000000, max_bytes_before_external_group_by = 1000000000, max_bytes_before_external_sort = 1000000000, timeout_before_checking_execution_speed = 0"
+
+	// networkHealthDeferredQuerySettings is networkHealthQuerySettings with a much
+	// higher max_execution_time (170s) for the deferred recovery-health scan. That
+	// scan (fetchRecoveryHealth over link_rollup_5m) is the one query that could
+	// exceed the main page's 35s/55s budget, so it is served from its own deferred
+	// endpoint (GetNetworkHealthDeferred) under a 170s request deadline. The memory
+	// cap and spill settings are unchanged (still 2 GiB), so this only buys time,
+	// never more memory.
+	networkHealthDeferredQuerySettings = " SETTINGS max_execution_time = 170, max_memory_usage = 2000000000, max_bytes_before_external_group_by = 1000000000, max_bytes_before_external_sort = 1000000000, timeout_before_checking_execution_speed = 0"
+
+	// throughputMaxThreads caps parallelism on the one query that dedups the
+	// whole user-traffic slice of device_interface_rollup_5m (~14.4M rows over
+	// 30d, one dedup group per row). At default parallelism each thread buffers
+	// its own native-stream read of that slice and the query breaches the 2 GB
+	// cap at the source read (code 241, SourceFromNativeStream); 4 threads keeps
+	// the concurrent read buffers small enough to finish under the cap (measured
+	// ~40 ms vs OOM). Appended after networkHealthQuerySettings so the later
+	// max_threads wins. This is the scan the network peak is derived from and the
+	// one that renders the throughput time series, so it fixes both.
+	throughputMaxThreads = ", max_threads = 4"
+)
+
+// nhGo runs one panel query concurrently as best-effort. If it fails or times out
+// (e.g. a heavy scan hitting max_execution_time on the remote proxy) the error is
+// logged with the panel name and the goroutine returns nil, so a single slow or
+// broken panel degrades to an empty box instead of cancelling every sibling query
+// and blanking the whole report. The panel name makes the failure diagnosable.
+func nhGo(g *errgroup.Group, panel string, fn func() error) {
+	g.Go(func() error {
+		if err := fn(); err != nil {
+			logError("network health panel failed", "panel", panel, "error", err)
+		}
+		return nil
+	})
+}
+
+// The Network Health page is served as independent data-source groups, each its
+// own endpoint + cache blob (see the *CacheKey constants and the Get* handlers).
+// Every group is a subset of the old monolith payload; nothing is dropped and no
+// field is owned by more than one group. Each group carries the resolved window
+// (so the frontend can label it), a generated_at stamp, and an optional error
+// (set only on the non-scoped path for the headline-critical groups, so the cache
+// worker keeps the last good blob instead of caching zeros — see the worker
+// entries in api/worker/workflow.go).
+
+// NHOverview is the Overview group: the headline signals plus trend context. It
+// deliberately does NOT own the outage/impactful headline tiles (those come from
+// the Outages and Impactful groups so their heavy scans never block Overview);
+// the frontend headline row cross-reads all three. Contributors is the list that
+// backs the filter-bar dropdown (code + footprint only, no outage breakdown).
+type NHOverview struct {
+	Window       NHWindow        `json:"window"`
+	Headline     NHHeadline      `json:"headline"`
+	Isis         NHIsis          `json:"isis"`
+	Freshness    NHFreshness     `json:"freshness"`
+	Throughput   []NHTsPoint     `json:"throughput_ts"`
+	Contributors []NHContributor `json:"contributors"`
+	GeneratedAt  string          `json:"generated_at"`
+	Error        string          `json:"error,omitempty"`
+}
+
+// NHAvailabilityGroup is the Availability group (no deltas).
+type NHAvailabilityGroup struct {
+	Window             NHWindow         `json:"window"`
+	LinkAvailability   []NHAvailability `json:"link_availability"`
+	DeviceAvailability []NHAvailability `json:"device_availability"`
+	GeneratedAt        string           `json:"generated_at"`
+	Error              string           `json:"error,omitempty"`
+}
+
+// NHLatencyGroup is the Latency group: committed-vs-measured link latency plus
+// the committed-RTT (SLA) adherence tile (no deltas).
+type NHLatencyGroup struct {
+	Window       NHWindow     `json:"window"`
+	LatencyLinks []NHPerfLink `json:"latency_links"`
+	Sla          NHSla        `json:"sla"`
+	GeneratedAt  string       `json:"generated_at"`
+	Error        string       `json:"error,omitempty"`
+}
+
+// NHCapacityGroup is the Capacity group. Capacity is the network SEAT-utilization
+// summary; CapacityLinks is the fullest-links (bandwidth) capacity-planning
+// panel — two different concepts (no deltas).
+type NHCapacityGroup struct {
+	Window        NHWindow         `json:"window"`
+	Capacity      NHCapacity       `json:"capacity"`
+	DeviceSlots   []NHDeviceSlots  `json:"device_slots"`
+	DiaInterfaces []NHDiaInterface `json:"dia_interfaces"`
+	TopLinks      []NHTrafficLink  `json:"top_links"`
+	CapacityLinks []NHCapacityLink `json:"capacity_links"`
+	GeneratedAt   string           `json:"generated_at"`
+	Error         string           `json:"error,omitempty"`
+}
+
+// NHOutagesGroup is the Outages group: the reliability episode scan (which also
+// feeds the headline OutageCount tile + its delta), outage summary, downtime
+// rankings, outages-over-time, and interface-error hotspots. Prev carries the
+// prior-window values for the reliability + outage-summary deltas. The
+// per-contributor footprint lives in the Overview group (the scope dropdown's
+// source), not here.
+type NHOutagesGroup struct {
+	Window           NHWindow         `json:"window"`
+	Reliability      NHReliability    `json:"reliability"`
+	OutageCount      uint64           `json:"outage_count"`
+	OutageCountDelta *float64         `json:"outage_count_delta"`
+	OutageSummary    *NHOutageSummary `json:"outage_summary"`
+	DowntimeLinks    []NHDowntimeRow  `json:"downtime_links"`
+	DowntimeDevices  []NHDowntimeRow  `json:"downtime_devices"`
+	OutagesOverTime  []NHCountPoint   `json:"outages_ts"`
+	ErrorHotspots    []NHErrorHotspot `json:"error_hotspots"`
+	Prev             *NHOutagesPrev   `json:"prev"`
+	GeneratedAt      string           `json:"generated_at"`
+	Error            string           `json:"error,omitempty"`
+}
+
+// NHOutagesPrev is the prior-window reliability + outage-summary values for the
+// Outages group's deltas.
+type NHOutagesPrev struct {
+	Reliability   NHReliabilityPrev `json:"reliability"`
+	OutageSummary *NHOutageSummary  `json:"outage_summary"`
+}
+
+// NHDrainGroup is the Drain group: the pure-Go drain/undrain timing figures. The
+// undrain (recovery-health) figures are NOT here — that heavy scan stays on the
+// /deferred endpoint. Prev carries the prior-window figures for the deltas.
+type NHDrainGroup struct {
+	Window      NHWindow       `json:"window"`
+	DrainTiming NHDrainTiming  `json:"drain_timing"`
+	Prev        *NHDrainTiming `json:"prev"`
+	GeneratedAt string         `json:"generated_at"`
+	Error       string         `json:"error,omitempty"`
+}
+
+// NHTicketsGroup is the Tickets group: the public ops-management aggregate for
+// the current and prior windows (split from one union fetch over the ops API).
+type NHTicketsGroup struct {
+	Window      NHWindow   `json:"window"`
+	OpsTickets  *NHTickets `json:"ops_tickets"`
+	Prev        *NHTickets `json:"prev"`
+	GeneratedAt string     `json:"generated_at"`
+	Error       string     `json:"error,omitempty"`
+}
+
+// NHImpactful is the Impactful group (its own heavy endpoint, 170s live deadline,
+// like /deferred): the impact-weighted downtime headline tile + its delta. The
+// frontend derives availability_pct from Overview.ActiveLinks + this figure.
+type NHImpactful struct {
+	Window                 NHWindow         `json:"window"`
+	ImpactfulDowntimeHours float64          `json:"impactful_downtime_hours"`
+	ImpactfulDowntimeDelta *float64         `json:"impactful_downtime_delta"`
+	Prev                   *NHImpactfulPrev `json:"prev"`
+	Unavailable            bool             `json:"unavailable"`
+	GeneratedAt            string           `json:"generated_at"`
+	Error                  string           `json:"error,omitempty"`
+}
+
+// NHImpactfulPrev is the prior-window impactful-downtime value for the delta.
+type NHImpactfulPrev struct {
+	ImpactfulDowntimeHours float64 `json:"impactful_downtime_hours"`
+}
+
+// NHReliabilityPrev is the prior-window reliability figures (a subset of
+// NHReliability) used to compute deltas on the reliability section.
+type NHReliabilityPrev struct {
+	OutageCount         uint64  `json:"outage_count"`
+	CappedDowntimeHours float64 `json:"capped_downtime_hours"`
+}
+
+// NHTickets is the PUBLIC ops-management aggregate. Text-free by construction:
+// only numbers and the fixed enums (severity, type). No ticket titles,
+// descriptions, reporter identities, contributor pubkeys, or root-cause text
+// ever appear here. It is produced by the Tickets group
+// (FetchNetworkHealthTicketsData): on its own endpoint the external ops-API
+// pagination is capped to 20s and never blocks another panel, so unlike the old
+// monolith the network-wide live path no longer skips it. A contributor-scoped
+// view filters the aggregate to that contributor's tickets.
+//
+// Timing (response/resolution) is computed over INCIDENTS ONLY. Maintenance is
+// scheduled ahead of time, so a created-before-start offset would drag those
+// medians negative; maintenance instead gets its own lead/duration figures.
+type NHTickets struct {
+	Total       int `json:"total"`
+	Incidents   int `json:"incidents"`
+	Maintenance int `json:"maintenance"`
+	Sev1        int `json:"sev1"`
+	Sev2        int `json:"sev2"`
+	Sev3        int `json:"sev3"`
+
+	ResponseP50Min   *int `json:"response_p50_min"`   // incident start -> ticket created
+	ResolutionP50Min *int `json:"resolution_p50_min"` // incident start -> ticket end (closed only)
+	ClosedIncidents  int  `json:"closed_incidents"`
+
+	// Self-reported classification (incidents only). An incident is
+	// self-reported when its creator (user_pubkey) is a contributor user, and
+	// DoubleZero-filed when the creator is DoubleZero staff or the creator is
+	// unknown. SelfReportedPct is the share of incidents the contributor filed
+	// themselves; it is nil when the /users registry could not be fetched (shown
+	// as "unavailable" rather than mislabeling every incident as DoubleZero).
+	SelfReportedCount    int      `json:"self_reported_count"`
+	DoubleZeroFiledCount int      `json:"doublezero_filed_count"`
+	SelfReportedPct      *float64 `json:"self_reported_pct"`
+
+	// Maintenance-only timing. Lead = scheduled start - created (how far ahead it
+	// was announced); Duration = end - start (how long the window ran, closed
+	// set includes "completed"). No time-to-file for maintenance.
+	MaintenanceLeadP50Min     *int `json:"maintenance_lead_p50_min"`
+	MaintenanceDurationP50Min *int `json:"maintenance_duration_p50_min"`
+	ClosedMaintenance         int  `json:"closed_maintenance"`
+
+	OutageCount       int      `json:"outage_count"`
+	OutagesWithTicket int      `json:"outages_with_ticket"`
+	OutagesNoTicket   int      `json:"outages_no_ticket"`
+	NoTicketSharePct  *float64 `json:"no_ticket_share_pct"`
+
+	// NoTicketOutages is the actionable list behind OutagesNoTicket: the
+	// telemetry-derived outages with no matching ops ticket, sorted by duration
+	// descending and capped to the longest few. Facts only (link code + start +
+	// duration hours); no ticket free text, since by definition these have no
+	// ticket. Lets an operator see WHICH outages went unfiled, not just how many.
+	NoTicketOutages []NHNoTicketOutage `json:"no_ticket_outages"`
+
+	// RootCauses is the incident root-cause breakdown over the window: one row
+	// per fixed root-cause enum token (self_resolved, network_external,
+	// fiber_cut, configuration, hardware, carrier, false_positive), sorted by
+	// count descending. Enum tokens only, so the text-free public contract holds.
+	RootCauses []NHRootCauseCount `json:"root_causes"`
+}
+
+// NHRootCauseCount is one incident root-cause enum's share of incidents that
+// have a recorded cause. Cause is a fixed enum token (never free text).
+type NHRootCauseCount struct {
+	Cause string   `json:"cause"`
+	Count int      `json:"count"`
+	Pct   *float64 `json:"pct"`
+}
+
+// NHNoTicketOutage is one telemetry-derived outage that has no matching ops
+// ticket. Facts only: the affected link's code, the outage start, and its
+// duration in hours. No ticket free text (there is no ticket).
+type NHNoTicketOutage struct {
+	LinkPK   string  `json:"link_pk"`
+	LinkCode string  `json:"link_code"`
+	StartTs  string  `json:"start_ts"`
+	Hours    float64 `json:"hours"`
+}
+
+// NHSla is committed-RTT adherence: links (with a committed RTT) whose observed
+// average RTT stayed within their onchain committed value over the window.
+type NHSla struct {
+	Within    uint64   `json:"within"`
+	Total     uint64   `json:"total"`
+	WithinPct *float64 `json:"within_pct"`
+}
+
+// NHCapacity is network seat utilization (users vs configured capacity).
+type NHCapacity struct {
+	UnicastUsers uint64   `json:"unicast_users"`
+	MaxUsers     uint64   `json:"max_users"`
+	UtilPct      *float64 `json:"util_pct"`
+}
+
+// NHDeviceSlots is one device's seat usage (unicast + multicast sub/pub) vs its
+// total configured max_users. Per-role maxes (max_unicast_users,
+// max_multicast_*) are 0/unset on most devices, so max_users (the device's
+// single overall cap) is the denominator; UsedPct is nil when max_users is 0.
+type NHDeviceSlots struct {
+	PK       string   `json:"pk"`
+	Code     string   `json:"code"`
+	Unicast  uint64   `json:"unicast"`
+	McastSub uint64   `json:"mcast_sub"`
+	McastPub uint64   `json:"mcast_pub"`
+	MaxUsers uint64   `json:"max_users"`
+	UsedPct  *float64 `json:"used_pct"`
+}
+
+// NHDiaInterface is one Direct Internet Access interface's provisioned
+// capacity (port speed, committed rate) vs observed traffic (p50/p99 out).
+// UtilPct is measured against interface bandwidth (physical port speed), so
+// Denom is always "port"; CirGbps is kept as an informational figure only.
+type NHDiaInterface struct {
+	DevicePK string   `json:"device_pk"`
+	Device   string   `json:"device"`
+	Intf     string   `json:"intf"`
+	PortGbps float64  `json:"port_gbps"`
+	CirGbps  float64  `json:"cir_gbps"`
+	P50Gbps  float64  `json:"p50_gbps"`
+	P99Gbps  float64  `json:"p99_gbps"`
+	UtilPct  *float64 `json:"util_pct"`
+	Denom    string   `json:"denom"` // "cir" or "port"
+}
+
+// NHIsis is a control-plane health tile.
+type NHIsis struct {
+	Overloaded  uint64 `json:"overloaded"`
+	Unreachable uint64 `json:"unreachable"`
+	Devices     uint64 `json:"devices"`
+	Adjacencies uint64 `json:"adjacencies"`
+}
+
+// NHFreshness lets a viewer date the data (a trust signal). Coverage is measured
+// relative to the feed's own latest timestamp, not wall-clock.
+type NHFreshness struct {
+	FeedMax       string `json:"feed_max"`
+	LagSeconds    int64  `json:"lag_seconds"`
+	DevicesFresh  uint64 `json:"devices_fresh"`
+	DevicesActive uint64 `json:"devices_active"`
+}
+
+// NHTsPoint is one throughput time-series point (bits/sec).
+type NHTsPoint struct {
+	T      string  `json:"t"`
+	AvgBps float64 `json:"avg_bps"`
+	MaxBps float64 `json:"max_bps"`
+}
+
+// NHCountPoint is one count time-series point (e.g. outages started per bucket).
+type NHCountPoint struct {
+	T     string `json:"t"`
+	Count uint64 `json:"count"`
+}
+
+// NHTrafficLink is a link ranked by traffic carried. Traffic is a neutral fact.
+type NHTrafficLink struct {
+	LinkPK     string  `json:"link_pk"`
+	LinkCode   string  `json:"link_code"`
+	SideAMetro string  `json:"side_a_metro"`
+	SideZMetro string  `json:"side_z_metro"`
+	Status     string  `json:"status"`
+	AvgGbps    float64 `json:"avg_gbps"`
+	MaxGbps    float64 `json:"max_gbps"`
+}
+
+// NHCapacityLink is a link's peak utilization against its provisioned bandwidth
+// (a capacity-planning signal: which links are closest to full).
+type NHCapacityLink struct {
+	LinkPK        string  `json:"link_pk"`
+	LinkCode      string  `json:"link_code"`
+	SideAMetro    string  `json:"side_a_metro"`
+	SideZMetro    string  `json:"side_z_metro"`
+	BandwidthGbps float64 `json:"bandwidth_gbps"`
+	PeakGbps      float64 `json:"peak_gbps"`
+	UtilPct       float64 `json:"util_pct"`
+	P50Util       float64 `json:"p50_util"`
+	P99Util       float64 `json:"p99_util"`
+}
+
+// NHPerfLink compares a link's onchain committed RTT to its measured RTT over
+// the window (the network's own latency promise). Facts, not pass/fail.
+type NHPerfLink struct {
+	LinkPK           string  `json:"link_pk"`
+	LinkCode         string  `json:"link_code"`
+	SideAMetro       string  `json:"side_a_metro"`
+	SideZMetro       string  `json:"side_z_metro"`
+	CommittedMs      float64 `json:"committed_ms"`
+	MeasuredAvgMs    float64 `json:"measured_avg_ms"`
+	MeasuredMaxMs    float64 `json:"measured_max_ms"`
+	OverCommittedPct float64 `json:"over_committed_pct"`
+	DriftMs          float64 `json:"drift_ms"`
+	DriftPct         float64 `json:"drift_pct"`
+	// RawCommittedMs is the onchain committed RTT before any delay override.
+	// Overridden is true when an IS-IS delay override is set, in which case
+	// CommittedMs (and the drift/over figures) reflect the override (the value
+	// the network actually routes on), not the raw onchain commitment.
+	RawCommittedMs float64 `json:"raw_committed_ms"`
+	Overridden     bool    `json:"overridden"`
+}
+
+// NHAvailability is one entity's time-based 3-way state split over the window,
+// summing to 100% of the (non-provisioning) window: Available (activated and
+// up), Drained (soft/hard drained: intentional, not a fault), and Outage
+// (activated but isis_down or high loss: the fault downtime that reconciles
+// with the downtime/incidents metric). Drain counts as unavailable but is
+// shown as its own segment rather than folded into "outage", so a heavily
+// soft-drained link doesn't read as if it had a fault. A fact, not a score.
+type NHAvailability struct {
+	PK           string  `json:"pk"`
+	Code         string  `json:"code"`
+	Metros       string  `json:"metros,omitempty"` // links only: "ams ↔ lon"
+	AvailPct     float64 `json:"avail_pct"`        // 100*avail/(avail+drained+outage)
+	DrainedPct   float64 `json:"drained_pct"`
+	OutagePct    float64 `json:"outage_pct"`
+	AvailHours   float64 `json:"avail_hours"`   // avail_buckets * 5 / 60
+	OutageHours  float64 `json:"outage_hours"`  // outage_buckets * 5 / 60
+	DrainedHours float64 `json:"drained_hours"` // drained_buckets * 5 / 60
+}
+
+// NHErrorHotspot is a device with interface errors/discards or carrier flaps
+// (an early warning of degrading optics/fiber before an outage).
+type NHErrorHotspot struct {
+	DevicePK     string `json:"device_pk"`
+	DeviceCode   string `json:"device_code"`
+	Errors       uint64 `json:"errors"`
+	CarrierFlaps uint64 `json:"carrier_flaps"`
+}
+
+// NHDrainTiming reports how link drains/undrains played out over the window.
+// Plain measurements (minutes); no targets, no pass/fail (see spec 1.1).
+type NHDrainTiming struct {
+	OutageCount         int      `json:"outage_count"`
+	EventsWithDrain     int      `json:"events_with_drain"`
+	Drains              int      `json:"drains"`
+	Undrains            int      `json:"undrains"`
+	TimeToDrainP50Min   *float64 `json:"time_to_drain_p50_min"`
+	TimeToDrainMaxMin   *float64 `json:"time_to_drain_max_min"`
+	TimeDrainedP50Min   *float64 `json:"time_drained_p50_min"`
+	TimeDrainedMaxMin   *float64 `json:"time_drained_max_min"`
+	TimeToUndrainP50Min *float64 `json:"time_to_undrain_p50_min"`
+	TimeToUndrainMaxMin *float64 `json:"time_to_undrain_max_min"`
+	DrainWithin30mPct   *float64 `json:"drain_within_30m_pct"`
+	// MatchedUndrains is the number of drain->undrain pairs found. When 0 the
+	// undrain-timing figures are absent because nothing was paired (not a
+	// failure). UndrainUnavailable is set when the recovery-health query failed,
+	// so the frontend shows "unavailable" rather than a bare dash.
+	MatchedUndrains    int  `json:"matched_undrains"`
+	UndrainUnavailable bool `json:"undrain_unavailable"`
+}
+
+// NHDeferred is the deferred (slow) portion of the drain-timing panel: the
+// recovery-health-derived "time to undrain a healthy link" figures. These come
+// from fetchRecoveryHealth, the one drain-timing query heavy enough to exceed
+// the main page's deadline, so they are served from GetNetworkHealthDeferred
+// (a separate endpoint under a longer 170s deadline) instead of blocking the
+// main payload. Prev holds the prior-window figures for the section delta.
+type NHDeferred struct {
+	TimeToUndrainP50Min *float64    `json:"time_to_undrain_p50_min"`
+	TimeToUndrainMaxMin *float64    `json:"time_to_undrain_max_min"`
+	UndrainUnavailable  bool        `json:"undrain_unavailable"`
+	MatchedUndrains     int         `json:"matched_undrains"`
+	Prev                *NHDeferred `json:"prev,omitempty"`
+	Error               string      `json:"error,omitempty"`
+}
+
+// nhDrainMatch is a matched drain->undrain interval for one link, used to find
+// when the link recovered (came back healthy) before it was undrained.
+type nhDrainMatch struct {
+	linkPK    string
+	drainTS   time.Time
+	undrainTS time.Time
+}
+
+// nhEvent is one reconstructed link-down incident (isis_down run on an activated link).
+type nhEvent struct {
+	linkPK string
+	start  time.Time
+	end    time.Time
+}
+
+// nhChange is one link status transition.
+type nhChange struct {
+	linkPK string
+	prev   string
+	next   string
+	ts     time.Time
+}
+
+type NHWindow struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+	Days  int    `json:"days"`
+	Label string `json:"label"`
+}
+
+type NHHeadline struct {
+	PeakBps                float64  `json:"peak_bps"`
+	JitterImprovePct       float64  `json:"jitter_improve_pct"`
+	DzLossPct              float64  `json:"dz_loss_pct"`
+	OutageCount            uint64   `json:"outage_count"`
+	ImpactfulDowntimeHours float64  `json:"impactful_downtime_hours"`
+	ActiveLinks            uint64   `json:"active_links"`
+	ActiveDevices          uint64   `json:"active_devices"`
+	ActiveMetros           uint64   `json:"active_metros"`
+	Deltas                 NHDeltas `json:"deltas"`
+}
+
+// NHDeltas are percentage changes versus the previous equal-length window.
+// nil means the prior value was zero/unavailable (no delta shown).
+type NHDeltas struct {
+	PeakBps           *float64 `json:"peak_bps"`
+	OutageCount       *float64 `json:"outage_count"`
+	ActiveLinks       *float64 `json:"active_links"`
+	ImpactfulDowntime *float64 `json:"impactful_downtime"`
+}
+
+type NHReliability struct {
+	OutageCount         uint64         `json:"outage_count"`
+	DistinctLinks       uint64         `json:"distinct_links"`
+	CappedDowntimeHours float64        `json:"capped_downtime_hours"`
+	DegradedLinks       uint64         `json:"degraded_links"`
+	DurationHistogram   NHDurationHist `json:"duration_histogram"`
+}
+
+// NHDurationHist buckets outages by duration. Descriptive only.
+type NHDurationHist struct {
+	FlapLE5m        uint64 `json:"flap_le5m"`
+	Short5to15m     uint64 `json:"short_5_15m"`
+	Medium15to60m   uint64 `json:"medium_15_60m"`
+	Sustained1to24h uint64 `json:"sustained_1_24h"`
+	ChronicGt24h    uint64 `json:"chronic_gt24h"`
+}
+
+// NHContributor is a plain per-contributor fact row. No score, no rank.
+type NHContributor struct {
+	Code                string  `json:"code"`
+	Outages             uint64  `json:"outages"`
+	CappedDowntimeHours float64 `json:"capped_downtime_hours"`
+	DistinctLinks       uint64  `json:"distinct_links"`
+	Links               uint64  `json:"links"`
+	Devices             uint64  `json:"devices"`
+}
+
+// NHOutageSummary is the network-wide (or contributor-scoped) outage total for
+// the window, split by entity kind. OutageHours is the link outage-hours total
+// (uncapped; a fact, not the headline's capped figure).
+type NHOutageSummary struct {
+	LinkOutages     uint64  `json:"link_outages"`
+	OutageHours     float64 `json:"outage_hours"`
+	LinksAffected   uint64  `json:"links_affected"`
+	DeviceOutages   uint64  `json:"device_outages"`
+	DevicesAffected uint64  `json:"devices_affected"`
+}
+
+// NHDowntimeRow is one entity's outage-hours total over the window, ranked by
+// Hours descending. PK lets the frontend link through to the entity's
+// drill-down page. Metros holds the metro pair for links ("ams ↔ lon") or the
+// single metro for devices.
+type NHDowntimeRow struct {
+	PK      string  `json:"pk"`
+	Code    string  `json:"code"`
+	Metros  string  `json:"metros,omitempty"`
+	Outages uint64  `json:"outages"`
+	Hours   float64 `json:"hours"`
+}
+
+// nhGroupDeadline is the live-compute deadline for the fast groups (cache MISS
+// or a non-default window). Matches the old monolith's 35s request budget; each
+// group is a strict subset so it finishes well inside it. Impactful uses its own
+// 170s deadline (see GetNetworkHealthImpactful), like /deferred.
+const nhGroupDeadline = 35 * time.Second
+
+// nhLiveComputeSem bounds concurrent LIVE (cache-miss or non-default-window)
+// Network Health computes across all group handlers to 4, matching the worker's
+// pageCacheRefreshConcurrency, so a burst of uncached public requests cannot
+// oversubscribe ClickHouse. It is acquired ONLY on the live-compute paths of the
+// HTTP handlers; cache HITs never touch it, and the worker calls Fetch*Data
+// directly (bypassing these handlers) so it is excluded too.
+var nhLiveComputeSem = make(chan struct{}, 4)
+
+// nhAcquireLive tries to reserve a live-compute slot within a short timeout. On
+// success it returns a release func and true; on failure it returns false and the
+// caller must return 503 without launching a query. Release must be deferred.
+func nhAcquireLive(ctx context.Context) (func(), bool) {
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case nhLiveComputeSem <- struct{}{}:
+		return func() { <-nhLiveComputeSem }, true
+	case <-timer.C:
+		return nil, false
+	case <-ctx.Done():
+		return nil, false
+	}
+}
+
+// nhWriteLiveUnavailable writes the fixed 503 used when the live-compute
+// concurrency limit is saturated (no query is launched).
+func nhWriteLiveUnavailable(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Cache", "MISS")
+	w.Header().Set("Retry-After", "5")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte(`{"error":"network health data temporarily unavailable"}`))
+}
+
+// serveNHGroup collapses the shared handler body for every Network Health group
+// endpoint: resolve the window, then serve the per-contributor or network-wide
+// precomputed blob on a cache HIT (default window, mainnet), else compute live
+// under the deadline. contribKey builds this group's per-contributor cache key;
+// fetch computes this group's payload for the resolved window + scope.
+func (a *API) serveNHGroup(
+	w http.ResponseWriter, r *http.Request,
+	defaultKey string, contribKey func(code string) string,
+	fetch func(ctx context.Context, start, end time.Time, contrib string) any,
+	deadline time.Duration,
+) {
+	start, end, cacheable := networkHealthWindow(
+		r.URL.Query().Get("start"),
+		r.URL.Query().Get("end"),
+		r.URL.Query().Get("days"),
+	)
+
+	writeLive := func(contrib string) {
+		// Bound concurrent live computes; shed load with 503 rather than piling on
+		// another ClickHouse query when the limit is saturated.
+		release, ok := nhAcquireLive(r.Context())
+		if !ok {
+			nhWriteLiveUnavailable(w)
+			return
+		}
+		defer release()
+		w.Header().Set("X-Cache", "MISS")
+		ctx, cancel := context.WithTimeout(r.Context(), deadline)
+		defer cancel()
+		resp := fetch(ctx, start, end, contrib)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logError("failed to encode network health group response", "key", defaultKey, "error", err)
+		}
+	}
+
+	// Contributor scope re-scopes the whole one-pager. The default window is
+	// precomputed per contributor by the worker (mainnet only); serve that on HIT,
+	// else compute live. The code is a bound parameter (no interpolation).
+	if code := r.URL.Query().Get("contributor"); code != "" {
+		if cacheable && isMainnet(r.Context()) {
+			if data, err := a.readPageCache(r.Context(), contribKey(code)); err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache", "HIT")
+				_, _ = w.Write(data)
+				return
+			}
+		}
+		writeLive(code)
+		return
+	}
+
+	// Default view is precomputed by the worker; serve from cache (mainnet only).
+	if cacheable && isMainnet(r.Context()) {
+		if data, err := a.readPageCache(r.Context(), defaultKey); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			_, _ = w.Write(data)
+			return
+		}
+	}
+	writeLive("")
+}
+
+// GetNetworkHealth serves the Overview group. The bare /api/network-health route
+// is repurposed to Overview (backward-compatible); the other groups have their
+// own /api/network-health/<group> routes. Public endpoint.
+func (a *API) GetNetworkHealth(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthOverviewCacheKey, NetworkHealthOverviewContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthOverviewData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthAvailability serves the Availability group. Public endpoint.
+func (a *API) GetNetworkHealthAvailability(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthAvailabilityCacheKey, NetworkHealthAvailabilityContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthAvailabilityData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthLatency serves the Latency group. Public endpoint.
+func (a *API) GetNetworkHealthLatency(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthLatencyCacheKey, NetworkHealthLatencyContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthLatencyData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthCapacity serves the Capacity group. Public endpoint.
+func (a *API) GetNetworkHealthCapacity(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthCapacityCacheKey, NetworkHealthCapacityContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthCapacityData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthOutages serves the Outages group. Public endpoint.
+func (a *API) GetNetworkHealthOutages(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthOutagesCacheKey, NetworkHealthOutagesContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthOutagesData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthDrain serves the Drain group. Public endpoint.
+func (a *API) GetNetworkHealthDrain(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthDrainCacheKey, NetworkHealthDrainContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthDrainData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthTickets serves the Tickets group. Unlike the old monolith's
+// network-wide live path (which skipped the ops-API fetch to stay under its
+// deadline), this dedicated endpoint always fetches: the external pagination is
+// capped to 20s internally and no longer blocks any other panel. Public endpoint.
+func (a *API) GetNetworkHealthTickets(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthTicketsCacheKey, NetworkHealthTicketsContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthTicketsData(ctx, start, end, contrib)
+		}, nhGroupDeadline)
+}
+
+// GetNetworkHealthImpactful serves the Impactful group. Like /deferred it runs
+// its heavy scan live under a longer 170s deadline so it never blocks the fast
+// groups. Public endpoint.
+func (a *API) GetNetworkHealthImpactful(w http.ResponseWriter, r *http.Request) {
+	a.serveNHGroup(w, r, NetworkHealthImpactfulCacheKey, NetworkHealthImpactfulContributorCacheKey,
+		func(ctx context.Context, start, end time.Time, contrib string) any {
+			return a.FetchNetworkHealthImpactfulData(ctx, start, end, contrib)
+		}, 170*time.Second)
+}
+
+// GetNetworkHealthDeferred serves the deferred (slow undrain) portion of the
+// Network Health drain-timing panel. It is split from GetNetworkHealth so the
+// main page loads without waiting on the heavy recovery-health scan; the
+// frontend fetches this endpoint separately and fills in the undrain figures
+// when they arrive. Mirrors GetNetworkHealth's window + contributor + cache-HIT
+// logic, but computes live under a longer 170s deadline. Public endpoint.
+func (a *API) GetNetworkHealthDeferred(w http.ResponseWriter, r *http.Request) {
+	start, end, cacheable := networkHealthWindow(
+		r.URL.Query().Get("start"),
+		r.URL.Query().Get("end"),
+		r.URL.Query().Get("days"),
+	)
+
+	// Contributor scope: serve the per-contributor precomputed deferred payload on
+	// HIT (mainnet only), else compute live under the long deadline.
+	if code := r.URL.Query().Get("contributor"); code != "" {
+		if cacheable && isMainnet(r.Context()) {
+			if data, err := a.readPageCache(r.Context(), NetworkHealthDeferredContributorCacheKey(code)); err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache", "HIT")
+				_, _ = w.Write(data)
+				return
+			}
+		}
+
+		// Bound concurrent live computes (see nhLiveComputeSem); shed with 503.
+		release, ok := nhAcquireLive(r.Context())
+		if !ok {
+			nhWriteLiveUnavailable(w)
+			return
+		}
+		defer release()
+		w.Header().Set("X-Cache", "MISS")
+		ctx, cancel := context.WithTimeout(r.Context(), 170*time.Second)
+		defer cancel()
+		resp := a.FetchNetworkHealthDeferredData(ctx, start, end, code)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logError("failed to encode network health deferred contributor response", "error", err)
+		}
+		return
+	}
+
+	// Default view is precomputed by the worker; serve from cache (mainnet only).
+	if cacheable && isMainnet(r.Context()) {
+		if data, err := a.readPageCache(r.Context(), NetworkHealthDeferredCacheKey); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			_, _ = w.Write(data)
+			return
+		}
+	}
+
+	// Bound concurrent live computes (see nhLiveComputeSem); shed with 503.
+	release, ok := nhAcquireLive(r.Context())
+	if !ok {
+		nhWriteLiveUnavailable(w)
+		return
+	}
+	defer release()
+	w.Header().Set("X-Cache", "MISS")
+	ctx, cancel := context.WithTimeout(r.Context(), 170*time.Second)
+	defer cancel()
+	resp := a.FetchNetworkHealthDeferredData(ctx, start, end, "")
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logError("failed to encode network health deferred response", "error", err)
+	}
+}
+
+// networkHealthWindow resolves the reporting window. If start+end are both given
+// (date 'YYYY-MM-DD' or RFC3339) it uses that custom range (clamped to
+// networkHealthMaxDays); otherwise it uses `days` (default 30) ending at the most
+// recent whole UTC day. cacheable is true only for the exact default view, so
+// custom ranges never read or write the shared cache.
+func networkHealthWindow(startStr, endStr, daysStr string) (time.Time, time.Time, bool) {
+	if startStr != "" && endStr != "" {
+		s, sok := parseNHTime(startStr)
+		e, eok := parseNHTime(endStr)
+		if sok && eok && e.After(s) {
+			maxSpan := time.Duration(networkHealthMaxDays) * 24 * time.Hour
+			if e.Sub(s) > maxSpan {
+				s = e.Add(-maxSpan)
+			}
+			return s, e, false
+		}
+	}
+	days := NetworkHealthDefaultDays
+	if v, err := strconv.Atoi(daysStr); err == nil {
+		days = v
+	}
+	if days < 1 {
+		days = 1
+	}
+	if days > networkHealthMaxDays {
+		days = networkHealthMaxDays
+	}
+	end := time.Now().UTC().Truncate(24 * time.Hour)
+	start := end.AddDate(0, 0, -days)
+	return start, end, days == NetworkHealthDefaultDays
+}
+
+// DefaultNetworkHealthWindow is the window the cache worker precomputes.
+func DefaultNetworkHealthWindow() (time.Time, time.Time) {
+	end := time.Now().UTC().Truncate(24 * time.Hour)
+	return end.AddDate(0, 0, -NetworkHealthDefaultDays), end
+}
+
+// nhContribKey builds one contributor's default-window (30d) cache key for a
+// group, so each per-contributor key carries the same version suffix as its
+// group's network-wide key and invalidates together with that group's shape.
+func nhContribKey(base, code string) string {
+	return base + networkHealthContributorCacheKeyInfix + code
+}
+
+// Per-group per-contributor cache-key builders (see nhContribKey).
+func NetworkHealthOverviewContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthOverviewCacheKey, code)
+}
+func NetworkHealthAvailabilityContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthAvailabilityCacheKey, code)
+}
+func NetworkHealthLatencyContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthLatencyCacheKey, code)
+}
+func NetworkHealthCapacityContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthCapacityCacheKey, code)
+}
+func NetworkHealthOutagesContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthOutagesCacheKey, code)
+}
+func NetworkHealthDrainContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthDrainCacheKey, code)
+}
+func NetworkHealthTicketsContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthTicketsCacheKey, code)
+}
+func NetworkHealthImpactfulContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthImpactfulCacheKey, code)
+}
+
+// NetworkHealthDeferredContributorCacheKey is the page_cache key for one
+// contributor's default-window (30d) deferred payload.
+func NetworkHealthDeferredContributorCacheKey(code string) string {
+	return nhContribKey(NetworkHealthDeferredCacheKey, code)
+}
+
+// FetchActiveContributorCodes returns the codes of contributors that have at
+// least one activated link or device. Used by the cache-refresh worker to
+// decide which per-contributor Network Health caches are worth precomputing —
+// a contributor record with no live network footprint would never be visited
+// by a scoped request, so refreshing its cache would just waste a cycle.
+func (a *API) FetchActiveContributorCodes(ctx context.Context) ([]string, error) {
+	q := `SELECT DISTINCT c.code FROM dz_contributors_current c
+		WHERE c.code != '' AND (
+			c.pk IN (SELECT contributor_pk FROM dz_links_current WHERE status = 'activated')
+			OR c.pk IN (SELECT contributor_pk FROM dz_devices_current WHERE status = 'activated')
+		)` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var codes []string
+	for rows.Next() {
+		var code string
+		if err := rows.Scan(&code); err != nil {
+			return nil, err
+		}
+		codes = append(codes, code)
+	}
+	return codes, rows.Err()
+}
+
+func parseNHTime(s string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), true
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.UTC(), true
+	}
+	return time.Time{}, false
+}
+
+func nhWindowLabel(start, end time.Time, days int) string {
+	if days == 7 || days == NetworkHealthDefaultDays {
+		return "Last " + strconv.Itoa(days) + " days"
+	}
+	return start.Format("2006-01-02") + " to " + end.Format("2006-01-02")
+}
+
+// nhWindow builds the resolved reporting window struct for a group payload.
+func nhWindow(start, end time.Time) NHWindow {
+	const layout = "2006-01-02 15:04:05"
+	days := int(math.Round(end.Sub(start).Hours() / 24))
+	return NHWindow{
+		Start: start.Format(layout),
+		End:   end.Format(layout),
+		Days:  days,
+		Label: nhWindowLabel(start, end, days),
+	}
+}
+
+// nhPriorWindow returns the previous equal-length window (priorStart, priorEnd)
+// ending exactly where the current window begins, for the "vs prior" deltas.
+func nhPriorWindow(start, end time.Time) (time.Time, time.Time) {
+	return start.Add(-end.Sub(start)), start
+}
+
+// fetchContribLinkPKs resolves the link pks owned by contrib for scoping the
+// drain-timing scans to one contributor's links. The bool reports whether the
+// scans should run at all:
+//   - contrib == ""             -> (nil, true):   network-wide, no link filter.
+//   - contrib set, links found  -> (pks, true):   filter to those link pks.
+//   - contrib set, zero links   -> (nil, false):  scoped to nothing; caller must
+//     return an empty result, NOT fall back to a network-wide scan.
+//   - contrib set, query error  -> (nil, false):  cannot scope safely; same as above.
+//
+// The false case is what keeps a scoped request from silently leaking network-wide
+// data when the contributor owns no links or the pk lookup fails.
+func (a *API) fetchContribLinkPKs(ctx context.Context, contrib string) ([]string, bool) {
+	if contrib == "" {
+		return nil, true
+	}
+	rows, err := a.envDB(ctx).Query(ctx,
+		`SELECT pk FROM dz_links_current WHERE contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)`+networkHealthQuerySettings, contrib)
+	if err != nil {
+		logError("network health: resolve contributor link pks failed", "error", err, "contributor", contrib)
+		return nil, false
+	}
+	var pks []string
+	for rows.Next() {
+		var pk string
+		if rows.Scan(&pk) == nil {
+			pks = append(pks, pk)
+		}
+	}
+	rows.Close()
+	if len(pks) == 0 {
+		return nil, false
+	}
+	return pks, true
+}
+
+// fetchImpactfulDowntime computes impact-weighted downtime (hours) over [s, e):
+// the downtime on links that were carrying traffic when they went down. This is
+// the heaviest query in the report, so it lives on its own /impactful endpoint
+// (like /deferred) under a 170s deadline and uses networkHealthDeferredQuerySettings
+// (max_execution_time = 170). contrib scopes it to one contributor's links.
+//
+// Impactful = the link was carrying traffic when it went down: either an
+// attributable link (has interface-counter rows) with pre-outage bps >= 1Mbps,
+// or an unattributable link (no rows at all, e.g. a port-channel subinterface
+// whose counters land on a different link_pk) that is the primary (lowest
+// committed-RTT) path for its metro-pair, i.e. the one actually carrying traffic.
+func (a *API) fetchImpactfulDowntime(ctx context.Context, s, e time.Time, contrib string) (float64, error) {
+	scoped := contrib != ""
+	impScopeJoin, impScopeFilter := "", ""
+	if scoped {
+		impScopeJoin = " JOIN dz_links_current l ON l.pk = r.link_pk"
+		impScopeFilter = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	// Bounded pre-outage scan (preserves the exact "traffic in the 60 min before
+	// the outage" semantics without an unbounded 30-day LEFT JOIN): the outage
+	// episodes come from link_rollup_5m (~a few hundred links), and both
+	// device_interface_rollup_5m scans are pruned to those outage links (olinks)
+	// and to the data-derived pre-outage span, so the correlated 60-min-pre-window
+	// join runs over a tiny slice. Episodes carry the A1 >= 2-bucket (>= 10 min)
+	// minimum.
+	q := `WITH outb AS (
+		SELECT r.link_pk AS link_pk, r.bucket_ts AS bucket_ts
+		FROM link_rollup_5m r FINAL` + impScopeJoin + `
+		WHERE r.bucket_ts >= ? AND r.bucket_ts < ? AND r.provisioning = false
+		  AND r.status = 'activated' AND (r.isis_down = 1 OR greatest(r.a_loss_pct, r.z_loss_pct) >= 10)` + impScopeFilter + `),
+	isl AS (
+		SELECT link_pk, bucket_ts,
+		  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+		FROM outb),
+	epi AS (
+		SELECT link_pk, grp, min(bucket_ts) AS started_at, least(count() * 300, 86400) AS capped, count() AS nbuckets
+		FROM isl GROUP BY link_pk, grp),
+	outages AS (
+		SELECT link_pk, started_at, capped FROM epi WHERE nbuckets >= 2),
+	olinks AS (SELECT DISTINCT link_pk FROM outages),
+	span AS (SELECT min(started_at) - INTERVAL 60 MINUTE AS pre_lo, max(started_at) AS pre_hi FROM outages),
+	ri AS (
+		SELECT link_pk, bucket_ts, avg_in_bps + avg_out_bps AS bps
+		FROM device_interface_rollup_5m
+		WHERE link_pk IN (SELECT link_pk FROM olinks)
+		  AND bucket_ts >= (SELECT pre_lo FROM span) AND bucket_ts < (SELECT pre_hi FROM span)),
+	attributable AS (
+		-- Links with at least one interface-counter row in the window, pruned to
+		-- the outage links. "Unattributed" is decided by this set rather than by
+		-- pre_bps IS NULL, because the LEFT JOIN below fills unmatched rows with
+		-- ClickHouse zero-values, not NULL.
+		SELECT DISTINCT link_pk FROM device_interface_rollup_5m
+		WHERE link_pk IN (SELECT link_pk FROM olinks)
+		  AND bucket_ts >= ? AND bucket_ts < ?),
+	bps AS (
+		SELECT o.link_pk AS link_pk, o.started_at AS started_at, any(o.capped) AS capped,
+		       if(o.link_pk IN (SELECT link_pk FROM attributable), max(r.bps), NULL) AS pre_bps
+		FROM outages o
+		LEFT JOIN ri r ON r.link_pk = o.link_pk
+			AND r.bucket_ts >= o.started_at - INTERVAL 60 MINUTE AND r.bucket_ts < o.started_at
+		GROUP BY o.link_pk, o.started_at),
+	link_metrics AS (
+		-- Inter-metro activated links, weighted like the isis_ksp topology graph:
+		-- isis_delay_override_ns when set, else committed_rtt_ns (1000000000 is the
+		-- "unmeasured" sentinel the ksp graph also excludes). Same-metro/DZX links
+		-- are left out here and fall back to the attributable rule above.
+		SELECT
+			l.pk AS link_pk,
+			if(da.metro_pk < dz.metro_pk, da.metro_pk, dz.metro_pk) AS metro_lo,
+			if(da.metro_pk < dz.metro_pk, dz.metro_pk, da.metro_pk) AS metro_hi,
+			if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) AS metric_ns
+		FROM dz_links_current l
+		JOIN dz_devices_current da ON l.side_a_pk = da.pk
+		JOIN dz_devices_current dz ON l.side_z_pk = dz.pk
+		WHERE l.status = 'activated'
+		  AND l.committed_rtt_ns != 1000000000
+		  AND da.metro_pk != '' AND dz.metro_pk != ''
+		  AND da.metro_pk != dz.metro_pk
+	),
+	primary_links AS (
+		-- Lowest-metric link(s) per metro-pair: the active path carrying traffic.
+		SELECT link_pk FROM (
+			SELECT link_pk, metric_ns,
+			       min(metric_ns) OVER (PARTITION BY metro_lo, metro_hi) AS min_metric_ns
+			FROM link_metrics
+		) WHERE metric_ns = min_metric_ns
+	)
+	SELECT
+		round(sumIf(capped, pre_bps >= 1000000
+			OR (pre_bps IS NULL AND link_pk IN (SELECT link_pk FROM primary_links))) / 3600, 1) AS impactful_h
+	FROM bps` + networkHealthDeferredQuerySettings
+	impArgs := []any{s, e}
+	if scoped {
+		impArgs = append(impArgs, contrib)
+	}
+	impArgs = append(impArgs, s, e)
+	var impactful float64
+	if err := a.envDB(ctx).QueryRow(ctx, q, impArgs...).Scan(&impactful); err != nil {
+		return 0, err
+	}
+	return nzFloat(impactful), nil
+}
+
+// FetchNetworkHealthOverviewData computes the Overview group: headline signals
+// (traffic, peak, latency-vs-internet, active counts + their deltas), IS-IS,
+// telemetry freshness, the throughput time series, and the contributor list that
+// backs the filter dropdown. Reuses the existing per-metric fetchers unchanged.
+// Called by the handler (cache miss) and the cache-refresh worker.
+func (a *API) FetchNetworkHealthOverviewData(ctx context.Context, start, end time.Time, contrib string) *NHOverview {
+	priorStart, priorEnd := nhPriorWindow(start, end)
+	scoped := contrib != ""
+	intervalSec := nhIntervalSeconds(start, end)
+
+	resp := &NHOverview{
+		Window:       nhWindow(start, end),
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Throughput:   []NHTsPoint{},
+		Contributors: []NHContributor{},
+	}
+
+	cHist := ""
+	if scoped {
+		cHist = " AND cpk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	withC := func(args ...any) []any {
+		if scoped {
+			return append(args, contrib)
+		}
+		return args
+	}
+
+	var priorPeak float64
+	var priorLinks uint64
+	linksByCode := map[string]uint64{}
+	devicesByCode := map[string]uint64{}
+	// throughput_ts is the only headline-critical panel in this group (peak +
+	// trend). Only one goroutine writes throughputErr, read after Wait — no lock.
+	var throughputErr error
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+
+	// --- Headline: active counts as-of window end ---
+	g.Go(func() error {
+		q := `SELECT count() FROM (
+			SELECT pk, argMax(status, snapshot_ts) AS st, argMax(is_deleted, snapshot_ts) AS del, argMax(contributor_pk, snapshot_ts) AS cpk
+			FROM dim_dz_devices_history WHERE snapshot_ts <= ? GROUP BY pk
+		) WHERE st = 'activated' AND del = 0` + cHist + networkHealthQuerySettings
+		return a.scanUint(ctx, &resp.Headline.ActiveDevices, q, withC(end)...)
+	})
+	g.Go(func() error {
+		q := `SELECT count() FROM (
+			SELECT pk, argMax(status, snapshot_ts) AS st, argMax(is_deleted, snapshot_ts) AS del, argMax(contributor_pk, snapshot_ts) AS cpk
+			FROM dim_dz_links_history WHERE snapshot_ts <= ? GROUP BY pk
+		) WHERE st = 'activated' AND del = 0` + cHist + networkHealthQuerySettings
+		return a.scanUint(ctx, &resp.Headline.ActiveLinks, q, withC(end)...)
+	})
+	if !scoped {
+		g.Go(func() error {
+			q := `SELECT count() FROM (
+				SELECT pk, argMax(is_deleted, snapshot_ts) AS del
+				FROM dim_dz_metros_history WHERE snapshot_ts <= ? GROUP BY pk
+			) WHERE del = 0` + networkHealthQuerySettings
+			return a.scanUint(ctx, &resp.Headline.ActiveMetros, q, end)
+		})
+	}
+	g.Go(func() error {
+		q := `SELECT count() FROM (
+			SELECT pk, argMax(status, snapshot_ts) AS st, argMax(is_deleted, snapshot_ts) AS del, argMax(contributor_pk, snapshot_ts) AS cpk
+			FROM dim_dz_links_history WHERE snapshot_ts <= ? GROUP BY pk
+		) WHERE st = 'activated' AND del = 0` + cHist + networkHealthQuerySettings
+		return a.scanUint(ctx, &priorLinks, q, withC(priorEnd)...)
+	})
+
+	// --- Headline: peak throughput (current from the trend scan; prior for delta) ---
+	g.Go(func() error {
+		ts, peak, err := a.fetchThroughputTS(ctx, start, end, intervalSec, contrib)
+		if err != nil {
+			logError("network health critical panel failed", "panel", "throughput_ts", "error", err)
+			throughputErr = err
+			return nil
+		}
+		resp.Throughput = ts
+		resp.Headline.PeakBps = peak
+		return nil
+	})
+	nhGo(g, "peak_prior", func() error {
+		_, peak, err := a.fetchThroughputTS(ctx, priorStart, priorEnd, nhIntervalSeconds(priorStart, priorEnd), contrib)
+		if err != nil {
+			return err
+		}
+		priorPeak = peak
+		return nil
+	})
+
+	// --- Headline: latency improvement vs internet (point-in-time, network-only) ---
+	if !scoped {
+		g.Go(func() error {
+			q := `SELECT
+				round(avgIf(jitter_improvement_pct, origin_metro != '' AND target_metro != ''), 2),
+				round(avgIf(dz_loss_pct, origin_metro != '' AND target_metro != ''), 2)
+				FROM dz_vs_internet_latency_comparison` + networkHealthQuerySettings
+			var jitter, loss float64
+			if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&jitter, &loss); err != nil {
+				return err
+			}
+			resp.Headline.JitterImprovePct = nzFloat(jitter)
+			resp.Headline.DzLossPct = nzFloat(loss)
+			return nil
+		})
+
+		// --- IS-IS + telemetry freshness (point-in-time, network-only) ---
+		g.Go(func() error {
+			q := `SELECT countIf(overload = 1), countIf(node_unreachable = 1), count()
+			FROM isis_devices_current` + networkHealthQuerySettings
+			if err := a.envDB(ctx).QueryRow(ctx, q).Scan(&resp.Isis.Overloaded, &resp.Isis.Unreachable, &resp.Isis.Devices); err != nil {
+				return err
+			}
+			return a.envDB(ctx).QueryRow(ctx, `SELECT count() FROM isis_adjacencies_current`+networkHealthQuerySettings).Scan(&resp.Isis.Adjacencies)
+		})
+		g.Go(func() error {
+			var feedMax time.Time
+			if err := a.envDB(ctx).QueryRow(ctx,
+				`SELECT max(event_ts), toInt64(dateDiff('second', max(event_ts), now()))
+			 FROM fact_dz_device_interface_counters`+networkHealthQuerySettings,
+			).Scan(&feedMax, &resp.Freshness.LagSeconds); err != nil {
+				return err
+			}
+			resp.Freshness.FeedMax = feedMax.UTC().Format(time.RFC3339)
+			q := `SELECT countIf(last >= ? - INTERVAL 1 HOUR), count() FROM (
+			SELECT device_pk, max(event_ts) AS last FROM fact_dz_device_interface_counters
+			WHERE event_ts >= ? - INTERVAL 2 HOUR GROUP BY device_pk
+		)` + networkHealthQuerySettings
+			return a.envDB(ctx).QueryRow(ctx, q, feedMax, feedMax).Scan(
+				&resp.Freshness.DevicesFresh, &resp.Freshness.DevicesActive)
+		})
+
+		// --- Contributor list (footprint only) for the filter dropdown. The
+		// per-contributor OUTAGE breakdown lives in the Outages group. ---
+		g.Go(func() error {
+			q := `SELECT c.code, count()
+			FROM dz_links_current AS l
+			LEFT JOIN dz_contributors_current AS c ON c.pk = l.contributor_pk
+			WHERE l.status = 'activated'
+			GROUP BY c.code` + networkHealthQuerySettings
+			return a.scanCodeCount(ctx, linksByCode, q)
+		})
+		g.Go(func() error {
+			q := `SELECT c.code, count()
+			FROM dz_devices_current AS d
+			LEFT JOIN dz_contributors_current AS c ON c.pk = d.contributor_pk
+			WHERE d.status = 'activated'
+			GROUP BY c.code` + networkHealthQuerySettings
+			return a.scanCodeCount(ctx, devicesByCode, q)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		logError("network health overview: partial data", "error", err)
+	}
+
+	// Deltas vs prior window (peak/active-links; outage/impactful deltas are owned
+	// by the Outages/Impactful groups).
+	resp.Headline.Deltas = NHDeltas{
+		PeakBps:     pctDelta(resp.Headline.PeakBps, priorPeak),
+		ActiveLinks: pctDelta(float64(resp.Headline.ActiveLinks), float64(priorLinks)),
+	}
+
+	// Contributor list = union of codes seen in the footprint queries.
+	if !scoped {
+		seen := map[string]bool{}
+		for code := range linksByCode {
+			seen[code] = true
+		}
+		for code := range devicesByCode {
+			seen[code] = true
+		}
+		for code := range seen {
+			if code == "" {
+				continue
+			}
+			resp.Contributors = append(resp.Contributors, NHContributor{
+				Code:    code,
+				Links:   linksByCode[code],
+				Devices: devicesByCode[code],
+			})
+		}
+	}
+
+	if !scoped && throughputErr != nil {
+		// Generic client-facing message; the raw DB error is logged, not exposed.
+		logError("network health overview: throughput_ts failed", "error", throughputErr)
+		resp.Error = "network health overview data temporarily unavailable"
+	}
+	return resp
+}
+
+// FetchNetworkHealthAvailabilityData computes the Availability group: the least-
+// available link and device rankings (no deltas).
+func (a *API) FetchNetworkHealthAvailabilityData(ctx context.Context, start, end time.Time, contrib string) *NHAvailabilityGroup {
+	resp := &NHAvailabilityGroup{
+		Window:             nhWindow(start, end),
+		GeneratedAt:        time.Now().UTC().Format(time.RFC3339),
+		LinkAvailability:   []NHAvailability{},
+		DeviceAvailability: []NHAvailability{},
+	}
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+	nhGo(g, "link_availability", func() error {
+		rows, err := a.fetchLinkAvailability(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.LinkAvailability = rows
+		return nil
+	})
+	nhGo(g, "device_availability", func() error {
+		rows, err := a.fetchDeviceAvailability(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.DeviceAvailability = rows
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		logError("network health availability: partial data", "error", err)
+	}
+	return resp
+}
+
+// FetchNetworkHealthLatencyData computes the Latency group: committed-vs-measured
+// per-link latency and the committed-RTT (SLA) adherence tile (no deltas).
+func (a *API) FetchNetworkHealthLatencyData(ctx context.Context, start, end time.Time, contrib string) *NHLatencyGroup {
+	scoped := contrib != ""
+	resp := &NHLatencyGroup{
+		Window:       nhWindow(start, end),
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		LatencyLinks: []NHPerfLink{},
+	}
+
+	cLinkCur := ""
+	if scoped {
+		cLinkCur = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	withC := func(args ...any) []any {
+		if scoped {
+			return append(args, contrib)
+		}
+		return args
+	}
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+	nhGo(g, "latency_links", func() error {
+		rows, err := a.fetchLatencyLinks(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.LatencyLinks = rows
+		return nil
+	})
+	g.Go(func() error {
+		q := `SELECT countIf(observed_us <= committed_us), count() FROM (
+			SELECT l.pk AS pk, l.committed_rtt_ns / 1000.0 AS committed_us,
+				avg((r.a_avg_rtt_us + r.z_avg_rtt_us) / 2) AS observed_us
+			FROM dz_links_current l
+			INNER JOIN link_rollup_5m r ON r.link_pk = l.pk
+			WHERE l.committed_rtt_ns > 0 AND l.status = 'activated'
+			  AND r.bucket_ts >= ? AND r.bucket_ts < ?
+			  AND r.status = 'activated' AND r.isis_down = 0` + cLinkCur + `
+			GROUP BY l.pk, committed_us
+		)` + networkHealthQuerySettings
+		if err := a.envDB(ctx).QueryRow(ctx, q, withC(start, end)...).Scan(&resp.Sla.Within, &resp.Sla.Total); err != nil {
+			return err
+		}
+		resp.Sla.WithinPct = pctPtr(int(resp.Sla.Within), int(resp.Sla.Total))
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		logError("network health latency: partial data", "error", err)
+	}
+	return resp
+}
+
+// FetchNetworkHealthCapacityData computes the Capacity group: the network seat-
+// utilization summary, fullest devices by seat, DIA interfaces, top links by
+// traffic, and fullest links by bandwidth (no deltas).
+func (a *API) FetchNetworkHealthCapacityData(ctx context.Context, start, end time.Time, contrib string) *NHCapacityGroup {
+	scoped := contrib != ""
+	resp := &NHCapacityGroup{
+		Window:        nhWindow(start, end),
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		DeviceSlots:   []NHDeviceSlots{},
+		DiaInterfaces: []NHDiaInterface{},
+		TopLinks:      []NHTrafficLink{},
+		CapacityLinks: []NHCapacityLink{},
+	}
+
+	cDevBare := ""
+	if scoped {
+		cDevBare = " AND contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	withC := func(args ...any) []any {
+		if scoped {
+			return append(args, contrib)
+		}
+		return args
+	}
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+	// --- Seat capacity utilization (point-in-time) ---
+	g.Go(func() error {
+		q := `SELECT sum(unicast_users_count), sum(max_users)
+			FROM dz_devices_current WHERE status = 'activated'` + cDevBare + networkHealthQuerySettings
+		var users uint64
+		var maxUsers int64
+		if err := a.envDB(ctx).QueryRow(ctx, q, withC()...).Scan(&users, &maxUsers); err != nil {
+			return err
+		}
+		resp.Capacity.UnicastUsers = users
+		if maxUsers > 0 {
+			resp.Capacity.MaxUsers = uint64(maxUsers)
+			p := math.Round(float64(users)/float64(maxUsers)*1000) / 10
+			resp.Capacity.UtilPct = &p
+		}
+		return nil
+	})
+	nhGo(g, "device_slots", func() error {
+		rows, err := a.fetchDeviceSlots(ctx, contrib)
+		if err != nil {
+			return err
+		}
+		resp.DeviceSlots = rows
+		return nil
+	})
+	nhGo(g, "dia_interfaces", func() error {
+		rows, err := a.fetchDiaInterfaces(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.DiaInterfaces = rows
+		return nil
+	})
+	nhGo(g, "top_links", func() error {
+		rows, err := a.fetchTopLinks(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.TopLinks = rows
+		return nil
+	})
+	nhGo(g, "fullest_links", func() error {
+		rows, err := a.fetchFullestLinks(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.CapacityLinks = rows
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		logError("network health capacity: partial data", "error", err)
+	}
+	return resp
+}
+
+// FetchNetworkHealthOutagesData computes the Outages group: the reliability
+// episode scan (which also feeds the headline OutageCount tile + delta),
+// degraded links, outage summary, downtime rankings, outages-over-time,
+// interface-error hotspots, and the per-contributor outage breakdown.
+// Prev holds the prior-window reliability + outage-summary for the deltas.
+func (a *API) FetchNetworkHealthOutagesData(ctx context.Context, start, end time.Time, contrib string) *NHOutagesGroup {
+	priorStart, priorEnd := nhPriorWindow(start, end)
+	scoped := contrib != ""
+	intervalSec := nhIntervalSeconds(start, end)
+
+	resp := &NHOutagesGroup{
+		Window:          nhWindow(start, end),
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+		DowntimeLinks:   []NHDowntimeRow{},
+		DowntimeDevices: []NHDowntimeRow{},
+		OutagesOverTime: []NHCountPoint{},
+		ErrorHotspots:   []NHErrorHotspot{},
+		Prev:            &NHOutagesPrev{},
+	}
+
+	cRollupLink := ""
+	if scoped {
+		cRollupLink = " AND link_pk IN (SELECT pk FROM dz_links_current WHERE contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?))"
+	}
+	withC := func(args ...any) []any {
+		if scoped {
+			return append(args, contrib)
+		}
+		return args
+	}
+
+	var priorOutages uint64
+	// reliability is the only headline-critical panel in this group. Single writer,
+	// read after Wait — no lock needed.
+	var reliabilityErr error
+
+	// Shared outage-episode CTE (contiguous isis_down/high-loss buckets collapsed
+	// into episodes via the row_number island trick; each episode's duration is
+	// buckets*300s). Same definition used across the page.
+	outEpisodeScopeJoin, outEpisodeScopeFilter := "", ""
+	if scoped {
+		outEpisodeScopeJoin = " JOIN dz_links_current l ON l.pk = r.link_pk"
+		outEpisodeScopeFilter = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	outEpisodeCTE := `WITH outb AS (
+			SELECT r.link_pk AS link_pk, r.bucket_ts AS bucket_ts
+			FROM link_rollup_5m r FINAL` + outEpisodeScopeJoin + `
+			WHERE r.bucket_ts >= ? AND r.bucket_ts < ? AND r.provisioning = false
+			  AND r.status = 'activated' AND (r.isis_down = 1 OR greatest(r.a_loss_pct, r.z_loss_pct) >= 10)` + outEpisodeScopeFilter + `),
+		isl AS (
+			SELECT link_pk, bucket_ts,
+			  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+			FROM outb),
+		epi AS (
+			SELECT link_pk, count() * 300 AS dur_s FROM isl GROUP BY link_pk, grp)`
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+
+	// --- Reliability (headline-critical): outages, distinct links, capped downtime, histogram ---
+	g.Go(func() error {
+		// The epi CTE carries ALL episodes (no >= 2-bucket floor). The sustained
+		// headline metrics gate on dur_s >= 600 (>= 10 min) so they stay de-saturated,
+		// while the duration histogram counts ALL episodes so the <= 5-minute flap
+		// bucket populates.
+		q := outEpisodeCTE + `
+			SELECT
+			countIf(dur_s >= 600),
+			uniqExactIf(link_pk, dur_s >= 600),
+			round(sumIf(least(dur_s, 86400), dur_s >= 600) / 3600, 1),
+			countIf(dur_s <= 300),
+			countIf(dur_s > 300 AND dur_s <= 900),
+			countIf(dur_s > 900 AND dur_s <= 3600),
+			countIf(dur_s > 3600 AND dur_s <= 86400),
+			countIf(dur_s > 86400)
+			FROM epi` + networkHealthQuerySettings
+		row := a.envDB(ctx).QueryRow(ctx, q, withC(start, end)...)
+		var h NHDurationHist
+		var count, distinct uint64
+		var downtime float64
+		if err := row.Scan(&count, &distinct, &downtime,
+			&h.FlapLE5m, &h.Short5to15m, &h.Medium15to60m, &h.Sustained1to24h, &h.ChronicGt24h); err != nil {
+			logError("network health critical panel failed", "panel", "reliability", "error", err)
+			reliabilityErr = err
+			return nil
+		}
+		resp.Reliability.OutageCount = count
+		resp.Reliability.DistinctLinks = distinct
+		resp.Reliability.CappedDowntimeHours = nzFloat(downtime)
+		resp.Reliability.DurationHistogram = h
+		resp.OutageCount = count
+		return nil
+	})
+	// Prior outage count + capped downtime (for the delta). Same shared CTE, gated
+	// on dur_s >= 600 to match the sustained OutageCount above.
+	g.Go(func() error {
+		q := outEpisodeCTE + `
+			SELECT countIf(dur_s >= 600),
+			round(sumIf(least(dur_s, 86400), dur_s >= 600) / 3600, 1)
+			FROM epi` + networkHealthQuerySettings
+		var cnt uint64
+		var downtime float64
+		if err := a.envDB(ctx).QueryRow(ctx, q, withC(priorStart, priorEnd)...).Scan(&cnt, &downtime); err != nil {
+			return err
+		}
+		priorOutages = cnt
+		resp.Prev.Reliability.OutageCount = cnt
+		resp.Prev.Reliability.CappedDowntimeHours = nzFloat(downtime)
+		return nil
+	})
+
+	// --- Reliability: degraded links (loss but not down) ---
+	g.Go(func() error {
+		q := `SELECT uniqExact(link_pk) FROM link_rollup_5m
+			WHERE bucket_ts >= ? AND bucket_ts < ?
+			  AND status = 'activated' AND isis_down = 0
+			  AND (a_loss_pct > 1.0 OR z_loss_pct > 1.0)` + cRollupLink + networkHealthQuerySettings
+		return a.scanUint(ctx, &resp.Reliability.DegradedLinks, q, withC(start, end)...)
+	})
+
+	nhGo(g, "outage_summary", func() error {
+		s, err := a.fetchOutageSummary(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.OutageSummary = s
+		return nil
+	})
+	nhGo(g, "outage_summary_prev", func() error {
+		s, err := a.fetchOutageSummary(ctx, priorStart, priorEnd, contrib)
+		if err != nil {
+			return err
+		}
+		resp.Prev.OutageSummary = s
+		return nil
+	})
+	nhGo(g, "downtime_links", func() error {
+		rows, err := a.fetchDowntimeLinks(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.DowntimeLinks = rows
+		return nil
+	})
+	nhGo(g, "downtime_devices", func() error {
+		rows, err := a.fetchDowntimeDevices(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.DowntimeDevices = rows
+		return nil
+	})
+	nhGo(g, "outages_ts", func() error {
+		ts, err := a.fetchOutagesTS(ctx, start, end, intervalSec, contrib)
+		if err != nil {
+			return err
+		}
+		resp.OutagesOverTime = ts
+		return nil
+	})
+	nhGo(g, "error_hotspots", func() error {
+		rows, err := a.fetchErrorHotspots(ctx, start, end, contrib)
+		if err != nil {
+			return err
+		}
+		resp.ErrorHotspots = rows
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		logError("network health outages: partial data", "error", err)
+	}
+
+	resp.OutageCountDelta = pctDelta(float64(resp.OutageCount), float64(priorOutages))
+
+	if !scoped && reliabilityErr != nil {
+		// Generic client-facing message; the raw DB error is logged, not exposed.
+		logError("network health outages: reliability failed", "error", reliabilityErr)
+		resp.Error = "network health outages data temporarily unavailable"
+	}
+	return resp
+}
+
+// FetchNetworkHealthDrainData computes the Drain group: the pure-Go drain/undrain
+// timing figures (the heavy undrain recovery-health figures stay on /deferred).
+// Prev holds the prior-window figures for the deltas.
+func (a *API) FetchNetworkHealthDrainData(ctx context.Context, start, end time.Time, contrib string) *NHDrainGroup {
+	priorStart, priorEnd := nhPriorWindow(start, end)
+	resp := &NHDrainGroup{
+		Window:      nhWindow(start, end),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	contribLinkPKs, ok := a.fetchContribLinkPKs(ctx, contrib)
+	if !ok {
+		// Scoped request that resolves to no links (or the pk lookup failed):
+		// return an empty result rather than falling back to a network-wide scan.
+		resp.Prev = &NHDrainTiming{}
+		return resp
+	}
+
+	var events, priorEvents []nhEvent
+	var changes, priorChanges []nhChange
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+	nhGo(g, "link_down_events", func() error {
+		evs, err := a.fetchLinkDownEvents(ctx, start, end, contribLinkPKs)
+		if err != nil {
+			return err
+		}
+		events = evs
+		return nil
+	})
+	nhGo(g, "status_changes", func() error {
+		chs, err := a.fetchStatusChanges(ctx, start, end, contribLinkPKs)
+		if err != nil {
+			return err
+		}
+		changes = chs
+		return nil
+	})
+	nhGo(g, "link_down_events_prev", func() error {
+		evs, err := a.fetchLinkDownEvents(ctx, priorStart, priorEnd, contribLinkPKs)
+		if err != nil {
+			return err
+		}
+		priorEvents = evs
+		return nil
+	})
+	nhGo(g, "status_changes_prev", func() error {
+		chs, err := a.fetchStatusChanges(ctx, priorStart, priorEnd, contribLinkPKs)
+		if err != nil {
+			return err
+		}
+		priorChanges = chs
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		logError("network health drain: partial data", "error", err)
+	}
+
+	// The undrain (recovery-health) figures are NOT computed here; they are served
+	// from the deferred endpoint. TimeToUndrain* stay nil (MatchedUndrains still
+	// reflects the Go-matched pair count).
+	dt, _ := computeDrainTiming(events, changes)
+	resp.DrainTiming = dt
+	dtPrev, _ := computeDrainTiming(priorEvents, priorChanges)
+	resp.Prev = &dtPrev
+	return resp
+}
+
+// FetchNetworkHealthTicketsData computes the Tickets group: the public ops-
+// management aggregate for the current and prior windows, split from one union
+// fetch over the ops API. resolveContributorScope + filterTicketsByContributor
+// scope it when contrib is set. Text-free by construction.
+func (a *API) FetchNetworkHealthTicketsData(ctx context.Context, start, end time.Time, contrib string) *NHTicketsGroup {
+	priorStart, _ := nhPriorWindow(start, end)
+	scoped := contrib != ""
+	resp := &NHTicketsGroup{
+		Window:      nhWindow(start, end),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Cap the external pagination loop independently of the caller's deadline.
+	tctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	// One fetch over the union window [priorStart, end): newest-first, stops at
+	// priorStart. The current and prior sets are split in Go (no second round-trip).
+	tickets, err := a.fetchOpsTicketsSince(tctx, priorStart)
+	if err != nil {
+		logError("network health: ops tickets fetch failed", "error", err)
+		// Surface the failure so GroupBoundary shows the unavailable state and the
+		// worker keeps the last-good blob, rather than the panels silently vanishing.
+		resp.Error = "network health: ops tickets unavailable"
+		return resp
+	}
+	if tickets == nil {
+		return resp // no API key configured (silent empty, not an error)
+	}
+
+	outageContrib := ""
+	scopePubkey := ""
+	if scoped {
+		cscope, err := a.resolveContributorScope(ctx, contrib)
+		if err != nil {
+			logError("network health: resolve contributor scope for tickets failed", "error", err, "contributor", contrib)
+			resp.Error = "network health: ops tickets unavailable"
+			return resp
+		}
+		tickets = filterTicketsByContributor(tickets, cscope)
+		outageContrib = contrib
+		scopePubkey = cscope.pubkey
+	}
+
+	// Split tickets into current (created >= start) and prior (priorStart <= created < start).
+	var curTickets, priorTickets []nhRawTicket
+	for _, t := range tickets {
+		ct, ok := nhParseTicketTime(&t.CreatedAt)
+		switch {
+		case !ok || !ct.Before(start):
+			curTickets = append(curTickets, t)
+		case !ct.Before(priorStart):
+			priorTickets = append(priorTickets, t)
+		}
+	}
+
+	// One wider outage-list scan over [priorStart, end), partitioned in Go.
+	outs, err := a.fetchOutageListForTickets(ctx, priorStart, end, outageContrib)
+	if err != nil {
+		logError("network health: outage list for tickets failed", "error", err)
+		outs = nil
+	}
+	var curOuts, priorOuts []nhOutage
+	for _, o := range outs {
+		if !o.start.Before(start) {
+			curOuts = append(curOuts, o)
+		} else {
+			priorOuts = append(priorOuts, o)
+		}
+	}
+
+	userContrib, err := a.fetchOpsUsers(ctx)
+	if err != nil {
+		logError("network health: ops users fetch failed", "error", err)
+	}
+	curAgg := computeTicketAggregates(curTickets, curOuts, userContrib, scopePubkey)
+	resp.OpsTickets = &curAgg
+	priorAgg := computeTicketAggregates(priorTickets, priorOuts, userContrib, scopePubkey)
+	resp.Prev = &priorAgg
+	return resp
+}
+
+// FetchNetworkHealthImpactfulData computes the Impactful group: impact-weighted
+// downtime for the current window and (network-wide only) the prior window for
+// the delta. Its heavy scan runs on this dedicated endpoint (170s) so it never
+// blocks the fast groups. Best-effort: on a current-window failure Unavailable is
+// set and Error is populated so the cache worker keeps the last good blob; a
+// prior-window failure only nils the delta.
+func (a *API) FetchNetworkHealthImpactfulData(ctx context.Context, start, end time.Time, contrib string) *NHImpactful {
+	priorStart, priorEnd := nhPriorWindow(start, end)
+	scoped := contrib != ""
+	resp := &NHImpactful{
+		Window:      nhWindow(start, end),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Prev:        &NHImpactfulPrev{},
+	}
+
+	cur, err := a.fetchImpactfulDowntime(ctx, start, end, contrib)
+	if err != nil {
+		logError("network health critical panel failed", "panel", "impactful", "error", err)
+		resp.Unavailable = true
+		if !scoped {
+			// Generic client-facing message; the raw DB error is logged above, not exposed.
+			resp.Error = "network health impactful data temporarily unavailable"
+		}
+		return resp
+	}
+	resp.ImpactfulDowntimeHours = cur
+
+	// Prior-window impactful downtime (for the delta), network-wide only so the
+	// live scoped request never pays a second heavy run. Strictly best-effort.
+	if !scoped {
+		if prior, err := a.fetchImpactfulDowntime(ctx, priorStart, priorEnd, contrib); err != nil {
+			logError("network health: prior impactful (best-effort) failed", "error", err)
+		} else {
+			resp.Prev.ImpactfulDowntimeHours = prior
+			resp.ImpactfulDowntimeDelta = pctDelta(cur, prior)
+		}
+	}
+	return resp
+}
+
+// scanUint runs a single-value uint64 query.
+func (a *API) scanUint(ctx context.Context, dst *uint64, query string, args ...any) error {
+	return a.envDB(ctx).QueryRow(ctx, query, args...).Scan(dst)
+}
+
+// scanCodeCount fills a map[code]count from a two-column (String, UInt64) query.
+func (a *API) scanCodeCount(ctx context.Context, dst map[string]uint64, query string, args ...any) error {
+	rows, err := a.envDB(ctx).Query(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var code string
+		var n uint64
+		if err := rows.Scan(&code, &n); err != nil {
+			return err
+		}
+		dst[code] = n
+	}
+	return rows.Err()
+}
+
+// nzFloat maps NaN/Inf to 0 so JSON encoding never fails.
+func nzFloat(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}
+
+// pctDelta returns the percentage change from prior to cur, or nil if prior is 0.
+func pctDelta(cur, prior float64) *float64 {
+	if prior == 0 {
+		return nil
+	}
+	d := (cur - prior) / prior * 100
+	if math.IsNaN(d) || math.IsInf(d, 0) {
+		return nil
+	}
+	d = math.Round(d*100) / 100
+	return &d
+}
+
+// fetchLinkDownEvents reconstructs link-down incidents (runs of isis_down buckets
+// on activated links) in the window. linkPKs optionally restricts to a set of links.
+func (a *API) fetchLinkDownEvents(ctx context.Context, start, end time.Time, linkPKs []string) ([]nhEvent, error) {
+	filter := ""
+	args := []any{start, end}
+	if linkPKs != nil {
+		filter = " AND link_pk IN ?"
+		args = append(args, linkPKs)
+	}
+	q := `SELECT link_pk, min(bucket_ts) AS started_at, max(bucket_ts) + INTERVAL 5 MINUTE AS ended_at
+		FROM (
+			SELECT link_pk, bucket_ts,
+				sum(is_start) OVER (PARTITION BY link_pk ORDER BY bucket_ts
+					ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS eid
+			FROM (
+				SELECT link_pk, bucket_ts,
+					if(dateDiff('second',
+						lagInFrame(bucket_ts) OVER (PARTITION BY link_pk ORDER BY bucket_ts),
+						bucket_ts) > 300, 1, 0) AS is_start
+				FROM link_rollup_5m
+				WHERE bucket_ts >= ? AND bucket_ts < ? AND isis_down = 1 AND status = 'activated'` + filter + `
+			)
+		)
+		GROUP BY link_pk, eid` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []nhEvent
+	for rows.Next() {
+		var e nhEvent
+		if err := rows.Scan(&e.linkPK, &e.start, &e.end); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// fetchStatusChanges returns link status transitions in the window. linkPKs
+// optionally restricts to a set of links.
+func (a *API) fetchStatusChanges(ctx context.Context, start, end time.Time, linkPKs []string) ([]nhChange, error) {
+	filter := ""
+	args := []any{start, end}
+	if linkPKs != nil {
+		filter = " AND link_pk IN ?"
+		args = append(args, linkPKs)
+	}
+	q := `SELECT link_pk, previous_status, new_status, changed_ts
+		FROM dz_link_status_changes
+		WHERE changed_ts >= ? AND changed_ts < ?` + filter + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []nhChange
+	for rows.Next() {
+		var c nhChange
+		if err := rows.Scan(&c.linkPK, &c.prev, &c.next, &c.ts); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// computeDrainTiming pairs each link-down event with the drain that followed and
+// the undrain after that, and summarizes the durations. Mirrors the ops-report
+// reconcile.match_drains / drain_timing logic (without the recovery-point refinement).
+func computeDrainTiming(events []nhEvent, changes []nhChange) (NHDrainTiming, []nhDrainMatch) {
+	// Build a per-link timeline of drain/undrain transitions.
+	type tev struct {
+		ts    time.Time
+		drain bool // true = drained, false = undrained (soft-drained -> activated)
+	}
+	timeline := map[string][]tev{}
+	drainsByLink := map[string][]time.Time{}
+	var drains, undrains int
+	for _, c := range changes {
+		switch {
+		case c.next == "soft-drained":
+			timeline[c.linkPK] = append(timeline[c.linkPK], tev{ts: c.ts, drain: true})
+			drainsByLink[c.linkPK] = append(drainsByLink[c.linkPK], c.ts)
+			drains++
+		case c.prev == "soft-drained" && c.next == "activated":
+			timeline[c.linkPK] = append(timeline[c.linkPK], tev{ts: c.ts, drain: false})
+			undrains++
+		}
+	}
+	for k := range drainsByLink {
+		sort.Slice(drainsByLink[k], func(i, j int) bool { return drainsByLink[k][i].Before(drainsByLink[k][j]) })
+	}
+
+	// Pair each drain with the undrain that ends it, via a per-link state machine.
+	// This covers ALL drains (planned maintenance included), not only drains that
+	// followed an outage, so "time drained" and "time to undrain" reflect how long
+	// healthy capacity actually sat out of service.
+	var drained []float64
+	matches := []nhDrainMatch{}
+	for lp, evs := range timeline {
+		sort.Slice(evs, func(i, j int) bool { return evs[i].ts.Before(evs[j].ts) })
+		var drainStart *time.Time
+		for _, e := range evs {
+			if e.drain {
+				if drainStart == nil {
+					d := e.ts
+					drainStart = &d
+				}
+			} else if drainStart != nil {
+				drained = append(drained, e.ts.Sub(*drainStart).Minutes())
+				matches = append(matches, nhDrainMatch{linkPK: lp, drainTS: *drainStart, undrainTS: e.ts})
+				drainStart = nil
+			}
+		}
+	}
+
+	// Time-to-drain and drain-within-30m are anchored to the outage event as t0,
+	// so they still require a link-down event to pair with a drain.
+	const matchWindow = 48 * time.Hour
+	var ttd []float64
+	eventsWithDrain := 0
+	drainWithin30m := 0
+	for _, e := range events {
+		// Is there a drain within 30 min of the failure (start .. end+30m)?
+		for _, d := range drainsByLink[e.linkPK] {
+			if !d.Before(e.start) && !d.After(e.end.Add(30*time.Minute)) {
+				drainWithin30m++
+				break
+			}
+		}
+		// First drain within the match window after the incident start.
+		for _, d := range drainsByLink[e.linkPK] {
+			if !d.Before(e.start) && !d.After(e.start.Add(matchWindow)) {
+				ttd = append(ttd, d.Sub(e.start).Minutes())
+				eventsWithDrain++
+				break
+			}
+		}
+	}
+
+	return NHDrainTiming{
+		OutageCount:       len(events),
+		EventsWithDrain:   eventsWithDrain,
+		Drains:            drains,
+		Undrains:          undrains,
+		TimeToDrainP50Min: medianMinutes(ttd),
+		TimeToDrainMaxMin: maxMinutes(ttd),
+		TimeDrainedP50Min: medianMinutes(drained),
+		TimeDrainedMaxMin: maxMinutes(drained),
+		DrainWithin30mPct: pctPtr(drainWithin30m, len(events)),
+		MatchedUndrains:   len(matches),
+	}, matches
+}
+
+// fetchRecoveryHealth returns, for each matched drain->undrain interval, the
+// minutes from when the link recovered (start of the unbroken healthy run ending
+// just before the undrain) to the undrain. This is "time to undrain a healthy
+// link". Links left drained while still unhealthy contribute 0 (recovered at the
+// undrain). Uses the same health expression as soak/recovery in the ops report.
+// This is the heavy scan split out of the main page: it runs only on the
+// deferred endpoint (GetNetworkHealthDeferred) and uses
+// networkHealthDeferredQuerySettings (max_execution_time = 170).
+func (a *API) fetchRecoveryHealth(ctx context.Context, matches []nhDrainMatch) ([]float64, error) {
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	type bucket struct {
+		ts      time.Time
+		healthy bool
+	}
+	byLink := map[string][]bucket{}
+	// Chunk is kept small and every chunk carries global time bounds + a link_pk IN
+	// list so the (bucket_ts, link_pk) primary key prunes the scan. Without these,
+	// the OR-only WHERE scanned link_rollup_5m unbounded and OOMed on heavy
+	// contributors (the memory limit was hit at multi-GiB).
+	const chunk = 20
+	for i := 0; i < len(matches); i += chunk {
+		end := i + chunk
+		if end > len(matches) {
+			end = len(matches)
+		}
+		clauses := make([]string, 0, end-i)
+		linkSet := map[string]struct{}{}
+		var gMin, gMax time.Time
+		for _, m := range matches[i:end] {
+			clauses = append(clauses, "(link_pk = ? AND bucket_ts >= ? AND bucket_ts <= ?)")
+			linkSet[m.linkPK] = struct{}{}
+			if gMin.IsZero() || m.drainTS.Before(gMin) {
+				gMin = m.drainTS
+			}
+			if m.undrainTS.After(gMax) {
+				gMax = m.undrainTS
+			}
+		}
+		linkPKs := make([]string, 0, len(linkSet))
+		for k := range linkSet {
+			linkPKs = append(linkPKs, k)
+		}
+		// Arg order matches placeholder order: global bounds, link IN list, then
+		// per-interval (link_pk, drainTS, undrainTS) triples.
+		args := make([]any, 0, 3+(end-i)*3)
+		args = append(args, gMin, gMax, linkPKs)
+		for _, m := range matches[i:end] {
+			args = append(args, m.linkPK, m.drainTS, m.undrainTS)
+		}
+		q := `SELECT link_pk, bucket_ts,
+				(isis_down = 0 AND provisioning = 0 AND a_loss_pct <= 0.5 AND z_loss_pct <= 0.5) AS healthy
+			FROM link_rollup_5m
+			WHERE bucket_ts >= ? AND bucket_ts <= ? AND link_pk IN ?
+			  AND (` + strings.Join(clauses, " OR ") + `)` + networkHealthDeferredQuerySettings
+		rows, err := a.envDB(ctx).Query(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var lp string
+			var ts time.Time
+			var h uint8
+			if err := rows.Scan(&lp, &ts, &h); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			byLink[lp] = append(byLink[lp], bucket{ts: ts, healthy: h == 1})
+		}
+		rows.Close()
+	}
+
+	var ttu []float64
+	for _, m := range matches {
+		bs := make([]bucket, 0)
+		for _, b := range byLink[m.linkPK] {
+			if !b.ts.Before(m.drainTS) && !b.ts.After(m.undrainTS) {
+				bs = append(bs, b)
+			}
+		}
+		sort.Slice(bs, func(i, j int) bool { return bs[i].ts.After(bs[j].ts) }) // desc
+		var recovery *time.Time
+		for _, b := range bs {
+			if !b.ts.Before(m.undrainTS) {
+				continue
+			}
+			if b.healthy {
+				t := b.ts
+				recovery = &t
+			} else {
+				break
+			}
+		}
+		if recovery != nil {
+			ttu = append(ttu, m.undrainTS.Sub(*recovery).Minutes())
+		} else {
+			ttu = append(ttu, 0)
+		}
+	}
+	return ttu, nil
+}
+
+// FetchNetworkHealthDeferredData computes the deferred (slow) undrain figures for
+// the drain-timing panel: the recovery-health-derived "time to undrain a healthy
+// link" p50/max for the current window and the prior window (for the section
+// delta). This is split from the Drain group (FetchNetworkHealthDrainData) so the
+// page does not wait on the heavy link_rollup_5m recovery scan. contrib scopes
+// the computation to one contributor's links (same scoping the Drain group uses).
+//
+// Best-effort throughout: a failed recovery-health scan marks the undrain figures
+// unavailable rather than failing the payload. out.Error is set only when the
+// CURRENT-window figures genuinely could not be computed (drain-timing inputs
+// failed, or the recovery-health scan errored while there were pairs to match),
+// so the cache worker keeps the last good blob instead of caching an "unavailable"
+// over a good value. A prior-window failure only nils the delta.
+func (a *API) FetchNetworkHealthDeferredData(ctx context.Context, start, end time.Time, contrib string) *NHDeferred {
+	priorStart, priorEnd := nhPriorWindow(start, end)
+
+	contribLinkPKs, ok := a.fetchContribLinkPKs(ctx, contrib)
+
+	out := &NHDeferred{}
+
+	if !ok {
+		// Scoped request that resolves to no links (or the pk lookup failed):
+		// return an empty result rather than falling back to a network-wide scan.
+		out.Prev = &NHDeferred{}
+		return out
+	}
+
+	// Current window: reconstruct drain->undrain pairs, then measure recovery.
+	events, evErr := a.fetchLinkDownEvents(ctx, start, end, contribLinkPKs)
+	changes, chErr := a.fetchStatusChanges(ctx, start, end, contribLinkPKs)
+	_, matches := computeDrainTiming(events, changes)
+	out.MatchedUndrains = len(matches)
+	if evErr != nil || chErr != nil {
+		out.UndrainUnavailable = true
+		out.Error = "network health deferred: drain-timing inputs failed"
+	} else if ttu, err := a.fetchRecoveryHealth(ctx, matches); err != nil {
+		logError("network health deferred: undrain timing (recovery health) failed", "error", err)
+		out.UndrainUnavailable = true
+		if len(matches) > 0 {
+			// Generic client-facing message; the raw DB error is logged above, not exposed.
+			out.Error = "network health deferred data temporarily unavailable"
+		}
+	} else {
+		out.TimeToUndrainP50Min = medianMinutes(ttu)
+		out.TimeToUndrainMaxMin = maxMinutes(ttu)
+	}
+
+	// Prior window (for the section delta). Strictly best-effort: a prior failure
+	// only marks the prior figures unavailable and never sets out.Error.
+	prev := &NHDeferred{}
+	priorEvents, pevErr := a.fetchLinkDownEvents(ctx, priorStart, priorEnd, contribLinkPKs)
+	priorChanges, pchErr := a.fetchStatusChanges(ctx, priorStart, priorEnd, contribLinkPKs)
+	_, priorMatches := computeDrainTiming(priorEvents, priorChanges)
+	prev.MatchedUndrains = len(priorMatches)
+	if pevErr != nil || pchErr != nil {
+		prev.UndrainUnavailable = true
+	} else if ttuPrev, err := a.fetchRecoveryHealth(ctx, priorMatches); err != nil {
+		logError("network health deferred: prior undrain timing (best-effort) failed", "error", err)
+		prev.UndrainUnavailable = true
+	} else {
+		prev.TimeToUndrainP50Min = medianMinutes(ttuPrev)
+		prev.TimeToUndrainMaxMin = maxMinutes(ttuPrev)
+	}
+	out.Prev = prev
+
+	return out
+}
+
+func medianMinutes(xs []float64) *float64 {
+	if len(xs) == 0 {
+		return nil
+	}
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	var m float64
+	n := len(s)
+	if n%2 == 1 {
+		m = s[n/2]
+	} else {
+		m = (s[n/2-1] + s[n/2]) / 2
+	}
+	m = math.Round(m)
+	return &m
+}
+
+func maxMinutes(xs []float64) *float64 {
+	if len(xs) == 0 {
+		return nil
+	}
+	m := xs[0]
+	for _, x := range xs[1:] {
+		if x > m {
+			m = x
+		}
+	}
+	m = math.Round(m)
+	return &m
+}
+
+func pctPtr(n, total int) *float64 {
+	if total == 0 {
+		return nil
+	}
+	p := math.Round(float64(n)/float64(total)*1000) / 10
+	return &p
+}
+
+// nhRawTicket decodes only the raw ops-API fields the aggregate needs. Kept
+// server-side and never marshaled to the response. The lake OpsTicket struct
+// omits root_cause, so we decode the raw JSON here. ContributorName/
+// ContributorPubkey and AffectedDevices are used only to match a ticket to a
+// scoped contributor (see filterTicketsByContributor) — never surfaced in the
+// NHTickets response.
+type nhRawTicket struct {
+	ID                string            `json:"id"`
+	Type              string            `json:"type"`
+	Severity          *string           `json:"severity"`
+	Status            string            `json:"status"`
+	StartAt           *string           `json:"start_at"`
+	EndAt             *string           `json:"end_at"`
+	CreatedAt         string            `json:"created_at"`
+	RootCause         *string           `json:"root_cause"`
+	UserPubkey        string            `json:"user_pubkey"` // ticket creator (for self-reported classification)
+	ReporterName      string            `json:"reporter_name"`
+	ContributorName   *string           `json:"contributor_name"`
+	ContributorPubkey *string           `json:"contributor_pubkey"`
+	AffectedLinks     []OpsTicketEntity `json:"affected_links"`
+	AffectedDevices   []OpsTicketEntity `json:"affected_devices"`
+}
+
+type nhOutage struct {
+	linkPK   string
+	linkCode string
+	start    time.Time
+	end      time.Time
+}
+
+// fetchOpsTicketsSince pages the ops-management API for tickets created at or
+// after `since`. The API has no date filter and is sorted newest-first, so we
+// stop once a page's oldest ticket predates the cutoff. Returns nil (no error)
+// when no API key is configured, so the panel is simply omitted.
+//
+// A mid-pagination failure (timeout, transient 5xx, rate limit) degrades to
+// the tickets already collected instead of discarding the whole window: the
+// aggregate undercounts the oldest pages rather than the panel going blank
+// until the next successful refresh. Only a failure on the very first page
+// (no partial data to salvage) is treated as a hard error.
+func (a *API) fetchOpsTicketsSince(ctx context.Context, since time.Time) ([]nhRawTicket, error) {
+	client := newOpsClient()
+	if client.apiKey == "" {
+		return nil, nil
+	}
+	sinceStr := since.UTC().Format(time.RFC3339)
+	const pageSize = 100
+	// maxPages*pageSize is a hard cap on the newest-first stream. The prior-window
+	// delta doubles the span this fetch covers (a 30d view now pages back 60d, a
+	// 92d custom window back 184d), so the cap is raised well above observed
+	// volume (~1,900 tickets / 60d) to keep the OLDEST prior-window tickets from
+	// truncating and undercounting the prior aggregate.
+	const maxPages = 100
+	out := []nhRawTicket{}
+	for page := 0; page < maxPages; page++ {
+		path := "/tickets?limit=" + strconv.Itoa(pageSize) + "&offset=" + strconv.Itoa(page*pageSize)
+		body, err := client.get(ctx, path)
+		if err != nil {
+			if page == 0 {
+				return nil, err
+			}
+			logError("network health: ops tickets pagination stopped early", "error", err, "page", page, "collected", len(out))
+			break
+		}
+		var env struct {
+			Data struct {
+				Tickets []nhRawTicket `json:"tickets"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			if page == 0 {
+				return nil, err
+			}
+			logError("network health: ops tickets pagination stopped early (bad json)", "error", err, "page", page, "collected", len(out))
+			break
+		}
+		tickets := env.Data.Tickets
+		if len(tickets) == 0 {
+			break
+		}
+		for _, t := range tickets {
+			if t.ID != "" && t.CreatedAt >= sinceStr {
+				out = append(out, t)
+			}
+		}
+		oldest := tickets[len(tickets)-1].CreatedAt
+		if oldest < sinceStr || len(tickets) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// fetchOpsUsers pages the ops-management /users registry and returns a map of
+// user pubkey -> the contributor_pubkey that user belongs to (empty string for
+// a DoubleZero user, whose contributor_pubkey is null). Used to classify who
+// filed each incident (see computeTicketAggregates: an incident is self-reported
+// only when its creator belongs to the SAME contributor the incident is about,
+// i.e. userContrib[user_pubkey] == ticket.contributor_pubkey). Returns an empty
+// map (no error) when no API key is configured. On a fetch/decode failure the
+// map is empty and the caller leaves SelfReportedPct nil ("unavailable") rather
+// than mislabeling every incident.
+func (a *API) fetchOpsUsers(ctx context.Context) (map[string]string, error) {
+	client := newOpsClient()
+	users := map[string]string{}
+	if client.apiKey == "" {
+		return users, nil
+	}
+	const pageSize = 500
+	const maxPages = 20
+	for page := 0; page < maxPages; page++ {
+		path := "/users?limit=" + strconv.Itoa(pageSize) + "&offset=" + strconv.Itoa(page*pageSize)
+		body, err := client.get(ctx, path)
+		if err != nil {
+			if page == 0 {
+				return map[string]string{}, err
+			}
+			logError("network health: ops users pagination stopped early", "error", err, "page", page)
+			break
+		}
+		var env struct {
+			Data []struct {
+				Pubkey            string  `json:"pubkey"`
+				ContributorPubkey *string `json:"contributor_pubkey"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			if page == 0 {
+				return map[string]string{}, err
+			}
+			logError("network health: ops users pagination stopped early (bad json)", "error", err, "page", page)
+			break
+		}
+		if len(env.Data) == 0 {
+			break
+		}
+		for _, u := range env.Data {
+			if u.Pubkey == "" {
+				continue
+			}
+			if u.ContributorPubkey == nil {
+				users[u.Pubkey] = "" // DoubleZero (no contributor affiliation)
+			} else {
+				users[u.Pubkey] = *u.ContributorPubkey
+			}
+		}
+		if len(env.Data) < pageSize {
+			break
+		}
+	}
+	return users, nil
+}
+
+// nhContributorScope identifies a contributor for matching ops tickets against:
+// its onchain pubkey/name (to match a ticket's own contributor_name/
+// contributor_pubkey fields directly) plus the link/device codes it owns (to
+// match tickets filed against its infrastructure even when the ticket's own
+// contributor field points elsewhere or is unset).
+type nhContributorScope struct {
+	pubkey      string
+	name        string
+	linkCodes   map[string]struct{}
+	deviceCodes map[string]struct{}
+}
+
+// resolveContributorScope resolves the onchain identity (pubkey/name) and the
+// set of link/device codes owned by the contributor with the given `code`, for
+// matching ops tickets in filterTicketsByContributor. One-time lookup per
+// scoped request (not per ticket).
+func (a *API) resolveContributorScope(ctx context.Context, code string) (*nhContributorScope, error) {
+	scope := &nhContributorScope{linkCodes: map[string]struct{}{}, deviceCodes: map[string]struct{}{}}
+	var pk string
+	q := `SELECT pk, name FROM dz_contributors_current WHERE code = ?` + networkHealthQuerySettings
+	if err := a.envDB(ctx).QueryRow(ctx, q, code).Scan(&pk, &scope.name); err != nil {
+		return nil, err
+	}
+	scope.pubkey = pk
+
+	if rows, err := a.envDB(ctx).Query(ctx,
+		`SELECT code FROM dz_links_current WHERE contributor_pk = ?`+networkHealthQuerySettings, pk); err == nil {
+		for rows.Next() {
+			var c string
+			if rows.Scan(&c) == nil {
+				scope.linkCodes[c] = struct{}{}
+			}
+		}
+		rows.Close()
+	} else {
+		logError("network health: resolve contributor link codes failed", "error", err, "contributor", code)
+	}
+	if rows, err := a.envDB(ctx).Query(ctx,
+		`SELECT code FROM dz_devices_current WHERE contributor_pk = ?`+networkHealthQuerySettings, pk); err == nil {
+		for rows.Next() {
+			var c string
+			if rows.Scan(&c) == nil {
+				scope.deviceCodes[c] = struct{}{}
+			}
+		}
+		rows.Close()
+	} else {
+		logError("network health: resolve contributor device codes failed", "error", err, "contributor", code)
+	}
+	return scope, nil
+}
+
+// nhTicketMatchesContributor reports whether a ticket belongs to the scoped
+// contributor: either the ticket's own contributor identity (name or pubkey)
+// matches, or one of its affected links/devices is owned by that contributor.
+func nhTicketMatchesContributor(t nhRawTicket, scope *nhContributorScope) bool {
+	if t.ContributorPubkey != nil && *t.ContributorPubkey == scope.pubkey {
+		return true
+	}
+	if t.ContributorName != nil && *t.ContributorName == scope.name {
+		return true
+	}
+	for _, l := range t.AffectedLinks {
+		if _, ok := scope.linkCodes[l.Code]; ok {
+			return true
+		}
+	}
+	for _, d := range t.AffectedDevices {
+		if _, ok := scope.deviceCodes[d.Code]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// filterTicketsByContributor returns only the tickets that belong to scope.
+func filterTicketsByContributor(tickets []nhRawTicket, scope *nhContributorScope) []nhRawTicket {
+	out := make([]nhRawTicket, 0, len(tickets))
+	for _, t := range tickets {
+		if nhTicketMatchesContributor(t, scope) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// fetchOutageListForTickets returns the window's outages (link code + interval)
+// for matching against tickets (the full list, not the top-N flappers).
+// contrib, when non-empty, restricts the outages to links owned by that
+// contributor, so a scoped view's outage-coverage numbers reconcile with its
+// own (filtered) tickets. Episodes are derived from link_rollup_5m (full
+// window) rather than the ~8-day-capped incident view.
+func (a *API) fetchOutageListForTickets(ctx context.Context, start, end time.Time, contrib string) ([]nhOutage, error) {
+	scopeFilter := ""
+	args := []any{start, end}
+	if contrib != "" {
+		scopeFilter = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH outb AS (
+			SELECT link_pk, bucket_ts
+			FROM link_rollup_5m FINAL
+			WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false
+			  AND status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)),
+		isl AS (
+			SELECT link_pk, bucket_ts,
+			  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+			FROM outb),
+		epi AS (
+			SELECT link_pk, min(bucket_ts) AS started_at, max(bucket_ts) + toIntervalSecond(300) AS ended_at
+			FROM isl GROUP BY link_pk, grp HAVING count() >= 2)
+		SELECT epi.link_pk, coalesce(l.code, ''), epi.started_at, epi.ended_at
+		FROM epi JOIN dz_links_current l ON l.pk = epi.link_pk
+		WHERE 1 = 1` + scopeFilter
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	q += networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []nhOutage{}
+	for rows.Next() {
+		var o nhOutage
+		if err := rows.Scan(&o.linkPK, &o.linkCode, &o.start, &o.end); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+func nhParseTicketTime(s *string) (time.Time, bool) {
+	if s == nil || *s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, *s); err == nil {
+		return t.UTC(), true
+	}
+	if t, err := time.Parse("2006-01-02 15:04:05", strings.TrimSuffix(strings.Replace(*s, "T", " ", 1), "Z")); err == nil {
+		return t.UTC(), true
+	}
+	return time.Time{}, false
+}
+
+// computeTicketAggregates ports the ops-report ticket_stats / ticket_timing /
+// outage-coverage logic. Aggregates whatever ticket set it's given: the full
+// network-wide set, or a contributor-filtered subset for a scoped view.
+// Text-free.
+//
+// dzUsers is the set of DoubleZero-staff pubkeys (see fetchOpsUsers). Incidents
+// are classified self-reported vs DoubleZero-filed by their creator's pubkey.
+// When dzUsers is empty (registry fetch failed) SelfReportedPct is left nil so
+// the frontend shows "unavailable" instead of mislabeling every incident.
+// userContrib maps a user pubkey -> the contributor it belongs to ("" for a
+// DoubleZero user); see fetchOpsUsers. scopePubkey, when non-empty, restricts
+// the incident metrics to incidents ABOUT that contributor (its own
+// contributor_pubkey) so that another contributor's self-filed incident on a
+// shared link does not leak into this contributor's numbers.
+func computeTicketAggregates(tickets []nhRawTicket, outages []nhOutage, userContrib map[string]string, scopePubkey string) NHTickets {
+	agg := NHTickets{Total: len(tickets)}
+
+	// Timing accumulators. resp/reso are INCIDENTS ONLY (maintenance is scheduled
+	// ahead, so its created-before-start offset would drag the medians negative);
+	// mLead/mDur are the maintenance-only lead/duration figures.
+	var resp, reso []float64
+	var mLead, mDur []float64
+	closedIncidents, closedMaintenance := 0, 0
+	selfReported, doubleZeroFiled := 0, 0
+	// Incident root-cause tally (enum tokens only). incidentsWithCause is the
+	// denominator for each cause's share.
+	rootCauseCounts := map[string]int{}
+	incidentsWithCause := 0
+	for _, t := range tickets {
+		// Scoped contributor view: count only tickets ABOUT this contributor (its
+		// own contributor_pubkey), not tickets that merely affect its links, which
+		// are filed by and belong to other contributors. Applies to every ticket
+		// type (incidents and maintenance alike) so a shared-link maintenance filed
+		// by another contributor does not leak into this contributor's numbers.
+		if scopePubkey != "" &&
+			(t.ContributorPubkey == nil || *t.ContributorPubkey != scopePubkey) {
+			continue
+		}
+		if t.Severity != nil {
+			switch *t.Severity {
+			case "sev1":
+				agg.Sev1++
+			case "sev2":
+				agg.Sev2++
+			case "sev3":
+				agg.Sev3++
+			}
+		}
+		startT, hasStart := nhParseTicketTime(t.StartAt)
+		createdT, hasCreated := nhParseTicketTime(&t.CreatedAt)
+
+		switch t.Type {
+		case "incident":
+			agg.Incidents++
+			if t.RootCause != nil && *t.RootCause != "" {
+				rootCauseCounts[*t.RootCause]++
+				incidentsWithCause++
+			}
+			if hasStart && hasCreated {
+				resp = append(resp, createdT.Sub(startT).Minutes())
+			}
+			// Self-reported = the incident's creator belongs to the SAME
+			// contributor the incident is about (the contributor filed it
+			// themselves). A DoubleZero creator (userContrib value ""), a creator
+			// not in the registry, or a creator from a different contributor is
+			// DoubleZero/other-filed.
+			ticketContrib := ""
+			if t.ContributorPubkey != nil {
+				ticketContrib = *t.ContributorPubkey
+			}
+			if ticketContrib != "" && t.UserPubkey != "" && userContrib[t.UserPubkey] == ticketContrib {
+				selfReported++
+			} else {
+				doubleZeroFiled++
+			}
+			if t.Status == "closed" || t.Status == "resolved" {
+				closedIncidents++
+				if endT, hasEnd := nhParseTicketTime(t.EndAt); hasEnd && hasStart {
+					reso = append(reso, endT.Sub(startT).Minutes())
+				}
+			}
+		case "maintenance":
+			agg.Maintenance++
+			if hasStart && hasCreated {
+				mLead = append(mLead, startT.Sub(createdT).Minutes())
+			}
+			if t.Status == "closed" || t.Status == "resolved" || t.Status == "completed" {
+				closedMaintenance++
+				if endT, hasEnd := nhParseTicketTime(t.EndAt); hasEnd && hasStart {
+					mDur = append(mDur, endT.Sub(startT).Minutes())
+				}
+			}
+		}
+	}
+	agg.ClosedIncidents = closedIncidents
+	agg.ResponseP50Min = medianInt(resp)
+	agg.ResolutionP50Min = medianInt(reso)
+	agg.SelfReportedCount = selfReported
+	agg.DoubleZeroFiledCount = doubleZeroFiled
+	if len(userContrib) > 0 {
+		agg.SelfReportedPct = pctPtr(selfReported, agg.Incidents)
+	}
+	agg.MaintenanceLeadP50Min = medianInt(mLead)
+	agg.MaintenanceDurationP50Min = medianInt(mDur)
+	agg.ClosedMaintenance = closedMaintenance
+
+	// Root-cause breakdown: one row per cause, sorted by count descending
+	// (cause name as a stable tiebreak). Pct is the share of incidents that have
+	// a recorded cause (self_resolved included).
+	agg.RootCauses = make([]NHRootCauseCount, 0, len(rootCauseCounts))
+	for cause, n := range rootCauseCounts {
+		agg.RootCauses = append(agg.RootCauses, NHRootCauseCount{
+			Cause: cause, Count: n, Pct: pctPtr(n, incidentsWithCause),
+		})
+	}
+	sort.Slice(agg.RootCauses, func(i, j int) bool {
+		if agg.RootCauses[i].Count != agg.RootCauses[j].Count {
+			return agg.RootCauses[i].Count > agg.RootCauses[j].Count
+		}
+		return agg.RootCauses[i].Cause < agg.RootCauses[j].Cause
+	})
+
+	// Coverage: outages matched to any ticket by affected-link code + time overlap.
+	const tol = 30 * time.Minute
+	byCode := map[string][]nhRawTicket{}
+	for _, t := range tickets {
+		for _, l := range t.AffectedLinks {
+			if l.Code != "" {
+				byCode[l.Code] = append(byCode[l.Code], t)
+			}
+		}
+	}
+	covered := 0
+	noTicket := []NHNoTicketOutage{}
+	for _, o := range outages {
+		isCovered := false
+		for _, t := range byCode[o.linkCode] {
+			tStart, ok := nhParseTicketTime(t.StartAt)
+			if !ok {
+				tStart = o.start
+			}
+			tEnd, ok := nhParseTicketTime(t.EndAt)
+			if !ok {
+				tEnd = tStart
+			}
+			// windows overlap within tolerance
+			if !tStart.Add(-tol).After(o.end) && !tEnd.Add(tol).Before(o.start) {
+				isCovered = true
+				break
+			}
+		}
+		if isCovered {
+			covered++
+			continue
+		}
+		noTicket = append(noTicket, NHNoTicketOutage{
+			LinkPK:   o.linkPK,
+			LinkCode: o.linkCode,
+			StartTs:  o.start.UTC().Format(time.RFC3339),
+			Hours:    math.Round(o.end.Sub(o.start).Hours()*100) / 100,
+		})
+	}
+	// Actionable list: longest unfiled outages first (link code as a stable
+	// tiebreak), capped so the public payload stays small.
+	sort.Slice(noTicket, func(i, j int) bool {
+		if noTicket[i].Hours != noTicket[j].Hours {
+			return noTicket[i].Hours > noTicket[j].Hours
+		}
+		return noTicket[i].LinkCode < noTicket[j].LinkCode
+	})
+	const noTicketOutageCap = 15
+	if len(noTicket) > noTicketOutageCap {
+		noTicket = noTicket[:noTicketOutageCap]
+	}
+	agg.NoTicketOutages = noTicket
+	agg.OutageCount = len(outages)
+	agg.OutagesWithTicket = covered
+	agg.OutagesNoTicket = len(outages) - covered
+	agg.NoTicketSharePct = pctPtr(len(outages)-covered, len(outages))
+	return agg
+}
+
+func medianInt(xs []float64) *int {
+	m := medianMinutes(xs)
+	if m == nil {
+		return nil
+	}
+	v := int(*m)
+	return &v
+}
+
+// nhIntervalSeconds picks a time-series bucket size that keeps the point count
+// readable for the window (about 100-200 points).
+func nhIntervalSeconds(start, end time.Time) int {
+	d := end.Sub(start)
+	switch {
+	case d <= 48*time.Hour:
+		return 300 // 5 min
+	case d <= 14*24*time.Hour:
+		return 3600 // 1 hour
+	default:
+		return 21600 // 6 hours
+	}
+}
+
+// fetchThroughputTS returns the per-interval network throughput time series and
+// the global peak (bits/sec) over the window. The peak is the max of the
+// per-5-min-bucket network bps, so it is the global max of the returned points'
+// MaxBps and needs no separate scan (see the peak-throughput headline wiring).
+func (a *API) fetchThroughputTS(ctx context.Context, start, end time.Time, sec int, contrib string) ([]NHTsPoint, float64, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND device_pk IN (SELECT pk FROM dz_devices_current WHERE contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?))"
+		args = append(args, contrib)
+	}
+	q := `SELECT toStartOfInterval(bucket_ts, INTERVAL ` + strconv.Itoa(sec) + ` SECOND) AS t,
+			round(avg(bps), 0), round(max(bps), 0)
+		FROM (
+			SELECT bucket_ts, sum(sout) AS bps FROM (
+				SELECT bucket_ts, device_pk, intf, argMax(avg_out_bps, ingested_at) AS sout
+				FROM device_interface_rollup_5m
+				WHERE bucket_ts >= ? AND bucket_ts < ? AND user_tunnel_id > 0` + cf + `
+				GROUP BY bucket_ts, device_pk, intf
+			) GROUP BY bucket_ts
+		) GROUP BY t ORDER BY t` + networkHealthQuerySettings + throughputMaxThreads
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	out := []NHTsPoint{}
+	var peak float64
+	for rows.Next() {
+		var t time.Time
+		var avg, mx float64
+		if err := rows.Scan(&t, &avg, &mx); err != nil {
+			return nil, 0, err
+		}
+		mx = nzFloat(mx)
+		if mx > peak {
+			peak = mx
+		}
+		out = append(out, NHTsPoint{T: t.UTC().Format(time.RFC3339), AvgBps: nzFloat(avg), MaxBps: mx})
+	}
+	return out, peak, rows.Err()
+}
+
+func (a *API) fetchOutagesTS(ctx context.Context, start, end time.Time, sec int, contrib string) ([]NHCountPoint, error) {
+	scopeJoin, scopeFilter, args := "", "", []any{start, end}
+	if contrib != "" {
+		scopeJoin = " JOIN dz_links_current l ON l.pk = r.link_pk"
+		scopeFilter = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		args = append(args, contrib)
+	}
+	q := `WITH outb AS (
+			SELECT r.link_pk AS link_pk, r.bucket_ts AS bucket_ts
+			FROM link_rollup_5m r FINAL` + scopeJoin + `
+			WHERE r.bucket_ts >= ? AND r.bucket_ts < ? AND r.provisioning = false
+			  AND r.status = 'activated' AND (r.isis_down = 1 OR greatest(r.a_loss_pct, r.z_loss_pct) >= 10)` + scopeFilter + `),
+		isl AS (
+			SELECT link_pk, bucket_ts,
+			  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+			FROM outb),
+		epi AS (SELECT link_pk, min(bucket_ts) AS started_at FROM isl GROUP BY link_pk, grp HAVING count() >= 2)
+		SELECT toStartOfInterval(started_at, INTERVAL ` + strconv.Itoa(sec) + ` SECOND) AS t, count()
+		FROM epi GROUP BY t ORDER BY t` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHCountPoint{}
+	for rows.Next() {
+		var t time.Time
+		var n uint64
+		if err := rows.Scan(&t, &n); err != nil {
+			return nil, err
+		}
+		out = append(out, NHCountPoint{T: t.UTC().Format(time.RFC3339), Count: n})
+	}
+	return out, rows.Err()
+}
+
+func (a *API) fetchTopLinks(ctx context.Context, start, end time.Time, contrib string) ([]NHTrafficLink, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND link_pk IN (SELECT pk FROM dz_links_current WHERE contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?))"
+		args = append(args, contrib)
+	}
+	q := `SELECT t.link_pk, coalesce(l.code, ''), coalesce(ma.code, ''), coalesce(mz.code, ''),
+			coalesce(l.status, ''), round(t.avg_bps / 1e9, 2), round(t.max_bps / 1e9, 2)
+		FROM (
+			SELECT link_pk, avg(bps) AS avg_bps, max(bps) AS max_bps FROM (
+				SELECT link_pk, bucket_ts, sum(sbps) AS bps FROM (
+					SELECT link_pk, bucket_ts, link_side, argMax(avg_out_bps, ingested_at) AS sbps
+					FROM device_interface_rollup_5m
+					WHERE link_pk != '' AND bucket_ts >= ? AND bucket_ts < ?` + cf + `
+					GROUP BY link_pk, bucket_ts, link_side
+				) GROUP BY link_pk, bucket_ts
+			) GROUP BY link_pk ORDER BY avg_bps DESC LIMIT 10
+		) AS t
+		LEFT JOIN dz_links_current AS l ON l.pk = t.link_pk
+		LEFT JOIN dz_devices_current AS da ON da.pk = l.side_a_pk
+		LEFT JOIN dz_devices_current AS dzz ON dzz.pk = l.side_z_pk
+		LEFT JOIN dz_metros_current AS ma ON ma.pk = da.metro_pk
+		LEFT JOIN dz_metros_current AS mz ON mz.pk = dzz.metro_pk
+		ORDER BY t.avg_bps DESC` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHTrafficLink{}
+	for rows.Next() {
+		var r NHTrafficLink
+		if err := rows.Scan(&r.LinkPK, &r.LinkCode, &r.SideAMetro, &r.SideZMetro, &r.Status, &r.AvgGbps, &r.MaxGbps); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchLatencyLinks compares each committed-RTT link's onchain committed value to
+// its measured RTT over the window. avg/ratio are unaffected by rollup duplicate
+// rows, so no FINAL/dedup is needed.
+func (a *API) fetchLatencyLinks(ctx context.Context, start, end time.Time, contrib string) ([]NHPerfLink, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		args = append(args, contrib)
+	}
+	// committed_ms, over_pct, drift_ms and drift_pct are all computed off the
+	// EFFECTIVE committed RTT: the IS-IS delay override when set (the value the
+	// network actually routes on), else the raw onchain committed_rtt_ns. Same
+	// pattern the impactful query uses. raw_committed_ms exposes the pre-override
+	// value and `overridden` flags the row. The WHERE guarantees effective > 0,
+	// so drift_pct's denominator is always > 0 (the old committed>0 guard is
+	// dropped). GROUP BY carries both raw cols so the two extra scalars are valid.
+	q := `SELECT r.link_pk, coalesce(l.code, ''), coalesce(ma.code, ''), coalesce(mz.code, ''),
+			round(if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) / 1e6, 3) AS committed_ms,
+			round(avg((r.a_avg_rtt_us + r.z_avg_rtt_us) / 2) / 1000, 3),
+			round(max(greatest(r.a_avg_rtt_us, r.z_avg_rtt_us)) / 1000, 3),
+			round(100 * countIf((r.a_avg_rtt_us + r.z_avg_rtt_us) / 2 > if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) / 1000) / count(), 1) AS over_pct,
+			round(avg((r.a_avg_rtt_us + r.z_avg_rtt_us) / 2) / 1000 - if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) / 1e6, 2) AS drift_ms,
+			round(100 * ((avg((r.a_avg_rtt_us + r.z_avg_rtt_us) / 2) / 1000) / (if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) / 1e6) - 1), 1) AS drift_pct,
+			round(l.committed_rtt_ns / 1e6, 3) AS raw_committed_ms,
+			toBool(l.isis_delay_override_ns > 0) AS overridden
+		FROM link_rollup_5m r
+		INNER JOIN dz_links_current l ON l.pk = r.link_pk
+		LEFT JOIN dz_devices_current da ON da.pk = l.side_a_pk
+		LEFT JOIN dz_devices_current dzz ON dzz.pk = l.side_z_pk
+		LEFT JOIN dz_metros_current ma ON ma.pk = da.metro_pk
+		LEFT JOIN dz_metros_current mz ON mz.pk = dzz.metro_pk
+		WHERE r.bucket_ts >= ? AND r.bucket_ts < ?
+		  AND r.status = 'activated' AND r.isis_down = 0
+		  AND if(l.isis_delay_override_ns > 0, l.isis_delay_override_ns, l.committed_rtt_ns) > 0` + cf + `
+		GROUP BY r.link_pk, l.code, ma.code, mz.code, l.committed_rtt_ns, l.isis_delay_override_ns
+		ORDER BY over_pct DESC, l.code` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHPerfLink{}
+	for rows.Next() {
+		var r NHPerfLink
+		if err := rows.Scan(&r.LinkPK, &r.LinkCode, &r.SideAMetro, &r.SideZMetro,
+			&r.CommittedMs, &r.MeasuredAvgMs, &r.MeasuredMaxMs, &r.OverCommittedPct,
+			&r.DriftMs, &r.DriftPct, &r.RawCommittedMs, &r.Overridden); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchFullestLinks ranks links by how full they are against their
+// provisioned bandwidth (l.bandwidth_bps > 0 only). A single dedup pass over device_interface_rollup_5m
+// (argMax by ingested_at, per link_pk+bucket_ts+link_side) feeds two views of
+// the same data: `peak` is the legacy combined-directions peak (summed across
+// sides per bucket, then maxed over the window) driving PeakGbps/UtilPct;
+// `util` is the P50/P99-vs-bandwidth pair from the redesign spec (avg/quantile
+// per side over the window, then maxed across sides — the busier direction).
+func (a *API) fetchFullestLinks(ctx context.Context, start, end time.Time, contrib string) ([]NHCapacityLink, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND link_pk IN (SELECT pk FROM dz_links_current WHERE contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?))"
+		args = append(args, contrib)
+	}
+	q := `WITH dedup AS (
+			SELECT link_pk, bucket_ts, link_side,
+			       argMax(p50_out_bps, ingested_at) AS p50bps,
+			       argMax(p99_out_bps, ingested_at) AS p99bps
+			FROM device_interface_rollup_5m
+			WHERE link_pk != '' AND bucket_ts >= ? AND bucket_ts < ?` + cf + `
+			GROUP BY link_pk, bucket_ts, link_side
+		),
+		peak AS (
+			SELECT link_pk, max(bps) AS peak_bps FROM (
+				SELECT link_pk, bucket_ts, sum(p99bps) AS bps FROM dedup GROUP BY link_pk, bucket_ts
+			) GROUP BY link_pk
+		),
+		util AS (
+			SELECT link_pk, max(p50bps) AS p50bps, max(p99bps) AS p99bps FROM (
+				SELECT link_pk, link_side, avg(p50bps) AS p50bps, quantile(0.99)(p99bps) AS p99bps
+				FROM dedup GROUP BY link_pk, link_side
+			) GROUP BY link_pk
+		)
+		SELECT peak.link_pk, coalesce(l.code, ''), coalesce(ma.code, ''), coalesce(mz.code, ''),
+			round(l.bandwidth_bps / 1e9, 1), round(peak.peak_bps / 1e9, 2),
+			round(100 * peak.peak_bps / l.bandwidth_bps, 1) AS util_pct,
+			round(100 * util.p50bps / l.bandwidth_bps, 1) AS p50_util,
+			round(100 * util.p99bps / l.bandwidth_bps, 1) AS p99_util
+		FROM peak
+		INNER JOIN util ON util.link_pk = peak.link_pk
+		INNER JOIN dz_links_current AS l ON l.pk = peak.link_pk
+		LEFT JOIN dz_devices_current AS da ON da.pk = l.side_a_pk
+		LEFT JOIN dz_devices_current AS dzz ON dzz.pk = l.side_z_pk
+		LEFT JOIN dz_metros_current AS ma ON ma.pk = da.metro_pk
+		LEFT JOIN dz_metros_current AS mz ON mz.pk = dzz.metro_pk
+		WHERE l.bandwidth_bps > 0
+		ORDER BY p99_util DESC LIMIT 10` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHCapacityLink{}
+	for rows.Next() {
+		var r NHCapacityLink
+		if err := rows.Scan(&r.LinkPK, &r.LinkCode, &r.SideAMetro, &r.SideZMetro, &r.BandwidthGbps, &r.PeakGbps, &r.UtilPct, &r.P50Util, &r.P99Util); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// nhAvailStateCountIfs is the shared bucket-classification snippet for the
+// availability 3-way split, used by fetchLinkAvailability, fetchDeviceAvailability,
+// and the single-link view. A bucket is 5 minutes of link_rollup_5m. See the
+// NHAvailability doc comment for the definition of each state; provisioning
+// buckets are filtered out by the caller's WHERE clause before this runs.
+const nhAvailStateCountIfs = `countIf(status = 'activated' AND isis_down = 0 AND greatest(a_loss_pct, z_loss_pct) < 10) AS avail_buckets,
+	       countIf(status IN ('soft-drained', 'hard-drained')) AS drained_buckets,
+	       countIf(status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)) AS outage_buckets`
+
+// fetchLinkAvailability ranks activated links by the 3-way availability split
+// (least available first) over the window: Available / Drained / Outage bucket
+// shares of link_rollup_5m, excluding provisioning buckets entirely. Links with
+// no classified buckets in the window (a full gap) are excluded rather than
+// counted as 0% available.
+func (a *API) fetchLinkAvailability(ctx context.Context, start, end time.Time, contrib string) ([]NHAvailability, error) {
+	scope := ""
+	args := []any{start, end}
+	if contrib != "" {
+		scope = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH agg AS (
+		SELECT link_pk, ` + nhAvailStateCountIfs + `
+		FROM link_rollup_5m FINAL
+		WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false
+		GROUP BY link_pk HAVING (avail_buckets + drained_buckets + outage_buckets) > 0)
+	  SELECT l.pk, l.code,
+	         concat(ma.code, ' ↔ ', mz.code) AS metros,
+	         round(100*avail_buckets/(avail_buckets+drained_buckets+outage_buckets), 2) AS avail_pct,
+	         round(100*drained_buckets/(avail_buckets+drained_buckets+outage_buckets), 2) AS drained_pct,
+	         round(100*outage_buckets/(avail_buckets+drained_buckets+outage_buckets), 2) AS outage_pct,
+	         round(avail_buckets*5/60, 2) AS avail_hours,
+	         round(outage_buckets*5/60, 2) AS outage_hours,
+	         round(drained_buckets*5/60, 2) AS drained_hours
+	  FROM agg
+	  JOIN dz_links_current l ON l.pk = agg.link_pk
+	  JOIN dz_devices_current da ON da.pk = l.side_a_pk
+	  JOIN dz_devices_current dz ON dz.pk = l.side_z_pk
+	  JOIN dz_metros_current ma ON ma.pk = da.metro_pk
+	  JOIN dz_metros_current mz ON mz.pk = dz.metro_pk
+	  WHERE l.status IN ('activated', 'soft-drained', 'hard-drained')` + scope + `
+	  ORDER BY avail_pct ASC LIMIT 10` + networkHealthQuerySettings
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHAvailability{}
+	for rows.Next() {
+		var r NHAvailability
+		if err := rows.Scan(&r.PK, &r.Code, &r.Metros, &r.AvailPct, &r.DrainedPct, &r.OutagePct, &r.AvailHours, &r.OutageHours, &r.DrainedHours); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchDeviceAvailability ranks activated devices by DEVICE REACHABILITY (least
+// reachable / most fault time first). Unlike the link panel, a device is
+// classified once per 5-min bucket from the states of ALL its links: AVAILABLE
+// whenever at least one link is working, OUTAGE only when it has a fault-down
+// link and no working link (the network genuinely cannot reach it), DRAINED
+// only when it is out purely for maintenance (drained link(s), none working, no
+// fault). So a single link down while others are up does not lower the device,
+// and a maintenance-only device is not flagged as least available. Every
+// device-bucket falls into exactly one state, so the three percentages sum to
+// ~100. Ranked by outage (fault) buckets descending.
+func (a *API) fetchDeviceAvailability(ctx context.Context, start, end time.Time, contrib string) ([]NHAvailability, error) {
+	devScope := ""
+	args := []any{start, end}
+	if contrib != "" {
+		devScope = " AND d.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH lb AS (
+		SELECT link_pk, bucket_ts,
+		  (status = 'activated' AND isis_down = 0 AND greatest(a_loss_pct, z_loss_pct) < 10) AS working,
+		  (status IN ('soft-drained','hard-drained')) AS drained,
+		  (status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)) AS fault
+		FROM link_rollup_5m FINAL
+		WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false),
+	  dev_bucket AS (
+		SELECT dev, bucket_ts,
+		  max(working) AS has_working, max(fault) AS has_fault, max(drained) AS has_drained
+		FROM (
+		  SELECT l.side_a_pk AS dev, lb.bucket_ts AS bucket_ts, lb.working AS working, lb.fault AS fault, lb.drained AS drained
+		  FROM lb JOIN dz_links_current l ON l.pk = lb.link_pk WHERE l.status = 'activated'
+		  UNION ALL
+		  SELECT l.side_z_pk AS dev, lb.bucket_ts AS bucket_ts, lb.working AS working, lb.fault AS fault, lb.drained AS drained
+		  FROM lb JOIN dz_links_current l ON l.pk = lb.link_pk WHERE l.status = 'activated')
+		GROUP BY dev, bucket_ts),
+	  dev_class AS (
+		SELECT dev,
+		  has_working AS avail,
+		  (NOT has_working AND has_fault) AS outage,
+		  (NOT has_working AND NOT has_fault AND has_drained) AS drained
+		FROM dev_bucket)
+	  SELECT d.pk, d.code,
+	         round(100*countIf(avail)/(countIf(avail)+countIf(outage)+countIf(drained)), 2) AS avail_pct,
+	         round(100*countIf(drained)/(countIf(avail)+countIf(outage)+countIf(drained)), 2) AS drained_pct,
+	         round(100*countIf(outage)/(countIf(avail)+countIf(outage)+countIf(drained)), 2) AS outage_pct,
+	         round(countIf(avail)*5/60, 2) AS avail_hours,
+	         round(countIf(outage)*5/60, 2) AS outage_hours,
+	         round(countIf(drained)*5/60, 2) AS drained_hours
+	  FROM dev_class JOIN dz_devices_current d ON d.pk = dev_class.dev
+	  WHERE 1=1` + devScope + `
+	  GROUP BY d.pk, d.code HAVING (countIf(avail)+countIf(outage)+countIf(drained)) > 0
+	  ORDER BY countIf(outage) DESC LIMIT 10` + networkHealthQuerySettings
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHAvailability{}
+	for rows.Next() {
+		var r NHAvailability
+		if err := rows.Scan(&r.PK, &r.Code, &r.AvailPct, &r.DrainedPct, &r.OutagePct, &r.AvailHours, &r.OutageHours, &r.DrainedHours); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchOutageSummary totals outage counts, combined outage-hours, and distinct
+// affected entities over the window, split by link vs device. Episodes are
+// derived from link_rollup_5m over the full window (the incident views cap to
+// ~8 days), using the unified outage definition shared across the page.
+func (a *API) fetchOutageSummary(ctx context.Context, start, end time.Time, contrib string) (*NHOutageSummary, error) {
+	linkScopeJoin, linkScopeFilter := "", ""
+	devScopeFilter := ""
+	linkArgs := []any{start, end}
+	devArgs := []any{start, end}
+	if contrib != "" {
+		linkScopeJoin = " JOIN dz_links_current l ON l.pk = r.link_pk"
+		linkScopeFilter = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		devScopeFilter = " AND d.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		linkArgs = append(linkArgs, contrib)
+		devArgs = append(devArgs, contrib)
+	}
+	var s NHOutageSummary
+	var linkHours float64
+	// Link outages: distinct episodes from link_rollup_5m over the full window.
+	linkQ := `WITH outb AS (
+			SELECT r.link_pk AS link_pk, r.bucket_ts AS bucket_ts
+			FROM link_rollup_5m r FINAL` + linkScopeJoin + `
+			WHERE r.bucket_ts >= ? AND r.bucket_ts < ? AND r.provisioning = false
+			  AND r.status = 'activated' AND (r.isis_down = 1 OR greatest(r.a_loss_pct, r.z_loss_pct) >= 10)` + linkScopeFilter + `),
+		isl AS (
+			SELECT link_pk, bucket_ts,
+			  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+			FROM outb),
+		epi AS (SELECT link_pk, count() * 300 AS dur_s FROM isl GROUP BY link_pk, grp HAVING count() >= 2)
+		SELECT count(), round(sum(least(dur_s, 86400)) / 3600, 0), uniqExact(link_pk)
+		FROM epi` + networkHealthQuerySettings
+	if err := a.envDB(ctx).QueryRow(ctx, linkQ, linkArgs...).
+		Scan(&s.LinkOutages, &linkHours, &s.LinksAffected); err != nil {
+		return nil, err
+	}
+	// Device outages: distinct episodes per activated device, aggregating each
+	// device's link outage buckets across both endpoints (mirrors
+	// fetchDowntimeDevices).
+	devQ := `WITH outb AS (
+			SELECT link_pk, bucket_ts
+			FROM link_rollup_5m FINAL
+			WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false
+			  AND status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)),
+		dev_buckets AS (
+			SELECT l.side_a_pk AS dev, o.bucket_ts AS bucket_ts
+			FROM outb o JOIN dz_links_current l ON l.pk = o.link_pk WHERE l.status = 'activated'
+			UNION DISTINCT
+			SELECT l.side_z_pk AS dev, o.bucket_ts AS bucket_ts
+			FROM outb o JOIN dz_links_current l ON l.pk = o.link_pk WHERE l.status = 'activated'),
+		isl AS (
+			SELECT dev, bucket_ts,
+			  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY dev ORDER BY bucket_ts) * 300) AS grp
+			FROM dev_buckets),
+		epi AS (SELECT dev, grp FROM isl GROUP BY dev, grp HAVING count() >= 2)
+		SELECT count(), uniqExact(epi.dev)
+		FROM epi
+		JOIN dz_devices_current d ON d.pk = epi.dev
+		WHERE d.status = 'activated'` + devScopeFilter + networkHealthQuerySettings
+	if err := a.envDB(ctx).QueryRow(ctx, devQ, devArgs...).
+		Scan(&s.DeviceOutages, &s.DevicesAffected); err != nil {
+		return nil, err
+	}
+	s.OutageHours = nzFloat(linkHours)
+	return &s, nil
+}
+
+// fetchDowntimeLinks ranks links by total outage-hours over the window (top 10),
+// for the "most downtime" view. Outage-hours are counted directly from
+// link_rollup_5m (full retention, no double-counting across incident types) using
+// the same outage definition as the availability panels: an activated link that
+// is isis_down or has >=10% loss in a 5-min bucket. Outages = the number of
+// distinct contiguous outage episodes (gaps between outage buckets split them),
+// found with the standard row_number island trick.
+func (a *API) fetchDowntimeLinks(ctx context.Context, start, end time.Time, contrib string) ([]NHDowntimeRow, error) {
+	scope, args := "", []any{start, end}
+	if contrib != "" {
+		scope = " AND l.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH outb AS (
+		SELECT link_pk, bucket_ts
+		FROM link_rollup_5m FINAL
+		WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false
+		  AND status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)),
+	  isl AS (
+		SELECT link_pk, bucket_ts,
+		  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY link_pk ORDER BY bucket_ts) * 300) AS grp
+		FROM outb),
+	  ep AS (SELECT link_pk, grp, count() AS b FROM isl GROUP BY link_pk, grp HAVING b >= 2),
+	  epi AS (SELECT link_pk, sum(b) AS buckets, count() AS episodes FROM ep GROUP BY link_pk)
+	  SELECT l.pk, l.code, concat(ma.code, ' ↔ ', mz.code) AS metros,
+	         epi.episodes AS outages, round(epi.buckets * 5 / 60, 1) AS hrs
+	  FROM epi
+	  JOIN dz_links_current l ON l.pk = epi.link_pk
+	  JOIN dz_devices_current da ON da.pk = l.side_a_pk
+	  JOIN dz_devices_current dz ON dz.pk = l.side_z_pk
+	  JOIN dz_metros_current ma ON ma.pk = da.metro_pk
+	  JOIN dz_metros_current mz ON mz.pk = dz.metro_pk
+	  WHERE l.status = 'activated'` + scope + `
+	  ORDER BY hrs DESC LIMIT 10` + networkHealthQuerySettings
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHDowntimeRow{}
+	for rows.Next() {
+		var r NHDowntimeRow
+		if err := rows.Scan(&r.PK, &r.Code, &r.Metros, &r.Outages, &r.Hours); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchDowntimeDevices ranks devices by total outage-hours over the window (top
+// 10). Device version of fetchDowntimeLinks: it aggregates each device's link
+// outage buckets across both endpoints (UNION DISTINCT so a bucket where two of a
+// device's links are down counts once), then counts hours and episodes the same
+// way. Sourced from link_rollup_5m rather than device_incidents_v, which only
+// retains ~2 days and so left this panel near-empty over a 30-day window.
+func (a *API) fetchDowntimeDevices(ctx context.Context, start, end time.Time, contrib string) ([]NHDowntimeRow, error) {
+	devScope, args := "", []any{start, end}
+	if contrib != "" {
+		devScope = " AND d.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH outb AS (
+		SELECT link_pk, bucket_ts
+		FROM link_rollup_5m FINAL
+		WHERE bucket_ts >= ? AND bucket_ts < ? AND provisioning = false
+		  AND status = 'activated' AND (isis_down = 1 OR greatest(a_loss_pct, z_loss_pct) >= 10)),
+	  dev_buckets AS (
+		SELECT l.side_a_pk AS dev, o.bucket_ts AS bucket_ts
+		FROM outb o JOIN dz_links_current l ON l.pk = o.link_pk WHERE l.status = 'activated'
+		UNION DISTINCT
+		SELECT l.side_z_pk AS dev, o.bucket_ts AS bucket_ts
+		FROM outb o JOIN dz_links_current l ON l.pk = o.link_pk WHERE l.status = 'activated'),
+	  isl AS (
+		SELECT dev, bucket_ts,
+		  bucket_ts - toIntervalSecond(row_number() OVER (PARTITION BY dev ORDER BY bucket_ts) * 300) AS grp
+		FROM dev_buckets),
+	  ep AS (SELECT dev, grp, count() AS b FROM isl GROUP BY dev, grp HAVING b >= 2),
+	  epi AS (SELECT dev, sum(b) AS buckets, count() AS episodes FROM ep GROUP BY dev)
+	  SELECT d.pk, d.code, m.code AS metro, epi.episodes AS outages, round(epi.buckets * 5 / 60, 1) AS hrs
+	  FROM epi
+	  JOIN dz_devices_current d ON d.pk = epi.dev
+	  JOIN dz_metros_current m ON m.pk = d.metro_pk
+	  WHERE d.status = 'activated'` + devScope + `
+	  ORDER BY hrs DESC LIMIT 10` + networkHealthQuerySettings
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHDowntimeRow{}
+	for rows.Next() {
+		var r NHDowntimeRow
+		if err := rows.Scan(&r.PK, &r.Code, &r.Metros, &r.Outages, &r.Hours); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (a *API) fetchErrorHotspots(ctx context.Context, start, end time.Time, contrib string) ([]NHErrorHotspot, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND d.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		args = append(args, contrib)
+	}
+	q := `SELECT r.device_pk, any(coalesce(d.code, '')),
+			sum(r.in_errors + r.out_errors + r.in_fcs_errors + r.in_discards + r.out_discards) AS errs,
+			sum(r.carrier_transitions) AS flaps
+		FROM device_interface_rollup_5m AS r
+		LEFT JOIN dz_devices_current AS d ON d.pk = r.device_pk
+		WHERE r.bucket_ts >= ? AND r.bucket_ts < ?` + cf + `
+		GROUP BY r.device_pk HAVING errs > 0 OR flaps > 0
+		ORDER BY errs DESC LIMIT 10` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHErrorHotspot{}
+	for rows.Next() {
+		var r NHErrorHotspot
+		if err := rows.Scan(&r.DevicePK, &r.DeviceCode, &r.Errors, &r.CarrierFlaps); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// fetchDeviceSlots returns the fullest activated devices by seat usage: unicast
+// users plus multicast subscribers/publishers against the device's total
+// max_users cap. Per-role maxes (max_unicast_users, max_multicast_*) are
+// 0/unset on most devices, so max_users is used as the single denominator;
+// UsedPct is nil (via SQL NULL) when max_users is 0.
+func (a *API) fetchDeviceSlots(ctx context.Context, contrib string) ([]NHDeviceSlots, error) {
+	cf, args := "", []any{}
+	if contrib != "" {
+		cf = " AND contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+		args = append(args, contrib)
+	}
+	q := `SELECT pk, code, unicast_users_count, multicast_subscribers_count, multicast_publishers_count,
+			max_users,
+			if(max_users > 0, round(100*(unicast_users_count+multicast_subscribers_count+multicast_publishers_count)/max_users,0), NULL) AS used_pct
+		FROM dz_devices_current
+		WHERE status='activated'` + cf + `
+		ORDER BY used_pct DESC NULLS LAST LIMIT 12` + networkHealthQuerySettings
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHDeviceSlots{}
+	for rows.Next() {
+		var s NHDeviceSlots
+		var unicast, mcastSub, mcastPub uint16
+		var maxUsers int32
+		if err := rows.Scan(&s.PK, &s.Code, &unicast, &mcastSub, &mcastPub, &maxUsers, &s.UsedPct); err != nil {
+			return nil, err
+		}
+		s.Unicast, s.McastSub, s.McastPub = uint64(unicast), uint64(mcastSub), uint64(mcastPub)
+		if maxUsers > 0 {
+			s.MaxUsers = uint64(maxUsers)
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// fetchDiaInterfaces returns the busiest Direct Internet Access interfaces by
+// p99 traffic, with utilization measured against interface bandwidth (physical
+// port speed); CIR is returned as an informational figure only. DIA
+// interfaces are almost all status='unlinked' (pre-activation onchain state),
+// so unlike other device-role fetchers this does NOT filter status='activated'.
+//
+// The dedup CTE restricts device_interface_rollup_5m to the (device_pk, intf)
+// pairs that are actually DIA (dia_intfs) before the argMax/GROUP BY dedup.
+// DIA interfaces are a small slice of all interfaces (~100 of ~550 network-wide),
+// so without this the dedup aggregates every interface on every device over the
+// whole window before the outer query's dia_type='dia' filter ever applies,
+// which was measured OOMing (code 241, AggregatingTransform) at the 2 GiB cap
+// on the live 30d default window. Restricting the join key first is a no-op on
+// the result (the outer WHERE i.dia_type='dia' already discards everything
+// else) and confirmed row-for-row identical against the unfiltered query on
+// shorter windows.
+func (a *API) fetchDiaInterfaces(ctx context.Context, start, end time.Time, contrib string) ([]NHDiaInterface, error) {
+	cf, args := "", []any{start, end}
+	if contrib != "" {
+		cf = " AND dev.contributor_pk IN (SELECT pk FROM dz_contributors_current WHERE code = ?)"
+	}
+	q := `WITH dia_intfs AS (
+			SELECT device_pk, intf FROM dz_device_interfaces_current WHERE dia_type = 'dia'
+		),
+		dedup AS (
+			SELECT device_pk, intf, bucket_ts,
+			       argMax(p50_out_bps, ingested_at) AS p50,
+			       argMax(p99_out_bps, ingested_at) AS p99
+			FROM device_interface_rollup_5m
+			WHERE bucket_ts >= ? AND bucket_ts < ?
+			  AND (device_pk, intf) IN (SELECT device_pk, intf FROM dia_intfs)
+			GROUP BY device_pk, intf, bucket_ts
+		),
+		cnt AS (
+			SELECT device_pk, intf, avg(p50) AS p50, quantile(0.99)(p99) AS p99
+			FROM dedup GROUP BY device_pk, intf
+		)
+		SELECT dev.pk, dev.code, i.intf,
+			round(i.bandwidth/1e9,1) AS port_g, round(i.cir/1e9,1) AS cir_g,
+			round(c.p50/1e9,2) AS p50_g, round(c.p99/1e9,2) AS p99_g,
+			if(i.bandwidth>0, round(100*c.p99/i.bandwidth,0), NULL) AS util,
+			'port' AS denom
+		FROM dz_device_interfaces_current i
+		INNER JOIN cnt c ON c.device_pk=i.device_pk AND c.intf=i.intf
+		JOIN dz_devices_current dev ON dev.pk=i.device_pk
+		WHERE i.dia_type='dia'` + cf + `
+		ORDER BY c.p99 DESC LIMIT 12` + networkHealthQuerySettings
+	if contrib != "" {
+		args = append(args, contrib)
+	}
+	rows, err := a.envDB(ctx).Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []NHDiaInterface{}
+	for rows.Next() {
+		var d NHDiaInterface
+		if err := rows.Scan(&d.DevicePK, &d.Device, &d.Intf, &d.PortGbps, &d.CirGbps, &d.P50Gbps, &d.P99Gbps, &d.UtilPct, &d.Denom); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}

--- a/api/handlers/network_health_availability_test.go
+++ b/api/handlers/network_health_availability_test.go
@@ -1,0 +1,595 @@
+package handlers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/lake/api/handlers"
+	apitesting "github.com/malbeclabs/lake/api/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findAvailability returns a pointer to the entry with the given code, or nil
+// if not present.
+func findAvailability(rows []handlers.NHAvailability, code string) *handlers.NHAvailability {
+	for i := range rows {
+		if rows[i].Code == code {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// insertAvailBuckets inserts n consecutive 5-minute link_rollup_5m rows for
+// linkPK, all with the given status/isis_down/loss/provisioning combination,
+// starting at base and stepping forward by 5 minutes per row.
+func insertAvailBuckets(t *testing.T, api *handlers.API, base time.Time, linkPK string, n int, status string, isisDown, provisioning bool) time.Time {
+	t.Helper()
+	ctx := t.Context()
+	for i := 0; i < n; i++ {
+		ts := base.Add(time.Duration(i*5) * time.Minute)
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO link_rollup_5m (bucket_ts, link_pk, ingested_at, a_loss_pct, z_loss_pct, a_samples, z_samples, status, isis_down, provisioning)
+			 VALUES ($1, $2, now(), 0, 0, 100, 100, $3, $4, $5)`,
+			ts, linkPK, status, isisDown, provisioning))
+	}
+	return base.Add(time.Duration(n*5) * time.Minute)
+}
+
+// TestNetworkHealthAvailability_ThreeWaySplit verifies the time/bucket-based
+// 3-way availability split (avail/drained/outage) computed by
+// fetchLinkAvailability and fetchDeviceAvailability. Each 5-minute bucket is
+// classified into exactly one of the three states (see the NHAvailability doc
+// comment), and the percentages must sum to 100 of the classified buckets.
+//
+// Case "mostly_available": 4 available buckets, 3 drained, 1 outage (8 total)
+// -> avail 50%, drained 37.5% (0.25h), outage 12.5% (0.08h, rounded).
+// Case "mostly_drained": 1 available, 6 drained, 1 outage (8 total)
+// -> avail 12.5%, drained 75% (0.5h), outage 12.5% (0.08h, rounded).
+func TestNetworkHealthAvailability_ThreeWaySplit(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	cases := []struct {
+		name                                              string
+		linkPK, linkCode, devAPK, devZPK                  string
+		avail, drained, outage                            int
+		wantAvailPct, wantDrainedPct                      float64
+		wantOutagePct                                     float64
+		wantAvailHours, wantDrainedHours, wantOutageHours float64
+	}{
+		{
+			name: "mostly_available", linkPK: "link-mostly-avail", linkCode: "NYC-LAX-AVAIL",
+			devAPK: "dev-a-avail", devZPK: "dev-z-avail",
+			avail: 4, drained: 3, outage: 1,
+			wantAvailPct: 50.0, wantDrainedPct: 37.5, wantOutagePct: 12.5,
+			wantAvailHours: 0.33, wantDrainedHours: 0.25, wantOutageHours: 0.08,
+		},
+		{
+			name: "mostly_drained", linkPK: "link-mostly-drained", linkCode: "NYC-LAX-DRAINED",
+			devAPK: "dev-a-drained", devZPK: "dev-z-drained",
+			avail: 1, drained: 6, outage: 1,
+			wantAvailPct: 12.5, wantDrainedPct: 75.0, wantOutagePct: 12.5,
+			wantAvailHours: 0.08, wantDrainedHours: 0.5, wantOutageHours: 0.08,
+		},
+	}
+
+	for _, c := range cases {
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO dz_devices_current (pk, code, device_type, metro_pk, contributor_pk, status) VALUES ($1, $2, 'router', 'metro-nyc', 'contrib-1', 'activated')`,
+			c.devAPK, c.devAPK+"-CODE"))
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO dz_devices_current (pk, code, device_type, metro_pk, contributor_pk, status) VALUES ($1, $2, 'router', 'metro-lax', 'contrib-1', 'activated')`,
+			c.devZPK, c.devZPK+"-CODE"))
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES ($1, $2, 'activated', 'WAN', $3, $4, 'contrib-1')`,
+			c.linkPK, c.linkCode, c.devAPK, c.devZPK))
+
+		base := now.Add(-90 * time.Minute)
+		base = insertAvailBuckets(t, api, base, c.linkPK, c.avail, "activated", false, false)
+		base = insertAvailBuckets(t, api, base, c.linkPK, c.drained, "soft-drained", false, false)
+		insertAvailBuckets(t, api, base, c.linkPK, c.outage, "activated", true, false)
+	}
+
+	resp := api.FetchNetworkHealthAvailabilityData(ctx, start, end, "")
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			link := findAvailability(resp.LinkAvailability, c.linkCode)
+			require.NotNil(t, link, "link %s missing from LinkAvailability", c.linkCode)
+			assert.InDelta(t, c.wantAvailPct, link.AvailPct, 0.001)
+			assert.InDelta(t, c.wantDrainedPct, link.DrainedPct, 0.001)
+			assert.InDelta(t, c.wantOutagePct, link.OutagePct, 0.001)
+			assert.InDelta(t, c.wantAvailHours, link.AvailHours, 0.001)
+			assert.InDelta(t, c.wantDrainedHours, link.DrainedHours, 0.001)
+			assert.InDelta(t, c.wantOutageHours, link.OutageHours, 0.001)
+			assert.Equal(t, "NYC ↔ LAX", link.Metros)
+
+			// The link's two endpoint devices are on no other link, so their
+			// availability should match the link's exactly.
+			devA := findAvailability(resp.DeviceAvailability, c.devAPK+"-CODE")
+			require.NotNil(t, devA, "device %s missing from DeviceAvailability", c.devAPK)
+			assert.InDelta(t, c.wantAvailPct, devA.AvailPct, 0.001)
+			assert.InDelta(t, c.wantDrainedPct, devA.DrainedPct, 0.001)
+			assert.InDelta(t, c.wantOutagePct, devA.OutagePct, 0.001)
+			assert.InDelta(t, c.wantAvailHours, devA.AvailHours, 0.001)
+
+			devZ := findAvailability(resp.DeviceAvailability, c.devZPK+"-CODE")
+			require.NotNil(t, devZ, "device %s missing from DeviceAvailability", c.devZPK)
+			assert.InDelta(t, c.wantAvailPct, devZ.AvailPct, 0.001)
+		})
+	}
+}
+
+// insertAvailLossBuckets inserts n consecutive 5-minute link_rollup_5m rows
+// for linkPK with status='activated', isis_down=false, provisioning=false,
+// but with high packet loss (a_loss_pct/z_loss_pct = lossPct). The shared
+// nhAvailStateCountIfs classification counts these as outage via the
+// "loss >= 10" branch rather than the isis_down branch, so this covers the
+// other half of that OR condition.
+func insertAvailLossBuckets(t *testing.T, api *handlers.API, base time.Time, linkPK string, n int, lossPct float64) time.Time {
+	t.Helper()
+	ctx := t.Context()
+	for i := 0; i < n; i++ {
+		ts := base.Add(time.Duration(i*5) * time.Minute)
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO link_rollup_5m (bucket_ts, link_pk, ingested_at, a_loss_pct, z_loss_pct, a_samples, z_samples, status, isis_down, provisioning)
+			 VALUES ($1, $2, now(), $3, $3, 100, 100, 'activated', false, false)`,
+			ts, linkPK, lossPct))
+	}
+	return base.Add(time.Duration(n*5) * time.Minute)
+}
+
+// TestNetworkHealthLinkAvailability_AllStates covers the full 3-way
+// availability split for a single link through fetchLinkAvailability (the
+// network-wide ranking query), exercising every branch of the shared
+// nhAvailStateCountIfs classifier in one link: both outage sub-conditions
+// (isis_down and loss>=10), both drained statuses, and provisioning exclusion.
+// The other tests above cover isis_down-only outage and provisioning, but not
+// the loss>=10 outage branch or hard-drained, so this retains that coverage
+// after the per-link drill-down builder was removed.
+//
+// Bucket mix inserted for one link (26 total, 20 classified + 6 excluded):
+//   - 8 available: status='activated', clean (isis_down=false, loss=0)
+//   - 5 drained (soft-drained) + 2 drained (hard-drained) = 7 drained
+//   - 3 outage via isis_down=true + 2 outage via loss>=10 = 5 outage
+//   - 6 provisioning=true buckets (isis_down=true, which would otherwise
+//     classify as outage) that must be excluded from the denominator entirely
+//
+// Expected, out of the 20 classified buckets: avail 40%, drained 35%, outage
+// 25% (summing to 100). outage_hours = 5 buckets * 5/60 = 0.4166.. -> 0.42
+// rounded; drained_hours = 7 buckets * 5/60 = 0.5833.. -> 0.58 rounded.
+func TestNetworkHealthLinkAvailability_AllStates(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	const linkPK = "link-single"
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk, bandwidth_bps) VALUES ($1, 'NYC-LAX-SINGLE', 'activated', 'WAN', 'dev-nyc-1', 'dev-lax-1', 'contrib-1', 10000000000)`,
+		linkPK))
+
+	base := now.Add(-100 * time.Minute)
+	base = insertAvailBuckets(t, api, base, linkPK, 8, "activated", false, false)    // available
+	base = insertAvailBuckets(t, api, base, linkPK, 5, "soft-drained", false, false) // drained
+	base = insertAvailBuckets(t, api, base, linkPK, 2, "hard-drained", false, false) // drained
+	base = insertAvailBuckets(t, api, base, linkPK, 3, "activated", true, false)     // outage (isis_down)
+	base = insertAvailLossBuckets(t, api, base, linkPK, 2, 15.0)                     // outage (loss >= 10)
+	insertAvailBuckets(t, api, base, linkPK, 6, "activated", true, true)             // provisioning, excluded
+
+	resp := api.FetchNetworkHealthAvailabilityData(ctx, start, end, "")
+
+	link := findAvailability(resp.LinkAvailability, "NYC-LAX-SINGLE")
+	require.NotNil(t, link, "link NYC-LAX-SINGLE missing from LinkAvailability")
+
+	assert.InDelta(t, 40.0, link.AvailPct, 0.001)
+	assert.InDelta(t, 35.0, link.DrainedPct, 0.001)
+	assert.InDelta(t, 25.0, link.OutagePct, 0.001)
+	assert.InDelta(t, 100.0, link.AvailPct+link.DrainedPct+link.OutagePct, 0.001, "the three shares must sum to 100")
+
+	assert.InDelta(t, 0.42, link.OutageHours, 0.001, "5 outage buckets * 5/60")
+	assert.InDelta(t, 0.58, link.DrainedHours, 0.001, "7 drained buckets * 5/60")
+}
+
+// TestNetworkHealthAvailability_ProvisioningExcluded confirms that
+// provisioning buckets are excluded from the denominator entirely (not
+// counted as outage, drained, or available), and that a link with only
+// provisioning buckets is excluded from the ranking altogether rather than
+// showing as 0%/100%.
+func TestNetworkHealthAvailability_ProvisioningExcluded(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	// link-real: 2 real available buckets, plus 5 provisioning buckets that
+	// would otherwise classify as outage (isis_down=true). The provisioning
+	// buckets must not pull avail_pct down from 100%.
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES ('link-real', 'REAL-LINK', 'activated', 'WAN', 'dev-nyc-1', 'dev-lax-1', 'contrib-1')`))
+	base := now.Add(-90 * time.Minute)
+	base = insertAvailBuckets(t, api, base, "link-real", 2, "activated", false, false)
+	insertAvailBuckets(t, api, base, "link-real", 5, "activated", true, true)
+
+	// link-prov-only: every bucket is provisioning=true, so it must be
+	// excluded from the ranking entirely (not shown as a gap/0%).
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_devices_current (pk, code, device_type, metro_pk, contributor_pk, status) VALUES ('dev-prov-a', 'PROV-A-CODE', 'router', 'metro-nyc', 'contrib-1', 'activated'), ('dev-prov-z', 'PROV-Z-CODE', 'router', 'metro-lax', 'contrib-1', 'activated')`))
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES ('link-prov-only', 'PROV-ONLY-LINK', 'activated', 'WAN', 'dev-prov-a', 'dev-prov-z', 'contrib-1')`))
+	insertAvailBuckets(t, api, base, "link-prov-only", 4, "activated", false, true)
+
+	resp := api.FetchNetworkHealthAvailabilityData(ctx, start, end, "")
+
+	real := findAvailability(resp.LinkAvailability, "REAL-LINK")
+	require.NotNil(t, real, "link with real (non-provisioning) buckets should appear")
+	assert.InDelta(t, 100.0, real.AvailPct, 0.001, "provisioning buckets must not count as outage")
+	assert.InDelta(t, 0.0, real.DrainedPct, 0.001)
+	assert.InDelta(t, 0.0, real.OutagePct, 0.001)
+	assert.InDelta(t, 0.17, real.AvailHours, 0.001, "2 available buckets * 5/60, provisioning buckets excluded")
+
+	assert.Nil(t, findAvailability(resp.LinkAvailability, "PROV-ONLY-LINK"), "an all-provisioning link should be excluded, not shown as a gap")
+	assert.Nil(t, findAvailability(resp.DeviceAvailability, "PROV-A-CODE"), "a device whose only link is all-provisioning should be excluded")
+}
+
+// TestNetworkHealthAvailability_DeviceReachability confirms the device
+// REACHABILITY semantics of fetchDeviceAvailability: a device is available in a
+// bucket whenever at least one of its links is working, even if another link is
+// down. The hub device is side_a on a fully-working link and side_z on a
+// fully-fault-down link over the same buckets; because one link works every
+// bucket, the device reads 100% available (a single link down does not lower
+// the device), which is the opposite of a link-hours average.
+func TestNetworkHealthAvailability_DeviceReachability(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_devices_current (pk, code, device_type, metro_pk, contributor_pk, status) VALUES
+			('dev-hub', 'HUB-CODE', 'router', 'metro-nyc', 'contrib-1', 'activated'),
+			('dev-x1', 'X1-CODE', 'router', 'metro-lax', 'contrib-1', 'activated'),
+			('dev-x2', 'X2-CODE', 'router', 'metro-lax', 'contrib-1', 'activated')`))
+
+	// Link 1: dev-hub is side_a, fully working (4 buckets) over the same times.
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES ('link-hub-1', 'HUB-LINK-1', 'activated', 'WAN', 'dev-hub', 'dev-x1', 'contrib-1')`))
+	insertAvailBuckets(t, api, now.Add(-90*time.Minute), "link-hub-1", 4, "activated", false, false)
+
+	// Link 2: dev-hub is side_z, fully fault-down (isis_down) over the same times.
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES ('link-hub-2', 'HUB-LINK-2', 'activated', 'WAN', 'dev-x2', 'dev-hub', 'contrib-1')`))
+	insertAvailBuckets(t, api, now.Add(-90*time.Minute), "link-hub-2", 4, "activated", true, false)
+
+	resp := api.FetchNetworkHealthAvailabilityData(ctx, start, end, "")
+
+	// Each link alone is 100% one state.
+	link1 := findAvailability(resp.LinkAvailability, "HUB-LINK-1")
+	require.NotNil(t, link1)
+	assert.InDelta(t, 100.0, link1.AvailPct, 0.001)
+
+	link2 := findAvailability(resp.LinkAvailability, "HUB-LINK-2")
+	require.NotNil(t, link2)
+	assert.InDelta(t, 100.0, link2.OutagePct, 0.001)
+
+	// The device is reachable through link-hub-1 every bucket, so it is 100%
+	// available despite link-hub-2 being fully down.
+	hub := findAvailability(resp.DeviceAvailability, "HUB-CODE")
+	require.NotNil(t, hub, "device dev-hub missing from DeviceAvailability")
+	assert.InDelta(t, 100.0, hub.AvailPct, 0.001, "one working link keeps the device available")
+	assert.InDelta(t, 0.0, hub.DrainedPct, 0.001)
+	assert.InDelta(t, 0.0, hub.OutagePct, 0.001)
+	assert.InDelta(t, 0.33, hub.AvailHours, 0.001, "4 available buckets * 5/60")
+
+	// dev-x2 (side_a on the fully-down link only) has no working link, so it is
+	// in outage the whole window.
+	x2 := findAvailability(resp.DeviceAvailability, "X2-CODE")
+	require.NotNil(t, x2, "device dev-x2 missing from DeviceAvailability")
+	assert.InDelta(t, 100.0, x2.OutagePct, 0.001, "a device with only a fault-down link is in outage")
+}
+
+// insertIfaceBps inserts one device_interface_rollup_5m row attributing traffic
+// (avg_out_bps) to linkPK at ts. Used to make an impactful-downtime link
+// "attributable" with a known pre-outage bps.
+func insertIfaceBps(t *testing.T, api *handlers.API, ts time.Time, linkPK, devicePK string, avgOutBps float64) {
+	t.Helper()
+	require.NoError(t, api.DB.Exec(t.Context(),
+		`INSERT INTO device_interface_rollup_5m (bucket_ts, device_pk, intf, link_pk, ingested_at, avg_in_bps, avg_out_bps)
+		 VALUES ($1, $2, 'eth0', $3, now(), 0, $4)`,
+		ts, devicePK, linkPK, avgOutBps))
+}
+
+// sumCountPoints totals the Count over an outages-over-time series.
+func sumCountPoints(pts []handlers.NHCountPoint) uint64 {
+	var n uint64
+	for _, p := range pts {
+		n += p.Count
+	}
+	return n
+}
+
+// hasCountAt reports whether the series carries a point whose T equals ts
+// (RFC3339 UTC), i.e. an episode started in that interval.
+func hasCountAt(pts []handlers.NHCountPoint, ts time.Time) bool {
+	want := ts.UTC().Format(time.RFC3339)
+	for _, p := range pts {
+		if p.T == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNetworkHealthOutages_EpisodeReconstruction drives the shared outage-episode
+// "island" CTE through FetchNetworkHealthOutagesData over link_rollup_5m and
+// pins its four rules using four separate links:
+//   - blip: a single sub-10-minute down bucket (300s) is DROPPED from the
+//     sustained OutageCount (>= 10 min floor) but still counted as a flap.
+//   - split: two down buckets separated by one clean bucket do NOT merge into one
+//     episode; they stay two 300s flaps (0 sustained), not one 600s episode.
+//   - run2: two contiguous down buckets = one 600s episode, which DOES clear the
+//     >= 2-bucket / 10-min floor (the inclusive boundary).
+//   - run3: three contiguous down buckets = one 900s episode with the right start.
+func TestNetworkHealthOutages_EpisodeReconstruction(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(5 * time.Minute)
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	tRun3 := now.Add(-90 * time.Minute)
+	tRun2 := now.Add(-60 * time.Minute)
+	tBlip := now.Add(-45 * time.Minute)
+	tSplit := now.Add(-30 * time.Minute)
+
+	// run3: 3 contiguous down buckets (900s, one episode).
+	insertAvailBuckets(t, api, tRun3, "epi-run3", 3, "activated", true, false)
+	// run2: 2 contiguous down buckets (600s, one episode, exactly at the floor).
+	insertAvailBuckets(t, api, tRun2, "epi-run2", 2, "activated", true, false)
+	// blip: 1 down bucket (300s, below the floor).
+	insertAvailBuckets(t, api, tBlip, "epi-blip", 1, "activated", true, false)
+	// split: down, gap of one clean bucket, down again -> two 300s islands.
+	insertAvailBuckets(t, api, tSplit, "epi-split", 1, "activated", true, false)
+	insertAvailBuckets(t, api, tSplit.Add(10*time.Minute), "epi-split", 1, "activated", true, false)
+
+	resp := api.FetchNetworkHealthOutagesData(ctx, start, end, "")
+
+	// Sustained OutageCount counts only the >= 2-bucket (>= 10 min) episodes:
+	// run3 and run2. The blip and both split flaps are excluded.
+	assert.Equal(t, uint64(2), resp.Reliability.OutageCount, "only run3 + run2 clear the 10-min floor")
+	assert.Equal(t, uint64(2), resp.OutageCount, "headline OutageCount mirrors reliability")
+
+	// The histogram counts ALL episodes: three 300s flaps (blip + two split
+	// islands) and two 5-15m episodes (run2 600s, run3 900s). If the split had
+	// merged, this would read one 600s episode (Short5to15m) and one flap instead.
+	assert.Equal(t, uint64(3), resp.Reliability.DurationHistogram.FlapLE5m, "blip + two non-merged split flaps")
+	assert.Equal(t, uint64(2), resp.Reliability.DurationHistogram.Short5to15m, "run2 (600s) + run3 (900s)")
+	assert.Equal(t, uint64(0), resp.Reliability.DurationHistogram.Medium15to60m)
+
+	// Capped downtime is the sum of the sustained episode seconds: 900 + 600.
+	assert.InDelta(t, 0.4, resp.Reliability.CappedDowntimeHours, 0.001, "(900+600)/3600 rounded to 0.1")
+
+	// outages_ts carries only the >= 2-bucket episodes (run3, run2), each starting
+	// in its own 5-min interval, so the total is 2 and run3's start is present.
+	assert.Equal(t, uint64(2), sumCountPoints(resp.OutagesOverTime), "only sustained episodes appear on the timeline")
+	assert.True(t, hasCountAt(resp.OutagesOverTime, tRun3), "run3's episode starts at its first down bucket")
+	assert.True(t, hasCountAt(resp.OutagesOverTime, tRun2), "run2's episode starts at its first down bucket")
+}
+
+// TestNetworkHealthImpactful_Weighting drives FetchNetworkHealthImpactfulData and
+// checks the impact weighting: only downtime on the primary path or a
+// traffic-carrying link is summed. Five links, each with a >= 2-bucket outage, on
+// one NYC-LAX metro pair:
+//   - primary (lowest committed RTT, unattributable): COUNTS via the primary rule.
+//   - backup (higher committed RTT, unattributable): EXCLUDED (not primary).
+//   - hightraffic (attributable, >= 1Mbps pre-outage): COUNTS via the traffic rule.
+//   - lowtraffic (attributable, < 1Mbps pre-outage): EXCLUDED (idle).
+//   - sentinel (unattributable, committed_rtt_ns == 1e9 sentinel): EXCLUDED
+//     (dropped from the metric graph, so never primary).
+//
+// Only primary (1200s) + hightraffic (600s) count -> 1800s = 0.5h.
+func TestNetworkHealthImpactful_Weighting(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	// The impactful query weights links by isis_delay_override_ns/committed_rtt_ns
+	// like the topology graph; the bare rollup schema omits the override column.
+	require.NoError(t, api.DB.Exec(ctx,
+		`ALTER TABLE dz_links_current ADD COLUMN IF NOT EXISTS isis_delay_override_ns Int64 DEFAULT 0`))
+
+	now := time.Now().UTC().Truncate(5 * time.Minute)
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	// All five links span the same NYC-LAX metro pair (dev-nyc-1 / dev-lax-1 from
+	// insertBaseMetadata), so they compete for the single primary slot.
+	links := []struct {
+		pk, code    string
+		committedNs int64
+	}{
+		{"imp-primary", "IMP-PRIMARY", 5_000_000},
+		{"imp-backup", "IMP-BACKUP", 20_000_000},
+		{"imp-hightraf", "IMP-HIGHTRAF", 8_000_000},
+		{"imp-lowtraf", "IMP-LOWTRAF", 10_000_000},
+		{"imp-sentinel", "IMP-SENTINEL", 1_000_000_000},
+	}
+	for _, l := range links {
+		require.NoError(t, api.DB.Exec(ctx,
+			`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk, committed_rtt_ns) VALUES ($1, $2, 'activated', 'WAN', 'dev-nyc-1', 'dev-lax-1', 'contrib-1', $3)`,
+			l.pk, l.code, l.committedNs))
+	}
+
+	base := now.Add(-30 * time.Minute)
+	insertAvailBuckets(t, api, base, "imp-primary", 4, "activated", true, false)  // 1200s, counts
+	insertAvailBuckets(t, api, base, "imp-hightraf", 2, "activated", true, false) // 600s, counts
+	insertAvailBuckets(t, api, base, "imp-backup", 2, "activated", true, false)   // excluded
+	insertAvailBuckets(t, api, base, "imp-lowtraf", 2, "activated", true, false)  // excluded
+	insertAvailBuckets(t, api, base, "imp-sentinel", 2, "activated", true, false) // excluded
+
+	// Pre-outage traffic (60 min before the outage start). hightraffic carries
+	// 5Mbps (>= 1Mbps -> impactful); lowtraffic carries 0.5Mbps (idle -> excluded).
+	pre := base.Add(-15 * time.Minute)
+	insertIfaceBps(t, api, pre, "imp-hightraf", "dev-nyc-1", 5_000_000)
+	insertIfaceBps(t, api, pre, "imp-lowtraf", "dev-nyc-1", 500_000)
+
+	resp := api.FetchNetworkHealthImpactfulData(ctx, start, end, "")
+
+	assert.False(t, resp.Unavailable, "the current-window scan should succeed")
+	assert.InDelta(t, 0.5, resp.ImpactfulDowntimeHours, 0.001,
+		"only primary (1200s) + traffic-carrying hightraffic (600s) count: 1800s = 0.5h")
+}
+
+// TestNetworkHealthScopeIsolation confirms per-contributor scoping across the SQL
+// groups. C1 owns one always-up link; C2 owns a fully-down link. A third
+// contributor CEMPTY owns no links at all.
+func TestNetworkHealthScopeIsolation(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(5 * time.Minute)
+	start := now.Add(-2 * time.Hour)
+	end := now.Add(2 * time.Hour)
+
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_contributors_current (pk, code, name) VALUES ('cc1', 'C1', 'One'), ('cc2', 'C2', 'Two'), ('cce', 'CEMPTY', 'Empty')`))
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_devices_current (pk, code, device_type, metro_pk, contributor_pk, status) VALUES
+			('dev-cc1-a', 'DEV-CC1-A', 'router', 'metro-nyc', 'cc1', 'activated'),
+			('dev-cc1-z', 'DEV-CC1-Z', 'router', 'metro-lax', 'cc1', 'activated'),
+			('dev-cc2-a', 'DEV-CC2-A', 'router', 'metro-nyc', 'cc2', 'activated'),
+			('dev-cc2-z', 'DEV-CC2-Z', 'router', 'metro-lax', 'cc2', 'activated')`))
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk) VALUES
+			('link-cc1', 'LINK-CC1', 'activated', 'WAN', 'dev-cc1-a', 'dev-cc1-z', 'cc1'),
+			('link-cc2-down', 'LINK-CC2-DOWN', 'activated', 'WAN', 'dev-cc2-a', 'dev-cc2-z', 'cc2')`))
+
+	linkBase := now.Add(-60 * time.Minute)
+	insertAvailBuckets(t, api, linkBase, "link-cc1", 6, "activated", false, false)     // C1: always up
+	insertAvailBuckets(t, api, linkBase, "link-cc2-down", 6, "activated", true, false) // C2: fully down (outage)
+
+	// A network-wide drain event so the drain group is non-empty when unscoped.
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_link_status_changes (link_pk, link_code, previous_status, new_status, changed_ts, side_a_metro, side_z_metro) VALUES ('link-cc2-down', 'LINK-CC2-DOWN', 'activated', 'soft-drained', $1, 'NYC', 'LAX')`,
+		now.Add(-50*time.Minute)))
+
+	// --- Availability group scoped to C1: only C1's link/devices, never C2's. ---
+	avail := api.FetchNetworkHealthAvailabilityData(ctx, start, end, "C1")
+	require.NotNil(t, findAvailability(avail.LinkAvailability, "LINK-CC1"), "C1's link should appear")
+	assert.Nil(t, findAvailability(avail.LinkAvailability, "LINK-CC2-DOWN"), "C2's down link must not leak into a C1-scoped view")
+	require.NotNil(t, findAvailability(avail.DeviceAvailability, "DEV-CC1-A"), "C1's device should appear")
+	assert.Nil(t, findAvailability(avail.DeviceAvailability, "DEV-CC2-A"), "C2's device must not leak into a C1-scoped view")
+
+	// --- Outages group scoped to C1: C2's outage is excluded entirely. ---
+	outC1 := api.FetchNetworkHealthOutagesData(ctx, start, end, "C1")
+	assert.Equal(t, uint64(0), outC1.OutageCount, "C1 has no outage; C2's must not count")
+	require.NotNil(t, outC1.OutageSummary)
+	assert.Equal(t, uint64(0), outC1.OutageSummary.LinkOutages, "no C1 link outages")
+	for _, r := range outC1.DowntimeLinks {
+		assert.NotEqual(t, "LINK-CC2-DOWN", r.Code, "C2's down link must not appear in C1's downtime ranking")
+	}
+	// Unscoped, C2's outage IS counted, proving the scope filter is what removed it.
+	outAll := api.FetchNetworkHealthOutagesData(ctx, start, end, "")
+	assert.GreaterOrEqual(t, outAll.OutageCount, uint64(1), "C2's outage is visible network-wide")
+	var sawC2 bool
+	for _, r := range outAll.DowntimeLinks {
+		if r.Code == "LINK-CC2-DOWN" {
+			sawC2 = true
+		}
+	}
+	assert.True(t, sawC2, "C2's down link appears in the network-wide downtime ranking")
+
+	// --- Drain group scoped to a zero-link contributor returns empty (A3): a
+	// scoped request that owns no links must NOT fall back to a network-wide scan. ---
+	drainEmpty := api.FetchNetworkHealthDrainData(ctx, start, end, "CEMPTY")
+	assert.Equal(t, 0, drainEmpty.DrainTiming.OutageCount, "zero-link scope must not see network outages")
+	assert.Equal(t, 0, drainEmpty.DrainTiming.Drains, "zero-link scope must not see network drains")
+	assert.Equal(t, 0, drainEmpty.DrainTiming.Undrains)
+	assert.Equal(t, 0, drainEmpty.DrainTiming.MatchedUndrains)
+	assert.Nil(t, drainEmpty.DrainTiming.TimeToDrainP50Min)
+	assert.Nil(t, drainEmpty.DrainTiming.DrainWithin30mPct)
+	require.NotNil(t, drainEmpty.Prev)
+	// Unscoped, the drain event is visible, proving the empty result is scoping.
+	drainAll := api.FetchNetworkHealthDrainData(ctx, start, end, "")
+	assert.GreaterOrEqual(t, drainAll.DrainTiming.Drains, 1, "the drain event is visible network-wide")
+}
+
+// TestNetworkHealthDeltas pins the sign and magnitude of the current-vs-prior
+// deltas so a current/prior swap fails. Current window has 3 sustained outages
+// (one on the primary link) and the prior window has 1; the primary link's
+// outage lasts longer in the current window than in the prior.
+func TestNetworkHealthDeltas(t *testing.T) {
+	t.Parallel()
+	api := apitesting.NewTestAPIBare(t, testChDB)
+	setupRollupTables(t, api)
+	insertBaseMetadata(t, api)
+	ctx := t.Context()
+
+	require.NoError(t, api.DB.Exec(ctx,
+		`ALTER TABLE dz_links_current ADD COLUMN IF NOT EXISTS isis_delay_override_ns Int64 DEFAULT 0`))
+
+	now := time.Now().UTC().Truncate(5 * time.Minute)
+	end := now
+	start := now.Add(-60 * time.Minute) // 1h window
+	// prior window is [now-120m, now-60m).
+
+	// implink is the sole NYC-LAX link, so it is the impactful primary path.
+	require.NoError(t, api.DB.Exec(ctx,
+		`INSERT INTO dz_links_current (pk, code, status, link_type, side_a_pk, side_z_pk, contributor_pk, committed_rtt_ns) VALUES ('implink', 'IMPLINK', 'activated', 'WAN', 'dev-nyc-1', 'dev-lax-1', 'contrib-1', 5000000)`))
+
+	// Current window: 3 sustained outages (implink 4 buckets, two plain links 2).
+	insertAvailBuckets(t, api, now.Add(-30*time.Minute), "implink", 4, "activated", true, false)
+	insertAvailBuckets(t, api, now.Add(-40*time.Minute), "plain1", 2, "activated", true, false)
+	insertAvailBuckets(t, api, now.Add(-40*time.Minute), "plain2", 2, "activated", true, false)
+	// Prior window: 1 sustained outage (implink 2 buckets).
+	insertAvailBuckets(t, api, now.Add(-90*time.Minute), "implink", 2, "activated", true, false)
+
+	out := api.FetchNetworkHealthOutagesData(ctx, start, end, "")
+	assert.Equal(t, uint64(3), out.OutageCount, "3 sustained outages in the current window")
+	require.NotNil(t, out.Prev)
+	assert.Equal(t, uint64(1), out.Prev.Reliability.OutageCount, "1 sustained outage in the prior window")
+	require.NotNil(t, out.OutageCountDelta, "delta is defined when the prior count is non-zero")
+	assert.InDelta(t, 200.0, *out.OutageCountDelta, 0.001, "(3-1)/1*100 = +200; a swap would be negative")
+
+	imp := api.FetchNetworkHealthImpactfulData(ctx, start, end, "")
+	assert.False(t, imp.Unavailable)
+	assert.InDelta(t, 0.3, imp.ImpactfulDowntimeHours, 0.001, "implink 1200s current -> 0.3h")
+	require.NotNil(t, imp.Prev)
+	assert.InDelta(t, 0.2, imp.Prev.ImpactfulDowntimeHours, 0.001, "implink 600s prior -> 0.2h")
+	require.NotNil(t, imp.ImpactfulDowntimeDelta, "delta is defined when the prior value is non-zero")
+	assert.InDelta(t, 50.0, *imp.ImpactfulDowntimeDelta, 0.001, "(0.3-0.2)/0.2*100 = +50; a swap would be negative")
+}

--- a/api/handlers/network_health_livecompute_test.go
+++ b/api/handlers/network_health_livecompute_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestServeNHGroupQueuesUnderConcurrentScopedLoad guards the fix for the
+// reported bug: a contributor-scoped Network Health page load fires ~9 group
+// requests at once, and every one bypasses cache (scoped is never precomputed)
+// and competes for the 4-slot nhLiveComputeSem. The OLD behavior shed any
+// request that couldn't grab a slot within a fixed 2s, so ~5 of 9 panels 503'd
+// and the UI showed "Couldn't load this section".
+//
+// With "queue, don't drop", a waiter blocks for a free slot up to its own
+// deadline instead of shedding after 2s. Slots free as the running queries
+// finish, so every panel is eventually served. Only a request whose deadline
+// expires while waiting (genuine sustained overload) or whose client
+// disconnected is shed.
+//
+// The stub fetch holds its slot for 3s (longer than the old 2s shed window),
+// so under the old code the 5 waiters would 503; under the fix they queue and
+// all complete well inside the 35s deadline.
+func TestServeNHGroupQueuesUnderConcurrentScopedLoad(t *testing.T) {
+	a := &API{}
+
+	fetch := func(ctx context.Context, start, end time.Time, contrib string) any {
+		select {
+		case <-time.After(3 * time.Second):
+		case <-ctx.Done():
+		}
+		return map[string]any{}
+	}
+
+	const n = 9 // overview, availability, latency, capacity, outages, drain, tickets, impactful, deferred
+	var got503, got200 int32
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/network-health/capacity?contributor=dgt&days=30", nil)
+			// testnet env => isMainnet false => scoped path skips the cache read
+			// (no DB needed) and goes straight to the live-compute semaphore.
+			req = req.WithContext(ContextWithEnv(req.Context(), EnvTestnet))
+			rw := httptest.NewRecorder()
+			a.serveNHGroup(rw, req,
+				"k", func(string) string { return "ck" },
+				fetch, nhGroupDeadline)
+			switch rw.Code {
+			case http.StatusServiceUnavailable:
+				atomic.AddInt32(&got503, 1)
+			case http.StatusOK:
+				atomic.AddInt32(&got200, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	t.Logf("of %d concurrent scoped requests: %d served (200), %d shed (503)", n, got200, got503)
+	if got503 != 0 {
+		t.Fatalf("expected all %d concurrent scoped requests to queue and be served, but %d were shed with 503", n, got503)
+	}
+	if got200 != n {
+		t.Fatalf("expected %d served (200), got %d", n, got200)
+	}
+}
+
+// TestNHAcquireLiveShedsWhenClientDisconnects verifies the queue still bails out
+// promptly (no hang, no query launched) when the caller's context is already
+// cancelled, e.g. the browser navigated away while all slots were busy.
+func TestNHAcquireLiveShedsWhenClientDisconnects(t *testing.T) {
+	// Fill every slot so the next acquire must wait.
+	for i := 0; i < cap(nhLiveComputeSem); i++ {
+		nhLiveComputeSem <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < cap(nhLiveComputeSem); i++ {
+			<-nhLiveComputeSem
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client already gone
+
+	release, ok := nhAcquireLive(ctx)
+	if ok {
+		release()
+		t.Fatal("expected nhAcquireLive to fail when context is cancelled and all slots are busy")
+	}
+}

--- a/api/handlers/network_health_test.go
+++ b/api/handlers/network_health_test.go
@@ -1,0 +1,660 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertKeysAllowed marshals v to JSON and fails if it carries a key outside
+// allowed. label names the struct in the failure message.
+func assertKeysAllowed(t *testing.T, label string, v any, allowed map[string]bool) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("%s marshal: %v", label, err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("%s unmarshal: %v", label, err)
+	}
+	for k := range m {
+		if !allowed[k] {
+			t.Errorf("%s exposes unexpected field %q; the public ops aggregate must be numbers/enums only (no free text)", label, k)
+		}
+	}
+}
+
+// TestNHTicketsNoFreeText enforces the public boundary structurally: the
+// ops-management aggregate served to the public browser must contain only
+// numeric/enum fields, never ticket titles, descriptions, reporter identities,
+// or root-cause text. The guard recurses into the nested lists
+// (NHNoTicketOutage, NHRootCauseCount), each populated with a sample element, so
+// a free-text field added at any level fails the test.
+func TestNHTicketsNoFreeText(t *testing.T) {
+	allowed := map[string]bool{
+		"total": true, "incidents": true, "maintenance": true,
+		"sev1": true, "sev2": true, "sev3": true,
+		"response_p50_min": true, "resolution_p50_min": true,
+		"closed_incidents":    true,
+		"self_reported_count": true, "doublezero_filed_count": true, "self_reported_pct": true,
+		"maintenance_lead_p50_min": true, "maintenance_duration_p50_min": true, "closed_maintenance": true,
+		"outage_count": true, "outages_with_ticket": true,
+		"outages_no_ticket": true, "no_ticket_share_pct": true,
+		"no_ticket_outages": true,
+		"root_causes":       true,
+	}
+	// Populate the nested lists so their element shape is exercised too; an empty
+	// NHTickets marshals them as empty arrays and would skip the recursion.
+	tk := NHTickets{
+		NoTicketOutages: []NHNoTicketOutage{{LinkPK: "lp", LinkCode: "ams-fra", StartTs: "2026-06-10T10:00:00Z", Hours: 1.5}},
+		RootCauses:      []NHRootCauseCount{{Cause: "carrier", Count: 2, Pct: f64ptr(50)}},
+	}
+	assertKeysAllowed(t, "NHTickets", tk, allowed)
+
+	// NHNoTicketOutage: link identity + start + duration only, never ticket text.
+	noTicketAllowed := map[string]bool{
+		"link_pk": true, "link_code": true, "start_ts": true, "hours": true,
+	}
+	for _, o := range tk.NoTicketOutages {
+		assertKeysAllowed(t, "NHNoTicketOutage", o, noTicketAllowed)
+	}
+
+	// NHRootCauseCount: fixed enum token + counts only, never free-text cause.
+	rootCauseAllowed := map[string]bool{"cause": true, "count": true, "pct": true}
+	for _, rc := range tk.RootCauses {
+		assertKeysAllowed(t, "NHRootCauseCount", rc, rootCauseAllowed)
+	}
+}
+
+// TestComputeTicketAggregates sanity-checks the aggregation: type/severity
+// counts, closed/root-cause, and outage coverage matching.
+func TestComputeTicketAggregates(t *testing.T) {
+	sev1 := "sev1"
+	rc := "carrier"
+	// Incident "1" has a blank creator (DoubleZero-filed); "3" is filed by a user
+	// belonging to the same contributor the incident is about (self-reported);
+	// "4" is filed by DoubleZero staff (a user with no contributor).
+	tickets := []nhRawTicket{
+		{ID: "1", Type: "incident", Severity: &sev1, Status: "resolved",
+			StartAt: strptr("2026-06-10T10:00:00Z"), EndAt: strptr("2026-06-10T11:00:00Z"),
+			CreatedAt: "2026-06-10T10:05:00Z", RootCause: &rc, ContributorPubkey: strptr("C-x"),
+			AffectedLinks: []OpsTicketEntity{{Code: "ams-fra"}}},
+		{ID: "2", Type: "maintenance", Status: "completed",
+			StartAt: strptr("2026-06-11T22:00:00Z"), EndAt: strptr("2026-06-11T23:00:00Z"),
+			CreatedAt: "2026-06-11T09:00:00Z"},
+		{ID: "3", Type: "incident", Status: "open", ContributorPubkey: strptr("C-jump"),
+			CreatedAt: "2026-06-12T08:00:00Z", UserPubkey: "contrib-noc-1"},
+		{ID: "4", Type: "incident", Status: "open", ContributorPubkey: strptr("C-galaxy"),
+			CreatedAt: "2026-06-13T08:00:00Z", UserPubkey: "dz-staff-1"},
+	}
+	// contrib-noc-1 belongs to C-jump; dz-staff-1 is DoubleZero (empty contributor).
+	userContrib := map[string]string{"dz-staff-1": "", "contrib-noc-1": "C-jump"}
+	outages := []nhOutage{
+		{linkCode: "ams-fra", start: mustTime("2026-06-10T10:10:00Z"), end: mustTime("2026-06-10T10:40:00Z")},
+		{linkCode: "nyc-chi", start: mustTime("2026-06-12T00:00:00Z"), end: mustTime("2026-06-12T00:30:00Z")},
+	}
+	agg := computeTicketAggregates(tickets, outages, userContrib, "")
+	if agg.Total != 4 || agg.Incidents != 3 || agg.Maintenance != 1 {
+		t.Errorf("volume: %+v", agg)
+	}
+	if agg.Sev1 != 1 {
+		t.Errorf("severity: %+v", agg)
+	}
+	if agg.ClosedIncidents != 1 {
+		t.Errorf("closed incidents: %+v", agg)
+	}
+	if agg.ClosedMaintenance != 1 {
+		t.Errorf("closed maintenance: %+v", agg)
+	}
+	// Self-reported: only incident "3" (contributor creator). "1" (blank creator)
+	// and "4" (DoubleZero staff) are DoubleZero-filed. Pct = 1/3 incidents.
+	if agg.SelfReportedCount != 1 || agg.DoubleZeroFiledCount != 2 {
+		t.Errorf("self-reported counts: %+v", agg)
+	}
+	if agg.SelfReportedPct == nil || *agg.SelfReportedPct != 33.3 {
+		t.Errorf("self-reported pct: %+v", agg.SelfReportedPct)
+	}
+	// The one incident with a cause carries root_cause "carrier"; the breakdown
+	// is a single carrier row at 100% of caused incidents.
+	if len(agg.RootCauses) != 1 || agg.RootCauses[0].Cause != "carrier" ||
+		agg.RootCauses[0].Count != 1 || agg.RootCauses[0].Pct == nil || *agg.RootCauses[0].Pct != 100 {
+		t.Errorf("root-cause breakdown: %+v", agg.RootCauses)
+	}
+	if agg.OutageCount != 2 || agg.OutagesWithTicket != 1 || agg.OutagesNoTicket != 1 {
+		t.Errorf("coverage: %+v", agg)
+	}
+	// The actionable list exposes the one unfiled outage (nyc-chi, 30 min = 0.5h),
+	// not the ams-fra outage that a ticket covers.
+	if len(agg.NoTicketOutages) != 1 {
+		t.Fatalf("no-ticket outages: %+v", agg.NoTicketOutages)
+	}
+	if agg.NoTicketOutages[0].LinkCode != "nyc-chi" || agg.NoTicketOutages[0].Hours != 0.5 ||
+		agg.NoTicketOutages[0].StartTs != "2026-06-12T00:00:00Z" {
+		t.Errorf("no-ticket outage item: %+v", agg.NoTicketOutages[0])
+	}
+
+	// With an empty user registry (fetch failed) the percentage is unavailable
+	// (nil) rather than mislabeling every incident as DoubleZero.
+	aggNoUsers := computeTicketAggregates(tickets, outages, map[string]string{}, "")
+	if aggNoUsers.SelfReportedPct != nil {
+		t.Errorf("self-reported pct should be nil when user registry is empty: %+v", aggNoUsers.SelfReportedPct)
+	}
+
+	// Scoped to contributor C-jump: only incident "3" is ABOUT C-jump, so
+	// incidents affecting-but-not-about it ("1" about C-x, "4" about C-galaxy)
+	// must not leak in. That one incident was filed by a C-jump user, so
+	// self-reported is 1/1 = 100%. (This is the Teraswitch-style bug: a scoped
+	// view must not count another contributor's self-filed incident.)
+	aggScoped := computeTicketAggregates(tickets, outages, userContrib, "C-jump")
+	if aggScoped.Incidents != 1 {
+		t.Errorf("scoped incidents should be 1 (only about C-jump): %+v", aggScoped)
+	}
+	if aggScoped.SelfReportedCount != 1 || aggScoped.SelfReportedPct == nil || *aggScoped.SelfReportedPct != 100 {
+		t.Errorf("scoped self-reported should be 1/1=100%%: count=%d pct=%v", aggScoped.SelfReportedCount, aggScoped.SelfReportedPct)
+	}
+	// A contributor with no self-filed incidents (scope C-x: incident "1" filed
+	// by a blank/DoubleZero creator) reads 0%, never inflated.
+	aggScopedX := computeTicketAggregates(tickets, outages, userContrib, "C-x")
+	if aggScopedX.Incidents != 1 || aggScopedX.SelfReportedCount != 0 ||
+		aggScopedX.SelfReportedPct == nil || *aggScopedX.SelfReportedPct != 0 {
+		t.Errorf("scoped C-x self-reported should be 0/1=0%%: %+v", aggScopedX)
+	}
+}
+
+// TestFilterTicketsByContributor covers the two ways a ticket can belong to a
+// scoped contributor: its own contributor identity (pubkey or name) matching,
+// or one of its affected links/devices being owned by that contributor.
+func TestFilterTicketsByContributor(t *testing.T) {
+	scope := &nhContributorScope{
+		pubkey:      "pk-acme",
+		name:        "Acme Contributor",
+		linkCodes:   map[string]struct{}{"ams-fra": {}},
+		deviceCodes: map[string]struct{}{"ams-dz01": {}},
+	}
+	pk := "pk-acme"
+	name := "Acme Contributor"
+	otherPk := "pk-other"
+	otherName := "Other Co"
+
+	tickets := []nhRawTicket{
+		{ID: "by-pubkey", ContributorPubkey: &pk},
+		{ID: "by-name", ContributorName: &name},
+		{ID: "by-link", AffectedLinks: []OpsTicketEntity{{Code: "ams-fra"}}},
+		{ID: "by-device", AffectedDevices: []OpsTicketEntity{{Code: "ams-dz01"}}},
+		{ID: "no-match", ContributorPubkey: &otherPk, ContributorName: &otherName,
+			AffectedLinks: []OpsTicketEntity{{Code: "nyc-chi"}}},
+		{ID: "empty"},
+	}
+
+	got := filterTicketsByContributor(tickets, scope)
+	var ids []string
+	for _, tk := range got {
+		ids = append(ids, tk.ID)
+	}
+	assert.ElementsMatch(t, []string{"by-pubkey", "by-name", "by-link", "by-device"}, ids)
+}
+
+// mockContributorRow is a minimal driver.Row double for
+// resolveContributorScope's pk/name lookup, returning a fixed pair (or an
+// error).
+type mockContributorRow struct {
+	pk, name string
+	err      error
+}
+
+func (r mockContributorRow) Err() error { return r.err }
+func (r mockContributorRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*string) = r.pk
+	*dest[1].(*string) = r.name
+	return nil
+}
+func (r mockContributorRow) ScanStruct(dest any) error { return nil }
+
+// mockCodeRows is a minimal driver.Rows double iterating over a fixed list of
+// single-column string values (link/device codes).
+type mockCodeRows struct {
+	codes []string
+	i     int
+}
+
+func (r *mockCodeRows) Next() bool { r.i++; return r.i <= len(r.codes) }
+func (r *mockCodeRows) Scan(dest ...any) error {
+	*dest[0].(*string) = r.codes[r.i-1]
+	return nil
+}
+func (r *mockCodeRows) ScanStruct(dest any) error        { return nil }
+func (r *mockCodeRows) ColumnTypes() []driver.ColumnType { return nil }
+func (r *mockCodeRows) Totals(dest ...any) error         { return nil }
+func (r *mockCodeRows) Columns() []string                { return []string{"code"} }
+func (r *mockCodeRows) Close() error                     { return nil }
+func (r *mockCodeRows) Err() error                       { return nil }
+func (r *mockCodeRows) HasData() bool                    { return len(r.codes) > 0 }
+
+// mockContributorScopeConn is a hand-built driver.Conn double for
+// TestResolveContributorScope and friends. It stands in for the three queries
+// resolveContributorScope issues (contributor pk/name lookup, then owned link
+// codes, then owned device codes) without requiring a live ClickHouse
+// instance: apitesting's DB fixtures (apitesting.NewTestAPIBare,
+// insertBaseMetadata) live in a package that imports `handlers`, so they
+// can't be used from this internal (package handlers) test file without an
+// import cycle, and resolveContributorScope/nhContributorScope are
+// unexported, so an external (package handlers_test) test can't reach them
+// either.
+type mockContributorScopeConn struct {
+	driver.Conn
+	pk, name                     string
+	rowErr                       error
+	linkCodes, deviceCodes       []string
+	linkQueryErr, deviceQueryErr error
+}
+
+func (m *mockContributorScopeConn) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
+	return mockContributorRow{pk: m.pk, name: m.name, err: m.rowErr}
+}
+
+func (m *mockContributorScopeConn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	switch {
+	case strings.Contains(query, "dz_links_current"):
+		if m.linkQueryErr != nil {
+			return nil, m.linkQueryErr
+		}
+		return &mockCodeRows{codes: m.linkCodes}, nil
+	case strings.Contains(query, "dz_devices_current"):
+		if m.deviceQueryErr != nil {
+			return nil, m.deviceQueryErr
+		}
+		return &mockCodeRows{codes: m.deviceCodes}, nil
+	default:
+		return nil, fmt.Errorf("mockContributorScopeConn: unexpected query %q", query)
+	}
+}
+
+// TestResolveContributorScope covers resolveContributorScope's query shape
+// (pubkey/name lookup by code, then owned link codes, then owned device
+// codes), plus an end-to-end-ish check that the resolved scope, fed into
+// filterTicketsByContributor, keeps a ticket matched by an owned link code
+// and drops an unrelated one.
+func TestResolveContributorScope(t *testing.T) {
+	api := &API{DB: &mockContributorScopeConn{
+		pk: "pk-acme", name: "Acme Contributor",
+		linkCodes:   []string{"ams-fra", "ams-lon"},
+		deviceCodes: []string{"ams-dz01"},
+	}}
+
+	scope, err := api.resolveContributorScope(context.Background(), "ACME")
+	require.NoError(t, err)
+	assert.Equal(t, "pk-acme", scope.pubkey)
+	assert.Equal(t, "Acme Contributor", scope.name)
+	assert.Len(t, scope.linkCodes, 2)
+	assert.Contains(t, scope.linkCodes, "ams-fra")
+	assert.Contains(t, scope.linkCodes, "ams-lon")
+	assert.Len(t, scope.deviceCodes, 1)
+	assert.Contains(t, scope.deviceCodes, "ams-dz01")
+
+	tickets := []nhRawTicket{
+		{ID: "own-link", AffectedLinks: []OpsTicketEntity{{Code: "ams-fra"}}},
+		{ID: "unrelated", AffectedLinks: []OpsTicketEntity{{Code: "nyc-chi"}}},
+	}
+	got := filterTicketsByContributor(tickets, scope)
+	require.Len(t, got, 1)
+	assert.Equal(t, "own-link", got[0].ID)
+}
+
+// TestResolveContributorScope_UnknownCode verifies an unresolvable
+// contributor code surfaces as an error (the caller in the Tickets group
+// treats this as best-effort and omits the ticket panel rather than failing
+// the whole request).
+func TestResolveContributorScope_UnknownCode(t *testing.T) {
+	api := &API{DB: &mockContributorScopeConn{rowErr: errors.New("no rows")}}
+	scope, err := api.resolveContributorScope(context.Background(), "NOPE")
+	require.Error(t, err)
+	assert.Nil(t, scope)
+}
+
+// TestResolveContributorScope_CodeQueryFailureTolerated verifies that a
+// transient failure fetching the owned link/device codes does not fail scope
+// resolution outright: it degrades to an empty set for that code type
+// (logged via logError) rather than losing the whole scoped ticket panel.
+func TestResolveContributorScope_CodeQueryFailureTolerated(t *testing.T) {
+	api := &API{DB: &mockContributorScopeConn{
+		pk: "pk-acme", name: "Acme Contributor",
+		linkQueryErr:   errors.New("boom"),
+		deviceQueryErr: errors.New("boom"),
+	}}
+	scope, err := api.resolveContributorScope(context.Background(), "ACME")
+	require.NoError(t, err)
+	assert.Equal(t, "pk-acme", scope.pubkey)
+	assert.Empty(t, scope.linkCodes)
+	assert.Empty(t, scope.deviceCodes)
+}
+
+// TestFetchOpsTicketsSincePartialPageTolerance verifies that a mid-pagination
+// upstream failure keeps the tickets already collected instead of discarding
+// the whole window (issue: the ticket panel going blank on any ops-API
+// hiccup). A failure on the very first page still returns an error since
+// there is nothing to salvage.
+func TestFetchOpsTicketsSincePartialPageTolerance(t *testing.T) {
+	savedURL := opsMgmtBaseURL
+	defer func() { opsMgmtBaseURL = savedURL }()
+	t.Setenv("OPS_MANAGEMENT_API_KEY", "test-key")
+
+	since := time.Now().Add(-24 * time.Hour).UTC()
+	newer := since.Add(1 * time.Hour).UTC().Format(time.RFC3339)
+
+	var calls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			// Return a full page (100 tickets) so the loop believes more pages
+			// may follow, then the second page fails.
+			tickets := make([]map[string]any, 0, 100)
+			for i := 0; i < 100; i++ {
+				tickets = append(tickets, map[string]any{
+					"id": fmt.Sprintf("t-%d", i), "type": "incident", "status": "open",
+					"created_at": newer,
+				})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"tickets": tickets}})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer upstream.Close()
+	opsMgmtBaseURL = upstream.URL
+
+	api := &API{}
+	tickets, err := api.fetchOpsTicketsSince(context.Background(), since)
+	require.NoError(t, err)
+	assert.Len(t, tickets, 100)
+	assert.Equal(t, 2, calls)
+}
+
+// TestFetchOpsTicketsSinceFirstPageFailureIsAnError verifies there is no
+// partial data to salvage when the very first request fails.
+func TestFetchOpsTicketsSinceFirstPageFailureIsAnError(t *testing.T) {
+	savedURL := opsMgmtBaseURL
+	defer func() { opsMgmtBaseURL = savedURL }()
+	t.Setenv("OPS_MANAGEMENT_API_KEY", "test-key")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+	opsMgmtBaseURL = upstream.URL
+
+	api := &API{}
+	tickets, err := api.fetchOpsTicketsSince(context.Background(), time.Now().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Nil(t, tickets)
+}
+
+func strptr(s string) *string { return &s }
+
+func f64ptr(f float64) *float64 { return &f }
+
+func mustTime(s string) time.Time {
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return tm.UTC()
+}
+
+// nhJSONMap marshals v and unmarshals it back into a generic map so a test can
+// assert the exact JSON key names and nesting the frontend reads.
+func nhJSONMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+// TestNHGroupJSONShape pins the wire shape of each group payload's `prev` block,
+// which the frontend deltas read directly. The split shipped with prev emitted
+// under the wrong nesting (a wrapper object) for drain/tickets, so the frontend
+// read undefined and every delta silently vanished. This asserts each group's
+// prev is at the nesting api.ts expects.
+func TestNHGroupJSONShape(t *testing.T) {
+	// Drain: prev is the bare NHDrainTiming (no "drain_timing" wrapper).
+	t.Run("drain", func(t *testing.T) {
+		m := nhJSONMap(t, NHDrainGroup{
+			DrainTiming: NHDrainTiming{TimeToDrainP50Min: f64ptr(12)},
+			Prev:        &NHDrainTiming{TimeToDrainP50Min: f64ptr(15)},
+		})
+		prev, ok := m["prev"].(map[string]any)
+		require.True(t, ok, "prev must be an object")
+		_, hasField := prev["time_to_drain_p50_min"]
+		assert.True(t, hasField, "prev must carry time_to_drain_p50_min at its top level")
+		_, hasWrapper := prev["drain_timing"]
+		assert.False(t, hasWrapper, "prev must NOT be wrapped in drain_timing")
+	})
+
+	// Tickets: prev is the bare NHTickets (no "ops_tickets" wrapper).
+	t.Run("tickets", func(t *testing.T) {
+		m := nhJSONMap(t, NHTicketsGroup{
+			OpsTickets: &NHTickets{},
+			Prev:       &NHTickets{Maintenance: 2, SelfReportedPct: f64ptr(50)},
+		})
+		prev, ok := m["prev"].(map[string]any)
+		require.True(t, ok, "prev must be an object")
+		_, hasPct := prev["self_reported_pct"]
+		assert.True(t, hasPct, "prev must carry self_reported_pct")
+		_, hasMaint := prev["maintenance"]
+		assert.True(t, hasMaint, "prev must carry maintenance")
+		_, hasWrapper := prev["ops_tickets"]
+		assert.False(t, hasWrapper, "prev must NOT be wrapped in ops_tickets")
+	})
+
+	// Outages: prev is nested {reliability, outage_summary}; reliability carries
+	// outage_count + capped_downtime_hours.
+	t.Run("outages", func(t *testing.T) {
+		m := nhJSONMap(t, NHOutagesGroup{
+			Prev: &NHOutagesPrev{
+				Reliability:   NHReliabilityPrev{OutageCount: 3, CappedDowntimeHours: 4.5},
+				OutageSummary: &NHOutageSummary{},
+			},
+		})
+		prev, ok := m["prev"].(map[string]any)
+		require.True(t, ok, "prev must be an object")
+		rel, ok := prev["reliability"].(map[string]any)
+		require.True(t, ok, "prev.reliability must be an object")
+		_, hasCount := rel["outage_count"]
+		assert.True(t, hasCount, "prev.reliability must carry outage_count")
+		_, hasDowntime := rel["capped_downtime_hours"]
+		assert.True(t, hasDowntime, "prev.reliability must carry capped_downtime_hours")
+		_, hasSummary := prev["outage_summary"]
+		assert.True(t, hasSummary, "prev must carry outage_summary")
+		// The dead contributor breakdown must not reappear on the wire.
+		_, hasContribs := m["contributors"]
+		assert.False(t, hasContribs, "outages group must not emit contributors")
+	})
+
+	// Impactful: prev carries impactful_downtime_hours.
+	t.Run("impactful", func(t *testing.T) {
+		m := nhJSONMap(t, NHImpactful{
+			Prev: &NHImpactfulPrev{ImpactfulDowntimeHours: 7},
+		})
+		prev, ok := m["prev"].(map[string]any)
+		require.True(t, ok, "prev must be an object")
+		_, has := prev["impactful_downtime_hours"]
+		assert.True(t, has, "prev must carry impactful_downtime_hours")
+	})
+
+	// Deferred: prev is the bare NHDeferred with time_to_undrain_p50_min.
+	t.Run("deferred", func(t *testing.T) {
+		m := nhJSONMap(t, NHDeferred{
+			Prev: &NHDeferred{TimeToUndrainP50Min: f64ptr(9)},
+		})
+		prev, ok := m["prev"].(map[string]any)
+		require.True(t, ok, "prev must be an object")
+		_, has := prev["time_to_undrain_p50_min"]
+		assert.True(t, has, "prev must carry time_to_undrain_p50_min")
+	})
+}
+
+// TestComputeDrainTiming exercises the pure-Go drain/undrain pairing: drain and
+// undrain counts, time-to-drain and time-drained medians/maxes, the
+// drain-within-30m window (inclusive boundary), and the no-pair / no-event
+// cases where the timing pointers must stay nil.
+func TestComputeDrainTiming(t *testing.T) {
+	// Full scenario: L1 drains 10 min after its outage and is undrained 30 min
+	// later; L2 drains 60 min after its outage (outside the 30m window) and is
+	// never undrained.
+	t.Run("full", func(t *testing.T) {
+		events := []nhEvent{
+			{linkPK: "L1", start: mustTime("2026-06-10T10:00:00Z"), end: mustTime("2026-06-10T10:20:00Z")},
+			{linkPK: "L2", start: mustTime("2026-06-10T12:00:00Z"), end: mustTime("2026-06-10T12:05:00Z")},
+		}
+		changes := []nhChange{
+			{linkPK: "L1", prev: "activated", next: "soft-drained", ts: mustTime("2026-06-10T10:10:00Z")},
+			{linkPK: "L1", prev: "soft-drained", next: "activated", ts: mustTime("2026-06-10T10:40:00Z")},
+			{linkPK: "L2", prev: "activated", next: "soft-drained", ts: mustTime("2026-06-10T13:00:00Z")},
+		}
+		dt, matches := computeDrainTiming(events, changes)
+		assert.Equal(t, 2, dt.OutageCount)
+		assert.Equal(t, 2, dt.Drains)
+		assert.Equal(t, 1, dt.Undrains)
+		assert.Equal(t, 2, dt.EventsWithDrain)
+		// ttd = {10, 60}: median 35, max 60.
+		require.NotNil(t, dt.TimeToDrainP50Min)
+		assert.Equal(t, float64(35), *dt.TimeToDrainP50Min)
+		require.NotNil(t, dt.TimeToDrainMaxMin)
+		assert.Equal(t, float64(60), *dt.TimeToDrainMaxMin)
+		// drained = {30}: median and max both 30.
+		require.NotNil(t, dt.TimeDrainedP50Min)
+		assert.Equal(t, float64(30), *dt.TimeDrainedP50Min)
+		require.NotNil(t, dt.TimeDrainedMaxMin)
+		assert.Equal(t, float64(30), *dt.TimeDrainedMaxMin)
+		// Only L1's drain (10:10) is within [start, end+30m]; L2's (13:00) is not.
+		require.NotNil(t, dt.DrainWithin30mPct)
+		assert.Equal(t, 50.0, *dt.DrainWithin30mPct)
+		assert.Equal(t, 1, dt.MatchedUndrains)
+		require.Len(t, matches, 1)
+		assert.Equal(t, "L1", matches[0].linkPK)
+	})
+
+	// Boundary: a drain landing exactly at end+30m still counts (inclusive).
+	t.Run("boundary_inclusive", func(t *testing.T) {
+		events := []nhEvent{
+			{linkPK: "L1", start: mustTime("2026-06-10T10:00:00Z"), end: mustTime("2026-06-10T10:20:00Z")},
+		}
+		changes := []nhChange{
+			{linkPK: "L1", prev: "activated", next: "soft-drained", ts: mustTime("2026-06-10T10:50:00Z")},
+		}
+		dt, _ := computeDrainTiming(events, changes)
+		require.NotNil(t, dt.DrainWithin30mPct)
+		assert.Equal(t, 100.0, *dt.DrainWithin30mPct)
+	})
+
+	// Boundary: one second past end+30m does not count.
+	t.Run("boundary_exclusive", func(t *testing.T) {
+		events := []nhEvent{
+			{linkPK: "L1", start: mustTime("2026-06-10T10:00:00Z"), end: mustTime("2026-06-10T10:20:00Z")},
+		}
+		changes := []nhChange{
+			{linkPK: "L1", prev: "activated", next: "soft-drained", ts: mustTime("2026-06-10T10:50:01Z")},
+		}
+		dt, _ := computeDrainTiming(events, changes)
+		require.NotNil(t, dt.DrainWithin30mPct)
+		assert.Equal(t, 0.0, *dt.DrainWithin30mPct)
+	})
+
+	// A drain with no matching undrain produces no pair, so time-drained is nil.
+	t.Run("no_pairs", func(t *testing.T) {
+		events := []nhEvent{
+			{linkPK: "L1", start: mustTime("2026-06-10T10:00:00Z"), end: mustTime("2026-06-10T10:20:00Z")},
+		}
+		changes := []nhChange{
+			{linkPK: "L1", prev: "activated", next: "soft-drained", ts: mustTime("2026-06-10T10:10:00Z")},
+		}
+		dt, matches := computeDrainTiming(events, changes)
+		assert.Equal(t, 1, dt.Drains)
+		assert.Equal(t, 0, dt.Undrains)
+		assert.Equal(t, 0, dt.MatchedUndrains)
+		assert.Empty(t, matches)
+		assert.Nil(t, dt.TimeDrainedP50Min)
+		assert.Nil(t, dt.TimeDrainedMaxMin)
+	})
+
+	// No events and no changes: every timing pointer is nil and the pct (0/0)
+	// is nil rather than a divide-by-zero.
+	t.Run("empty", func(t *testing.T) {
+		dt, matches := computeDrainTiming(nil, nil)
+		assert.Equal(t, 0, dt.OutageCount)
+		assert.Empty(t, matches)
+		assert.Nil(t, dt.TimeToDrainP50Min)
+		assert.Nil(t, dt.TimeToDrainMaxMin)
+		assert.Nil(t, dt.TimeDrainedP50Min)
+		assert.Nil(t, dt.TimeDrainedMaxMin)
+		assert.Nil(t, dt.DrainWithin30mPct)
+	})
+}
+
+// TestNetworkHealthWindow covers the window resolver: the default 30d window is
+// cacheable, an explicit custom range is not, an over-long range is clamped to
+// the max span, and a sub-1-day day count floors to a single day.
+func TestNetworkHealthWindow(t *testing.T) {
+	day := 24 * time.Hour
+
+	t.Run("default_30d_cacheable", func(t *testing.T) {
+		start, end, cacheable := networkHealthWindow("", "", "")
+		assert.True(t, cacheable, "the default window must be cacheable")
+		assert.Equal(t, time.Duration(NetworkHealthDefaultDays)*day, end.Sub(start))
+	})
+
+	t.Run("custom_range_not_cacheable", func(t *testing.T) {
+		start, end, cacheable := networkHealthWindow("2026-01-01", "2026-01-10", "")
+		assert.False(t, cacheable, "an explicit custom range must not be cacheable")
+		assert.Equal(t, 9*day, end.Sub(start))
+	})
+
+	t.Run("over_max_clamps", func(t *testing.T) {
+		start, end, cacheable := networkHealthWindow("2026-01-01", "2026-12-31", "")
+		assert.False(t, cacheable)
+		assert.Equal(t, time.Duration(networkHealthMaxDays)*day, end.Sub(start),
+			"a range longer than the max must clamp to the max span")
+	})
+
+	t.Run("sub_one_day_floors", func(t *testing.T) {
+		start, end, cacheable := networkHealthWindow("", "", "0")
+		assert.False(t, cacheable)
+		assert.Equal(t, 1*day, end.Sub(start), "a day count below 1 must floor to a single day")
+	})
+}
+
+// TestPctDelta covers the percent-change helper: a zero prior yields nil (no
+// divide-by-zero), a normal case returns the right percent, and NaN/Inf inputs
+// are guarded to nil.
+func TestPctDelta(t *testing.T) {
+	assert.Nil(t, pctDelta(5, 0), "a zero prior must return nil")
+
+	up := pctDelta(150, 100)
+	require.NotNil(t, up)
+	assert.Equal(t, 50.0, *up)
+
+	down := pctDelta(50, 100)
+	require.NotNil(t, down)
+	assert.Equal(t, -50.0, *down)
+
+	assert.Nil(t, pctDelta(math.Inf(1), 1), "an Inf result must be guarded to nil")
+	assert.Nil(t, pctDelta(math.NaN(), 1), "a NaN result must be guarded to nil")
+}

--- a/api/main.go
+++ b/api/main.go
@@ -626,6 +626,19 @@ func main() {
 		r.Get("/api/dz/field-values", api.GetFieldValues)
 		r.Get("/api/dz/ledger", api.GetDZLedger)
 
+		// Network Health Reporting (public, windowed network-performance report).
+		// Split into independent data-source-group endpoints so the page loads
+		// progressively; the bare route serves the Overview group.
+		r.Get("/api/network-health", api.GetNetworkHealth)
+		r.Get("/api/network-health/availability", api.GetNetworkHealthAvailability)
+		r.Get("/api/network-health/latency", api.GetNetworkHealthLatency)
+		r.Get("/api/network-health/capacity", api.GetNetworkHealthCapacity)
+		r.Get("/api/network-health/outages", api.GetNetworkHealthOutages)
+		r.Get("/api/network-health/drain", api.GetNetworkHealthDrain)
+		r.Get("/api/network-health/tickets", api.GetNetworkHealthTickets)
+		r.Get("/api/network-health/impactful", api.GetNetworkHealthImpactful)
+		r.Get("/api/network-health/deferred", api.GetNetworkHealthDeferred)
+
 		// Geolocation routes (internal only)
 		r.Group(func(r chi.Router) {
 			r.Use(handlers.RequireInternalDomain)

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -42,6 +42,9 @@ const (
 	defaultRefreshInterval    = 30 * time.Second
 	defaultRefreshConcurrency = 8
 	defaultActivityTimeout    = 3 * time.Minute
+	// defaultRefreshTimeout is the per-entry refresh context deadline, applied
+	// when a cacheEntry does not set its own timeout.
+	defaultRefreshTimeout = 60 * time.Second
 
 	// continueAsNewTargetWindow bounds workflow history: PageCacheWorkflow
 	// continues-as-new after roughly this much wall-clock regardless of the
@@ -109,6 +112,10 @@ type cacheEntry struct {
 	name string
 	key  string
 	fn   func(ctx context.Context) (any, error)
+	// timeout overrides the per-refresh context deadline. Zero means the default
+	// (see refresh). The two heavy Network Health groups (impactful, deferred)
+	// set it to 180s so their max_execution_time=170 queries can finish and cache.
+	timeout time.Duration
 }
 
 // Activities holds the logger and API deps for the refresh activity.
@@ -127,7 +134,27 @@ type Activities struct {
 func (a *Activities) entries() []cacheEntry {
 	api := a.API
 	return []cacheEntry{
-		{"topology", "topology", func(ctx context.Context) (any, error) {
+		// The two heavy Network Health groups are scheduled FIRST so they start at
+		// the head of the concurrency-limited batch and have the whole activity
+		// budget to finish their 170s queries, rather than being cut when scheduled
+		// last. Their per-entry timeout is 180s (see cacheEntry.timeout).
+		{name: "network health impactful", key: handlers.NetworkHealthImpactfulCacheKey, timeout: 180 * time.Second, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			resp := api.FetchNetworkHealthImpactfulData(ctx, start, end, "")
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
+		}},
+		{name: "network health deferred", key: handlers.NetworkHealthDeferredCacheKey, timeout: 180 * time.Second, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			resp := api.FetchNetworkHealthDeferredData(ctx, start, end, "")
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
+		}},
+		{name: "topology", key: "topology", fn: func(ctx context.Context) (any, error) {
 			resp, err := api.FetchTopologyData(ctx)
 			if err != nil {
 				return nil, err
@@ -137,93 +164,142 @@ func (a *Activities) entries() []cacheEntry {
 			}
 			return resp, nil
 		}},
-		{"status", "status", func(ctx context.Context) (any, error) {
+		{name: "status", key: "status", fn: func(ctx context.Context) (any, error) {
 			resp := api.FetchStatusData(ctx)
 			if resp.Error != "" {
 				return nil, &refreshError{resp.Error}
 			}
 			return resp, nil
 		}},
-		{"incidents", "incidents", func(ctx context.Context) (any, error) {
+		{name: "incidents", key: "incidents", fn: func(ctx context.Context) (any, error) {
 			resp := api.FetchDefaultIncidentsData(ctx)
 			if resp == nil {
 				return nil, &refreshError{"nil response"}
 			}
 			return resp, nil
 		}},
-		{"device incidents", "device_incidents", func(ctx context.Context) (any, error) {
+		{name: "device incidents", key: "device_incidents", fn: func(ctx context.Context) (any, error) {
 			resp := api.FetchDefaultDeviceIncidentsData(ctx)
 			if resp == nil {
 				return nil, &refreshError{"nil response"}
 			}
 			return resp, nil
 		}},
-		{"link history", "link_history:24h:72", func(ctx context.Context) (any, error) {
+		{name: "link history", key: "link_history:24h:72", fn: func(ctx context.Context) (any, error) {
 			return api.FetchLinkHistoryData(ctx, "24h", 72)
 		}},
-		{"device history", "device_history:24h:72", func(ctx context.Context) (any, error) {
+		{name: "device history", key: "device_history:24h:72", fn: func(ctx context.Context) (any, error) {
 			return api.FetchDeviceHistoryData(ctx, "24h", 72)
 		}},
-		{"latency comparison", "latency_comparison", func(ctx context.Context) (any, error) {
+		{name: "latency comparison", key: "latency_comparison", fn: func(ctx context.Context) (any, error) {
 			return api.FetchLatencyComparisonData(ctx)
 		}},
-		{"dz ledger", "dz_ledger", func(ctx context.Context) (any, error) {
+		{name: "dz ledger", key: "dz_ledger", fn: func(ctx context.Context) (any, error) {
 			return handlers.FetchLedgerData(ctx, handlers.GetDZLedgerRPCURL())
 		}},
-		{"solana ledger", "solana_ledger", func(ctx context.Context) (any, error) {
+		{name: "solana ledger", key: "solana_ledger", fn: func(ctx context.Context) (any, error) {
 			return handlers.FetchLedgerData(ctx, handlers.GetSolanaRPCURL())
 		}},
-		{"validator perf", "validator_perf", func(ctx context.Context) (any, error) {
+		{name: "validator perf", key: "validator_perf", fn: func(ctx context.Context) (any, error) {
 			return api.FetchValidatorPerfData(ctx)
 		}},
-		{"stake overview", "stake_overview", func(ctx context.Context) (any, error) {
+		{name: "stake overview", key: "stake_overview", fn: func(ctx context.Context) (any, error) {
 			return api.FetchStakeOverviewData(ctx)
 		}},
-		{"publisher check", "publisher_check", func(ctx context.Context) (any, error) {
+		{name: "publisher check", key: "publisher_check", fn: func(ctx context.Context) (any, error) {
 			return api.FetchPublisherCheckData(ctx, "", 2, 0)
 		}},
-		{"shreds rewards", "shreds_rewards", func(ctx context.Context) (any, error) {
+		{name: "shreds rewards", key: "shreds_rewards", fn: func(ctx context.Context) (any, error) {
 			return api.FetchShredsRewardsData(ctx)
 		}},
-		{"edge scoreboard", "edge_scoreboard", func(ctx context.Context) (any, error) {
+		{name: "edge scoreboard", key: "edge_scoreboard", fn: func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardData(ctx, "24h", false, 0, 0, 1000)
 		}},
-		{"edge scoreboard (leaders)", "edge_scoreboard:leaders", func(ctx context.Context) (any, error) {
+		{name: "edge scoreboard (leaders)", key: "edge_scoreboard:leaders", fn: func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardData(ctx, "24h", true, 0, 0, 1000)
 		}},
-		{"hyperliquid scoreboard", "hyperliquid_scoreboard", func(ctx context.Context) (any, error) {
+		{name: "hyperliquid scoreboard", key: "hyperliquid_scoreboard", fn: func(ctx context.Context) (any, error) {
 			return api.FetchHyperliquidScoreboardData(ctx, "1h", "")
 		}},
-		{"bulk link metrics", "bulk_link_metrics", func(ctx context.Context) (any, error) {
+		{name: "bulk link metrics", key: "bulk_link_metrics", fn: func(ctx context.Context) (any, error) {
 			return api.FetchBulkLinkMetricsData(ctx)
 		}},
-		{"bulk link metrics (issues)", "bulk_link_metrics_issues", func(ctx context.Context) (any, error) {
+		{name: "bulk link metrics (issues)", key: "bulk_link_metrics_issues", fn: func(ctx context.Context) (any, error) {
 			return api.FetchBulkLinkMetricsIssuesData(ctx)
 		}},
-		{"bulk device metrics", "bulk_device_metrics", func(ctx context.Context) (any, error) {
+		{name: "bulk device metrics", key: "bulk_device_metrics", fn: func(ctx context.Context) (any, error) {
 			return api.FetchBulkDeviceMetricsData(ctx)
 		}},
-		{"bulk device metrics (issues)", "bulk_device_metrics_issues", func(ctx context.Context) (any, error) {
+		{name: "bulk device metrics (issues)", key: "bulk_device_metrics_issues", fn: func(ctx context.Context) (any, error) {
 			return api.FetchBulkDeviceMetricsIssuesData(ctx)
 		}},
-		{"geo concentration", "geo_concentration", func(ctx context.Context) (any, error) {
+		{name: "geo concentration", key: "geo_concentration", fn: func(ctx context.Context) (any, error) {
 			return api.FetchGeoConcentrationData(ctx)
 		}},
-		{"geo validators", "geo_validators", func(ctx context.Context) (any, error) {
+		{name: "geo validators", key: "geo_validators", fn: func(ctx context.Context) (any, error) {
 			return api.FetchGeoValidatorsData(ctx, "", "")
 		}},
-		{"multicast health summaries", handlers.MulticastHealthSummariesCacheKey, func(ctx context.Context) (any, error) {
+		{name: "multicast health summaries", key: handlers.MulticastHealthSummariesCacheKey, fn: func(ctx context.Context) (any, error) {
 			return api.FetchMulticastHealthSummariesData(ctx, handlers.ShredGroupPK)
 		}},
 		// Pre-fetch the hot first page of /health/users and /health/paths for
 		// ShredGroupPK. The UI's default request (offset=0, limit=
 		// MulticastHealthCachedPageSize) hits these caches and returns in ~1ms
 		// instead of running the view live (multi-second on edge-solana-shreds).
-		{"multicast health users (shreds)", handlers.MulticastHealthUsersCacheKey(handlers.ShredGroupPK), func(ctx context.Context) (any, error) {
+		{name: "multicast health users (shreds)", key: handlers.MulticastHealthUsersCacheKey(handlers.ShredGroupPK), fn: func(ctx context.Context) (any, error) {
 			return api.FetchMulticastHealthUsersPageData(ctx, handlers.ShredGroupPK)
 		}},
-		{"multicast health paths (shreds)", handlers.MulticastHealthPathsCacheKey(handlers.ShredGroupPK), func(ctx context.Context) (any, error) {
+		{name: "multicast health paths (shreds)", key: handlers.MulticastHealthPathsCacheKey(handlers.ShredGroupPK), fn: func(ctx context.Context) (any, error) {
 			return api.FetchMulticastHealthPathsPageData(ctx, handlers.ShredGroupPK)
+		}},
+		// Network Health is split into independent data-source-group caches so the
+		// page loads progressively and no slow group blocks another. Each group is a
+		// strict subset of the old monolith, so each refreshes faster than the single
+		// entry did. Only the headline-critical groups (overview: throughput/peak;
+		// outages: reliability; impactful; deferred) return a refreshError on a
+		// critical failure so their last-good blob is kept; the rest always write. See
+		// pageCacheRefreshConcurrency for the aggregate-load guardrail.
+		{name: "network health overview", key: handlers.NetworkHealthOverviewCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			resp := api.FetchNetworkHealthOverviewData(ctx, start, end, "")
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
+		}},
+		{name: "network health availability", key: handlers.NetworkHealthAvailabilityCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			return api.FetchNetworkHealthAvailabilityData(ctx, start, end, ""), nil
+		}},
+		{name: "network health latency", key: handlers.NetworkHealthLatencyCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			return api.FetchNetworkHealthLatencyData(ctx, start, end, ""), nil
+		}},
+		{name: "network health capacity", key: handlers.NetworkHealthCapacityCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			return api.FetchNetworkHealthCapacityData(ctx, start, end, ""), nil
+		}},
+		{name: "network health outages", key: handlers.NetworkHealthOutagesCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			resp := api.FetchNetworkHealthOutagesData(ctx, start, end, "")
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
+		}},
+		{name: "network health drain", key: handlers.NetworkHealthDrainCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			return api.FetchNetworkHealthDrainData(ctx, start, end, ""), nil
+		}},
+		{name: "network health tickets", key: handlers.NetworkHealthTicketsCacheKey, fn: func(ctx context.Context) (any, error) {
+			start, end := handlers.DefaultNetworkHealthWindow()
+			resp := api.FetchNetworkHealthTicketsData(ctx, start, end, "")
+			// A transient ops-API outage sets resp.Error; keep the last-good blob
+			// instead of caching an empty aggregate (like overview/outages/impactful).
+			if resp.Error != "" {
+				return nil, &refreshError{resp.Error}
+			}
+			return resp, nil
 		}},
 	}
 }
@@ -258,7 +334,7 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 
 	for _, entry := range a.entries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown, errBatchDeadline)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, entry.timeout, shuttingDown, errBatchDeadline)
 			return nil
 		})
 	}
@@ -268,11 +344,22 @@ func (a *Activities) RefreshCaches(ctx context.Context) error {
 		g.Go(func() error {
 			a.refresh(gctx, "metro path latency:"+strategy, "metro_path_latency:"+strategy, func(ctx context.Context) (any, error) {
 				return a.API.FetchMetroPathLatencyData(ctx, strategy)
-			}, shuttingDown, errBatchDeadline)
+			}, 0, shuttingDown, errBatchDeadline)
 			return nil
 		})
 	}
 
+	// Network health, per contributor: NOT precomputed. This used to iterate
+	// every active contributor here and run the full heavy network-health
+	// pipeline (topology graph + 30d path-impact + DIA scan + rollup scans) per
+	// code, which meant ~15 full heavy pipelines running alongside the other
+	// cache entries every refresh cycle. That oversubscribed ClickHouse badly
+	// enough to saturate the cluster and starve the network-default view's own
+	// queries (see .superpowers/sdd/stabilize-report.md). Scoped requests now
+	// always fall back to a live compute: each group handler reads its
+	// per-contributor cache key first, MISSes, and computes that group live
+	// under its deadline — slower per-contributor page loads, but it does not
+	// compete with the default view for cluster capacity.
 	_ = g.Wait()
 	a.Log.Info("page cache refresh complete", "duration", time.Since(start).Round(time.Millisecond))
 	return nil
@@ -299,10 +386,10 @@ func workerStopping(ctx context.Context) func() bool {
 func (a *Activities) latestEntries() []cacheEntry {
 	api := a.API
 	return []cacheEntry{
-		{"edge scoreboard (latest)", "edge_scoreboard:latest", func(ctx context.Context) (any, error) {
+		{name: "edge scoreboard (latest)", key: "edge_scoreboard:latest", fn: func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardLatest(ctx, false, 1000)
 		}},
-		{"edge scoreboard (latest, leaders)", "edge_scoreboard:latest:leaders", func(ctx context.Context) (any, error) {
+		{name: "edge scoreboard (latest, leaders)", key: "edge_scoreboard:latest:leaders", fn: func(ctx context.Context) (any, error) {
 			return api.FetchEdgeScoreboardLatest(ctx, true, 1000)
 		}},
 	}
@@ -314,7 +401,7 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	for _, entry := range a.latestEntries() {
 		g.Go(func() error {
-			a.refresh(gctx, entry.name, entry.key, entry.fn, shuttingDown, errFastRefreshDeadline)
+			a.refresh(gctx, entry.name, entry.key, entry.fn, entry.timeout, shuttingDown, errFastRefreshDeadline)
 			return nil
 		})
 	}
@@ -322,13 +409,19 @@ func (a *Activities) RefreshLatestCaches(ctx context.Context) error {
 	return nil
 }
 
-// deadlineErr is the sentinel recorded when the parent (activity) context is
-// cancelled by its own deadline rather than a worker shutdown — it selects the
-// escalation cadence (errBatchDeadline for the slow batch, errFastRefreshDeadline
-// for the fast loop).
-func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error), shuttingDown func() bool, deadlineErr error) {
+// refresh runs one cache entry's fetch under a per-attempt context deadline and
+// writes the result. timeout overrides that deadline when > 0; otherwise
+// defaultRefreshTimeout applies. deadlineErr is the sentinel recorded when the
+// parent (activity) context is cancelled by its own deadline rather than a
+// worker shutdown; it selects the escalation cadence (errBatchDeadline for the
+// slow batch, errFastRefreshDeadline for the fast loop).
+func (a *Activities) refresh(parentCtx context.Context, name, key string, fn func(context.Context) (any, error), timeout time.Duration, shuttingDown func() bool, deadlineErr error) {
 	start := time.Now()
 	var queryDuration, writeDuration time.Duration
+
+	if timeout <= 0 {
+		timeout = defaultRefreshTimeout
+	}
 
 	const maxAttempts = 2
 	for attempt := range maxAttempts {
@@ -338,7 +431,7 @@ func (a *Activities) refresh(parentCtx context.Context, name, key string, fn fun
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
+		ctx, cancel := context.WithTimeout(parentCtx, timeout)
 		queryStart := time.Now()
 		result, err := fn(ctx)
 		queryDuration = time.Since(queryStart)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import { TopologyPage } from '@/components/topology-page'
 import { PathCalculatorPage } from '@/components/path-calculator-page'
 import { RedundancyReportPage } from '@/components/redundancy-report-page'
 import { MetroConnectivityPage } from '@/components/metro-connectivity-page'
+import { NetworkHealthReportingPage } from '@/components/network-health-reporting-page'
 import { DzVsInternetPage } from '@/components/dz-vs-internet-page'
 import { PathLatencyPage } from '@/components/path-latency-page'
 import { LinkLatencyPage } from '@/pages/link-latency-page'
@@ -686,6 +687,7 @@ function AppContent() {
             <Route path="/ops/incidents/links" element={<IncidentsPage />} />
             <Route path="/ops/incidents/devices" element={<IncidentsPage />} />
             <Route path="/ops/maintenance" element={<MaintenanceCalendarPage />} />
+            <Route path="/ops/network-health-reporting" element={<NetworkHealthReportingPage />} />
 
 
             {/* Settings */}

--- a/web/src/components/network-health-reporting-page.tsx
+++ b/web/src/components/network-health-reporting-page.tsx
@@ -1,0 +1,2285 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams, useNavigate } from 'react-router-dom'
+import { useQuery, keepPreviousData, type UseQueryResult } from '@tanstack/react-query'
+import { BarChart3, Loader2, AlertCircle, ChevronDown, ArrowLeft, Info } from 'lucide-react'
+import {
+  BarChart,
+  Bar,
+  LabelList,
+  AreaChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ReferenceLine,
+  ReferenceArea,
+  Tooltip as ReTooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import {
+  fetchNetworkHealthDeferred,
+  fetchNHOverview,
+  fetchNHAvailability,
+  fetchNHLatency,
+  fetchNHCapacity,
+  fetchNHOutages,
+  fetchNHDrain,
+  fetchNHTickets,
+  fetchNHImpactful,
+  type NetworkHealthDeferred,
+  type NetworkHealthParams,
+  type NetworkHealthDeltas,
+  type NetworkHealthReliability,
+  type NetworkHealthReliabilityPrev,
+  type NetworkHealthDrainTiming,
+  type NetworkHealthTrafficLink,
+  type NetworkHealthCapacityLink,
+  type NetworkHealthDeviceSlots,
+  type NetworkHealthDiaInterface,
+  type NetworkHealthPerfLink,
+  type NetworkHealthErrorHotspot,
+  type NetworkHealthTickets,
+  type NetworkHealthRootCause,
+  type NetworkHealthAvailability,
+  type NetworkHealthOutageSummary,
+  type NetworkHealthDowntimeRow,
+  type NetworkHealthTsPoint,
+  type NetworkHealthCountPoint,
+  type NHOverview,
+  type NHLatencyGroup,
+  type NHCapacityGroup,
+  type NHOutagesGroup,
+  type NHImpactful,
+} from '@/lib/api'
+import { PageHeader } from '@/components/page-header'
+import { StatCard } from '@/components/stat-card'
+import { deltaColorClass, toneColorClass, formatDelta } from '@/components/stat-card-utils'
+import { Tooltip } from '@/components/ui/tooltip'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table'
+import {
+  getDays,
+  formatDateRange,
+  formatISODate,
+  parseISODate,
+  isSameDay,
+  startOfDay,
+} from '@/components/maintenance-calendar/date-utils'
+
+// Network Health Reporting. FACTS ONLY (see plans/network-health-dashboard/SPEC.md
+// section 1.1): the page never ranks, scores, or grades contributors against each
+// other. Per-contributor data is shown in neutral, sortable tables with no best/worst
+// labels. Directional (green/red) deltas are direction-aware per metric: green marks
+// movement in the good direction for that metric (fewer outages is green, higher
+// throughput is green), and a metric with no inherent good direction stays neutral.
+// One deliberate exception to facts-only: on a contributor's own view the share of
+// incidents they self-reported is graded green/yellow/red. That grades the contributor
+// against their own reporting on their own view, not against other contributors (there
+// is no cross-contributor leaderboard). Every metric carries a plain-language
+// explanation via a hover info icon (DEFS below).
+
+type Sort = { key: string; dir: 'asc' | 'desc' }
+
+// Canonical bar fills reused by every ranked-bar panel (traffic, capacity, etc).
+const BAR = { blue: '#3b82f6', amber: '#f59e0b', slate: '#64748b' } as const
+
+// Plain-language explanation for every metric on the page.
+const DEFS = {
+  peak: 'The highest total user throughput seen in any 5-minute window over the period. This is the top of the peak line on the throughput chart.',
+  jitter:
+    'How much steadier DoubleZero latency is than the public internet. Jitter is the wobble in latency, not the latency itself, so this is not a claim about speed. For each metro pair we take internet jitter minus DoubleZero jitter, divided by internet jitter, then average across pairs. Higher is better. A route where DoubleZero wobbled more than the internet would show a negative number.',
+  loss: 'Share of DoubleZero probe packets marked lost, averaged across measured metro pairs. This is DoubleZero\'s own loss, not a comparison with the internet. Lower is better.',
+  outages: 'Link failure episodes (a link with IS-IS down or 10% or more packet loss on 5-minute buckets) in this window. Counts sustained failures lasting at least 10 minutes. Brief flaps under 10 minutes are not counted here; they appear in "Link failures by duration". In this routed mesh a link failure usually means traffic rerouted with added latency, not lost service.',
+  impactfulDowntime:
+    'Failure hours weighted toward the links that mattered: counted only for links that were carrying traffic (at least 1 Mbps just before they failed) or were the primary lowest-latency path for their metro pair. This traffic almost always rerouted onto another path (added latency) rather than being dropped. Failures on idle, non-primary links are excluded.',
+  activeLinks: 'Links in the "activated" state at the end of the window.',
+  activeDevices: 'Devices in the "activated" state at the end of the window.',
+  activeMetros: 'Metros with at least one active device at the end of the window.',
+  drainTiming:
+    'How quickly a failed link was taken out of service (drained) and how long it stayed drained. Measured from telemetry and status changes.',
+  timeToDrain: 'Minutes from a link going down to it being soft-drained (taken out of service).',
+  timeDrained: 'Minutes a link stayed soft-drained, from the drain until it was returned to service.',
+  timeToUndrain:
+    'Minutes from when a drained link came back healthy to when it was actually returned to service. Long times mean healthy capacity sat out of service.',
+  drainWithin30m: 'Share of link failures where the link was drained within 30 minutes of failing.',
+  capacityLinks:
+    'Links closest to their provisioned bandwidth: typical (P50) and peak (P99) throughput as a share of link capacity, side by side. P99 (not raw 5-minute max) so a single outlier bucket does not overstate utilization. A capacity-planning signal for which links to upgrade first.',
+  durationHist:
+    'The distribution of individual failure lengths, from brief flaps to sustained multi-hour events. This includes every episode, even brief flaps under 5 minutes, so it shows more episodes than the headline link-failure count, which counts only sustained failures of 10 minutes or more. Where "Most failure time" totals hours per link or device, this counts failures by how long each one lasted.',
+  degraded: 'Links that stayed up but saw more than 1% packet loss at some point in the window.',
+  trend: 'Change versus the previous window of the same length (the period immediately before this one).',
+  availability:
+    'Network-wide availability from traffic-weighted failure hours: 1 minus (traffic-weighted failure hours / (active links x window hours)). Uses the same figure shown in the headline, so it excludes idle, non-primary links and intentional drain (maintenance). The per-link and per-device availability panels further down the page take a stricter cut and count maintenance drain as unavailable.',
+  sla: 'Of links that have an onchain committed round-trip time, the share whose average measured RTT stayed within that committed value over the window.',
+  perfLinks:
+    'Links that carry an onchain committed round-trip time, comparing the committed value to the measured RTT over the window (average and worst 5-minute bucket). A committed value tagged "override" reflects an active IS-IS delay override rather than the raw onchain commitment.',
+  linkCommitted:
+    'The link\'s onchain committed round-trip time: the latency it promises. When a contributor sets an IS-IS delay override, this shows the override (the value the network actually routes on) and the row is tagged; the raw onchain value is in the tag\'s tooltip.',
+  linkMeasured: 'The link\'s measured round-trip time over the window: the average across 5-minute buckets, and the worst single bucket.',
+  linkOverCommitted: 'Share of 5-minute buckets where the measured RTT was above the committed value.',
+  linkDrift:
+    'Measured average RTT minus the committed value, in ms and as a percent of committed. Positive means the link is measuring slower than its onchain commitment.',
+  linkTrend:
+    'Daily user throughput on this link over the window (average and peak per day), against the link\'s provisioned bandwidth (dashed line). A capacity-planning view.',
+  linkBandwidth: 'The link\'s provisioned bandwidth (capacity) from its onchain configuration.',
+  linkIncidents:
+    'Every incident recorded on this link in the window (any type: IS-IS down, carrier, packet loss, errors, discards, FCS), with when it started and how long it lasted. Use it to line an interface-error spike up with a failure.',
+  linkErrors:
+    'Errors + discards and carrier flaps on this link\'s interfaces over the window, so you can see exactly when they happened and match them to the traffic trend and incidents.',
+  linkPeakUtil: 'The highest 5-minute throughput on this link in the window, as a share of its provisioned bandwidth.',
+  capacity: 'User seats in use versus configured seat capacity across activated devices. Low utilization means headroom to grow.',
+  deviceSlots:
+    'Devices with the most user slots in use: unicast, multicast-subscriber, and multicast-publisher seats, against the device\'s configured max_users cap.',
+  dia: 'Direct Internet Access (DIA) interfaces: typical (P50) and peak (P99) outbound throughput as a share of interface bandwidth (the physical port speed, e.g. a 10G port = 10G of capacity). The committed rate (CIR) is shown alongside for reference but is not the denominator. Port speed comes from a snapshot refreshed roughly once a month, so a recently changed interface may not yet be reflected.',
+  isis: 'IS-IS control-plane health: devices asking to be routed around (overload bit) or unreachable, and the count of established adjacencies.',
+  freshness: 'How fresh the telemetry is: seconds since the interface-counters feed last advanced, and how many active devices reported within the last hour of that feed.',
+  throughputChart: 'User traffic throughput over the window, averaged per bucket, with the peak per bucket. From the 5-minute device interface rollups.',
+  outagesChart:
+    'Link-down incidents (from the 5-minute link rollups) that started in each time bucket, across the full selected window.',
+  topLinks: 'Links carrying the most user traffic in the window (average and peak).',
+  hotspots: 'Devices with the most interface errors, discards, and FCS errors, plus carrier transitions. An early warning of degrading optics or fiber before it becomes a failure.',
+  opsMgmt:
+    'Tickets logged in the Ops Management portal over the window: incidents vs maintenance, severity, how quickly they were filed and resolved, and how many link failures had a matching ticket. Aggregate numbers only, no ticket details. On the whole-network view this reflects the cached 30-day view; on a contributor view it is computed live and filtered to that contributor.',
+  opsResponse:
+    'Median of (ticket created time minus event start), across incidents that have both timestamps. Incidents only: scheduled maintenance is filed ahead of the event and is excluded so it does not pull this negative. A single high-volume filer can dominate this median; use the contributor filter to narrow it.',
+  opsResolution: 'Median minutes from event start to ticket close, across closed incidents.',
+  selfReported:
+    'Share of incidents in this window that the contributor filed themselves, rather than DoubleZero filing on their behalf. Each incident is credited to whoever created its ticket. Higher means the contributor is surfacing its own issues. Shown as unavailable when the ticket-creator registry could not be read.',
+  maintenance:
+    'Scheduled maintenance tickets in this window, split into completed and still planned. Timing and response are not tracked for scheduled maintenance because it is filed ahead of the work.',
+  rootCauses:
+    'Recorded root cause for incident tickets in this window (maintenance excluded), with each cause as a share of incidents that have a cause. Self-resolved incidents cleared on their own with no operator action and are shown separately below the charted causes.',
+  opsNoTicket:
+    'Link failures detected from telemetry that had no matching ticket in the window, by affected link and overlapping time. These are the clearest candidates to file a ticket for.',
+  adjacencies: 'Established IS-IS neighbor adjacencies for this device.',
+  intfErrors: 'Per-interface error, discard, FCS, and carrier-transition totals over the window, split by direction (in/out). Rising counts are an early sign of degrading optics, fiber, or congestion (out-discards).',
+  deviceThroughput: 'Total egress across this device\'s onchain interfaces (link sides + user tunnels), averaged and peak per bucket. Unregistered ports (e.g. local test interfaces) are excluded, so test spikes do not appear; link traffic on a transit device still does. The DIA line sums only this device\'s Direct Internet Access interfaces, so you can see how much of the total is internet-bound.',
+  trafficByIntf: 'Which interfaces carry the most traffic on this device, the link each belongs to, and where packets are being discarded. DIA (Direct Internet Access) interfaces are included and labeled with their committed rate (CIR). Use it to trace where a spike enters or leaves the device and to find congestion.',
+  metroLatency: 'Round-trip time from this metro to other metros: DoubleZero versus the public internet.',
+  metroValidators: 'Validators connected via devices in this metro, and their total activated stake.',
+  cDowntime: "Total failure hours across this contributor's links (each failure capped at 24h).",
+  availabilityLink:
+    "Each link's time in the window split three ways, as a percent of the window: available (up), maintenance (intentionally drained, taken out of service e.g. for maintenance), and down (a fault: link down or high loss). Intentional maintenance drain counts as down here, and is shown as its own segment so planned maintenance is not mistaken for a fault. Currently soft- or hard-drained links are included, so a link fully out for maintenance shows near the top as mostly drained. Least available first. For total fault-hours with maintenance excluded, see \"Most failure time\" in Operations; a link parked in maintenance ranks low here but does not appear there.",
+  availabilityDevice:
+    "Device reachability over the window, as a percent of time. This is the page's true-outage signal: a device is counted unreachable only when it has no working path at all. Available: at least one of its links is working. Unreachable: a fault leaves every activated link down (IS-IS down or 10%+ loss). Maintenance: reachable-blocked only because every link was intentionally drained (soft- or hard-drained) with no fault on any link, so this is planned, not an outage. One link down while others are up does not lower the device. Ranked by unreachable (fault) time, so a device out only for maintenance is not counted as least available.",
+  linkAvailabilitySummary:
+    "This link's time in the window split the same 3 ways as the network rankings above. Down here is the same fault time as the failure hours above; the two should closely match.",
+  outageSummary:
+    'Link and device failures in this window: how many, total failure-hours, and how many distinct links/devices were affected. The count and the failure-hours are measured independently, so a near match between the two numbers is coincidence. Detected from telemetry, independent of whether a ticket was filed.',
+  mostDowntime: 'Total hours each link or device was actually down from a fault in this window, biggest total first, summed from failure episodes on the 5-minute link rollups (an episode is IS-IS down or 10% or more loss lasting at least 10 minutes). This counts hours, not a percentage of the window. It differs from "Least available", which is a percent of the window and counts intentional maintenance drain as down; here maintenance is excluded and only real faults count, so the two rank different links and devices. These bars are uncapped totals, so they can exceed the per-failure 24h cap used in the failure summary.',
+  devicesAffected:
+    'Count of distinct devices that had at least one real fault in this window: a link they terminate was IS-IS down or saw 10% or more packet loss for at least 10 minutes, derived from the 5-minute link rollups. Maintenance drains are not counted, so this can be lower than the total number of active devices. A device counts once no matter how many failures it had.',
+}
+
+export function NetworkHealthReportingPage() {
+  const [params, setParams] = useSearchParams()
+  const contributor = params.get('contributor') ?? ''
+  const days = Number(params.get('days')) || 30
+  const start = params.get('start') ?? ''
+  const end = params.get('end') ?? ''
+
+  const range: NetworkHealthParams = start && end ? { start, end } : { days }
+
+  const setRange = (next: { days?: number; start?: string; end?: string }) =>
+    setParams((p) => {
+      const n = new URLSearchParams(p)
+      n.delete('days')
+      n.delete('start')
+      n.delete('end')
+      if (next.start && next.end) {
+        n.set('start', next.start)
+        n.set('end', next.end)
+      } else if (next.days && next.days !== 30) {
+        n.set('days', String(next.days))
+      }
+      return n
+    })
+
+  const control = <NetworkHealthFilterBar days={days} start={start} end={end} onRange={setRange} />
+
+  // A contributor re-scopes the whole one-pager (same NetworkView, filtered).
+  return <NetworkView range={range} control={control} onRange={setRange} contributor={contributor} />
+}
+
+// Shared scope navigation: switch between the whole network and a contributor
+// scope, preserving the window params. Available to any panel without
+// prop-drilling.
+function useScopeNav() {
+  const [, setParams] = useSearchParams()
+  const set = (key: 'contributor' | '', value: string) =>
+    setParams((p) => {
+      const n = new URLSearchParams(p)
+      n.delete('contributor')
+      if (key) n.set(key, value)
+      return n
+    })
+  return {
+    openContributor: (v: string) => set('contributor', v),
+    toNetwork: () => set('', ''),
+  }
+}
+
+// Outbound navigation to the standalone device/link detail pages. These are
+// plain react-router Links (NOT the removed in-page scope drill-down): a device
+// or link NAME anywhere on the report links out to /dz/devices/:pk or
+// /dz/links/:pk. Subtle affordance (hover underline), keeps whatever truncation
+// classes the call site passes on the anchor. When pk is missing it degrades to
+// a plain span so the name still renders.
+type EntityLinkProps = { pk?: string; className?: string; title?: string; children: React.ReactNode }
+
+function EntityLink({ kind, pk, className, title, children }: EntityLinkProps & { kind: 'link' | 'device' }) {
+  const cls = className ?? ''
+  if (!pk) return <span className={cls} title={title}>{children}</span>
+  const base = kind === 'link' ? '/dz/links/' : '/dz/devices/'
+  return (
+    <Link to={base + pk} title={title} className={`hover:underline hover:text-foreground transition-colors ${cls}`}>
+      {children}
+    </Link>
+  )
+}
+
+function LinkLink(p: EntityLinkProps) {
+  return <EntityLink kind="link" {...p} />
+}
+
+function DeviceLink(p: EntityLinkProps) {
+  return <EntityLink kind="device" {...p} />
+}
+
+// --- Network scope ---
+
+// One react-query hook per data-source group. Every group is keyed identically
+// ([nh, group, range, contributor]) so the window preset/custom range and the
+// contributor scope re-key ALL groups at once, each re-fetching independently.
+// keepPreviousData holds the last window's values (dimmed) during a range change
+// instead of flashing every panel back to a skeleton.
+function useGroup<T>(
+  group: string,
+  fetcher: (p: NetworkHealthParams, c: string) => Promise<T>,
+  range: NetworkHealthParams,
+  contributor: string,
+): UseQueryResult<T> {
+  return useQuery({
+    queryKey: ['nh', group, range, contributor],
+    queryFn: () => fetcher(range, contributor),
+    staleTime: 60_000,
+    placeholderData: keepPreviousData,
+  })
+}
+
+// --- Network scope ---
+
+function NetworkView({
+  range,
+  control,
+  onRange,
+  contributor,
+}: {
+  range: NetworkHealthParams
+  control: React.ReactNode
+  onRange: (next: { days?: number; start?: string; end?: string }) => void
+  contributor?: string
+}) {
+  const { toNetwork } = useScopeNav()
+  const scoped = !!contributor
+  const c = contributor ?? ''
+
+  // Each data-source group fetches + caches on its own, so the page shell renders
+  // immediately and every panel shows its own loading state until its group
+  // resolves. A slow or failed group only affects its own panels.
+  const overviewQ = useGroup('overview', fetchNHOverview, range, c)
+  const availQ = useGroup('availability', fetchNHAvailability, range, c)
+  const latencyQ = useGroup('latency', fetchNHLatency, range, c)
+  const capacityQ = useGroup('capacity', fetchNHCapacity, range, c)
+  const outagesQ = useGroup('outages', fetchNHOutages, range, c)
+  const drainQ = useGroup('drain', fetchNHDrain, range, c)
+  const ticketsQ = useGroup('tickets', fetchNHTickets, range, c)
+  const impactfulQ = useGroup('impactful', fetchNHImpactful, range, c)
+
+  // Undrain timing loads on its own slow endpoint (recovery-health query); the
+  // Drain panel renders its fast fields immediately and fills the undrain
+  // MiniStats in when this resolves.
+  const deferredQ = useGroup('deferred', fetchNetworkHealthDeferred, range, c)
+  const deferred = deferredQ.data
+  const deferredPending = deferredQ.isPending
+
+  return (
+    <Scroll>
+      {scoped && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+          <button onClick={toNetwork} className="inline-flex items-center gap-1 hover:text-foreground">
+            <ArrowLeft className="h-4 w-4" /> Whole network
+          </button>
+          <span className="text-muted-foreground/50">/</span>
+          <span className="text-foreground font-medium">Contributor: {contributor}</span>
+        </div>
+      )}
+      <PageHeader
+        icon={BarChart3}
+        title={scoped ? (contributor as string) : 'Network Health Reporting'}
+        subtitle={
+          <span className="text-muted-foreground text-sm">
+            {scoped ? 'Contributor view · ' : ''}
+            {overviewQ.data?.window.label ?? ''}
+          </span>
+        }
+        actions={control}
+      />
+
+      {/* TOP OVERVIEW: headline tiles cross-read three groups (overview, outages,
+          impactful) and each tile shows its own loading. */}
+      <HeadlineStrip overview={overviewQ} outages={outagesQ} impactful={impactfulQ} />
+      <KeyFacts overview={overviewQ} impactful={impactfulQ} capacity={capacityQ} latency={latencyQ} scoped={scoped} />
+      <GroupBoundary query={overviewQ} title="Throughput over time" info={DEFS.throughputChart} height={300}>
+        {(o) => <TrendsSection points={o.throughput_ts} onRange={onRange} />}
+      </GroupBoundary>
+
+      <SectionBand
+        title="Performance"
+        subtitle="The latency the network committed to versus what it delivered, and which links and devices were least available."
+      />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <GroupBoundary query={availQ} title="Least available links" info={DEFS.availabilityLink}>
+          {(g) => <LinkAvailabilityPanel rows={g.link_availability ?? []} />}
+        </GroupBoundary>
+        <GroupBoundary query={availQ} title="Least available devices" info={DEFS.availabilityDevice}>
+          {(g) => <DeviceAvailabilityPanel rows={g.device_availability ?? []} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={latencyQ} title="Committed vs measured latency" info={DEFS.perfLinks} height={200}>
+          {(g) => <PerfLinksPanel rows={g.latency_links ?? []} />}
+        </GroupBoundary>
+      </div>
+
+      <SectionBand
+        title="Capacity"
+        subtitle="Which links and devices are filling up, and where DIA uplinks stand against their committed rate."
+      />
+      <div className="mb-6">
+        <GroupBoundary query={capacityQ} title="Links carrying the most traffic" info={DEFS.topLinks}>
+          {(g) => <TopLinksPanel rows={g.top_links ?? []} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={capacityQ} title="Fullest devices (user slots)" info={DEFS.deviceSlots}>
+          {(g) => <DeviceSlotsPanel rows={g.device_slots ?? []} />}
+        </GroupBoundary>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <GroupBoundary query={capacityQ} title="Fullest links (capacity planning)" info={DEFS.capacityLinks}>
+          {(g) => <CapacityPanel rows={g.capacity_links ?? []} />}
+        </GroupBoundary>
+        <GroupBoundary query={capacityQ} title="DIA interfaces (capacity vs bandwidth)" info={DEFS.dia}>
+          {(g) => <DiaPanel rows={g.dia_interfaces ?? []} />}
+        </GroupBoundary>
+      </div>
+
+      <SectionBand
+        title="Operations"
+        subtitle="DoubleZero is a routed mesh. When a link fails, traffic almost always reroutes over another path, so the usual effect is added latency, not lost service. A genuine outage (traffic with nowhere to go) happens only when a device loses every path (see the device panel below). Read the counts below as link and device failures to fix, not as time the network was down."
+      />
+      {/* MIXED groups under one band: outages, tickets and drain interleave, so
+          each panel gates on its own group (never the whole band). */}
+      <div className="mb-6">
+        <GroupBoundary query={outagesQ} title="Link failures over time" info={DEFS.outagesChart}>
+          {(g) => <OutagesOverTimePanel rows={g.outages_ts ?? []} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={outagesQ} title="Failure summary" info={DEFS.outageSummary}>
+          {(g) => <OutageSummaryStrip summary={g.outage_summary} prev={g.prev?.outage_summary} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={ticketsQ} title="Incidents" info={DEFS.opsMgmt}>
+          {(g) => <IncidentsStrip tickets={g.ops_tickets} prev={g.prev} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={ticketsQ} title="Maintenance" info={DEFS.maintenance}>
+          {(g) => <MaintenanceStrip tickets={g.ops_tickets} prev={g.prev} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={outagesQ} title="Most failure time" info={DEFS.mostDowntime}>
+          {(g) => <MostDowntimePanel links={g.downtime_links ?? []} devices={g.downtime_devices ?? []} />}
+        </GroupBoundary>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <GroupBoundary query={drainQ} title="Drain & undrain timing" info={DEFS.drainTiming}>
+          {(g) => (
+            <DrainTimingPanel dt={g.drain_timing} prev={g.prev} deferred={deferred} deferredLoading={deferredPending} />
+          )}
+        </GroupBoundary>
+        <GroupBoundary query={outagesQ} title="Link failures by duration" info={DEFS.durationHist}>
+          {(g) => <ReliabilityPanel rel={g.reliability} prev={g.prev?.reliability} />}
+        </GroupBoundary>
+      </div>
+      <div className="mb-6">
+        <GroupBoundary query={outagesQ} title="Interface errors & carrier flaps" info={DEFS.hotspots}>
+          {(g) => <HotspotsPanel rows={g.error_hotspots ?? []} />}
+        </GroupBoundary>
+      </div>
+
+      {overviewQ.data && <Footer window={overviewQ.data.window} generatedAt={overviewQ.data.generated_at} />}
+    </Scroll>
+  )
+}
+
+// --- Progressive-loading primitives ---
+//
+// GroupBoundary renders loading/error/data for one group query. Loading shows a
+// muted skeleton inside the same bordered section the real panel uses (so layout
+// doesn't jump); a resolved-but-errored payload (data.error) reads as
+// unavailable, matching the old data.error check. Only one branch renders at a
+// time, so a panel's own SectionTitle never double-renders with the shell's.
+function GroupBoundary<T extends { error?: string }>({
+  query,
+  title,
+  info,
+  bare = false,
+  height = 120,
+  children,
+}: {
+  query: UseQueryResult<T>
+  title?: string
+  info?: string
+  bare?: boolean
+  height?: number
+  children: (data: T) => React.ReactNode
+}) {
+  if (query.isPending) return <PanelLoading title={title} info={info} bare={bare} height={height} />
+  if (query.error || !query.data || query.data.error)
+    return <PanelUnavailable title={title} info={info} bare={bare} message={query.data?.error} />
+  // On a window change keepPreviousData keeps the prior data visible; dim it
+  // while the new window is in flight.
+  //
+  // h-full + [&>section]:h-full: this wrapper is the grid item in the paired
+  // two-column rows, so it stretches to the row height; forcing the panel's own
+  // <section> to fill it keeps side-by-side cards equal height (in single-column
+  // rows the parent has no fixed height, so both are a no-op).
+  return (
+    <div className={`h-full [&>section]:h-full ${query.isPlaceholderData ? 'opacity-60 transition-opacity' : ''}`}>
+      {children(query.data)}
+    </div>
+  )
+}
+
+function PanelShell({
+  title,
+  info,
+  bare,
+  children,
+}: {
+  title?: string
+  info?: string
+  bare?: boolean
+  children: React.ReactNode
+}) {
+  if (bare) return <div className="mb-6">{children}</div>
+  return (
+    <section className="rounded-lg border border-border p-4">
+      {title && <SectionTitle title={title} info={info} />}
+      {children}
+    </section>
+  )
+}
+
+function PanelLoading({
+  title,
+  info,
+  bare,
+  height = 120,
+}: {
+  title?: string
+  info?: string
+  bare?: boolean
+  height?: number
+}) {
+  return (
+    <PanelShell title={title} info={info} bare={bare}>
+      <div className="animate-pulse space-y-2" style={{ minHeight: height }} aria-busy="true">
+        <div className="h-3 w-1/3 rounded bg-muted" />
+        <div className="h-3 w-2/3 rounded bg-muted" />
+        <div className="h-3 w-1/2 rounded bg-muted" />
+      </div>
+      <div className="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> loading...
+      </div>
+    </PanelShell>
+  )
+}
+
+function PanelUnavailable({
+  title,
+  info,
+  bare,
+  message,
+}: {
+  title?: string
+  info?: string
+  bare?: boolean
+  message?: string
+}) {
+  return (
+    <PanelShell title={title} info={info} bare={bare}>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+        <AlertCircle className="h-4 w-4 text-amber-500" />
+        <span>Couldn't load this section.{message ? ` ${message}` : ''}</span>
+      </div>
+    </PanelShell>
+  )
+}
+
+// A muted headline tile shown when a tile's own group fails to load. Mirrors the
+// StatCard container so the headline row keeps its shape.
+function UnavailableTile({ label, info }: { label: string; info?: string }) {
+  return (
+    <div className="text-center rounded-[0.3rem] bg-muted/50 p-2 lg:p-4">
+      <div className="text-2xl lg:text-3xl font-medium tabular-nums tracking-tight mb-1 text-muted-foreground">—</div>
+      <div className="text-sm text-muted-foreground inline-flex items-center gap-1">
+        {label}
+        {info && <InfoTip text={info} />}
+      </div>
+    </div>
+  )
+}
+
+// One headline tile bound to its own group query. StatCard's built-in
+// value===undefined skeleton covers the pending state; a failed group shows a
+// muted "—" tile instead of spinning forever.
+function HeadlineStat<T extends { error?: string }>({
+  q,
+  pick,
+  delta,
+  label,
+  info,
+  format,
+  decimals,
+  goodDirection,
+  unavailable,
+}: {
+  q: UseQueryResult<T>
+  pick: (d: T) => number | undefined
+  delta?: (d: T) => number | undefined
+  label: string
+  info?: string
+  format: 'number' | 'bandwidth'
+  decimals?: number
+  goodDirection?: 'up' | 'down' | 'neutral'
+  // Some groups return a successful payload that is still unusable (e.g. a
+  // scoped impactful query that could not compute), flagged by their own field.
+  // Render the muted tile for those too, so a failed compute does not show 0.
+  unavailable?: (d: T) => boolean | undefined
+}) {
+  if (q.error || q.data?.error) return <UnavailableTile label={label} info={info} />
+  if (q.data && unavailable?.(q.data)) return <UnavailableTile label={label} info={info} />
+  const value = q.data ? pick(q.data) : undefined
+  const d = q.data && delta ? delta(q.data) : undefined
+  return (
+    <StatCard
+      label={label}
+      value={value}
+      format={format}
+      decimals={decimals}
+      delta={d}
+      goodDirection={goodDirection}
+      info={info}
+    />
+  )
+}
+
+// --- Shared panels ---
+
+function HeadlineStrip({
+  overview,
+  outages,
+  impactful,
+}: {
+  overview: UseQueryResult<NHOverview>
+  outages: UseQueryResult<NHOutagesGroup>
+  impactful: UseQueryResult<NHImpactful>
+}) {
+  const days = overview.data?.window.days
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-2 lg:grid-cols-4">
+        <HeadlineStat
+          q={overview}
+          label="Peak throughput"
+          format="bandwidth"
+          decimals={1}
+          goodDirection="up"
+          info={DEFS.peak}
+          pick={(o) => o.headline.peak_bps}
+          delta={(o) => deltaOrUndef(o.headline.deltas, 'peak_bps')}
+        />
+        <HeadlineStat
+          q={outages}
+          label="Link failures"
+          format="number"
+          goodDirection="down"
+          info={DEFS.outages}
+          pick={(g) => g.outage_count}
+          delta={(g) => g.outage_count_delta ?? undefined}
+        />
+        <HeadlineStat
+          q={impactful}
+          label="Traffic-weighted failure hours"
+          format="number"
+          decimals={1}
+          goodDirection="down"
+          info={DEFS.impactfulDowntime}
+          pick={(g) => g.impactful_downtime_hours}
+          delta={(g) => g.impactful_downtime_delta ?? undefined}
+          unavailable={(g) => g.unavailable}
+        />
+        <HeadlineStat
+          q={overview}
+          label="Active links"
+          format="number"
+          goodDirection="neutral"
+          info={DEFS.activeLinks}
+          pick={(o) => o.headline.active_links}
+          delta={(o) => deltaOrUndef(o.headline.deltas, 'active_links')}
+        />
+      </div>
+      {days !== undefined && (
+        <div className="text-xs text-muted-foreground mb-3 inline-flex items-center gap-1">
+          Coloured +/- values are the change versus the previous {days} days (green = better, red = worse) <InfoTip text={DEFS.trend} />
+        </div>
+      )}
+    </>
+  )
+}
+
+// Traffic-weighted availability, derived on the frontend from the Overview active
+// link count and the traffic-weighted failure hours (same formula the server used:
+// 1 - impactful_hours / (active_links x window_hours)).
+function deriveAvailability(o: NHOverview | undefined, imp: NHImpactful | undefined): number | null {
+  if (!o || !imp || imp.unavailable) return null
+  const windowHours = o.window.days * 24
+  const activeLinks = o.headline.active_links
+  if (activeLinks > 0 && windowHours > 0) {
+    let avail = 100 * (1 - imp.impactful_downtime_hours / (activeLinks * windowHours))
+    if (avail < 0) avail = 0
+    return Math.round(avail * 1000) / 1000
+  }
+  return null
+}
+
+// A single inline fact that renders its own group's loading/unavailable state.
+function statText<T extends { error?: string }>(q: UseQueryResult<T>, fmt: (d: T) => string): string {
+  if (q.isPending) return 'loading...'
+  if (q.error || !q.data || q.data.error) return 'unavailable'
+  return fmt(q.data)
+}
+
+function KeyFacts({
+  overview,
+  impactful,
+  capacity,
+  latency,
+  scoped,
+}: {
+  overview: UseQueryResult<NHOverview>
+  impactful: UseQueryResult<NHImpactful>
+  capacity: UseQueryResult<NHCapacityGroup>
+  latency: UseQueryResult<NHLatencyGroup>
+  scoped: boolean
+}) {
+  const o = overview.data
+  // Traffic-weighted availability cross-reads two groups (overview + impactful);
+  // show loading until both resolve and unavailable if either failed.
+  const availValue =
+    overview.isPending || impactful.isPending
+      ? 'loading...'
+      : overview.error || impactful.error || o?.error || impactful.data?.error
+        ? 'unavailable'
+        : (() => {
+            const a = deriveAvailability(o, impactful.data)
+            return a === null ? '—' : `${a}%`
+          })()
+
+  const freshInfo = o
+    ? `${DEFS.freshness} The feed last advanced at ${o.freshness.feed_max} UTC; on the cached view the "behind" minutes are frozen at cache time, so compute the live lag from that timestamp.`
+    : DEFS.freshness
+
+  return (
+    <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground mb-8">
+      <Stat label="traffic-weighted availability" value={availValue} info={DEFS.availability} />
+      <Stat
+        label="of seat capacity used"
+        value={statText(capacity, (g) => (g.capacity.util_pct === null ? '—' : `${g.capacity.util_pct}%`))}
+        info={DEFS.capacity}
+      />
+      <Stat
+        label="links within committed RTT"
+        value={statText(latency, (g) => (g.sla.total === 0 ? '—' : `${g.sla.within} of ${g.sla.total}`))}
+        info={DEFS.sla}
+      />
+      <Stat label="active devices" value={statText(overview, (g) => g.headline.active_devices.toLocaleString())} info={DEFS.activeDevices} />
+      {!scoped && (
+        <>
+          <Stat label="active metros" value={statText(overview, (g) => g.headline.active_metros.toLocaleString())} info={DEFS.activeMetros} />
+          <Stat label="less latency jitter than internet" value={statText(overview, (g) => `${g.headline.jitter_improve_pct}%`)} info={DEFS.jitter} />
+          <Stat label="avg packet loss on DoubleZero" value={statText(overview, (g) => `${g.headline.dz_loss_pct}%`)} info={DEFS.loss} />
+          <Stat
+            label={
+              o
+                ? `IS-IS devices ${o.isis.overloaded === 0 && o.isis.unreachable === 0 ? 'all healthy' : 'flagged'}`
+                : 'IS-IS devices'
+            }
+            value={statText(overview, (g) => `${g.isis.overloaded} overloaded, ${g.isis.unreachable} unreachable of ${g.isis.devices}`)}
+            info={DEFS.isis}
+          />
+          <Stat
+            label={o ? `behind · ${o.freshness.devices_fresh}/${o.freshness.devices_active} devices reporting` : 'telemetry freshness'}
+            value={statText(overview, (g) => `telemetry ${Math.round(g.freshness.lag_seconds / 60)}m`)}
+            info={freshInfo}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+// OUTAGES: the plain outage facts detected from telemetry (counts, hours,
+// breadth), independent of any ticket. Ticket data lives in the separate
+// INCIDENTS and MAINTENANCE sections below, so no metric is shown twice. Same
+// visual language as HeadlineStrip/KeyFacts (StatCard grid).
+function OutageSummaryStrip({
+  summary,
+  prev,
+}: {
+  summary: NetworkHealthOutageSummary | null | undefined
+  prev?: NetworkHealthOutageSummary | null
+}) {
+  if (!summary) return null
+  return (
+    <section className="rounded-lg border border-border p-4 mb-6">
+      <SectionTitle title="Failure summary" info={DEFS.outageSummary} />
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mt-3">
+        <StatCard label="Link failures" value={summary.link_outages} format="number" delta={pctChange(summary.link_outages, prev?.link_outages)} goodDirection="down" />
+        <StatCard label="Failure hours" value={summary.outage_hours} format="number" decimals={0} delta={pctChange(summary.outage_hours, prev?.outage_hours)} goodDirection="down" />
+        <StatCard label="Links affected" value={summary.links_affected} format="number" delta={pctChange(summary.links_affected, prev?.links_affected)} goodDirection="down" />
+        <StatCard label="Devices affected" value={summary.devices_affected} format="number" delta={pctChange(summary.devices_affected, prev?.devices_affected)} goodDirection="down" info={DEFS.devicesAffected} />
+      </div>
+    </section>
+  )
+}
+
+// Grade for the self-reported share: green when the contributor files most of
+// its own incidents, amber in the middle, red when it rarely does. A self-fact
+// on the entity's own view, not a cross-contributor ranking.
+function selfReportedTone(pct: number): 'good' | 'warn' | 'bad' {
+  if (pct >= 90) return 'good'
+  if (pct >= 70) return 'warn'
+  return 'bad'
+}
+
+// INCIDENTS: incident tickets only. Leads with the graded self-reported share
+// (the one deliberate self-fact grade on the page, see the file header), then
+// incident count + severity, timing (filed/resolved), outage-to-ticket
+// coverage, the root-cause breakdown, and the contributor-actionable list of
+// outages that still have no ticket.
+function IncidentsStrip({ tickets, prev }: { tickets: NetworkHealthTickets | null | undefined; prev?: NetworkHealthTickets | null }) {
+  if (!tickets) return null
+  const sr = tickets.self_reported_pct
+  return (
+    <section className="rounded-lg border border-border p-4 mb-6">
+      <SectionTitle title="Incidents" info={DEFS.opsMgmt} />
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-1 text-xs text-muted-foreground mt-1 mb-3">
+        <span className="inline-flex items-center gap-1">
+          <span className="font-medium tabular-nums text-foreground">{tickets.incidents}</span> incidents
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="font-medium tabular-nums text-amber-600 dark:text-amber-400">{tickets.sev1}</span> sev1
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="font-medium tabular-nums text-amber-600 dark:text-amber-400">{tickets.sev2}</span> sev2
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="font-medium tabular-nums text-foreground">{tickets.sev3}</span> sev3
+        </span>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        {sr === null ? (
+          <MiniStat label="Self-reported by contributor" value="unavailable" info={DEFS.selfReported} />
+        ) : (
+          <MiniStat
+            label="Self-reported by contributor"
+            value={`${sr.toFixed(0)}%`}
+            tone={selfReportedTone(sr)}
+            delta={ppDelta(sr, prev?.self_reported_pct)}
+            goodDirection="up"
+            deltaUnit="pp"
+            info={DEFS.selfReported}
+          />
+        )}
+        <MiniStat label="Median time to file" value={timeToFileLabel(tickets.response_p50_min)} delta={pctChange(tickets.response_p50_min, prev?.response_p50_min)} goodDirection="down" info={DEFS.opsResponse} />
+        <MiniStat label="Median time to resolve" value={minutes(tickets.resolution_p50_min)} delta={pctChange(tickets.resolution_p50_min, prev?.resolution_p50_min)} goodDirection="down" info={DEFS.opsResolution} />
+        <MiniStat
+          label="Failures with a ticket"
+          value={`${tickets.outages_with_ticket} / ${tickets.outage_count}`}
+          delta={pctChange(tickets.outages_with_ticket, prev?.outages_with_ticket)}
+          goodDirection="up"
+          info={DEFS.opsMgmt}
+        />
+        <MiniStat
+          label="Failures without a ticket"
+          value={`${tickets.outages_no_ticket}${tickets.no_ticket_share_pct === null ? '' : ` (${tickets.no_ticket_share_pct}%)`}`}
+          delta={pctChange(tickets.outages_no_ticket, prev?.outages_no_ticket)}
+          goodDirection="down"
+          info={DEFS.opsNoTicket}
+        />
+      </div>
+      <RootCauseBreakdown causes={tickets.root_causes ?? []} />
+      <NoTicketOutages tickets={tickets} />
+    </section>
+  )
+}
+
+// Contributor-actionable call-out (plan B5): the outages that still have no
+// matching ticket are the clearest "file these" list. Leads with the count and
+// share, then lists each affected link with its start time and duration. Each
+// link_code links out to its detail page when the pk resolved; otherwise it is
+// plain text.
+function NoTicketOutages({ tickets }: { tickets: NetworkHealthTickets }) {
+  if (tickets.outages_no_ticket <= 0) return null
+  const share = tickets.no_ticket_share_pct === null ? '' : ` (${tickets.no_ticket_share_pct}% of failures)`
+  const list = tickets.no_ticket_outages ?? []
+  return (
+    <div className="mt-4 border-t border-border pt-4">
+      <div className="text-xs text-muted-foreground/70 mb-1 inline-flex items-center gap-1">
+        Failures without a ticket <InfoTip text={DEFS.opsNoTicket} />
+      </div>
+      <p className="text-xs text-muted-foreground mb-2">
+        <span className="font-medium tabular-nums text-foreground">{tickets.outages_no_ticket}</span> link failure
+        {tickets.outages_no_ticket === 1 ? '' : 's'} detected from telemetry have no matching ticket{share}. File a
+        ticket for each so it is recorded.
+      </p>
+      {list.length > 0 && (
+        <ul className="space-y-1">
+          {list.map((o, i) => (
+            <li
+              key={`${o.link_code}-${o.start_ts}-${i}`}
+              className="grid grid-cols-[1fr_auto] items-baseline gap-3 text-xs"
+            >
+              <LinkLink pk={o.link_pk} className="block max-w-[280px] truncate font-medium" title={o.link_code}>
+                {o.link_code}
+              </LinkLink>
+              <span className="text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                {fmtT(o.start_ts)} · {o.hours.toLocaleString(undefined, { maximumFractionDigits: 1 })} h
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+// MAINTENANCE: scheduled maintenance tickets, counts only. Timing and response
+// are intentionally not shown (maintenance is filed ahead of the work, so
+// time-to-file is not meaningful); see DEFS.maintenance.
+function MaintenanceStrip({ tickets, prev }: { tickets: NetworkHealthTickets | null | undefined; prev?: NetworkHealthTickets | null }) {
+  if (!tickets || tickets.maintenance === 0) return null
+  const planned = Math.max(0, tickets.maintenance - tickets.closed_maintenance)
+  const plannedPrev = prev ? Math.max(0, prev.maintenance - prev.closed_maintenance) : undefined
+  return (
+    <section className="rounded-lg border border-border p-4 mb-6">
+      <SectionTitle title="Maintenance" info={DEFS.maintenance} />
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mt-3">
+        <StatCard label="Scheduled maintenance" value={tickets.maintenance} format="number" info={DEFS.maintenance} />
+        <StatCard label="Completed" value={tickets.closed_maintenance} format="number" delta={pctChange(tickets.closed_maintenance, prev?.closed_maintenance)} goodDirection="neutral" />
+        <StatCard label="Planned" value={planned} format="number" delta={pctChange(planned, plannedPrev)} goodDirection="neutral" />
+      </div>
+      <p className="text-xs text-muted-foreground mt-3">
+        Timing and response are not tracked for scheduled maintenance because it is filed ahead of the work.
+      </p>
+    </section>
+  )
+}
+
+// Display labels for the root-cause enum. Passthrough for any future value.
+const ROOT_CAUSE_LABELS: Record<string, string> = {
+  self_resolved: 'Self-resolved',
+  network_external: 'External network',
+  fiber_cut: 'Fiber cut',
+  configuration: 'Configuration',
+  hardware: 'Hardware',
+  carrier: 'Carrier',
+  false_positive: 'False positive',
+}
+
+function rootCauseLabel(cause: string): string {
+  return ROOT_CAUSE_LABELS[cause] ?? cause
+}
+
+// Incident root-cause breakdown. Real causes render as labeled horizontal bars
+// scaled to the largest count; self-resolved incidents (cleared on their own,
+// no operator action) are shown as a separate muted line so they do not read
+// as a fault category.
+function RootCauseBreakdown({ causes }: { causes: NetworkHealthRootCause[] }) {
+  if (causes.length === 0) return null
+  const real = causes.filter((c) => c.cause !== 'self_resolved')
+  const selfResolved = causes.find((c) => c.cause === 'self_resolved')
+  const max = Math.max(1, ...real.map((c) => c.count))
+  return (
+    <div className="mt-4 border-t border-border pt-4">
+      <div className="text-xs text-muted-foreground/70 mb-2 inline-flex items-center gap-1">
+        Incident root causes <InfoTip text={DEFS.rootCauses} />
+      </div>
+      {real.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No root causes recorded.</p>
+      ) : (
+        <div className="space-y-1.5">
+          {real.map((c) => (
+            <div key={c.cause} className="grid grid-cols-[130px_1fr_72px] items-center gap-3 text-xs">
+              <span className="truncate text-muted-foreground" title={rootCauseLabel(c.cause)}>
+                {rootCauseLabel(c.cause)}
+              </span>
+              <div className="h-3 rounded-sm bg-muted/30 overflow-hidden">
+                <div className="h-full" style={{ width: `${(100 * c.count) / max}%`, background: BAR.amber }} />
+              </div>
+              <span className="text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                {c.count}{c.pct === null ? '' : ` · ${c.pct}%`}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {selfResolved && (
+        <div className="mt-2 text-xs text-muted-foreground/60 inline-flex items-center gap-1">
+          <span className="font-medium tabular-nums">{selfResolved.count}</span>
+          {rootCauseLabel(selfResolved.cause)} (cleared with no operator action)
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DrainTimingPanel({
+  dt,
+  prev,
+  deferred,
+  deferredLoading,
+}: {
+  dt: NetworkHealthDrainTiming | undefined
+  prev?: NetworkHealthDrainTiming | null
+  deferred?: NetworkHealthDeferred
+  deferredLoading?: boolean
+}) {
+  if (!dt) return null
+  // Undrain timing arrives from a separate, slower query. While it loads the two
+  // undrain MiniStats show a muted "loading..." and the summary line omits the
+  // matched-undrain clause.
+  const undrainPending = deferredLoading || !deferred
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Drain & undrain timing" info={DEFS.drainTiming} />
+      <p className="text-xs text-muted-foreground mb-4">
+        {dt.drains} drains, {dt.undrains} undrains; {dt.events_with_drain} of {dt.outage_count} link-down events
+        had a matching drain
+        {undrainPending
+          ? '.'
+          : deferred!.undrain_unavailable
+            ? '. Undrain timing is unavailable this window.'
+            : dt.undrains > 0
+              ? `; ${deferred!.matched_undrains} of ${dt.undrains} undrains matched a recovered link.`
+              : '.'}
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <MiniStat label="Median time to drain" value={minutes(dt.time_to_drain_p50_min)} delta={pctChange(dt.time_to_drain_p50_min, prev?.time_to_drain_p50_min)} goodDirection="down" info={DEFS.timeToDrain} />
+        <MiniStat label="Max time to drain" value={minutes(dt.time_to_drain_max_min)} delta={pctChange(dt.time_to_drain_max_min, prev?.time_to_drain_max_min)} goodDirection="down" info={DEFS.timeToDrain} />
+        <MiniStat label="Median time drained" value={minutes(dt.time_drained_p50_min)} delta={pctChange(dt.time_drained_p50_min, prev?.time_drained_p50_min)} goodDirection="down" info={DEFS.timeDrained} />
+        <MiniStat label="Max time drained" value={minutes(dt.time_drained_max_min)} delta={pctChange(dt.time_drained_max_min, prev?.time_drained_max_min)} goodDirection="down" info={DEFS.timeDrained} />
+        <MiniStat
+          label="Median time to undrain"
+          value={undrainPending ? 'loading...' : deferredUndrainValue(dt.undrains, deferred!, deferred!.time_to_undrain_p50_min)}
+          muted={undrainPending}
+          delta={undrainPending ? undefined : pctChange(deferred!.time_to_undrain_p50_min, deferred!.prev?.time_to_undrain_p50_min)}
+          goodDirection="down"
+          info={DEFS.timeToUndrain}
+        />
+        <MiniStat
+          label="Max time to undrain"
+          value={undrainPending ? 'loading...' : deferredUndrainValue(dt.undrains, deferred!, deferred!.time_to_undrain_max_min)}
+          muted={undrainPending}
+          delta={undrainPending ? undefined : pctChange(deferred!.time_to_undrain_max_min, deferred!.prev?.time_to_undrain_max_min)}
+          goodDirection="down"
+          info={DEFS.timeToUndrain}
+        />
+        <MiniStat
+          label="Failures drained within 30 min"
+          value={dt.drain_within_30m_pct === null ? '—' : `${dt.drain_within_30m_pct}%`}
+          delta={ppDelta(dt.drain_within_30m_pct, prev?.drain_within_30m_pct)}
+          goodDirection="up"
+          deltaUnit="pp"
+          info={DEFS.drainWithin30m}
+        />
+      </div>
+    </section>
+  )
+}
+
+function ReliabilityPanel({
+  rel,
+  prev,
+}: {
+  rel: NetworkHealthReliability | undefined
+  prev?: NetworkHealthReliabilityPrev | null
+}) {
+  if (!rel || !rel.duration_histogram) return null
+  const hist = rel.duration_histogram
+  const data = [
+    { label: '≤5m', count: hist.flap_le5m },
+    { label: '5–15m', count: hist.short_5_15m },
+    { label: '15–60m', count: hist.medium_15_60m },
+    { label: '1–24h', count: hist.sustained_1_24h },
+    { label: '>24h', count: hist.chronic_gt24h },
+  ]
+  // vs-prior deltas on the two headline figures below (fewer failures / less
+  // failure time is better, so goodDirection is "down"); each hides when the prior
+  // is missing or the change is zero.
+  const outageDelta = pctChange(rel.outage_count, prev?.outage_count)
+  const downtimeDelta = pctChange(rel.capped_downtime_hours, prev?.capped_downtime_hours)
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Link failures by duration" info={DEFS.durationHist} />
+      <p className="text-xs text-muted-foreground mb-1">
+        How long each link failure lasted, not which link or device carried the most hours (see Most failure time above).
+        This shows all failure episodes by length, including brief flaps under 5 minutes, so it counts more
+        episodes than the headline link-failure count above (which counts only sustained failures of 10 minutes or more).
+      </p>
+      <p className="text-xs text-muted-foreground mb-4">
+        {rel.outage_count.toLocaleString()} link failures
+        {outageDelta !== undefined && outageDelta !== 0 && (
+          <span className={`ml-1 ${deltaColorClass(outageDelta, 'down')}`}>{formatDelta(outageDelta)}</span>
+        )}{' '}
+        on {rel.distinct_links} links ·{' '}
+        {rel.capped_downtime_hours.toLocaleString()} failure hours
+        {downtimeDelta !== undefined && downtimeDelta !== 0 && (
+          <span className={`ml-1 ${deltaColorClass(downtimeDelta, 'down')}`}>{formatDelta(downtimeDelta)}</span>
+        )}{' '}
+        ·{' '}
+        <span className="inline-flex items-center gap-1">
+          {rel.degraded_links} links saw loss without going down <InfoTip text={DEFS.degraded} />
+        </span>
+      </p>
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={data} margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+          <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fontSize: 11, fill: 'var(--muted-foreground)' }} dy={6} />
+          <YAxis tickLine={false} axisLine={false} tick={{ fontSize: 11, fill: 'var(--muted-foreground)' }} width={28} allowDecimals={false} />
+          <ReTooltip
+            cursor={{ fill: 'var(--muted)', opacity: 0.4 }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null
+              return (
+                <div className="bg-card border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+                  <div className="text-muted-foreground mb-1">{label}</div>
+                  <div className="font-semibold text-foreground">{payload[0].value} failures</div>
+                </div>
+              )
+            }}
+          />
+          <Bar dataKey="count" fill={BAR.amber} fillOpacity={0.85} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </section>
+  )
+}
+
+// --- Trends + operator panels ---
+
+function TrendsSection({
+  points,
+  onRange,
+}: {
+  points: NetworkHealthTsPoint[]
+  onRange: (next: { days?: number; start?: string; end?: string }) => void
+}) {
+  const tput = points.map((p) => ({ t: p.t, avg: p.avg_bps / 1e9, max: p.max_bps / 1e9 }))
+  // In-chart drag-to-zoom: press inside the chart and drag; on release, zoom the
+  // whole report to the selected time range. left/right are the `t` values (RFC3339)
+  // under the cursor (recharts activeLabel).
+  const [dragLeft, setDragLeft] = useState<string | null>(null)
+  const [dragRight, setDragRight] = useState<string | null>(null)
+  const endDrag = () => {
+    if (dragLeft && dragRight && dragLeft !== dragRight) {
+      const [s, e] = dragLeft < dragRight ? [dragLeft, dragRight] : [dragRight, dragLeft]
+      onRange({ start: s, end: e })
+    }
+    setDragLeft(null)
+    setDragRight(null)
+  }
+  return (
+    <div className="mb-6">
+      <section className="rounded-lg border border-border p-4">
+        <SectionTitle title="Throughput over time" info={DEFS.throughputChart} />
+        <p className="mb-3 text-xs text-muted-foreground">
+          Drag across the chart to zoom the whole report to that time range, then see what carried traffic
+          and what broke in that window. Use the presets in the filter bar to reset.
+        </p>
+        <ChartLegend items={[[BAR.blue, 'Average'], [BAR.slate, 'Peak']]} />
+        <ChartFrame empty={tput.length === 0} height={260}>
+          <AreaChart
+            data={tput}
+            margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+            onMouseDown={(e) => {
+              const lbl = (e as { activeLabel?: string } | null)?.activeLabel
+              if (lbl) {
+                setDragLeft(lbl)
+                setDragRight(null)
+              }
+            }}
+            onMouseMove={(e) => {
+              if (!dragLeft) return
+              const lbl = (e as { activeLabel?: string } | null)?.activeLabel
+              if (lbl) setDragRight(lbl)
+            }}
+            onMouseUp={endDrag}
+            style={{ userSelect: 'none' }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+            <XAxis dataKey="t" tickFormatter={fmtT} tickLine={false} axisLine={false} minTickGap={40} tick={AXIS_TICK} />
+            <YAxis tickLine={false} axisLine={false} width={36} tick={AXIS_TICK} unit=" G" />
+            <ReTooltip content={makeChartTip('Gbps')} />
+            <Area type="monotone" dataKey="avg" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.15} strokeWidth={1.5} name="avg" isAnimationActive={false} />
+            <Line type="monotone" dataKey="max" stroke="#64748b" dot={false} strokeWidth={1} name="peak" isAnimationActive={false} />
+            {dragLeft && dragRight && (
+              <ReferenceArea x1={dragLeft} x2={dragRight} strokeOpacity={0.3} fill="#3b82f6" fillOpacity={0.12} />
+            )}
+          </AreaChart>
+        </ChartFrame>
+      </section>
+    </div>
+  )
+}
+
+function OutagesOverTimePanel({ rows }: { rows: NetworkHealthCountPoint[] }) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Link failures over time" info={DEFS.outagesChart} />
+      <p className="text-xs text-muted-foreground mb-3">
+        When link failures started, bucketed over the window. A different cut from "Most failure time" (total hours per
+        link or device) and "Link failures by duration" (how long each failure ran), shown further down.
+      </p>
+      <ChartFrame empty={rows.length === 0}>
+        <BarChart data={rows} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+          <XAxis dataKey="t" tickFormatter={fmtT} tickLine={false} axisLine={false} minTickGap={40} tick={AXIS_TICK} />
+          <YAxis tickLine={false} axisLine={false} width={28} allowDecimals={false} tick={AXIS_TICK} />
+          <ReTooltip content={makeChartTip('failures')} />
+          <Bar dataKey="count" fill={BAR.amber} fillOpacity={0.85} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ChartFrame>
+    </section>
+  )
+}
+
+// Horizontal bar chart of links ranked by a single fact (traffic, utilization).
+// Neutral: these are link facts, not contributor rankings.
+function LinkBarChart({
+  rows,
+  kind,
+  unit,
+  color = BAR.blue,
+  refLine,
+  emptyLabel = 'No links in this window.',
+  labelWidth = 52,
+}: {
+  rows: { label: string; value: number; sub: string; pk: string; endLabel: string }[]
+  kind: 'link' | 'device'
+  unit?: string
+  color?: string
+  refLine?: number
+  emptyLabel?: string
+  labelWidth?: number
+}) {
+  const Tick = useEntityAxisTick(rows, kind)
+  if (rows.length === 0) {
+    return <div className="flex h-[120px] items-center justify-center text-sm text-muted-foreground">{emptyLabel}</div>
+  }
+  const height = rows.length * 30 + 24
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={rows} layout="vertical" margin={{ top: 4, right: labelWidth, left: 8, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+        <XAxis type="number" tickLine={false} axisLine={false} tick={AXIS_TICK} unit={unit} />
+        <YAxis type="category" dataKey="label" width={160} interval={0} tickLine={false} axisLine={false} tick={<Tick />} />
+        <ReTooltip
+          cursor={{ fill: 'var(--muted)', opacity: 0.3 }}
+          content={(raw: unknown) => {
+            const p = raw as { active?: boolean; payload?: Array<{ payload?: { label: string; value: number; sub: string } }> }
+            const d = p.active && p.payload?.length ? p.payload[0].payload : undefined
+            if (!d) return null
+            return (
+              <div className="bg-card border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+                <div className="font-semibold text-foreground">{d.label}</div>
+                {d.sub && <div className="text-muted-foreground">{d.sub}</div>}
+                <div className="tabular-nums mt-1">
+                  {d.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                  {unit ?? ''}
+                </div>
+              </div>
+            )
+          }}
+        />
+        {refLine !== undefined && <ReferenceLine x={refLine} stroke="#64748b" strokeDasharray="4 4" strokeOpacity={0.7} />}
+        <Bar
+          dataKey="value"
+          fill={color}
+          radius={[0, 3, 3, 0]}
+          isAnimationActive={false}
+        >
+          <LabelList
+            dataKey="endLabel"
+            position="right"
+            offset={6}
+            fontSize={11}
+            fill="var(--foreground)"
+            className="tabular-nums"
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+// Horizontal grouped-bar chart: two or three facts per link on one shared axis
+// (all series are the same unit here). The third series `c` is optional and
+// only rendered when at least one row supplies it (e.g. peak utilization on the
+// capacity panel); the DIA panel omits it and stays a 2-bar chart. `note` adds
+// a small clarifying line to the tooltip.
+function GroupedBarChart({ rows, kind, unit, refLine, labels = ['P50', 'P99', 'Peak'], note }: {
+  rows: { label: string; a: number; b: number; c?: number; sub: string; pk: string }[]
+  kind: 'link' | 'device'
+  unit?: string; refLine?: number; labels?: [string, string, string]; note?: string
+}) {
+  const Tick = useEntityAxisTick(rows, kind)
+  if (rows.length === 0) return <div className="flex h-[120px] items-center justify-center text-sm text-muted-foreground">No data in this window.</div>
+  const hasC = rows.some((r) => r.c !== undefined)
+  const height = rows.length * (hasC ? 58 : 44) + 24
+  const fmt = (v: number) => `${v.toLocaleString(undefined, { maximumFractionDigits: 2 })}${unit ?? ''}`
+  const legendItems: Array<[string, string]> = [[BAR.blue, labels[0]], [BAR.amber, labels[1]]]
+  if (hasC) legendItems.push([BAR.slate, labels[2]])
+  return (
+    <>
+    <ChartLegend items={legendItems} />
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 56, left: 8, bottom: 0 }} barGap={2}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+        <XAxis type="number" tickLine={false} axisLine={false} tick={AXIS_TICK} unit={unit} />
+        <YAxis type="category" dataKey="label" width={160} interval={0} tickLine={false} axisLine={false} tick={<Tick />} />
+        <ReTooltip
+          cursor={{ fill: 'var(--muted)', opacity: 0.3 }}
+          content={(raw: unknown) => {
+            const p = raw as { active?: boolean; payload?: Array<{ payload?: { label: string; sub: string; a: number; b: number; c?: number } }> }
+            const d = p.active && p.payload?.length ? p.payload[0].payload : undefined
+            if (!d) return null
+            return (
+              <div className="bg-card border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+                <div className="font-semibold text-foreground">{d.label}</div>
+                {d.sub && <div className="text-muted-foreground">{d.sub}</div>}
+                <div className="tabular-nums mt-1">{labels[0]} {fmt(d.a)}</div>
+                <div className="tabular-nums">{labels[1]} {fmt(d.b)}</div>
+                {d.c !== undefined && <div className="tabular-nums">{labels[2]} {fmt(d.c)}</div>}
+                {note && d.c !== undefined && (
+                  <div className="text-muted-foreground mt-1 max-w-[220px]">{note}</div>
+                )}
+              </div>
+            )
+          }}
+        />
+        {refLine !== undefined && <ReferenceLine x={refLine} stroke={BAR.slate} strokeDasharray="4 4" strokeOpacity={0.7} />}
+        <Bar dataKey="a" name={labels[0]} fill={BAR.blue} fillOpacity={0.85} radius={[0,2,2,0]} isAnimationActive={false}>
+          <LabelList dataKey="a" position="right" offset={6} formatter={(v) => fmt(Number(v))} fontSize={10} fill={BAR.blue} className="tabular-nums" />
+        </Bar>
+        <Bar dataKey="b" name={labels[1]} fill={BAR.amber} fillOpacity={0.85} radius={[0,2,2,0]} isAnimationActive={false}>
+          <LabelList dataKey="b" position="right" offset={6} formatter={(v) => fmt(Number(v))} fontSize={10} fill={BAR.amber} className="tabular-nums" />
+        </Bar>
+        {hasC && (
+          <Bar dataKey="c" name={labels[2]} fill={BAR.slate} fillOpacity={0.85} radius={[0,2,2,0]} isAnimationActive={false}>
+            <LabelList dataKey="c" position="right" offset={6} formatter={(v) => fmt(Number(v))} fontSize={10} fill={BAR.slate} className="tabular-nums" />
+          </Bar>
+        )}
+      </BarChart>
+    </ResponsiveContainer>
+    </>
+  )
+}
+
+// Reusable color legend: a wrapping row of dot + label pairs. Used by every
+// colored panel (availability segments, capacity bars, device slots, throughput).
+function ChartLegend({ items }: { items: Array<[string, string]> }) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 text-[11px] text-muted-foreground mb-3">
+      {items.map(([color, label]) => (
+        <span key={label} className="inline-flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ background: color }} />
+          {label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+// Legend for the 3-way availability segments, shared by the link and device
+// availability panels. The middle (drained) label is parametrized so the device
+// panel can spell out that it only turns this color when ALL links are drained.
+function AvailabilityLegend({ drainedLabel, faultLabel }: { drainedLabel: string; faultLabel: string }) {
+  return (
+    <ChartLegend
+      items={[
+        [BAR.blue, 'Available'],
+        [BAR.slate, drainedLabel],
+        [BAR.amber, faultLabel],
+      ]}
+    />
+  )
+}
+
+// Segmented per-entity meter: Available / Drained / Outage shares of the
+// window, summing to 100%. Reuses the segmented-meter div pattern from
+// DeviceSlotsPanel (not recharts), since this is a per-entity time split, not
+// a comparable-magnitude bar chart. Rows are pre-sorted least-available-first
+// by the backend.
+function AvailabilityRows({ rows, drainedLabel, faultLabel, kind }: { rows: NetworkHealthAvailability[]; drainedLabel: string; faultLabel: string; kind: 'link' | 'device' }) {
+  if (rows.length === 0) {
+    return <p className="text-xs text-muted-foreground">No data in this window.</p>
+  }
+  return (
+    <div className="space-y-2">
+      {rows.map((r) => (
+        <div
+          key={r.pk}
+          className="grid grid-cols-[140px_1fr_92px] items-center gap-3 text-xs"
+        >
+          <EntityLink kind={kind} pk={r.pk} className="truncate text-muted-foreground" title={r.metros}>
+            {r.code}
+          </EntityLink>
+          <Tooltip content={<AvailabilityTooltip r={r} drainedLabel={drainedLabel} faultLabel={faultLabel} />} className="bg-card shadow-xl">
+            <div className="flex h-3 rounded-sm bg-muted/30 overflow-hidden">
+              <div className="h-full" style={{ width: `${Math.max(0, r.avail_pct)}%`, background: BAR.blue }} />
+              <div className="h-full" style={{ width: `${Math.max(0, r.drained_pct)}%`, background: BAR.slate }} />
+              <div className="h-full" style={{ width: `${Math.max(0, r.outage_pct)}%`, background: BAR.amber }} />
+            </div>
+          </Tooltip>
+          <span className="text-right tabular-nums text-muted-foreground whitespace-nowrap">{r.avail_pct}% avail</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Full available/drained/outage breakdown (percent and hours) shown on hover
+// over an AvailabilityRows bar. The row label only shows the availability
+// percent (the bar is the visual signal), so this is where the other two
+// segments' numbers live.
+function AvailabilityTooltip({ r, drainedLabel, faultLabel }: { r: NetworkHealthAvailability; drainedLabel: string; faultLabel: string }) {
+  const segs: Array<[string, string, number, number]> = [
+    [BAR.blue, 'Available', r.avail_pct, r.avail_hours],
+    [BAR.slate, drainedLabel, r.drained_pct, r.drained_hours],
+    [BAR.amber, faultLabel, r.outage_pct, r.outage_hours],
+  ]
+  return (
+    <div className="min-w-[170px]">
+      <div className="font-semibold text-foreground mb-1">{r.code}</div>
+      {segs.map(([color, label, pct, hours]) => (
+        <div key={label} className="flex items-center justify-between gap-4 tabular-nums">
+          <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: color }} />
+            {label}
+          </span>
+          <span>
+            {pct}% · {hours}h
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LinkAvailabilityPanel({ rows }: { rows: NetworkHealthAvailability[] }) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Least available links" info={DEFS.availabilityLink} />
+      <p className="text-xs text-muted-foreground mb-3">
+        Available / maintenance (drained) / down (fault) over the window, as a percent of time. Intentional
+        maintenance drain counts as unavailable but is not a fault. Least available first.
+      </p>
+      <AvailabilityLegend drainedLabel="Maintenance (drained)" faultLabel="Down (fault)" />
+      <AvailabilityRows rows={rows} drainedLabel="Maintenance (drained)" faultLabel="Down (fault)" kind="link" />
+    </section>
+  )
+}
+
+function DeviceAvailabilityPanel({ rows }: { rows: NetworkHealthAvailability[] }) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Least available devices" info={DEFS.availabilityDevice} />
+      <p className="text-xs text-muted-foreground mb-3">
+        Device reachability, the page's true-outage signal: a device is unreachable only when it has no working
+        path at all. Available when at least one link is working, unreachable when a fault leaves every link down,
+        maintenance when every link was intentionally drained with no fault. One link down while others work does
+        not lower the device. Ranked by unreachable time.
+      </p>
+      <AvailabilityLegend drainedLabel="Maintenance (all links drained)" faultLabel="Unreachable (fault)" />
+      <AvailabilityRows rows={rows} drainedLabel="Maintenance (all links drained)" faultLabel="Unreachable (fault)" kind="device" />
+    </section>
+  )
+}
+
+// Links and devices ranked by total fault-hours over the window, counted from
+// the 5-minute link rollups (full retention). Amber bars mark the down (fault)
+// dimension, matching the availability panels' fault color.
+function MostDowntimePanel({
+  links,
+  devices,
+}: {
+  links: NetworkHealthDowntimeRow[]
+  devices: NetworkHealthDowntimeRow[]
+}) {
+  const linkData = links.map((l) => ({ label: l.code, value: l.hours, sub: `${l.metros ?? ''} · ${l.outages} failures`, pk: l.pk, endLabel: `${l.hours.toLocaleString(undefined, { maximumFractionDigits: 1 })} h` }))
+  const deviceData = devices.map((d) => ({ label: d.code, value: d.hours, sub: `${d.metros ?? ''} · ${d.outages} failures`, pk: d.pk, endLabel: `${d.hours.toLocaleString(undefined, { maximumFractionDigits: 1 })} h` }))
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Most failure time" info={DEFS.mostDowntime} />
+      <p className="text-xs text-muted-foreground mb-3">
+        Total hours each link or device was actually down from a fault, biggest total first. This is a count of
+        hours, not a percentage of the window like "Least available" above. Maintenance is excluded, and only
+        faults lasting 10 or more minutes count.
+      </p>
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Links</h3>
+      <LinkBarChart rows={linkData} kind="link" unit=" h" color={BAR.amber} emptyLabel="No link failures in this window." />
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2 mt-6">Devices</h3>
+      <LinkBarChart
+        rows={deviceData}
+        kind="device"
+        unit=" h"
+        color={BAR.amber}
+        emptyLabel="No device failures in this window."
+      />
+    </section>
+  )
+}
+
+function TopLinksPanel({ rows }: { rows: NetworkHealthTrafficLink[] }) {
+  const data = rows.map((l) => ({
+    label: l.link_code,
+    value: l.avg_gbps,
+    sub: `${l.side_a_metro} ↔ ${l.side_z_metro} · peak ${l.max_gbps} G`,
+    pk: l.link_pk,
+    endLabel: `${l.avg_gbps.toLocaleString(undefined, { maximumFractionDigits: 2 })} / ${l.max_gbps.toLocaleString(undefined, { maximumFractionDigits: 2 })} G`,
+  }))
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Links carrying the most traffic" info={DEFS.topLinks} />
+      <p className="text-xs text-muted-foreground mb-3">Average Gbps over the window. Label shows avg / peak.</p>
+      <LinkBarChart rows={data} kind="link" unit=" G" labelWidth={124} />
+    </section>
+  )
+}
+
+function CapacityPanel({ rows }: { rows: NetworkHealthCapacityLink[] }) {
+  const data = rows.map((l) => ({
+    label: l.link_code,
+    a: l.p50_util,
+    b: l.p99_util,
+    c: l.util_pct,
+    sub: `${l.side_a_metro} ↔ ${l.side_z_metro} · ${l.peak_gbps}/${l.bandwidth_gbps} G`,
+    pk: l.link_pk,
+  }))
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Fullest links (capacity planning)" info={DEFS.capacityLinks} />
+      <p className="text-xs text-muted-foreground mb-3">
+        P50 (typical), P99, and peak utilization of provisioned bandwidth. Dashed line = 100%. Port-channel subinterface links are not measured yet.
+      </p>
+      <GroupedBarChart
+        rows={data}
+        kind="link"
+        unit="%"
+        refLine={100}
+        labels={['P50', 'P99', 'Peak']}
+        note="Peak is the combined both-directions 5-minute max; P50/P99 are the busier single direction, so Peak sits above P99."
+      />
+    </section>
+  )
+}
+
+// Segmented per-device meter: user slots in use (unicast, multicast sub,
+// multicast pub) vs the device's max_users cap.
+function DeviceSlotsPanel({ rows }: { rows: NetworkHealthDeviceSlots[] }) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Fullest devices (user slots)" info={DEFS.deviceSlots} />
+      <p className="text-xs text-muted-foreground mb-3">Used vs max_users.</p>
+      <ChartLegend items={[[BAR.blue, 'Unicast'], [BAR.amber, 'Multicast subscriber'], [BAR.slate, 'Multicast publisher']]} />
+      <div className="space-y-2">
+        {rows.map((d) => {
+          const denom = d.max_users || 1
+          const seg = (n: number) => `${(100 * n / denom).toFixed(1)}%`
+          const used = d.unicast + d.mcast_sub + d.mcast_pub
+          return (
+            <div
+              key={d.pk}
+              className="grid grid-cols-[130px_1fr_128px] items-center gap-3 text-xs"
+            >
+              <DeviceLink pk={d.pk} className="truncate text-muted-foreground">{d.code}</DeviceLink>
+              <div
+                className="relative h-3 rounded-sm bg-muted/30 overflow-hidden"
+                title={`Unicast ${d.unicast}, Multicast subscriber ${d.mcast_sub}, Multicast publisher ${d.mcast_pub}. ${used} of ${d.max_users} max.`}
+              >
+                <div className="absolute inset-y-0" style={{ left: 0, width: seg(d.unicast), background: BAR.blue }} title={`Unicast ${d.unicast}`} />
+                <div className="absolute inset-y-0" style={{ left: seg(d.unicast), width: seg(d.mcast_sub), background: BAR.amber }} title={`Multicast subscriber ${d.mcast_sub}`} />
+                <div
+                  className="absolute inset-y-0"
+                  style={{ left: `calc(${seg(d.unicast)} + ${seg(d.mcast_sub)})`, width: seg(d.mcast_pub), background: BAR.slate }}
+                  title={`Multicast publisher ${d.mcast_pub}`}
+                />
+              </div>
+              <span className="text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                <span style={{ color: BAR.blue }}>{d.unicast}</span>
+                {' / '}
+                <span style={{ color: BAR.amber }}>{d.mcast_sub}</span>
+                {' / '}
+                <span style={{ color: BAR.slate }}>{d.mcast_pub}</span>
+                {' of '}
+                {d.max_users}
+              </span>
+            </div>
+          )
+        })}
+        {rows.length === 0 && <p className="text-xs text-muted-foreground">No devices in this window.</p>}
+      </div>
+    </section>
+  )
+}
+
+// Direct Internet Access interfaces: P50/P99 outbound utilization as a percent
+// of provisioned capacity (CIR when set, else port speed), so headroom is
+// obvious without having to hold an unknown committed rate in your head.
+// Fullest first (by P99 utilization). The absolute Gbps and which capacity
+// figure applied still surface in the row sub / hover tooltip.
+function DiaPanel({ rows }: { rows: NetworkHealthDiaInterface[] }) {
+  const data = rows
+    .map((d) => {
+      const denomGbps = d.port_gbps
+      const p50Util = denomGbps > 0 ? (d.p50_gbps / denomGbps) * 100 : 0
+      const p99Util = d.util_pct ?? 0
+      const cirNote = d.cir_gbps > 0 ? ` · CIR ${d.cir_gbps} G` : ''
+      return {
+        label: `${d.device} ${d.intf}`,
+        a: p50Util,
+        b: p99Util,
+        sub: `P99 ${d.p99_gbps.toFixed(1)} G of ${denomGbps.toFixed(1)} G port speed${cirNote}`,
+        pk: d.device_pk,
+      }
+    })
+    .sort((x, y) => y.b - x.b)
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="DIA interfaces (capacity vs bandwidth)" info={DEFS.dia} />
+      <p className="text-xs text-muted-foreground mb-3">
+        P50 (typical) vs P99 (peak) outbound utilization, as a share of interface bandwidth (port speed).
+        Dashed line = 100%. The committed rate (CIR) is shown alongside for reference. Port speed is a
+        snapshot refreshed roughly monthly, so a recently changed interface may lag.
+      </p>
+      <GroupedBarChart rows={data} kind="device" unit="%" refLine={100} />
+    </section>
+  )
+}
+
+function PerfLinksPanel({ rows }: { rows: NetworkHealthPerfLink[] }) {
+  const [sort, setSort] = useState<Sort>({ key: 'drift_ms', dir: 'desc' })
+  const sorted = useMemo(() => sortRows(rows, sort), [rows, sort])
+  const paged = usePaged(sorted)
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Committed vs measured latency" info={DEFS.perfLinks} />
+      <p className="text-xs text-muted-foreground mb-4">
+        Links with an onchain committed round-trip time, compared to what was measured this window.
+        Plain measurements, sortable, no pass/fail. A committed value tagged "override" reflects an active
+        IS-IS delay override rather than the raw onchain commitment.
+      </p>
+      <Table className="[&_th]:h-8 [&_th]:px-2 [&_td]:px-2 [&_td]:py-1 [&_th]:whitespace-nowrap [&_td]:whitespace-nowrap">
+        <TableHeader>
+          <TableRow>
+            <SortableHead label="Link" sortKey="link_code" sort={sort} setSort={setSort} />
+            <TableHead>Metros</TableHead>
+            <SortableHead label="Committed (ms)" sortKey="committed_ms" sort={sort} setSort={setSort} align="right" info={DEFS.linkCommitted} />
+            <SortableHead label="Measured avg (ms)" sortKey="measured_avg_ms" sort={sort} setSort={setSort} align="right" info={DEFS.linkMeasured} />
+            <SortableHead label="Measured max (ms)" sortKey="measured_max_ms" sort={sort} setSort={setSort} align="right" info={DEFS.linkMeasured} />
+            <SortableHead label="Over committed %" sortKey="over_committed_pct" sort={sort} setSort={setSort} align="right" info={DEFS.linkOverCommitted} />
+            <SortableHead label="Drift (ms)" sortKey="drift_ms" sort={sort} setSort={setSort} align="right" info={DEFS.linkDrift} />
+            <SortableHead label="Drift (%)" sortKey="drift_pct" sort={sort} setSort={setSort} align="right" info={DEFS.linkDrift} />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {paged.pageRows.map((l) => {
+            const driftClass = l.drift_ms > 0 ? 'text-amber-500' : 'text-muted-foreground'
+            return (
+              <TableRow key={l.link_pk}>
+                <TableCell className="font-medium"><LinkLink pk={l.link_pk} className="block max-w-[240px] truncate" title={l.link_code}>{l.link_code}</LinkLink></TableCell>
+                <TableCell className="text-muted-foreground">
+                  {l.side_a_metro} ↔ {l.side_z_metro}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  <span className="inline-flex items-center justify-end gap-1.5">
+                    {l.overridden && l.raw_committed_ms != null && (
+                      <span
+                        className="rounded bg-muted px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+                        title={`IS-IS delay override in effect. Onchain committed ${l.raw_committed_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })} ms, overridden to ${l.committed_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })} ms (the value the network routes on). Committed, over-committed %, and drift use the override.`}
+                      >
+                        override
+                      </span>
+                    )}
+                    {l.committed_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{l.measured_avg_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })}</TableCell>
+                <TableCell className="text-right tabular-nums">{l.measured_max_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })}</TableCell>
+                <TableCell className="text-right tabular-nums text-muted-foreground">{l.over_committed_pct}%</TableCell>
+                <TableCell className={`text-right tabular-nums ${driftClass}`}>{l.drift_ms.toLocaleString(undefined, { maximumFractionDigits: 2 })}</TableCell>
+                <TableCell className={`text-right tabular-nums ${driftClass}`}>{l.drift_pct}%</TableCell>
+              </TableRow>
+            )
+          })}
+          {sorted.length === 0 && (
+            <TableRow>
+              <TableCell className="text-muted-foreground text-sm" colSpan={8}>
+                No links with a committed RTT in this window.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <PageControls {...paged} />
+    </section>
+  )
+}
+
+function HotspotsPanel({ rows }: { rows: NetworkHealthErrorHotspot[] }) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <SectionTitle title="Interface errors & carrier flaps" info={DEFS.hotspots} />
+      <p className="text-xs text-muted-foreground mb-3">
+        Physical-layer noise on device interfaces, not logged failures. A leading signal that can show up before a
+        failure does.
+      </p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Device</TableHead>
+            <TableHead className="text-right">Errors + discards</TableHead>
+            <TableHead className="text-right">Carrier transitions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((d) => (
+            <TableRow key={d.device_pk}>
+              <TableCell className="font-medium"><DeviceLink pk={d.device_pk}>{d.device_code || d.device_pk.slice(0, 8)}</DeviceLink></TableCell>
+              <TableCell className="text-right tabular-nums">{d.errors.toLocaleString()}</TableCell>
+              <TableCell className="text-right tabular-nums">{d.carrier_flaps.toLocaleString()}</TableCell>
+            </TableRow>
+          ))}
+          {rows.length === 0 && (
+            <TableRow>
+              <TableCell className="text-muted-foreground text-sm" colSpan={3}>
+                No interface errors or carrier flaps in this window.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}
+
+const AXIS_TICK = { fontSize: 11, fill: 'var(--muted-foreground)' }
+
+// A Recharts YAxis category tick that renders the entity label as SVG text and,
+// when the row carries a pk, links out to the entity detail page on click.
+// Recharts injects x, y and payload (payload.value = the label, payload.index =
+// the row index in data order), so we map the tick back to its row's pk. Rows
+// without a pk render as plain, non-interactive text. This replaces the old
+// under-chart ChartLinkList: the bar's own label is now the link.
+function useEntityAxisTick(rows: { pk?: string }[], kind: 'link' | 'device') {
+  const navigate = useNavigate()
+  const base = kind === 'link' ? '/dz/links/' : '/dz/devices/'
+  return function EntityAxisTick(props: { x?: number; y?: number; payload?: { value?: string | number; index?: number } }) {
+    const { x = 0, y = 0, payload } = props
+    const label = String(payload?.value ?? '')
+    const pk = payload?.index != null ? rows[payload.index]?.pk : undefined
+    const attrs = { x, y, dy: 4, textAnchor: 'end' as const, fontSize: 11 }
+    if (!pk) return <text {...attrs} fill="var(--muted-foreground)">{label}</text>
+    return (
+      <text
+        {...attrs}
+        fill="var(--muted-foreground)"
+        className="cursor-pointer hover:underline hover:fill-[var(--foreground)]"
+        onClick={() => navigate(base + pk)}
+      >
+        {label}
+      </text>
+    )
+  }
+}
+
+function ChartFrame({ children, empty, height = 200 }: { children: React.ReactElement; empty: boolean; height?: number }) {
+  if (empty) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
+        No data in this window.
+      </div>
+    )
+  }
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      {children}
+    </ResponsiveContainer>
+  )
+}
+
+function makeChartTip(unit?: string) {
+  return (raw: unknown) => {
+    const { active, payload, label } = (raw ?? {}) as {
+      active?: boolean
+      payload?: Array<{ name?: string; value?: number; color?: string }>
+      label?: string | number
+    }
+    if (!active || !payload?.length) return null
+    return (
+      <div className="bg-card border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+        <div className="text-muted-foreground mb-1">{fmtT(String(label))}</div>
+        {payload.map((p, i) => (
+          <div key={i} className="font-medium" style={{ color: p.color }}>
+            {typeof p.value === 'number' ? p.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) : p.value}
+            {unit ? ` ${unit}` : ''}
+            {p.name ? ` ${p.name}` : ''}
+          </div>
+        ))}
+      </div>
+    )
+  }
+}
+
+function fmtT(t: string): string {
+  const d = new Date(t)
+  if (isNaN(d.getTime())) return t
+  return `${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')} ${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+}
+
+
+
+
+// --- Small building blocks ---
+
+// Top filter bar: scope selector (whole network / a contributor) + time-range
+// presets + a two-click calendar range picker. Reads scope from the URL and
+// re-scopes every panel through useScopeNav; the range flows through onRange
+// (same contract as the old TimeRangeControl).
+function NetworkHealthFilterBar({
+  days,
+  start,
+  end,
+  onRange,
+}: {
+  days: number
+  start: string
+  end: string
+  onRange: (next: { days?: number; start?: string; end?: string }) => void
+}) {
+  const [params] = useSearchParams()
+  const { openContributor, toNetwork } = useScopeNav()
+  const [scopeOpen, setScopeOpen] = useState(false)
+  const [calOpen, setCalOpen] = useState(false)
+
+  const scopeContributor = params.get('contributor') ?? ''
+  const scopeActive = !!scopeContributor
+  const scopeLabel = scopeContributor ? `Contributor: ${scopeContributor}` : 'Whole network'
+
+  // Contributor list for the scope dropdown. Only fetched on the network view,
+  // where it shares NetworkView's cached query (no extra request). On scoped
+  // views the fetch is skipped and the menu just offers "Whole network".
+  const range: NetworkHealthParams = start && end ? { start, end } : { days }
+  const { data: net } = useQuery({
+    queryKey: ['nh', 'overview', range, ''],
+    queryFn: () => fetchNHOverview(range, ''),
+    staleTime: 60_000,
+    placeholderData: keepPreviousData,
+    enabled: !scopeActive,
+  })
+  const contributors = (net?.contributors ?? []).map((c) => c.code)
+
+  const lastMonth = getLastMonth()
+  const isCustom = !!(start && end)
+  const isLastMonth = isCustom && start === lastMonth.start && end === lastMonth.end
+  const active = isLastMonth ? 'month' : isCustom ? 'custom' : days === 7 ? '7d' : '30d'
+
+  const chip = (key: string, label: string, onClick: () => void) => (
+    <button
+      key={key}
+      onClick={onClick}
+      className={`px-3 py-1 text-sm ${active === key ? 'bg-muted font-medium' : 'text-muted-foreground hover:bg-muted/50'}`}
+    >
+      {label}
+    </button>
+  )
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="relative">
+        <button
+          onClick={() => {
+            if (scopeActive) {
+              toNetwork()
+              return
+            }
+            setScopeOpen((o) => !o)
+            setCalOpen(false)
+          }}
+          className="inline-flex items-center gap-1 rounded-md border border-border px-3 py-1 text-sm hover:bg-muted/50"
+        >
+          {scopeActive && <ArrowLeft className="h-3.5 w-3.5" />}
+          {scopeActive ? 'Whole network' : scopeLabel}
+          {!scopeActive && <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />}
+        </button>
+        {scopeOpen && !scopeActive && (
+          <>
+            <div className="fixed inset-0 z-10" onClick={() => setScopeOpen(false)} />
+            <div className="absolute left-0 z-20 mt-1 max-h-72 w-56 overflow-auto rounded-md border border-border bg-card py-1 text-sm shadow-xl">
+              <button
+                className={`block w-full px-3 py-1.5 text-left hover:bg-muted ${!scopeActive ? 'bg-muted font-medium' : ''}`}
+                onClick={() => {
+                  setScopeOpen(false)
+                  toNetwork()
+                }}
+              >
+                Whole network
+              </button>
+              {contributors.length > 0 && (
+                <div className="px-3 py-1 text-xs text-muted-foreground">Contributors</div>
+              )}
+              {contributors.map((c) => (
+                <button
+                  key={c}
+                  className={`block w-full px-3 py-1.5 text-left hover:bg-muted ${c === scopeContributor ? 'bg-muted font-medium' : ''}`}
+                  onClick={() => {
+                    setScopeOpen(false)
+                    openContributor(c)
+                  }}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="relative">
+        <div className="inline-flex overflow-hidden rounded-md border border-border">
+          {chip('7d', '7d', () => {
+            setCalOpen(false)
+            onRange({ days: 7 })
+          })}
+          {chip('30d', '30d', () => {
+            setCalOpen(false)
+            onRange({ days: 30 })
+          })}
+          {chip('month', 'Last month', () => {
+            setCalOpen(false)
+            onRange(lastMonth)
+          })}
+          {chip('custom', 'Custom', () => {
+            setCalOpen((o) => !o)
+            setScopeOpen(false)
+          })}
+        </div>
+        {calOpen && (
+          <>
+            <div className="fixed inset-0 z-10" onClick={() => setCalOpen(false)} />
+            <div className="absolute right-0 z-20 mt-1">
+              <RangeCalendar
+                startStr={start}
+                endStr={end}
+                onApply={(s, e) => {
+                  setCalOpen(false)
+                  onRange({ start: s, end: e })
+                }}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Two-click date-range picker: first click sets the start, second sets the end
+// (swapping if earlier), Apply emits YYYY-MM-DD strings. Built on the existing
+// maintenance-calendar date helpers so no date library is added.
+function RangeCalendar({
+  startStr,
+  endStr,
+  onApply,
+}: {
+  startStr: string
+  endStr: string
+  onApply: (start: string, end: string) => void
+}) {
+  const [from, setFrom] = useState<Date | null>(parseISODate(startStr))
+  const [to, setTo] = useState<Date | null>(parseISODate(endStr))
+  const [anchor, setAnchor] = useState<Date>(parseISODate(startStr) ?? startOfDay(new Date()))
+
+  const monthDays = getDays('month', anchor)
+  const lead = (monthDays[0].getDay() + 6) % 7 // Monday-first leading blanks
+  const canApply = !!(from && to && from < to)
+
+  const clickDay = (d: Date) => {
+    if (!from || (from && to)) {
+      setFrom(d)
+      setTo(null)
+    } else if (d < from) {
+      setTo(from)
+      setFrom(d)
+    } else {
+      setTo(d)
+    }
+  }
+
+  return (
+    <div className="w-64 rounded-md border border-border bg-card p-3 shadow-xl">
+      <div className="mb-2 flex items-center justify-between">
+        <button
+          className="rounded px-2 py-1 text-muted-foreground hover:bg-muted"
+          onClick={() => setAnchor(new Date(anchor.getFullYear(), anchor.getMonth() - 1, 1))}
+        >
+          ‹
+        </button>
+        <div className="text-sm font-medium">{formatDateRange('month', anchor, monthDays)}</div>
+        <button
+          className="rounded px-2 py-1 text-muted-foreground hover:bg-muted"
+          onClick={() => setAnchor(new Date(anchor.getFullYear(), anchor.getMonth() + 1, 1))}
+        >
+          ›
+        </button>
+      </div>
+      <div className="mb-1 grid grid-cols-7 gap-0.5 text-center text-[10px] text-muted-foreground">
+        {['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'].map((d) => (
+          <div key={d}>{d}</div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-0.5">
+        {Array.from({ length: lead }).map((_, i) => (
+          <div key={`b${i}`} />
+        ))}
+        {monthDays.map((d) => {
+          const endpoint = (from && isSameDay(d, from)) || (to && isSameDay(d, to))
+          const within = from && to && d > from && d < to
+          return (
+            <button
+              key={d.getTime()}
+              onClick={() => clickDay(d)}
+              className={`flex h-8 items-center justify-center rounded text-sm ${
+                endpoint ? 'bg-primary text-primary-foreground' : within ? 'bg-muted' : 'hover:bg-muted'
+              }`}
+            >
+              {d.getDate()}
+            </button>
+          )
+        })}
+      </div>
+      <div className="mt-3 flex items-center justify-between text-xs">
+        <span className="text-muted-foreground tabular-nums">
+          {from ? formatISODate(from) : '—'} → {to ? formatISODate(to) : '—'}
+        </span>
+        <button
+          disabled={!canApply}
+          onClick={() => {
+            if (from && to) onApply(formatISODate(from), formatISODate(to))
+          }}
+          className="rounded-md bg-primary px-3 py-1 text-primary-foreground disabled:opacity-40"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// A top-level section band that groups panels (General / Performance / Capacity /
+// Operations). Neutral, factual heading; no judgment.
+function SectionBand({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mt-4 mb-3 border-b border-border pb-1.5">
+      <h2 className="text-base font-semibold">{title}</h2>
+      {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+    </div>
+  )
+}
+
+function SectionTitle({ title, info }: { title: string; info?: string }) {
+  return (
+    <h2 className="text-sm font-medium mb-1 inline-flex items-center gap-1">
+      {title}
+      {info && <InfoTip text={info} />}
+    </h2>
+  )
+}
+
+function InfoTip({ text }: { text: string }) {
+  return (
+    <Tooltip content={text}>
+      <span className="cursor-help text-muted-foreground/50 hover:text-foreground inline-flex align-middle">
+        <Info className="h-3.5 w-3.5" />
+      </span>
+    </Tooltip>
+  )
+}
+
+// A compact stat tile. Value is a pre-formatted string. Optional tone grades the
+// value (green/amber/red), matching StatCard's tone. Optional delta shows the
+// change versus the prior window next to the value, colored by goodDirection and
+// formatted as a percent change ('pct') or percentage points ('pp') for rate
+// metrics. No delta renders when it is undefined or exactly zero.
+function MiniStat({
+  label,
+  value,
+  info,
+  tone,
+  delta,
+  goodDirection = 'neutral',
+  deltaUnit = 'pct',
+  muted = false,
+}: {
+  label: string
+  value: string
+  info?: string
+  tone?: 'good' | 'warn' | 'bad'
+  delta?: number
+  goodDirection?: 'up' | 'down' | 'neutral'
+  deltaUnit?: 'pct' | 'pp'
+  muted?: boolean
+}) {
+  const showDelta = delta !== undefined && delta !== 0
+  return (
+    <div className="rounded-md bg-muted/50 p-3">
+      <div className="text-xl font-medium tabular-nums inline-flex items-baseline gap-2">
+        <span className={muted ? 'text-sm font-normal text-muted-foreground' : tone ? toneColorClass(tone) : ''}>{value}</span>
+        {showDelta && (
+          <span className={`text-xs font-normal ${deltaColorClass(delta, goodDirection)}`}>
+            {formatDelta(delta, deltaUnit)}
+          </span>
+        )}
+      </div>
+      <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
+        {label}
+        {info && <InfoTip text={info} />}
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value, info }: { label: string; value: string; info?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-foreground font-medium tabular-nums">{value}</span> {label}
+      {info && <InfoTip text={info} />}
+    </span>
+  )
+}
+
+function SortableHead({
+  label,
+  sortKey,
+  sort,
+  setSort,
+  align = 'left',
+  info,
+}: {
+  label: string
+  sortKey: string
+  sort: Sort
+  setSort: (s: Sort) => void
+  align?: 'left' | 'right'
+  info?: string
+}) {
+  const active = sort.key === sortKey
+  const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : ''
+  return (
+    <TableHead className={align === 'right' ? 'text-right' : ''}>
+      <span className="inline-flex items-center gap-1">
+        {align === 'right' && info && <InfoTip text={info} />}
+        <button
+          className="hover:text-foreground transition-colors"
+          onClick={() => setSort({ key: sortKey, dir: active && sort.dir === 'asc' ? 'desc' : 'asc' })}
+        >
+          {label}
+          {arrow}
+        </button>
+        {align !== 'right' && info && <InfoTip text={info} />}
+      </span>
+    </TableHead>
+  )
+}
+
+const PAGE_SIZE = 10
+
+// Client-side pagination for a list table. Page 1 is the top of the (already
+// sorted) list, so it doubles as a "top 10" view; Prev/Next reach the rest.
+function usePaged<T>(rows: T[], pageSize = PAGE_SIZE) {
+  const [page, setPage] = useState(0)
+  useEffect(() => setPage(0), [rows])
+  const total = rows.length
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const clamped = Math.min(page, totalPages - 1)
+  const pageRows = rows.slice(clamped * pageSize, clamped * pageSize + pageSize)
+  return { page: clamped, setPage, pageRows, total, totalPages, pageSize }
+}
+
+function PageControls({
+  page,
+  setPage,
+  total,
+  totalPages,
+  pageSize,
+}: {
+  page: number
+  setPage: (n: number) => void
+  total: number
+  totalPages: number
+  pageSize: number
+}) {
+  if (total <= pageSize) return null
+  const from = page * pageSize + 1
+  const to = Math.min((page + 1) * pageSize, total)
+  return (
+    <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+      <span className="tabular-nums">
+        {from}–{to} of {total}
+      </span>
+      <div className="inline-flex items-center gap-1">
+        <button
+          disabled={page === 0}
+          onClick={() => setPage(page - 1)}
+          className="rounded border border-border px-2 py-0.5 hover:bg-muted disabled:opacity-40"
+        >
+          Prev
+        </button>
+        <span className="px-1 tabular-nums">
+          {page + 1}/{totalPages}
+        </span>
+        <button
+          disabled={page >= totalPages - 1}
+          onClick={() => setPage(page + 1)}
+          className="rounded border border-border px-2 py-0.5 hover:bg-muted disabled:opacity-40"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Scroll({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-8">{children}</div>
+    </div>
+  )
+}
+
+function Footer({ window, generatedAt }: { window: { start: string; end: string }; generatedAt: string }) {
+  return (
+    <p className="text-xs text-muted-foreground mt-8">
+      {window.start} to {window.end} UTC · generated {generatedAt}.
+    </p>
+  )
+}
+
+// --- helpers ---
+
+function deltaOrUndef(deltas: NetworkHealthDeltas | undefined, key: keyof NetworkHealthDeltas): number | undefined {
+  const v = deltas?.[key]
+  return v === null || v === undefined ? undefined : v
+}
+
+// Percent change of a current value versus its prior-window value, for a "vs
+// prior" delta on a count/duration metric. Mirrors the server pctDelta guards:
+// returns undefined when the prior is missing OR zero, so we never divide by
+// zero or show a delta against a period with no baseline.
+function pctChange(cur: number | null | undefined, prior: number | null | undefined): number | undefined {
+  if (cur == null || prior == null || prior === 0) return undefined
+  return ((cur - prior) / prior) * 100
+}
+
+// Percentage-POINT delta (cur - prior) for rate metrics that are themselves
+// percentages (self-reported share, drained-within-30m), where a percent change
+// of a percent would be misleading. Undefined when either side is missing.
+function ppDelta(cur: number | null | undefined, prior: number | null | undefined): number | undefined {
+  if (cur == null || prior == null) return undefined
+  return cur - prior
+}
+
+function minutes(v: number | null | undefined): string {
+  if (v == null) return '—'
+  if (v >= 120) return `${(v / 60).toFixed(1)} h`
+  return `${v} min`
+}
+
+// Undrain timing label that always states a reason instead of a bare dash:
+// "unavailable" when the recovery signal could not be read, "no undrains" when
+// nothing was returned to service, "no matched undrains" when undrains happened
+// but none paired with a recovered link, otherwise the minutes value.
+// Undrain-availability comes from the deferred query, but the undrains count is
+// already known from the main drain-timing payload, so it is passed in.
+function deferredUndrainValue(undrains: number, d: NetworkHealthDeferred, v: number | null | undefined): string {
+  if (d.undrain_unavailable) return 'unavailable'
+  if (undrains === 0) return 'no undrains'
+  if (d.matched_undrains === 0) return 'no matched undrains'
+  return minutes(v)
+}
+
+// Ops-management "median time to file" is server-rounded to whole minutes, so
+// a near-instant ticket rounds down to 0 and a bare "0 min" reads as broken
+// data rather than "filed almost immediately". Show "<1 min" instead of "0 min".
+function timeToFileLabel(v: number | null | undefined): string {
+  if (v == null) return '—'
+  if (v === 0) return '<1 min'
+  return minutes(v)
+}
+
+function getLastMonth(): { start: string; end: string } {
+  const now = new Date()
+  const firstThis = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+  const firstPrev = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+  return { start: firstPrev.toISOString().slice(0, 10), end: firstThis.toISOString().slice(0, 10) }
+}
+
+function sortRows<T>(rows: T[], sort: Sort): T[] {
+  return [...rows].sort((a, b) => {
+    const av = (a as Record<string, unknown>)[sort.key]
+    const bv = (b as Record<string, unknown>)[sort.key]
+    let c: number
+    if (typeof av === 'string' || typeof bv === 'string') {
+      c = String(av).localeCompare(String(bv))
+    } else {
+      c = (av as number) - (bv as number)
+    }
+    return sort.dir === 'asc' ? c : -c
+  })
+}

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -72,6 +72,7 @@ const { resolvedTheme, setTheme } = useTheme()
   const isOpsIncidentsLinksRoute = location.pathname === '/ops/incidents/links'
   const isOpsIncidentsDevicesRoute = location.pathname === '/ops/incidents/devices'
   const isOpsMaintenanceRoute = location.pathname === '/ops/maintenance'
+  const isNetworkHealthReportingRoute = location.pathname === '/ops/network-health-reporting'
   const isChatRoute = location.pathname.startsWith('/chat')
   const isChatSessions = location.pathname === '/chat/sessions'
   const isTopologyRoute = location.pathname === '/topology' || location.pathname.startsWith('/topology/')
@@ -548,6 +549,13 @@ const { resolvedTheme, setTheme } = useTheme()
             <Link to="/ops/maintenance" className={navItemClass(isOpsMaintenanceRoute)}>
               <CalendarClock className="h-4 w-4" />
               Maintenance
+            </Link>
+            <Link
+              to="/ops/network-health-reporting"
+              className={navItemClass(isNetworkHealthReportingRoute)}
+            >
+              <BarChart3 className="h-4 w-4" />
+              Network Health Reporting
             </Link>
           </div>
         </div>

--- a/web/src/components/stat-card-utils.ts
+++ b/web/src/components/stat-card-utils.ts
@@ -1,0 +1,31 @@
+// Formatting and color helpers shared by StatCard and plain-text stats (MiniStat).
+// Kept in a non-component module so the component files stay fast-refresh clean
+// (a file may not export both a component and plain helpers).
+
+// Color for a delta given the metric's good direction. Green marks movement in
+// the good direction, red the bad direction; a neutral metric stays muted.
+export function deltaColorClass(delta: number, goodDirection: 'up' | 'down' | 'neutral'): string {
+  if (goodDirection === 'neutral') return 'text-muted-foreground'
+  const good = goodDirection === 'up' ? delta > 0 : delta < 0
+  return good ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+}
+
+// Color for a graded value (tone). Kept separate from deltaColorClass so the
+// value grade and the delta arrow can be colored independently.
+export function toneColorClass(tone: 'good' | 'warn' | 'bad'): string {
+  switch (tone) {
+    case 'good':
+      return 'text-green-600 dark:text-green-400'
+    case 'warn':
+      return 'text-amber-600 dark:text-amber-400'
+    case 'bad':
+      return 'text-red-600 dark:text-red-400'
+  }
+}
+
+// Format a delta with a leading sign, as a percent or percentage points.
+export function formatDelta(delta: number, unit: 'pct' | 'pp' = 'pct'): string {
+  const sign = delta >= 0 ? '+' : ''
+  if (unit === 'pp') return `${sign}${delta.toFixed(1)} pp`
+  return `${sign}${delta.toFixed(2)}%`
+}

--- a/web/src/components/stat-card.tsx
+++ b/web/src/components/stat-card.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { Info } from 'lucide-react'
+import { Tooltip } from '@/components/ui/tooltip'
+import { deltaColorClass, toneColorClass, formatDelta } from './stat-card-utils'
 
 interface StatCardPeer {
   label: string
@@ -13,9 +16,20 @@ interface StatCardProps {
   format: 'number' | 'stake' | 'bandwidth' | 'percent'
   decimals?: number // Override default decimal places for the format
   delta?: number // Optional delta value to show change (percentage points for percent format)
+  // Which delta direction is "good" for this metric, so the delta color reads
+  // correctly. 'up' (default): a rise is green (e.g. throughput). 'down': a
+  // fall is green (e.g. outages). 'neutral': no good direction, delta stays
+  // muted (e.g. active links).
+  goodDirection?: 'up' | 'down' | 'neutral'
+  // Optional grade on the value itself: good=green, warn=amber, bad=red. Used
+  // for a metric that is a genuine self-fact grade on the entity's own view
+  // (e.g. a contributor's share of self-reported incidents), never a
+  // cross-entity ranking.
+  tone?: 'good' | 'warn' | 'bad'
   max?: number // Optional maximum to display as "value / max"
   href?: string // Optional link to entity listing page
   peer?: StatCardPeer // Optional second stat shown side-by-side in the same card
+  info?: string // Optional explanation shown in a hover tooltip next to the label
 }
 
 function useAnimatedNumber(target: number | undefined, duration = 500) {
@@ -91,19 +105,21 @@ function formatValue(
   }
 }
 
-function formatDelta(delta: number): string {
-  const sign = delta >= 0 ? '+' : ''
-  return `${sign}${delta.toFixed(2)}%`
-}
-
+// Render a delta with its sign. 'pct' (default) is a percent-change of the value
+// versus the prior window ("+3.20%"); 'pp' is a percentage-POINT change for rate
+// metrics that are themselves percentages ("+3.2 pp"), so the two are not
+// confused. Exported for MiniStat, which reuses the same formatting.
 function StatCardContent({
   label,
   value,
   format,
   decimals,
   delta,
+  goodDirection = 'up',
+  tone,
   max,
-}: Pick<StatCardProps, 'label' | 'value' | 'format' | 'decimals' | 'delta' | 'max'>) {
+  info,
+}: Pick<StatCardProps, 'label' | 'value' | 'format' | 'decimals' | 'delta' | 'goodDirection' | 'tone' | 'max' | 'info'>) {
   const animatedValue = useAnimatedNumber(value)
   const isLoading = value === undefined
   const [showSkeleton, setShowSkeleton] = useState(false)
@@ -130,38 +146,45 @@ function StatCardContent({
           )
         ) : (
           <span className="inline-flex items-baseline gap-2">
-            <span className="tabular-nums">
+            <span className={`tabular-nums ${tone ? toneColorClass(tone) : ''}`}>
               {formatValue(animatedValue, format, decimals)}
               {max !== undefined && (
                 <span className="text-muted-foreground">/{formatValue(max, format, decimals)}</span>
               )}
             </span>
             {showDelta && (
-              <span
-                className={`text-sm font-normal ${delta > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
-              >
+              <span className={`text-sm font-normal ${deltaColorClass(delta, goodDirection)}`}>
                 {formatDelta(delta)}
               </span>
             )}
           </span>
         )}
       </div>
-      <div className="text-sm text-muted-foreground">{label}</div>
+      <div className="text-sm text-muted-foreground inline-flex items-center gap-1">
+        {label}
+        {info && (
+          <Tooltip content={info}>
+            <span className="cursor-help text-muted-foreground/60 hover:text-foreground">
+              <Info className="h-3 w-3" />
+            </span>
+          </Tooltip>
+        )}
+      </div>
     </>
   )
 }
 
-export function StatCard({ label, value, format, decimals, delta, max, href, peer }: StatCardProps) {
+export function StatCard({ label, value, format, decimals, delta, goodDirection, tone, max, href, peer, info }: StatCardProps) {
   if (peer) {
     return (
       <div className="rounded-[0.3rem] bg-muted/50 p-2 lg:p-4 flex items-stretch divide-x divide-border">
         <div className="flex-1 text-center pr-2 lg:pr-4">
           {href ? (
             <Link to={href} className="block hover:text-foreground transition-colors">
-              <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} max={max} />
+              <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} goodDirection={goodDirection} tone={tone} max={max} info={info} />
             </Link>
           ) : (
-            <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} max={max} />
+            <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} goodDirection={goodDirection} tone={tone} max={max} info={info} />
           )}
         </div>
         <div className="flex-1 text-center pl-2 lg:pl-4">
@@ -178,7 +201,7 @@ export function StatCard({ label, value, format, decimals, delta, max, href, pee
   }
 
   const content = (
-    <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} max={max} />
+    <StatCardContent label={label} value={value} format={format} decimals={decimals} delta={delta} goodDirection={goodDirection} tone={tone} max={max} info={info} />
   )
 
   if (href) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1356,6 +1356,468 @@ export async function fetchStatus(): Promise<StatusResponse> {
   return res.json()
 }
 
+// --- Network Health Reporting ---
+// A public, windowed report of how the network performed. Facts only: the UI
+// presents these numbers neutrally and never ranks or grades contributors.
+
+export interface NetworkHealthDeltas {
+  peak_bps: number | null
+  outage_count: number | null
+  active_links: number | null
+  // Percent change of impactful downtime hours vs the prior window. Optional so
+  // the frontend type-checks even if the backend field lands slightly later.
+  impactful_downtime?: number | null
+}
+
+export interface NetworkHealthHeadline {
+  peak_bps: number
+  jitter_improve_pct: number
+  dz_loss_pct: number
+  outage_count: number
+  impactful_downtime_hours: number
+  active_links: number
+  active_devices: number
+  active_metros: number
+  deltas: NetworkHealthDeltas
+}
+
+export interface NetworkHealthDrainTiming {
+  outage_count: number
+  events_with_drain: number
+  drains: number
+  undrains: number
+  time_to_drain_p50_min: number | null
+  time_to_drain_max_min: number | null
+  time_drained_p50_min: number | null
+  time_drained_max_min: number | null
+  time_to_undrain_p50_min: number | null
+  time_to_undrain_max_min: number | null
+  drain_within_30m_pct: number | null
+  // Undrains that matched a recovered link (a healthy link returned to service).
+  // The undrain timing stats are computed only over these matched pairs.
+  matched_undrains: number
+  // True when the recovery-health signal the undrain stats depend on could not
+  // be fetched this window, so undrain timing is unavailable rather than zero.
+  undrain_unavailable?: boolean
+}
+
+export interface NetworkHealthDurationHistogram {
+  flap_le5m: number
+  short_5_15m: number
+  medium_15_60m: number
+  sustained_1_24h: number
+  chronic_gt24h: number
+}
+
+export interface NetworkHealthReliability {
+  outage_count: number
+  distinct_links: number
+  capped_downtime_hours: number
+  degraded_links: number
+  duration_histogram: NetworkHealthDurationHistogram
+}
+
+export interface NetworkHealthContributor {
+  code: string
+  outages: number
+  capped_downtime_hours: number
+  distinct_links: number
+  links: number
+  devices: number
+}
+
+export interface NetworkHealthWindow {
+  start: string
+  end: string
+  days: number
+  label: string
+}
+
+export interface NetworkHealthSla {
+  within: number
+  total: number
+  within_pct: number | null
+}
+
+export interface NetworkHealthCapacity {
+  unicast_users: number
+  max_users: number
+  util_pct: number | null
+}
+
+export interface NetworkHealthDeviceSlots {
+  pk: string
+  code: string
+  unicast: number
+  mcast_sub: number
+  mcast_pub: number
+  max_users: number
+  used_pct: number | null
+}
+
+export interface NetworkHealthDiaInterface {
+  device_pk: string
+  device: string
+  intf: string
+  port_gbps: number
+  cir_gbps: number
+  p50_gbps: number
+  p99_gbps: number
+  util_pct: number | null
+  denom: string
+}
+
+export interface NetworkHealthIsis {
+  overloaded: number
+  unreachable: number
+  devices: number
+  adjacencies: number
+}
+
+export interface NetworkHealthFreshness {
+  feed_max: string
+  lag_seconds: number
+  devices_fresh: number
+  devices_active: number
+}
+
+export interface NetworkHealthTsPoint {
+  t: string
+  avg_bps: number
+  max_bps: number
+}
+
+export interface NetworkHealthCountPoint {
+  t: string
+  count: number
+}
+
+export interface NetworkHealthTrafficLink {
+  link_pk: string
+  link_code: string
+  side_a_metro: string
+  side_z_metro: string
+  status: string
+  avg_gbps: number
+  max_gbps: number
+}
+
+export interface NetworkHealthCapacityLink {
+  link_pk: string
+  link_code: string
+  side_a_metro: string
+  side_z_metro: string
+  bandwidth_gbps: number
+  peak_gbps: number
+  util_pct: number
+  p50_util: number
+  p99_util: number
+}
+
+export interface NetworkHealthPerfLink {
+  link_pk: string
+  link_code: string
+  side_a_metro: string
+  side_z_metro: string
+  committed_ms: number
+  measured_avg_ms: number
+  measured_max_ms: number
+  over_committed_pct: number
+  drift_ms: number
+  drift_pct: number
+  // When the link carries an IS-IS delay override, committed_ms (and the drift /
+  // over-committed figures) reflect the override, not the raw onchain value.
+  // raw_committed_ms is the untouched onchain commitment. Optional so the type
+  // checks even if the backend field lands slightly later.
+  raw_committed_ms?: number
+  overridden?: boolean
+}
+
+export interface NetworkHealthErrorHotspot {
+  device_pk: string
+  device_code: string
+  errors: number
+  carrier_flaps: number
+}
+
+// One entity's time-based 3-way state split over the window (see the Go
+// NHAvailability doc comment): avail_pct + drained_pct + outage_pct sum to
+// 100 of the classified (non-provisioning) buckets. Drain counts as
+// unavailable but is broken out as its own segment rather than folded into
+// outage_pct, so a heavily soft-drained link doesn't read as if it had a fault.
+export interface NetworkHealthAvailability {
+  pk: string
+  code: string
+  metros?: string
+  avail_pct: number
+  drained_pct: number
+  outage_pct: number
+  avail_hours: number
+  outage_hours: number
+  drained_hours: number
+}
+
+// One recorded root cause and how many incident tickets in the window carried
+// it. cause is the raw enum (self_resolved, network_external, fiber_cut,
+// configuration, hardware, carrier, false_positive); pct is its share of
+// incidents that have a cause.
+export interface NetworkHealthRootCause {
+  cause: string
+  count: number
+  pct: number | null
+}
+
+// One telemetry-detected outage in the window that had no matching ops ticket:
+// the affected link, when it started (RFC3339), and how long it lasted (hours).
+// link_pk is present when the link resolved to an onchain pubkey, so the
+// frontend can link through to its detail page; absent means render plain text.
+export interface NetworkHealthNoTicketOutage {
+  link_code: string
+  link_pk?: string
+  start_ts: string
+  hours: number
+}
+
+export interface NetworkHealthTickets {
+  total: number
+  incidents: number
+  maintenance: number
+  sev1: number
+  sev2: number
+  sev3: number
+  // Incident timing (incidents only; maintenance is scheduled ahead of time and
+  // is excluded so it does not drag these negative).
+  response_p50_min: number | null
+  resolution_p50_min: number | null
+  closed_incidents: number
+  // Who filed each incident, by ticket creator resolved through the ops user
+  // registry. self_reported = a contributor filed it; doublezero_filed = a
+  // DoubleZero staff account filed it. self_reported_pct is null when the user
+  // registry could not be fetched (frontend then shows "unavailable").
+  self_reported_count: number
+  doublezero_filed_count: number
+  self_reported_pct: number | null
+  // Scheduled maintenance timing (present in the contract for completeness; the
+  // maintenance section shows counts and notes that timing is not tracked).
+  maintenance_lead_p50_min: number | null
+  maintenance_duration_p50_min: number | null
+  closed_maintenance: number
+  root_causes: NetworkHealthRootCause[]
+  outage_count: number
+  outages_with_ticket: number
+  outages_no_ticket: number
+  no_ticket_share_pct: number | null
+  // Telemetry-detected outages in the window with no matching ticket, one row
+  // per affected link + overlapping episode. Present alongside the count/share
+  // above; optional so an older backend that omits it still type-checks.
+  no_ticket_outages?: NetworkHealthNoTicketOutage[]
+}
+
+// Network-wide (or contributor-scoped) outage total for the window, split by
+// entity kind. outage_hours is the link outage-hours total (uncapped; a fact,
+// not the headline's capped figure).
+export interface NetworkHealthOutageSummary {
+  link_outages: number
+  outage_hours: number
+  links_affected: number
+  device_outages: number
+  devices_affected: number
+}
+
+// One entity's outage-hours total over the window, ranked by hours descending.
+// pk lets the frontend link through to the entity's drill-down page. metros
+// holds the metro pair for links ("ams ↔ lon") or the single metro for devices.
+export interface NetworkHealthDowntimeRow {
+  pk: string
+  code: string
+  metros?: string
+  outages: number
+  hours: number
+}
+
+// Prior-window (previous equal-length period) reliability values that back the
+// "vs prior" deltas on the Outages-by-duration caption. outage_count and
+// capped_downtime_hours mirror the current-window reliability figures. Emitted
+// by the Outages group under prev.reliability every refresh.
+export interface NetworkHealthReliabilityPrev {
+  outage_count: number
+  capped_downtime_hours: number
+}
+
+export interface NetworkHealthParams {
+  days?: number
+  start?: string // YYYY-MM-DD
+  end?: string // YYYY-MM-DD
+}
+
+function networkHealthQuery(p: NetworkHealthParams): URLSearchParams {
+  const qs = new URLSearchParams()
+  if (p.start && p.end) {
+    qs.set('start', p.start)
+    qs.set('end', p.end)
+  } else if (p.days && p.days !== 30) {
+    qs.set('days', String(p.days))
+  }
+  return qs
+}
+
+// The undrain-timing slice of drain timing, fetched separately because its
+// recovery-health query is slow. The main network-health payload renders
+// immediately; this loads in parallel and fills in the two undrain MiniStats.
+export interface NetworkHealthDeferred {
+  time_to_undrain_p50_min: number | null
+  time_to_undrain_max_min: number | null
+  undrain_unavailable?: boolean
+  matched_undrains: number
+  // Prior-window values so the undrain MiniStats can show a "vs prior" delta.
+  prev?: NetworkHealthDeferred
+  error?: string
+}
+
+export async function fetchNetworkHealthDeferred(
+  p: NetworkHealthParams = {},
+  contributor = '',
+): Promise<NetworkHealthDeferred> {
+  const qs = networkHealthQuery(p)
+  if (contributor) qs.set('contributor', contributor)
+  const s = qs.toString()
+  const res = await fetchWithRetry(`/api/network-health/deferred${s ? `?${s}` : ''}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch network health undrain timing')
+  }
+  return res.json()
+}
+
+// --- Network health, per-data-source groups (progressive loading) ---
+//
+// The single /api/network-health payload is split into independent group
+// endpoints so the page loads progressively: each group fetches + caches on its
+// own, and a slow or failed group only affects its own panels. Every group type
+// below is a SUBSET of the full network-health payload (same field names / JSON tags), plus
+// its own prior-window values where its panels show a "vs prior" delta and an
+// optional `error` string (same convention across every group endpoint).
+
+// Overview: the cheap headline signals + throughput chart + the contributor list
+// that feeds the scope dropdown. The Outages group owns the headline outage
+// count and the Impactful endpoint owns impactful downtime, so this headline is
+// read together with those two (each tile loads with its own group).
+export interface NHOverview {
+  window: NetworkHealthWindow
+  headline: NetworkHealthHeadline
+  isis: NetworkHealthIsis
+  freshness: NetworkHealthFreshness
+  throughput_ts: NetworkHealthTsPoint[]
+  contributors: NetworkHealthContributor[]
+  generated_at: string
+  error?: string
+}
+
+export interface NHAvailabilityGroup {
+  link_availability: NetworkHealthAvailability[]
+  device_availability: NetworkHealthAvailability[]
+  error?: string
+}
+
+export interface NHLatencyGroup {
+  latency_links: NetworkHealthPerfLink[]
+  sla: NetworkHealthSla
+  error?: string
+}
+
+export interface NHCapacityGroup {
+  capacity: NetworkHealthCapacity
+  device_slots: NetworkHealthDeviceSlots[]
+  dia_interfaces: NetworkHealthDiaInterface[]
+  top_links: NetworkHealthTrafficLink[]
+  capacity_links: NetworkHealthCapacityLink[]
+  error?: string
+}
+
+export interface NHOutagesGroup {
+  // Headline outage count (sustained outages >= 10 min) + its prior-window
+  // percent-change delta, cross-read by the headline row.
+  outage_count: number
+  outage_count_delta: number | null
+  reliability: NetworkHealthReliability
+  outage_summary: NetworkHealthOutageSummary | null
+  downtime_links: NetworkHealthDowntimeRow[]
+  downtime_devices: NetworkHealthDowntimeRow[]
+  outages_ts: NetworkHealthCountPoint[]
+  error_hotspots: NetworkHealthErrorHotspot[]
+  prev?: {
+    outage_summary: NetworkHealthOutageSummary | null
+    reliability: NetworkHealthReliabilityPrev
+  }
+  error?: string
+}
+
+export interface NHDrainGroup {
+  drain_timing: NetworkHealthDrainTiming
+  // prev is the prior-window drain-timing figures directly (the backend emits the
+  // bare NHDrainTiming under `prev`, not a wrapper), used for the panel deltas.
+  prev?: NetworkHealthDrainTiming | null
+  error?: string
+}
+
+export interface NHTicketsGroup {
+  ops_tickets: NetworkHealthTickets | null
+  // prev is the prior-window ticket aggregate directly (bare NHTickets under
+  // `prev`), used for the incidents/maintenance deltas.
+  prev?: NetworkHealthTickets | null
+  error?: string
+}
+
+// Impactful downtime is the heaviest query, so it has its own deferred endpoint
+// (mirrors /deferred). Impact-weighted availability is derived on the frontend
+// from Overview.headline.active_links + this impactful_downtime_hours (the
+// backend does not emit it); see deriveAvailability.
+export interface NHImpactful {
+  window: NetworkHealthWindow
+  impactful_downtime_hours: number
+  impactful_downtime_delta: number | null
+  unavailable?: boolean
+  prev?: { impactful_downtime_hours: number }
+  error?: string
+}
+
+// Shared fetcher for a group endpoint. Mirrors fetchNetworkHealthDeferred:
+// builds the same window query string, threads the
+// optional contributor scope, and reuses fetchWithRetry.
+async function fetchNHGroup<T>(
+  path: string,
+  p: NetworkHealthParams,
+  contributor: string,
+): Promise<T> {
+  const qs = networkHealthQuery(p)
+  if (contributor) qs.set('contributor', contributor)
+  const s = qs.toString()
+  const base = path ? `/api/network-health/${path}` : '/api/network-health'
+  const res = await fetchWithRetry(`${base}${s ? `?${s}` : ''}`)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch network health: ${path || 'overview'}`)
+  }
+  return res.json()
+}
+
+// Overview is served by the bare /api/network-health route (repurposed from the
+// old monolith); the rest hang off named sub-paths.
+export const fetchNHOverview = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHOverview>('', p, c)
+export const fetchNHAvailability = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHAvailabilityGroup>('availability', p, c)
+export const fetchNHLatency = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHLatencyGroup>('latency', p, c)
+export const fetchNHCapacity = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHCapacityGroup>('capacity', p, c)
+export const fetchNHOutages = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHOutagesGroup>('outages', p, c)
+export const fetchNHDrain = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHDrainGroup>('drain', p, c)
+export const fetchNHTickets = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHTicketsGroup>('tickets', p, c)
+export const fetchNHImpactful = (p: NetworkHealthParams = {}, c = '') =>
+  fetchNHGroup<NHImpactful>('impactful', p, c)
+
 // Link history types for status timeline
 export interface LinkHourStatus {
   hour: string


### PR DESCRIPTION
## Summary

Adds the Network Health Reporting page, a public windowed report of how the DoubleZero network performed over a selected time range, organized into three sections:

- **Performance**: the links and devices that were least available over the window (time split across available, maintenance drain, and fault), and committed versus measured latency for links that carry an onchain committed round-trip time.
- **Capacity**: the links closest to their provisioned bandwidth, DIA interface utilization against port speed, the links carrying the most traffic, and the devices closest to their user-slot capacity.
- **Operations**: link and device failures over time and by duration, the links and devices with the most fault time, how quickly links were drained and returned to service, and an incidents and maintenance summary from the ops-management portal.

Every metric supports a selectable window (default 30 days) and is compared against the previous equal-length window. The report can be viewed for the whole network or scoped to a single contributor, and presents the figures neutrally without ranking or grading contributors.

Each panel is served by its own endpoint and cached independently, so the page renders progressively and a slow query on one panel does not hold up the others. Expensive aggregates are pre-computed by a background refresh.

## Testing Verification

- Tests cover outage-episode reconstruction (the sustained-failure floor and episode boundaries), impact-weighted downtime (primary-path and traffic weighting), per-contributor scope isolation across the availability, outage, and drain data, drain and undrain timing, previous-window delta direction, and the JSON contract of each group endpoint.