### PR TITLE
api: move tiredsolid scoreboard feed config to postgres

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,35 @@ The API has a background page cache (`api/handlers/page_cache.go`) that pre-comp
 
 Add caching when a page runs expensive queries, has a common default view, and 30–60s staleness is acceptable. See publisher check or edge scoreboard handlers for reference implementations.
 
+## Hyperliquid Scoreboard Feed Config
+
+The feeds shown on the Hyperliquid scoreboard are **not** in code — they live in the
+Postgres table `hyperliquid_scoreboard_entry` (`feed`, `label`, `display_order`, `enabled`).
+Only enabled rows are raced, counted, or displayed; a feed with no row never appears.
+
+Add, remove, or reorder a feed by changing rows — no code change, no deploy.
+
+**These statements are run by a human operator against the target environment.** They are
+recorded here as a runbook, not as something to execute automatically: do not run them, or
+any other write against this table, from an agent session unless explicitly asked to.
+
+```sql
+-- stop showing a feed
+UPDATE hyperliquid_scoreboard_entry SET enabled = FALSE, updated_at = NOW() WHERE feed = '<feed>';
+-- start showing a feed
+INSERT INTO hyperliquid_scoreboard_entry (feed, label, display_order, enabled)
+VALUES ('<feed>', '<label>', <n>, TRUE)
+ON CONFLICT (feed) DO UPDATE SET enabled = TRUE, label = EXCLUDED.label,
+    display_order = EXCLUDED.display_order, updated_at = NOW();
+```
+
+Changes take effect on the next cache refresh with no restart: about 60s for the 1h view
+(page-cache worker) and about 10min for the 24h/7d views (background refresher).
+
+The migration creates the table **empty on purpose** — rows are environment config and are
+inserted out of band, so they never live in this repository. An unseeded environment renders
+an empty scoreboard, which is also the expected local-dev state.
+
 ## Logging Levels
 
 ERROR-level log lines page on-call (alerts fire on `level="ERR"` — prod → `#alerts`, staging → `#alerts-l2`). Reserve raw `.Error(...)` calls for genuinely-actionable terminal failures: process/component death, startup failures, panics, config errors.

