### PR TITLE
api: treat unknown multicast group (ErrNoRows) as 404, not an error

### DIFF
--- a/api/handlers/multicast.go
+++ b/api/handlers/multicast.go
@@ -298,6 +298,11 @@ func (a *API) GetMulticastGroupMembers(w http.ResponseWriter, r *http.Request) {
 	var groupPK string
 	err := a.envDB(ctx).QueryRow(ctx,
 		`SELECT pk FROM dz_multicast_groups_current WHERE pk = ? OR code = ?`, pkOrCode, pkOrCode).Scan(&groupPK)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Unknown group pk/code is an ordinary 404, not an error — don't log/page.
+		http.Error(w, "multicast group not found", http.StatusNotFound)
+		return
+	}
 	if err != nil {
 		logError("multicast group members group query error", "error", err)
 		http.Error(w, "multicast group not found", http.StatusNotFound)
@@ -728,6 +733,11 @@ func (a *API) GetMulticastGroupTraffic(w http.ResponseWriter, r *http.Request) {
 	var groupPK string
 	err := a.envDB(ctx).QueryRow(ctx,
 		`SELECT pk FROM dz_multicast_groups_current WHERE pk = ? OR code = ?`, pkOrCode, pkOrCode).Scan(&groupPK)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Unknown group pk/code is an ordinary 404, not an error — don't log/page.
+		http.Error(w, "multicast group not found", http.StatusNotFound)
+		return
+	}
 	if err != nil {
 		logError("multicast group traffic group query error", "error", err)
 		http.Error(w, "multicast group not found", http.StatusNotFound)

--- a/api/handlers/multicast_test.go
+++ b/api/handlers/multicast_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// recordingHandler captures emitted records so a test can assert on log level.
+type recordingHandler struct{ records *[]slog.Record }
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
 
 func insertMulticastTestData(t *testing.T, api *handlers.API) {
 	ctx := t.Context()
@@ -191,6 +203,32 @@ func TestGetMulticastGroupMembers_ReturnsMembers(t *testing.T) {
 	assert.Equal(t, "nyc001-dz001", sub.DeviceCode)
 	assert.Equal(t, "nyc", sub.MetroCode)
 	assert.Equal(t, int32(502), sub.TunnelID)
+}
+
+// TestGetMulticastGroupMembers_UnknownGroupIsNotAnError guards the fix: a request
+// for a non-existent group must return 404 *without* logging at ERROR (an unknown
+// group is an ordinary not-found, and logging it ERROR paged prod #alerts).
+// Not parallel: it swaps the global slog default to inspect log level.
+func TestGetMulticastGroupMembers_UnknownGroupIsNotAnError(t *testing.T) {
+	api := apitesting.NewTestAPI(t, testChDB)
+
+	var recs []slog.Record
+	prev := slog.Default()
+	slog.SetDefault(slog.New(recordingHandler{&recs}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dz/multicast-groups/does-not-exist/members", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("pk", "does-not-exist")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	api.GetMulticastGroupMembers(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	for _, r := range recs {
+		assert.NotEqual(t, slog.LevelError, r.Level, "unknown group should not log ERROR: %q", r.Message)
+	}
 }
 
 func TestGetMulticastGroupMembers_TrafficBps(t *testing.T) {


### PR DESCRIPTION
## Summary

Prod `lake-api` was paging `#alerts` with `multicast group members group query error: sql: no rows in result set`. The group-members and group-traffic handlers resolve the group PK with a `QueryRow(...).Scan()`, and on a **non-existent group** that returns `sql.ErrNoRows` — an ordinary not-found, but the handlers logged it at ERROR before returning 404. So any request for an unknown/stale group id paged on-call.

Both handlers now match the idiom the sibling `GetMulticastGroup` handler already uses: `sql.ErrNoRows` → 404 with no log; a genuine query error still logs + returns. Fixes two handlers (`GetMulticastGroupMembers`, group-traffic) that were missing the guard.

## Testing Verification

- Added `TestGetMulticastGroupMembers_UnknownGroupIsNotAnError`: requests a non-existent group, asserts 404 **and** captures slog to assert no `ERROR`-level record is emitted (a 404-only assertion wouldn't catch a regression, since the old code also 404'd — it just logged ERROR).