### PR TITLE
indexer: fix permission-events refresh timeout poison loop; classify InfluxDB throttle as transient

### DIFF
--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -200,52 +200,56 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		return result, fmt.Errorf("get high water marks: %w", err)
 	}
 
+	// Persist each account's events as soon as it finishes fetching, rather than
+	// accumulating every account into one end-of-cycle insert. The per-account cursor is
+	// derived from the fact table (max(slot) per permission_pk), so committing an account
+	// immediately advances its cursor. If the refresh later times out — the Temporal activity
+	// has a bounded StartToCloseTimeout — the accounts already committed are not re-fetched
+	// next cycle. A single terminal batch instead discards the whole cycle's work on timeout
+	// and re-fetches it forever: a poison loop once the backlog exceeds one timeout window.
 	var (
-		mu        sync.Mutex
-		allEvents []PermissionEventRow
+		mu            sync.Mutex
+		totalInserted int64
 	)
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentFetches)
 	for _, pda := range pdas {
 		g.Go(func() error {
-			events, err := v.fetchAccountEvents(ctx, pda, hwms[pda.String()])
+			events, fetchErr := v.fetchAccountEvents(ctx, pda, hwms[pda.String()])
+			// Persist whatever decoded cleanly before surfacing any fetch error (idempotent
+			// via ReplacingMergeTree). A failed account isn't cursor-advanced past its
+			// un-indexed signatures, so it is simply re-fetched next refresh — no silent gap.
 			if len(events) > 0 {
+				if err := v.store.InsertEvents(ctx, events); err != nil {
+					return fmt.Errorf("insert permission events for %s: %w", pda.String(), err)
+				}
 				mu.Lock()
-				allEvents = append(allEvents, events...)
+				totalInserted += int64(len(events))
 				mu.Unlock()
 			}
-			if err != nil {
+			if fetchErr != nil {
 				v.log.Warn("serviceability/permission-events: failed to fetch account",
-					"permission_pk", pda.String(), "error", err)
-				return err
+					"permission_pk", pda.String(), "error", fetchErr)
+				return fetchErr
 			}
 			return nil
 		})
 	}
-	fetchErr := g.Wait()
-
-	// Persist whatever decoded cleanly (idempotent via ReplacingMergeTree). Because the
-	// per-account cursor is derived from the fact table, a failed account simply isn't
-	// advanced — it is re-fetched next refresh rather than leaving a silent gap.
-	if err := v.store.InsertEvents(ctx, allEvents); err != nil {
+	if err := g.Wait(); err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-		return result, fmt.Errorf("insert permission events: %w", err)
-	}
-	if fetchErr != nil {
-		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
-		return result, fmt.Errorf("fetch account events: %w", fetchErr)
+		return result, fmt.Errorf("refresh permission accounts: %w", err)
 	}
 
-	result.RowsAffected = int64(len(allEvents))
+	result.RowsAffected = totalInserted
 	fetchedAt := time.Now().UTC()
 	result.SourceMaxEventTS = &fetchedAt
 
 	v.markReady()
 	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
 
-	if len(allEvents) > 0 {
+	if totalInserted > 0 {
 		v.log.Info("serviceability/permission-events: indexed new events",
-			"count", len(allEvents), "watched_accounts", len(pdas))
+			"count", totalInserted, "watched_accounts", len(pdas))
 	}
 	return result, nil
 }