--- a/api/config/migrations/00016_add_hyperliquid_scoreboard_entry.sql
+++ b/api/config/migrations/00016_add_hyperliquid_scoreboard_entry.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Scoreboard feed allow-list. Only enabled rows are raced, counted, or displayed on the
+-- Hyperliquid scoreboard. Intentionally seeded with no rows: the rows are environment
+-- config, inserted out of band, so they never live in this repository.
+CREATE TABLE hyperliquid_scoreboard_entry (
+    feed          TEXT PRIMARY KEY,
+    label         TEXT NOT NULL,
+    display_order INT  NOT NULL DEFAULT 0,
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS hyperliquid_scoreboard_entry;

--- a/api/config/migrations/00016_add_hyperliquid_scoreboard_entry.sql
+++ b/api/config/migrations/00016_add_hyperliquid_scoreboard_entry.sql
@@ -4,7 +4,7 @@
 -- config, inserted out of band, so they never live in this repository.
 CREATE TABLE hyperliquid_scoreboard_entry (
     feed          TEXT PRIMARY KEY,
-    label         TEXT NOT NULL,
+    label         TEXT NOT NULL CHECK (length(label) BETWEEN 1 AND 64),
     display_order INT  NOT NULL DEFAULT 0,
     enabled       BOOLEAN NOT NULL DEFAULT TRUE,
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -103,37 +103,6 @@ func (a *API) loadHyperliquidScoreboardEntries(ctx context.Context) hyperliquidE
 	return e
 }
 
-// hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
-// in display order, mapping each raw feed name to its label.
-var hyperliquidCompetitors = []struct{ Feed, Label string }{
-	{"hyperliquid_public_bbo", "Public API"},
-	{"hydromancer_bbo", "Hydromancer"},
-	{"dwellir_l2book_bbo", "Dwellir"},
-	{"quicknode_l2book_bbo", "QuickNode"},
-}
-
-// hyperliquidExcludedFeeds are competitor feeds withheld from every scoreboard measurement
-// (per-competitor, per-node, headline totals, and recent races) because their upstream data is
-// currently unreliable. hyperpc_shared_bbo (HypeRPC) arrives a median ~100s stale during
-// recurring multi-hour backlog episodes — vs ~300ms for the other feeds — which would render
-// DoubleZero "winning" by seconds-to-minutes and is a HypeRPC-side feed fault, not a real result.
-// Remove entries here (and re-add to hyperliquidCompetitors) once the feed is fixed.
-var hyperliquidExcludedFeeds = []string{"hyperpc_shared_bbo"}
-
-// hyperliquidExcludedFeedsClause returns a SQL predicate dropping excluded feeds from either
-// side of a race, or "" if none are excluded.
-func hyperliquidExcludedFeedsClause() string {
-	if len(hyperliquidExcludedFeeds) == 0 {
-		return ""
-	}
-	quoted := make([]string, len(hyperliquidExcludedFeeds))
-	for i, f := range hyperliquidExcludedFeeds {
-		quoted[i] = "'" + f + "'"
-	}
-	in := strings.Join(quoted, ", ")
-	return fmt.Sprintf("AND feed NOT IN (%[1]s) AND loser_feed NOT IN (%[1]s)", in)
-}
-
 // hyperliquidWindows maps window params to ClickHouse interval expressions.
 var hyperliquidWindows = map[string]string{
 	"1h":  "1 HOUR",
@@ -266,23 +235,19 @@ type HyperliquidCompositeLatency struct {
 
 const hyperliquidCompositeLatencyCacheKey = "hyperliquid_composite_latency"
 
-// labelForFeed maps a raw competitor feed to its display label (falls back to the raw name).
-func labelForFeed(feed string) string {
-	for _, c := range hyperliquidCompetitors {
-		if c.Feed == feed {
-			return c.Label
-		}
+// emptyHyperliquidScoreboard is the empty-but-valid response served when the scoreboard has
+// nothing to compute — the proxied summary table is absent (e.g. local dev) or no feeds are
+// configured. Returning this instead of an error keeps the page-cache refresher caching a
+// clean payload rather than logging every cycle.
+func emptyHyperliquidScoreboard(window string) *HyperliquidScoreboardResponse {
+	return &HyperliquidScoreboardResponse{
+		Window:      window,
+		GeneratedAt: time.Now().UTC(),
+		FeedType:    "bbo",
+		Competitors: []HyperliquidCompetitor{},
+		Nodes:       []HyperliquidNode{},
+		RecentRaces: []HyperliquidRace{},
 	}
-	return feed
-}
-
-// hyperliquidFeedDisplay returns "DoubleZero" for any tob_ DZ feed, else the competitor label.
-// Used so a competitor-won recent race reads "Hydromancer … vs DoubleZero", not a raw tob_ id.
-func hyperliquidFeedDisplay(feed string) string {
-	if strings.HasPrefix(feed, "tob_") {
-		return "DoubleZero"
-	}
-	return labelForFeed(feed)
 }
 
 // FetchHyperliquidScoreboardData computes the aggregated scoreboard for a window and
@@ -299,23 +264,24 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	// proxy/seed), return an empty-but-valid response so the page-cache refresher
 	// caches a clean empty payload instead of logging an error every cycle.
 	if !a.hyperliquidFeedsTableExists(ctx) {
-		return &HyperliquidScoreboardResponse{
-			Window:      window,
-			GeneratedAt: time.Now().UTC(),
-			FeedType:    "bbo",
-			Competitors: []HyperliquidCompetitor{},
-			Nodes:       []HyperliquidNode{},
-			RecentRaces: []HyperliquidRace{},
-		}, nil
+		return emptyHyperliquidScoreboard(window), nil
+	}
+
+	// The configured feed allow-list drives which feeds are raced, counted, and labelled.
+	// With nothing configured there is no scoreboard to compute, so serve the same
+	// empty-but-valid payload rather than scanning for feeds we would then discard.
+	entries := a.loadHyperliquidScoreboardEntries(ctx)
+	if entries.empty() {
+		return emptyHyperliquidScoreboard(window), nil
 	}
 
 	symbolFilter := hyperliquidLiquidSymbolFilter()
 	if symbol != "" {
 		symbolFilter = fmt.Sprintf("AND symbol = '%s'", symbol)
 	}
-	// Drop excluded (unreliable) competitor feeds from the per-competitor and per-node
-	// aggregations. Flows into both compQ and nodeQ via the shared symbolFilter slot.
-	symbolFilter = strings.TrimSpace(symbolFilter + " " + hyperliquidExcludedFeedsClause())
+	// Restrict both aggregations to configured feeds. Flows into the scan via the shared
+	// symbolFilter slot.
+	symbolFilter = strings.TrimSpace(symbolFilter + " " + entries.inClause())
 	db := fmt.Sprintf("`%s`", a.FeedsDB)
 
 	resp := &HyperliquidScoreboardResponse{
@@ -408,7 +374,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 		return rows.Err()
 	})
 	g.Go(func() error {
-		r, err := a.fetchHyperliquidRecentRaces(gctx, time.Time{}, 10)
+		r, err := a.fetchHyperliquidRecentRaces(gctx, time.Time{}, 10, entries)
 		if err != nil {
 			return err
 		}
@@ -427,7 +393,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	}
 
 	// Emit competitors in configured order.
-	for _, c := range hyperliquidCompetitors {
+	for _, c := range entries.ordered {
 		s, ok := byFeed[c.Feed]
 		if !ok {
 			continue
@@ -456,7 +422,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 			Competitors:       []HyperliquidCompetitor{},
 		}
 		var wins, races uint64
-		for _, c := range hyperliquidCompetitors {
+		for _, c := range entries.ordered {
 			s, ok := na.byFeed[c.Feed]
 			if !ok {
 				continue
@@ -509,7 +475,7 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 
 // fetchHyperliquidRecentRaces returns the most recent races (one row per race,
 // winner + closest competitor + lead). sinceTs zero -> last 5 minutes.
-func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time, perSymbol int) ([]HyperliquidRace, error) {
+func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time, perSymbol int, entries hyperliquidEntries) ([]HyperliquidRace, error) {
 	if perSymbol <= 0 || perSymbol > 50 {
 		perSymbol = 10
 	}
@@ -537,7 +503,7 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time
 		GROUP BY capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash, location_code, feed
 		ORDER BY max_event_ts DESC
 		LIMIT %d BY symbol`, db,
-		strings.TrimSpace(hyperliquidRecentRaceSymbolFilter()+" "+hyperliquidExcludedFeedsClause()), timeFilter, perSymbol)
+		strings.TrimSpace(hyperliquidRecentRaceSymbolFilter()+" "+entries.inClause()), timeFilter, perSymbol)
 	rows, err := a.envDB(ctx).Query(ctx, q)
 	if err != nil {
 		return nil, err
@@ -551,8 +517,8 @@ func (a *API) fetchHyperliquidRecentRaces(ctx context.Context, sinceTs time.Time
 			return nil, err
 		}
 		r.IsDZ = isDZ == 1
-		r.WinnerLabel = hyperliquidFeedDisplay(r.WinnerFeed)
-		r.RunnerUpLabel = hyperliquidFeedDisplay(r.RunnerUpFeed)
+		r.WinnerLabel = entries.display(r.WinnerFeed)
+		r.RunnerUpLabel = entries.display(r.RunnerUpFeed)
 		out = append(out, r)
 	}
 	return out, rows.Err()

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -66,31 +66,42 @@ func (e hyperliquidEntries) display(feed string) string {
 }
 
 // loadHyperliquidScoreboardEntries reads the enabled scoreboard feeds from Postgres, in
-// display order. A load failure degrades to an empty set (the scoreboard renders empty)
-// rather than failing the request: this is display config, and a Postgres blip must not take
-// the page down. Logged at WARN, never ERROR — ERROR pages on-call.
-func (a *API) loadHyperliquidScoreboardEntries(ctx context.Context) hyperliquidEntries {
+// display order. Zero configured rows is not an error — it is the deliberate "nothing
+// configured yet" state and returns a clean empty set with a nil error. A genuine load
+// failure (query, scan, or row iteration) returns a non-nil error instead of degrading to an
+// empty set: the caller must not treat a Postgres blip as "zero feeds configured", or the
+// background refresher and page-cache worker would overwrite the last-good cached payload
+// with an empty one. Logged at WARN, never ERROR — ERROR pages on-call.
+func (a *API) loadHyperliquidScoreboardEntries(ctx context.Context) (hyperliquidEntries, error) {
 	e := hyperliquidEntries{labels: map[string]string{}}
 	if a.PgPool == nil {
-		return e
+		return e, nil
 	}
 	rows, err := a.PgPool.Query(ctx, `
 		SELECT feed, label FROM hyperliquid_scoreboard_entry
 		WHERE enabled ORDER BY display_order, feed`)
 	if err != nil {
 		slog.Warn("hyperliquid scoreboard entry load failed", "error", err)
-		return e
+		return hyperliquidEntries{}, err
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var feed, label string
 		if err := rows.Scan(&feed, &label); err != nil {
 			slog.Warn("hyperliquid scoreboard entry scan failed", "error", err)
-			return hyperliquidEntries{labels: map[string]string{}}
+			return hyperliquidEntries{}, err
 		}
 		// A malformed feed would be inlined into SQL; drop it and keep serving the rest.
 		if !hyperliquidFeedRe.MatchString(feed) {
 			slog.Warn("hyperliquid scoreboard entry skipped: unsafe feed id", "feed", feed)
+			continue
+		}
+		// tob_ feeds are DoubleZero's own; the allow-list clause relies on them never being
+		// configured entries (see inClause). A tob_ config row would broaden the clause to
+		// match races against unconfigured competitors, leaking their raw feed ids into the
+		// public payload, so it is dropped rather than trusted.
+		if strings.HasPrefix(feed, "tob_") {
+			slog.Warn("hyperliquid scoreboard entry skipped: tob_ feed not allowed", "feed", feed)
 			continue
 		}
 		e.ordered = append(e.ordered, hyperliquidEntry{Feed: feed, Label: label})
@@ -98,9 +109,9 @@ func (a *API) loadHyperliquidScoreboardEntries(ctx context.Context) hyperliquidE
 	}
 	if err := rows.Err(); err != nil {
 		slog.Warn("hyperliquid scoreboard entry iteration failed", "error", err)
-		return hyperliquidEntries{labels: map[string]string{}}
+		return hyperliquidEntries{}, err
 	}
-	return e
+	return e, nil
 }
 
 // hyperliquidWindows maps window params to ClickHouse interval expressions.
@@ -268,9 +279,15 @@ func (a *API) FetchHyperliquidScoreboardData(ctx context.Context, window, symbol
 	}
 
 	// The configured feed allow-list drives which feeds are raced, counted, and labelled.
-	// With nothing configured there is no scoreboard to compute, so serve the same
-	// empty-but-valid payload rather than scanning for feeds we would then discard.
-	entries := a.loadHyperliquidScoreboardEntries(ctx)
+	// A load failure propagates as an error so the caller (page-cache refresher, request
+	// handler) does not mistake it for "nothing configured" and overwrite a last-good cached
+	// payload with an empty one. Zero configured rows is not an error — with nothing
+	// configured there is no scoreboard to compute, so serve the empty-but-valid payload
+	// rather than scanning for feeds we would then discard.
+	entries, err := a.loadHyperliquidScoreboardEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if entries.empty() {
 		return emptyHyperliquidScoreboard(window), nil
 	}

--- a/api/handlers/hyperliquid_scoreboard.go
+++ b/api/handlers/hyperliquid_scoreboard.go
@@ -13,6 +13,96 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// hyperliquidFeedRe bounds feed ids to characters safe to inline into ClickHouse SQL.
+// Config rows are operator-managed rather than user input, but the values are concatenated
+// into queries, so anything outside this set is dropped rather than trusted.
+var hyperliquidFeedRe = regexp.MustCompile(`^[A-Za-z0-9:_.-]{1,64}$`)
+
+// hyperliquidEntry is one configured scoreboard feed.
+type hyperliquidEntry struct{ Feed, Label string }
+
+// hyperliquidEntries is the scoreboard's configured feed allow-list, loaded from Postgres.
+// Only feeds present here are raced, counted, or displayed, so a feed is added, removed, or
+// reordered by changing rows — no code change and no deploy.
+type hyperliquidEntries struct {
+	ordered []hyperliquidEntry // display order
+	labels  map[string]string  // feed -> label
+}
+
+// empty reports whether any feed is configured.
+func (e hyperliquidEntries) empty() bool { return len(e.ordered) == 0 }
+
+// inClause returns the SQL predicate restricting a race to configured feeds, or "" if none
+// are configured. Every race pairs one tob_* DoubleZero feed with one competing feed, and DZ
+// feeds are never configured entries, so requiring either side to be in the set is equivalent
+// to requiring the non-DZ side to be configured.
+func (e hyperliquidEntries) inClause() string {
+	if e.empty() {
+		return ""
+	}
+	quoted := make([]string, 0, len(e.ordered))
+	for _, en := range e.ordered {
+		quoted = append(quoted, "'"+en.Feed+"'")
+	}
+	in := strings.Join(quoted, ", ")
+	return fmt.Sprintf("AND (feed IN (%[1]s) OR loser_feed IN (%[1]s))", in)
+}
+
+// label maps a raw feed to its configured display label (falls back to the raw name).
+func (e hyperliquidEntries) label(feed string) string {
+	if l, ok := e.labels[feed]; ok {
+		return l
+	}
+	return feed
+}
+
+// display returns "DoubleZero" for any tob_ DZ feed, else the configured label. Used so a
+// competitor-won recent race reads "<Label> … vs DoubleZero", not a raw tob_ id.
+func (e hyperliquidEntries) display(feed string) string {
+	if strings.HasPrefix(feed, "tob_") {
+		return "DoubleZero"
+	}
+	return e.label(feed)
+}
+
+// loadHyperliquidScoreboardEntries reads the enabled scoreboard feeds from Postgres, in
+// display order. A load failure degrades to an empty set (the scoreboard renders empty)
+// rather than failing the request: this is display config, and a Postgres blip must not take
+// the page down. Logged at WARN, never ERROR — ERROR pages on-call.
+func (a *API) loadHyperliquidScoreboardEntries(ctx context.Context) hyperliquidEntries {
+	e := hyperliquidEntries{labels: map[string]string{}}
+	if a.PgPool == nil {
+		return e
+	}
+	rows, err := a.PgPool.Query(ctx, `
+		SELECT feed, label FROM hyperliquid_scoreboard_entry
+		WHERE enabled ORDER BY display_order, feed`)
+	if err != nil {
+		slog.Warn("hyperliquid scoreboard entry load failed", "error", err)
+		return e
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var feed, label string
+		if err := rows.Scan(&feed, &label); err != nil {
+			slog.Warn("hyperliquid scoreboard entry scan failed", "error", err)
+			return hyperliquidEntries{labels: map[string]string{}}
+		}
+		// A malformed feed would be inlined into SQL; drop it and keep serving the rest.
+		if !hyperliquidFeedRe.MatchString(feed) {
+			slog.Warn("hyperliquid scoreboard entry skipped: unsafe feed id", "feed", feed)
+			continue
+		}
+		e.ordered = append(e.ordered, hyperliquidEntry{Feed: feed, Label: label})
+		e.labels[feed] = label
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("hyperliquid scoreboard entry iteration failed", "error", err)
+		return hyperliquidEntries{labels: map[string]string{}}
+	}
+	return e
+}
+
 // hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
 // in display order, mapping each raw feed name to its label.
 var hyperliquidCompetitors = []struct{ Feed, Label string }{

--- a/api/handlers/hyperliquid_scoreboard_internal_test.go
+++ b/api/handlers/hyperliquid_scoreboard_internal_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHyperliquidEntries_InClause(t *testing.T) {
+	var empty hyperliquidEntries
+	assert.Equal(t, "", empty.inClause(), "no configured feeds must produce no predicate")
+
+	e := hyperliquidEntries{ordered: []hyperliquidEntry{
+		{Feed: "feed_a_bbo", Label: "Feed A"},
+		{Feed: "feed_b_bbo", Label: "Feed B"},
+	}}
+	assert.Equal(t,
+		"AND (feed IN ('feed_a_bbo', 'feed_b_bbo') OR loser_feed IN ('feed_a_bbo', 'feed_b_bbo'))",
+		e.inClause())
+}
+
+func TestHyperliquidEntries_Display(t *testing.T) {
+	e := hyperliquidEntries{labels: map[string]string{"feed_a_bbo": "Feed A"}}
+
+	// Any tob_ feed is DoubleZero regardless of config.
+	assert.Equal(t, "DoubleZero", e.display("tob_gcp_tyo_hl_mainnet1"))
+	assert.Equal(t, "Feed A", e.display("feed_a_bbo"))
+	// Unknown feeds fall back to the raw name.
+	assert.Equal(t, "feed_z_bbo", e.display("feed_z_bbo"))
+}
+
+func TestHyperliquidEntries_Empty(t *testing.T) {
+	var e hyperliquidEntries
+	assert.True(t, e.empty())
+
+	e.ordered = []hyperliquidEntry{{Feed: "feed_a_bbo", Label: "Feed A"}}
+	assert.False(t, e.empty())
+}
+
+func TestHyperliquidFeedRe(t *testing.T) {
+	assert.True(t, hyperliquidFeedRe.MatchString("feed_a_bbo"))
+	assert.True(t, hyperliquidFeedRe.MatchString("tob_gcp_tyo_hl_mainnet1"))
+	// Anything that could break out of a quoted SQL literal must be rejected.
+	assert.False(t, hyperliquidFeedRe.MatchString("bad'; DROP TABLE x --"))
+	assert.False(t, hyperliquidFeedRe.MatchString(""))
+	assert.False(t, hyperliquidFeedRe.MatchString("has space"))
+}

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -204,3 +204,15 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	// Lead p50 over the 3 DZ wins (1.0, 2.0, 3.0) = 2.0 (quantileTDigest(0.5), exact at this size).
 	assert.InDelta(t, 2.0, hydro.LeadP50Ms, 0.001)
 }
+
+// The migration must create an empty config table: rows are environment config inserted
+// out of band, never seeded by the migration.
+func TestHyperliquidScoreboardEntry_TableCreatedEmpty(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+
+	var n int
+	err := api.PgPool.QueryRow(t.Context(),
+		`SELECT count(*) FROM hyperliquid_scoreboard_entry`).Scan(&n)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -57,8 +58,26 @@ func insertPairwise(t *testing.T, api *handlers.API, node, loc, symbol string, s
 	`, db, node, node, loc, symbol, srcTs, hash, winner, loser, leadMs, leadMs)))
 }
 
+// insertEntry adds a scoreboard feed config row. Feed names and labels here are deliberately
+// neutral placeholders — this repository is public.
+//
+// SetupPostgresForTest gives no per-test isolation (see cleanupPublisherCheckCache in
+// v1_shreds_publishers_test.go for the same issue), so this cleans up its own row after
+// the test — otherwise fixtures shared across tests (e.g. "feed_a_bbo") collide on the
+// table's primary key.
+func insertEntry(t *testing.T, api *handlers.API, feed, label string, order int, enabled bool) {
+	t.Helper()
+	_, err := api.PgPool.Exec(t.Context(), `
+		INSERT INTO hyperliquid_scoreboard_entry (feed, label, display_order, enabled)
+		VALUES ($1, $2, $3, $4)`, feed, label, order, enabled)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = api.PgPool.Exec(context.Background(), `DELETE FROM hyperliquid_scoreboard_entry WHERE feed = $1`, feed)
+	})
+}
+
 func TestGetHyperliquidScoreboard_Empty(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	createFeedsTable(t, api) // empty table -> empty-but-valid response
 
 	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
@@ -73,7 +92,7 @@ func TestGetHyperliquidScoreboard_Empty(t *testing.T) {
 }
 
 func TestGetHyperliquidScoreboard_MissingTable(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	// Do NOT create the table -> handler must degrade to empty 200, not 500.
 
 	req := httptest.NewRequest(http.MethodGet, "/api/dz/hyperliquid/scoreboard", nil)
@@ -87,7 +106,7 @@ func TestGetHyperliquidScoreboard_MissingTable(t *testing.T) {
 }
 
 func TestFetchHyperliquidScoreboardData_MissingTable(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	// Do NOT create the table -> FetchHyperliquidScoreboardData must return an
 	// empty-but-valid response (nil error, non-nil resp, empty slices).
 
@@ -101,14 +120,15 @@ func TestFetchHyperliquidScoreboardData_MissingTable(t *testing.T) {
 }
 
 func TestHyperliquidScoreboard_PerNode(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
 
-	// tyo: DZ wins both vs QuickNode. nyc: DZ wins 1, loses 1 vs QuickNode.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
-	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "quicknode_l2book_bbo", 1.0)
-	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "quicknode_l2book_bbo", "tob_aws_galaxy1", 1.0)
+	// tyo: DZ wins both vs Feed A. nyc: DZ wins 1, loses 1 vs Feed A.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 2.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "feed_a_bbo", "tob_aws_galaxy1", 1.0)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -123,12 +143,14 @@ func TestHyperliquidScoreboard_PerNode(t *testing.T) {
 }
 
 func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+	insertEntry(t, api, "feed_b_bbo", "Feed B", 2, true)
 
 	// A DZ-won race (BTC) and a competitor-won race (ETH), both pairwise.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.5)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "quicknode_l2book_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.5)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "feed_b_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
 
 	races, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -139,21 +161,23 @@ func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
 		bySym[r.Symbol] = r
 	}
 	assert.True(t, bySym["BTC"].IsDZ)
-	assert.Equal(t, "Hydromancer", bySym["BTC"].RunnerUpLabel)
+	assert.Equal(t, "Feed A", bySym["BTC"].RunnerUpLabel)
 	assert.InDelta(t, 1.5, bySym["BTC"].LeadMs, 0.001)
 	assert.False(t, bySym["ETH"].IsDZ)
+	assert.Equal(t, "Feed B", bySym["ETH"].WinnerLabel)
 }
 
-// A cell where DoubleZero won zero races (competitor swept it) makes the lead-time
+// A cell where DoubleZero won zero races (a competitor swept it) makes the lead-time
 // quantile aggregate over an empty predicate set, which ClickHouse returns as NaN. If that
 // NaN reaches the float64 fields, json encoding of the whole response fails — breaking the
 // scoreboard for everyone and poisoning the page cache. The percentiles must coalesce to 0.
 func TestHyperliquidScoreboard_ZeroDZWins_Encodable(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
 
-	// Only a competitor-won race: DZ has zero wins vs Hydromancer in this window.
-	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 10, 1, "hydromancer_bbo", "tob_aws_galaxy1", 3.0)
+	// Only a competitor-won race: DZ has zero wins vs Feed A in this window.
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 10, 1, "feed_a_bbo", "tob_aws_galaxy1", 3.0)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -162,27 +186,28 @@ func TestHyperliquidScoreboard_ZeroDZWins_Encodable(t *testing.T) {
 	_, err = json.Marshal(resp)
 	require.NoError(t, err, "response must not contain NaN percentiles")
 
-	var hydro *handlers.HyperliquidCompetitor
+	var got *handlers.HyperliquidCompetitor
 	for i := range resp.Competitors {
-		if resp.Competitors[i].Feed == "hydromancer_bbo" {
-			hydro = &resp.Competitors[i]
+		if resp.Competitors[i].Feed == "feed_a_bbo" {
+			got = &resp.Competitors[i]
 		}
 	}
-	require.NotNil(t, hydro)
-	assert.InDelta(t, 0.0, hydro.DZWinPct, 0.001)
-	assert.InDelta(t, 0.0, hydro.LeadP50Ms, 0.001)
-	assert.InDelta(t, 0.0, hydro.LeadP95Ms, 0.001)
+	require.NotNil(t, got)
+	assert.InDelta(t, 0.0, got.DZWinPct, 0.001)
+	assert.InDelta(t, 0.0, got.LeadP50Ms, 0.001)
+	assert.InDelta(t, 0.0, got.LeadP95Ms, 0.001)
 }
 
 func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
-	api := apitesting.NewTestAPIBare(t, testChDB)
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
 	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
 
-	// 4 races at node tyo: DZ (tob_*) beats Hydromancer three times, loses once.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 2.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 4000, 4, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
+	// 4 races at node tyo: DZ (tob_*) beats Feed A three times, loses once.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 3.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 4000, 4, "feed_a_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -191,18 +216,18 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	assert.InDelta(t, 75.0, resp.DZWinSharePct, 0.1)
 	assert.EqualValues(t, 4, resp.TotalRaces)
 
-	var hydro *handlers.HyperliquidCompetitor
+	var got *handlers.HyperliquidCompetitor
 	for i := range resp.Competitors {
-		if resp.Competitors[i].Feed == "hydromancer_bbo" {
-			hydro = &resp.Competitors[i]
+		if resp.Competitors[i].Feed == "feed_a_bbo" {
+			got = &resp.Competitors[i]
 		}
 	}
-	require.NotNil(t, hydro)
-	assert.Equal(t, "Hydromancer", hydro.Label)
-	assert.InDelta(t, 75.0, hydro.DZWinPct, 0.1)
-	assert.EqualValues(t, 4, hydro.Races)
+	require.NotNil(t, got)
+	assert.Equal(t, "Feed A", got.Label)
+	assert.InDelta(t, 75.0, got.DZWinPct, 0.1)
+	assert.EqualValues(t, 4, got.Races)
 	// Lead p50 over the 3 DZ wins (1.0, 2.0, 3.0) = 2.0 (quantileTDigest(0.5), exact at this size).
-	assert.InDelta(t, 2.0, hydro.LeadP50Ms, 0.001)
+	assert.InDelta(t, 2.0, got.LeadP50Ms, 0.001)
 }
 
 // The migration must create an empty config table: rows are environment config inserted
@@ -215,4 +240,107 @@ func TestHyperliquidScoreboardEntry_TableCreatedEmpty(t *testing.T) {
 		`SELECT count(*) FROM hyperliquid_scoreboard_entry`).Scan(&n)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
+}
+
+// Feeds are emitted in configured display_order, so reordering the scoreboard is a row edit.
+func TestHyperliquidScoreboard_RespectsDisplayOrder(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+	// Insert out of order; display_order decides the emitted order.
+	insertEntry(t, api, "feed_b_bbo", "Feed B", 2, true)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_b_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.Len(t, resp.Competitors, 2)
+	assert.Equal(t, "feed_a_bbo", resp.Competitors[0].Feed)
+	assert.Equal(t, "feed_b_bbo", resp.Competitors[1].Feed)
+}
+
+// Disabling a row removes the feed everywhere: columns, headline totals, and recent races.
+// This is the "remove a feed without a deploy" path.
+func TestHyperliquidScoreboard_DisabledEntryExcludedEverywhere(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+	insertEntry(t, api, "feed_b_bbo", "Feed B", 2, false)
+
+	// DZ beats Feed A once and Feed B once; only the Feed A race may count.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_b_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	require.Len(t, resp.Competitors, 1)
+	assert.Equal(t, "feed_a_bbo", resp.Competitors[0].Feed)
+	assert.EqualValues(t, 1, resp.TotalRaces)
+	for _, r := range resp.RecentRaces {
+		assert.NotEqual(t, "feed_b_bbo", r.RunnerUpFeed)
+		assert.NotEqual(t, "feed_b_bbo", r.WinnerFeed)
+	}
+}
+
+// A feed with no config row at all never surfaces — including in the recent-races strip,
+// which previously could show an unlisted feed under its raw name.
+func TestHyperliquidScoreboard_UnconfiguredFeedNeverSurfaces(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_unlisted_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	require.Len(t, resp.Competitors, 1)
+	assert.Equal(t, "feed_a_bbo", resp.Competitors[0].Feed)
+	for _, r := range resp.RecentRaces {
+		assert.NotEqual(t, "feed_unlisted_bbo", r.RunnerUpFeed)
+		assert.NotEqual(t, "feed_unlisted_bbo", r.WinnerFeed)
+	}
+}
+
+// A malformed feed id must be dropped rather than inlined into SQL, and must not stop the
+// remaining valid rows from serving.
+func TestHyperliquidScoreboard_UnsafeFeedIDSkipped(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+	insertEntry(t, api, "bad'; DROP TABLE hyperliquid_scoreboard_entry --", "Bad", 2, true)
+
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.Len(t, resp.Competitors, 1)
+	assert.Equal(t, "feed_a_bbo", resp.Competitors[0].Feed)
+
+	// The config table must still exist — proving nothing was executed.
+	var n int
+	require.NoError(t, api.PgPool.QueryRow(t.Context(),
+		`SELECT count(*) FROM hyperliquid_scoreboard_entry`).Scan(&n))
+	assert.Equal(t, 2, n)
+}
+
+// With the feeds table present but no configured rows, the scoreboard serves an
+// empty-but-valid payload rather than erroring — the local-dev and unseeded-env path.
+func TestHyperliquidScoreboard_NoConfiguredEntries(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "24h", resp.Window)
+	assert.Empty(t, resp.Competitors)
+	assert.Empty(t, resp.Nodes)
+	assert.Empty(t, resp.RecentRaces)
+	assert.EqualValues(t, 0, resp.TotalRaces)
 }

--- a/api/handlers/hyperliquid_scoreboard_test.go
+++ b/api/handlers/hyperliquid_scoreboard_test.go
@@ -344,3 +344,52 @@ func TestHyperliquidScoreboard_NoConfiguredEntries(t *testing.T) {
 	assert.Empty(t, resp.RecentRaces)
 	assert.EqualValues(t, 0, resp.TotalRaces)
 }
+
+// A genuine Postgres failure while loading the feed config must propagate as an error rather
+// than degrade to the same empty-but-valid response as "zero rows configured" — otherwise the
+// background refresher and page-cache worker would treat the failure as success and overwrite
+// the last-good cached payload with an empty one.
+func TestFetchHyperliquidScoreboardData_ConfigLoadFailure(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+
+	api.PgPool.Close() // force loadHyperliquidScoreboardEntries's query to fail
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// A tob_ feed accidentally added as a scoreboard config row must be ignored. tob_* feeds are
+// DoubleZero's own; the allow-list clause assumes they are never configured entries, so a
+// configured tob_ row would broaden the clause to match races against unconfigured
+// competitors, leaking their raw feed ids into the public payload.
+func TestHyperliquidScoreboard_TobFeedEntryIgnored(t *testing.T) {
+	api := apitesting.NewTestAPIBarePg(t, testChDB, testPgDB)
+	createFeedsTable(t, api)
+	insertEntry(t, api, "feed_a_bbo", "Feed A", 1, true)
+	insertEntry(t, api, "tob_gcp_tyo_hl_mainnet1", "Bad DZ Entry", 2, true)
+
+	// If the tob_ row were honored, this race would slip through the allow-list purely
+	// because tob_gcp_tyo_hl_mainnet1 appears in the IN(...) list, exposing the otherwise
+	// unconfigured feed_unlisted_bbo.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_a_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_unlisted_bbo", 1.0)
+
+	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
+	require.NoError(t, err)
+
+	require.Len(t, resp.Competitors, 1)
+	assert.Equal(t, "feed_a_bbo", resp.Competitors[0].Feed)
+	for _, r := range resp.RecentRaces {
+		assert.NotEqual(t, "feed_unlisted_bbo", r.RunnerUpFeed)
+		assert.NotEqual(t, "feed_unlisted_bbo", r.WinnerFeed)
+	}
+
+	// The config table must still hold the tob_ row — it's dropped from the in-memory
+	// allow-list, not deleted from Postgres.
+	var n int
+	require.NoError(t, api.PgPool.QueryRow(t.Context(),
+		`SELECT count(*) FROM hyperliquid_scoreboard_entry`).Scan(&n))
+	assert.Equal(t, 2, n)
+}

--- a/api/testing/api.go
+++ b/api/testing/api.go
@@ -30,6 +30,29 @@ func NewTestAPIBare(t *testing.T, chDB *ClickHouseDB) *handlers.API {
 	return api
 }
 
+// NewTestAPIBarePg creates an isolated *handlers.API with a bare per-test ClickHouse
+// database (no ClickHouse migrations — the test creates the tables it needs) plus a
+// PostgreSQL pool with migrations applied. Use it for handlers that read both a
+// test-created ClickHouse table and Postgres-backed config.
+func NewTestAPIBarePg(t *testing.T, chDB *ClickHouseDB, pgDB *DB) *handlers.API {
+	t.Helper()
+	conn, dbName := SetupClickHouseForTest(t, chDB)
+	api := &handlers.API{
+		DB:            conn,
+		PublicQueryDB: conn,
+		EnvDBs:        map[string]driver.Conn{},
+		EnvDatabases:  map[string]string{},
+		Database:      dbName,
+		ShredderDB:    dbName,
+		PublisherDB:   dbName,
+		DZDPDB:        "dzdp",
+		FeedsDB:       dbName,
+		PgPool:        SetupPostgresForTest(t, pgDB),
+	}
+	api.Manager = handlers.NewWorkflowManager(api)
+	return api
+}
+
 // NewTestAPI creates an isolated *handlers.API for a single test with a
 // per-test ClickHouse database (with full schema migrations).
 // This is the most common test setup pattern.

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -25,13 +25,13 @@ Solana slot.
 **DoubleZero = every feed whose name starts with `tob_`** (our top-of-book feeds
 across clouds/regions). All other feeds are competitors:
 
-| Raw feed(s)              | Rollup label  | Role                  |
-|--------------------------|---------------|-----------------------|
-| `tob_*` (all)            | **DoubleZero**| us                    |
-| `hyperliquid_public_bbo` | Public API    | baseline (free)       |
-| `hydromancer_bbo`        | Hydromancer   | paid competitor       |
-| `hyperpc_shared_bbo`     | HypeRPC       | paid competitor       |
-| `quicknode_l2book_bbo`   | QuickNode     | paid competitor       |
+| Raw feed(s)    | Rollup label   |
+|----------------|----------------|
+| `tob_*` (all)  | **DoubleZero** |
+| `feed_a_bbo`   | Feed A         |
+| `feed_b_bbo`   | Feed B         |
+| `feed_c_bbo`   | Feed C         |
+| `feed_d_bbo`   | Feed D         |
 
 The competitor set lives as a small ordered slice of `{rawFeed, label}` in Go;
 adding/renaming a competitor is a one-line change. The `tob_*` rollup is applied
@@ -124,10 +124,10 @@ live query (`X-Cache: MISS`).
   "dz_win_share_pct": 96.4,
   "total_races": 13680322,
   "competitors": [
-    { "feed": "hyperliquid_public_bbo", "label": "Public API",  "dz_win_pct": 99.1, "lead_p50_ms": 2.4, "lead_p95_ms": 8.1, "races": 12300000 },
-    { "feed": "hydromancer_bbo",        "label": "Hydromancer", "dz_win_pct": 94.2, "lead_p50_ms": 0.9, "lead_p95_ms": 3.7, "races": 1100000 },
-    { "feed": "hyperpc_shared_bbo",     "label": "HypeRPC",     "dz_win_pct": 97.8, "lead_p50_ms": 1.6, "lead_p95_ms": 5.2, "races": 400000 },
-    { "feed": "quicknode_l2book_bbo",   "label": "QuickNode",   "dz_win_pct": 95.0, "lead_p50_ms": 1.1, "lead_p95_ms": 4.4, "races": 900000 }
+    { "feed": "feed_a_bbo", "label": "Feed A", "dz_win_pct": 99.1, "lead_p50_ms": 2.4, "lead_p95_ms": 8.1, "races": 12300000 },
+    { "feed": "feed_b_bbo", "label": "Feed B", "dz_win_pct": 94.2, "lead_p50_ms": 0.9, "lead_p95_ms": 3.7, "races": 1100000 },
+    { "feed": "feed_c_bbo", "label": "Feed C", "dz_win_pct": 97.8, "lead_p50_ms": 1.6, "lead_p95_ms": 5.2, "races": 400000 },
+    { "feed": "feed_d_bbo", "label": "Feed D", "dz_win_pct": 95.0, "lead_p50_ms": 1.1, "lead_p95_ms": 4.4, "races": 900000 }
   ],
   "nodes": [
     {
@@ -136,12 +136,12 @@ live query (`X-Cache: MISS`).
       "dz_win_share_pct": 99.2,
       "total_races": 4600000,
       "competitors": [
-        { "feed": "hydromancer_bbo", "label": "Hydromancer", "dz_win_pct": 98.9, "lead_p50_ms": 0.6, "lead_p95_ms": 2.1, "races": 380000 }
+        { "feed": "feed_b_bbo", "label": "Feed B", "dz_win_pct": 98.9, "lead_p50_ms": 0.6, "lead_p95_ms": 2.1, "races": 380000 }
       ]
     }
   ],
   "recent_races": [
-    { "event_ts": "2026-06-29T16:59:59.9Z", "symbol": "BTC", "winner_feed": "tob_gcp_tyo_hl_mainnet1", "is_dz": true, "runner_up_feed": "hydromancer_bbo", "runner_up_label": "Hydromancer", "lead_ms": 1.2, "location_code": "tyo" }
+    { "event_ts": "2026-06-29T16:59:59.9Z", "symbol": "BTC", "winner_feed": "tob_gcp_tyo_hl_mainnet1", "is_dz": true, "runner_up_feed": "feed_b_bbo", "runner_up_label": "Feed B", "lead_ms": 1.2, "location_code": "tyo" }
   ]
 }
 ```
@@ -205,15 +205,15 @@ Hyperliquid ▸ BBO Scoreboard         window:[24h ▾]   symbol:[All ▾]
   DoubleZero wins  96.4%  of races            (all vantages, 24h)
 
   vs Competitor   DZ win%    median lead    p95 lead    races
-  Public API       99.1%      +2.4 ms        +8.1 ms     12.3M
-  Hydromancer      94.2%      +0.9 ms        +3.7 ms      1.1M
-  HypeRPC          97.8%      +1.6 ms        +5.2 ms      0.4M
-  QuickNode        95.0%      +1.1 ms        +4.4 ms      0.9M
+  Feed A          99.1%      +2.4 ms        +8.1 ms     12.3M
+  Feed B          94.2%      +0.9 ms        +3.7 ms      1.1M
+  Feed C          97.8%      +1.6 ms        +5.2 ms      0.4M
+  Feed D          95.0%      +1.1 ms        +4.4 ms      0.9M
 
   By vantage:   [chi]   [nyc]   [tyo]        (per-node cards, same stats)
 
   Recent races (live)   symbol  winner               lead vs runner-up
-  BTC   DoubleZero (tob_gcp_tyo)     +1.2 ms vs Hydromancer
+  BTC   DoubleZero (tob_gcp_tyo)     +1.2 ms vs Feed B
   ...                                            (polls :latest cache)
 ```
 

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-design.md
@@ -33,9 +33,11 @@ across clouds/regions). All other feeds are competitors:
 | `feed_c_bbo`   | Feed C         |
 | `feed_d_bbo`   | Feed D         |
 
-The competitor set lives as a small ordered slice of `{rawFeed, label}` in Go;
-adding/renaming a competitor is a one-line change. The `tob_*` rollup is applied
-in SQL via `startsWith(feed, 'tob_')`.
+The feed set lives in the Postgres table `hyperliquid_scoreboard_entry`
+(`feed`, `label`, `display_order`, `enabled`), seeded out of band per
+environment; adding, removing, or reordering a feed is a row change rather than
+a code change. The `tob_*` rollup is applied in SQL via
+`startsWith(feed, 'tob_')`.
 
 ## Data Source
 

--- a/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
+++ b/docs/plans/2026-06-29-hyperliquid-bbo-scoreboard-plan.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - User-facing product name is **"DoubleZero Data"**, not "Lake".
-- DoubleZero rollup = any feed where `startsWith(feed, 'tob_')`. Competitors (raw feed → label): `hyperliquid_public_bbo`→`Public API`, `hydromancer_bbo`→`Hydromancer`, `hyperpc_shared_bbo`→`HypeRPC`, `quicknode_l2book_bbo`→`QuickNode`.
+- DoubleZero rollup = any feed where `startsWith(feed, 'tob_')`. Competitors (raw feed → label): `feed_a_bbo`→`Feed A`, `feed_b_bbo`→`Feed B`, `feed_c_bbo`→`Feed C`, `feed_d_bbo`→`Feed D`.
 - Source table: `{FeedsDB}.hyperliquid_bbo_feed_race_summary`, default db name `feeds`, overridable via `CLICKHOUSE_FEEDS_DB`. Always query with `FINAL` (ReplacingMergeTree).
 - Race key columns: `(capture_run_id, measurement_node_id, symbol, source_ts_ms, bbo_hash)`.
 - Window values: `1h`, `24h`, `7d`; default `24h`. Default (cacheable) request shape = no `symbol`, no `since_ts`, window omitted or `24h`.