--- a/utils/pkg/dberror/dberror.go
+++ b/utils/pkg/dberror/dberror.go
@@ -123,8 +123,10 @@ func Classify(err error) ErrorType {
 		"rate limited",
 		"too many requests",
 		"status 429",
+		"request too large",
 		"resourceexhausted",
 		"resource exhausted",
+		"resources exhausted",
 	}
 
 	for _, pattern := range rateLimitPatterns {

--- a/utils/pkg/dberror/dberror_test.go
+++ b/utils/pkg/dberror/dberror_test.go
@@ -22,6 +22,11 @@ func TestClassifyAndIsTransient(t *testing.T) {
 		{"rpc rate limit message", errors.New("rate limited (status 429)"), dberror.ErrorTypeRateLimit, true},
 		{"too many requests", errors.New("upstream returned Too Many Requests"), dberror.ErrorTypeRateLimit, true},
 		{"grpc resource exhausted", errors.New("rpc error: code = ResourceExhausted desc = token bucket exhausted"), dberror.ErrorTypeRateLimit, true},
+		// InfluxDB Cloud throttle signatures. It emits the plural "Resources exhausted",
+		// which the singular "resource exhausted" pattern does not substring-match, plus a
+		// "request too large" prefix — both must classify as transient rate limits.
+		{"influxdb resources exhausted plural", errors.New("Resources exhausted: Heap exhausted"), dberror.ErrorTypeRateLimit, true},
+		{"influxdb request too large", errors.New("request too large: Error running series plans for namespace 'x': Resources exhausted: Heap exhausted"), dberror.ErrorTypeRateLimit, true},
 
 		// The actual prod CH-connection-drop errors we saw — must be transient.
 		{"ch read packet reset", errors.New("query processing: failed to read packet from 52.4.220.199:9440 (conn_id=492): read: connection reset by peer"), dberror.ErrorTypeConnectivity, true},


### PR DESCRIPTION
## Summary

- **Break the permission-events poison loop.** Steady-state `RefreshPermissionEvents` accumulated every watched account's events into one end-of-cycle `InsertEvents`. The per-account cursor is derived from the fact table (`max(slot)` per `permission_pk`), so it only advances when events are persisted — and nothing persisted until that single terminal insert. When a cycle's fetch+insert exceeded the 5-minute Temporal activity `StartToCloseTimeout`, the insert was cancelled, no cursor advanced, and the next cycle re-did identical work: a permanent poison loop. Now each account is inserted as soon as it finishes fetching, so a mid-cycle timeout still advances the completed accounts and the backlog drains instead of restarting every cycle. This mirrors the checkpoint-per-chunk pattern `BackfillRefresh` already uses.
- **Classify InfluxDB Cloud throttle signatures as transient.** `dberror.Classify` matched the singular `"resource exhausted"` but not InfluxDB's plural `"Resources exhausted"` (`strings.Contains` won't match across the extra `s`), and had no `"request too large"` pattern — so `RefreshTelemetryUsage`'s recurring `request too large: … Resources exhausted: Heap exhausted` classified as Unknown/non-transient, contradicting the documented intent that InfluxDB resource-exhaustion is transient (escalate at 10, not 3). Added both patterns with tests.

## Context

On 2026-07-22 the prod **Lake Indexer: Errors** alert flapped ~hourly (21:21–23:01 UTC). Root cause was `lake_testnet` / `RefreshPermissionEvents` timing out every ~300s with `context deadline exceeded` on the batch insert (14 failures over ~100 min), while mainnet-beta was healthy. The first change fixes that outage-adjacent behavior; the second is an independent correctness cleanup surfaced during the investigation.

A third finding — that testnet/devnet secondary-indexer errors page the **prod** on-call because the alert has no network dimension — is tracked separately in `malbeclabs/infra` (alert-scoping change): https://github.com/malbeclabs/infra/issues/2071

## Testing Verification

- Local build/test could not run in the agent environment (no Go toolchain present); CI must exercise build/lint/test.
- `dberror` change is covered by new table cases asserting `Classify` → `ErrorTypeRateLimit` and `IsTransient` → true for both `"Resources exhausted: Heap exhausted"` and the full `request too large: …` message.
- Behavior of the permission-events refresh is otherwise unchanged: all accounts are still attempted per cycle (plain `errgroup`, no early cancel), partially-decoded accounts still persist what decoded cleanly, and a failed account is still re-fetched next cycle (cursor never advances past un-indexed signatures). Idempotency is preserved via the fact table's ReplacingMergeTree dedup, so per-account inserts are safe to repeat.