@@ -255,10 +255,10 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)
 
-	// 3 races at node tyo: DZ (tob_*) beats Hydromancer twice, loses once.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 3.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "hydromancer_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
+	// 3 races at node tyo: DZ (tob_*) beats Feed B twice, loses once.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 1000, 1, "tob_gcp_tyo_hl_mainnet1", "feed_b_bbo", 1.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 2000, 2, "tob_gcp_tyo_hl_mainnet1", "feed_b_bbo", 3.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 3000, 3, "feed_b_bbo", "tob_gcp_tyo_hl_mainnet1", 0.5)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -267,18 +267,18 @@ func TestHyperliquidScoreboard_HeadlineAndCompetitors(t *testing.T) {
 	assert.InDelta(t, 66.67, resp.DZWinSharePct, 0.1)
 	assert.EqualValues(t, 3, resp.TotalRaces)
 
-	var hydro *handlers.HyperliquidCompetitor
+	var feedB *handlers.HyperliquidCompetitor
 	for i := range resp.Competitors {
-		if resp.Competitors[i].Feed == "hydromancer_bbo" {
-			hydro = &resp.Competitors[i]
+		if resp.Competitors[i].Feed == "feed_b_bbo" {
+			feedB = &resp.Competitors[i]
 		}
 	}
-	require.NotNil(t, hydro)
-	assert.Equal(t, "Hydromancer", hydro.Label)
-	assert.InDelta(t, 66.67, hydro.DZWinPct, 0.1)
-	assert.EqualValues(t, 3, hydro.Races)
+	require.NotNil(t, feedB)
+	assert.Equal(t, "Feed B", feedB.Label)
+	assert.InDelta(t, 66.67, feedB.DZWinPct, 0.1)
+	assert.EqualValues(t, 3, feedB.Races)
 	// Lead p50 over the 2 DZ wins (1.0, 3.0) = 1.0 (quantileExact lower).
-	assert.InDelta(t, 1.0, hydro.LeadP50Ms, 0.001)
+	assert.InDelta(t, 1.0, feedB.LeadP50Ms, 0.001)
 }
 ```
 
@@ -304,10 +304,10 @@ import (
 // hyperliquidCompetitors lists the non-DoubleZero feeds shown on the scoreboard,
 // in display order, mapping each raw feed name to its label.
 var hyperliquidCompetitors = []struct{ Feed, Label string }{
-	{"hyperliquid_public_bbo", "Public API"},
-	{"hydromancer_bbo", "Hydromancer"},
-	{"hyperpc_shared_bbo", "HypeRPC"},
-	{"quicknode_l2book_bbo", "QuickNode"},
+	{"feed_a_bbo", "Feed A"},
+	{"feed_b_bbo", "Feed B"},
+	{"feed_c_bbo", "Feed C"},
+	{"feed_d_bbo", "Feed D"},
 }
 
 // hyperliquidWindows maps window params to ClickHouse interval expressions.
@@ -522,11 +522,11 @@ func TestHyperliquidScoreboard_PerNode(t *testing.T) {
 	api := apitesting.NewTestAPIBare(t, testChDB)
 	createFeedsTable(t, api)
 
-	// tyo: DZ wins both vs QuickNode. nyc: DZ wins 1, loses 1 vs QuickNode.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "quicknode_l2book_bbo", 2.0)
-	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "quicknode_l2book_bbo", 1.0)
-	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "quicknode_l2book_bbo", "tob_aws_galaxy1", 1.0)
+	// tyo: DZ wins both vs Feed D. nyc: DZ wins 1, loses 1 vs Feed D.
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 10, 1, "tob_gcp_tyo_hl_mainnet1", "feed_d_bbo", 2.0)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 20, 2, "tob_gcp_tyo_hl_mainnet1", "feed_d_bbo", 2.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 30, 3, "tob_aws_galaxy1", "feed_d_bbo", 1.0)
+	insertPairwise(t, api, "nyc-rec1", "nyc", "ETH", 40, 4, "feed_d_bbo", "tob_aws_galaxy1", 1.0)
 
 	resp, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -668,8 +668,8 @@ func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
 	createFeedsTable(t, api)
 
 	// A DZ-won race (BTC) and a competitor-won race (ETH), both pairwise.
-	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "hydromancer_bbo", 1.5)
-	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "quicknode_l2book_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "BTC", 100, 1, "tob_gcp_tyo_hl_mainnet1", "feed_b_bbo", 1.5)
+	insertPairwise(t, api, "tyo-rec1", "tyo", "ETH", 200, 2, "feed_d_bbo", "tob_gcp_tyo_hl_mainnet1", 0.7)
 
 	races, err := api.FetchHyperliquidScoreboardData(t.Context(), "24h", "")
 	require.NoError(t, err)
@@ -680,7 +680,7 @@ func TestHyperliquidScoreboard_RecentRaces(t *testing.T) {
 		bySym[r.Symbol] = r
 	}
 	assert.True(t, bySym["BTC"].IsDZ)
-	assert.Equal(t, "Hydromancer", bySym["BTC"].RunnerUpLabel)
+	assert.Equal(t, "Feed B", bySym["BTC"].RunnerUpLabel)
 	assert.InDelta(t, 1.5, bySym["BTC"].LeadMs, 0.001)
 	assert.False(t, bySym["ETH"].IsDZ)
 }

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -218,7 +218,17 @@ export function HyperliquidScoreboardPage() {
           <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">Loading…</div>
         )}
 
-        {data && (
+        {/* No configured feeds yet (post-deploy, pre-seeding): show a neutral empty state
+            instead of a headline hero implying real data (0 races, 0.0% win rate). */}
+        {data && data.total_races === 0 && data.competitors.length === 0 && (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-border bg-card py-12 text-center">
+            <Trophy className="mb-4 h-12 w-12 text-muted-foreground" />
+            <h3 className="mb-2 text-lg font-medium">Scoreboard not configured</h3>
+            <p className="text-sm text-muted-foreground">No feed data available for this time window yet.</p>
+          </div>
+        )}
+
+        {data && (data.total_races > 0 || data.competitors.length > 0) && (
           <>
             {/* Hero stats — 3 columns: description+stats | metrics | gauge */}
             <div className="mb-8 flex flex-col rounded-lg border border-border bg-card lg:flex-row">

--- a/web/src/components/hyperliquid-scoreboard-page.tsx
+++ b/web/src/components/hyperliquid-scoreboard-page.tsx
@@ -223,7 +223,7 @@ export function HyperliquidScoreboardPage() {
         {data && data.total_races === 0 && data.competitors.length === 0 && (
           <div className="flex flex-col items-center justify-center rounded-lg border border-border bg-card py-12 text-center">
             <Trophy className="mb-4 h-12 w-12 text-muted-foreground" />
-            <h3 className="mb-2 text-lg font-medium">Scoreboard not configured</h3>
+            <h3 className="mb-2 text-lg font-medium">No scoreboard data yet</h3>
             <p className="text-sm text-muted-foreground">No feed data available for this time window yet.</p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- Moves the tiredsolid scoreboard's feed list out of hardcoded Go slices and into a Postgres config table (`feed`, `label`, `display_order`, `enabled`). Adding, removing, or reordering a feed is now a row change instead of a deploy.
- Collapses the previous two lists (shown set + withheld set) into a single allow-list. Feeds with no enabled row no longer surface anywhere, including the recent-races strip.
- Config load failures now propagate instead of quietly caching an empty payload, so the refresher keeps serving the last good result and escalates.
- Adds an empty state so an unseeded environment renders nothing rather than a 0.0% headline.
- Redacts vendor names from two existing design docs.

The migration ships the table **empty on purpose** — rows are environment config, seeded out of band, so values never live in the repo. Until an environment is seeded its scoreboard renders empty. Changes take effect on the next cache refresh (~60s for the 1h view, ~10min for 24h/7d), no restart.

## Testing Verification

- `go test ./api/handlers/` green, 0 failures.
- New tests cover allow-list filtering, display order, disabled rows, unlisted feeds staying hidden, malformed feed ids being skipped, config-load failure surfacing as an error, and the empty-config path.
- Confirmed the headline math is unchanged: totals previously summed only the configured set, so moving the restriction into SQL narrows the scan without moving the math.
