### PR TITLE
indexer: drain permission-events accounts in durable chunks to break testnet poison loop

### DIFF
--- a/indexer/db/clickhouse/migrations/20260723000001_dz_permission_events_account_cursor.sql
+++ b/indexer/db/clickhouse/migrations/20260723000001_dz_permission_events_account_cursor.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- Durable per-account resume cursor for the steady-state Permission PDA watch.
+-- The fact table cannot serve as the cursor: a Permission PDA is also referenced
+-- by non-permission serviceability instructions (e.g. multicast allowlist ops)
+-- that decode to zero audit rows, so max(slot) over fact rows never advances
+-- through them. This tracks the newest fully-processed signature per PDA so each
+-- refresh resumes where the last one stopped, even mid-backlog.
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS dz_permission_events_account_cursor
+(
+    permission_pk     String,
+    last_tx_signature String,
+    last_slot         UInt64,
+    updated_at        DateTime64(3)
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (permission_pk);
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS dz_permission_events_account_cursor;

--- a/indexer/pkg/dz/serviceability/permissionevents/main_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/main_test.go
@@ -1,0 +1,30 @@
+package permissionevents
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+var sharedDB *clickhousetesting.DB
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("failed to create shared DB", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}
+
+func testClient(t *testing.T) clickhouse.Client {
+	return laketesting.NewClient(t, sharedDB)
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/store.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/store.go
@@ -109,9 +109,68 @@ func (s *Store) SetScanCursor(ctx context.Context, programPK string, cur ScanCur
 	return nil
 }
 
+// GetAccountCursors returns the durable per-account resume cursor for every Permission
+// PDA that has one. Unlike the fact-derived high-water marks, these advance through
+// transactions that decode to zero audit rows (a Permission PDA is also referenced by
+// non-permission serviceability instructions), so a large row-less backlog still drains.
+func (s *Store) GetAccountCursors(ctx context.Context) (map[string]HighWaterMark, error) {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+
+	// ReplacingMergeTree: the highest updated_at row per PDA is the current cursor.
+	// Chunks can commit within the same millisecond (updated_at's resolution), so break
+	// ties by last_slot — per-account cursor slots only ever advance within one ledger,
+	// while updated_at stays authoritative across ledger resets (where slots restart low).
+	const query = `
+		SELECT permission_pk,
+		       argMax(last_tx_signature, (updated_at, last_slot)),
+		       argMax(last_slot, (updated_at, last_slot))
+		FROM dz_permission_events_account_cursor
+		GROUP BY permission_pk
+	`
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query account cursors: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]HighWaterMark)
+	for rows.Next() {
+		var pk string
+		var cur HighWaterMark
+		if err := rows.Scan(&pk, &cur.TxSignature, &cur.Slot); err != nil {
+			return nil, fmt.Errorf("failed to scan account cursor row: %w", err)
+		}
+		result[pk] = cur
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating account cursors: %w", err)
+	}
+	return result, nil
+}
+
+// SetAccountCursor records the newest fully-processed signature/slot for a Permission PDA.
+func (s *Store) SetAccountCursor(ctx context.Context, permissionPK string, cur HighWaterMark) error {
+	conn, err := s.cfg.ClickHouse.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ClickHouse connection: %w", err)
+	}
+	const query = `
+		INSERT INTO dz_permission_events_account_cursor
+			(permission_pk, last_tx_signature, last_slot, updated_at)
+		VALUES (?, ?, ?, ?)
+	`
+	if err := conn.Exec(ctx, query, permissionPK, cur.TxSignature, cur.Slot, time.Now().UTC()); err != nil {
+		return fmt.Errorf("failed to write account cursor: %w", err)
+	}
+	return nil
+}
+
 // GetHighWaterMarks returns the newest indexed signature/slot per Permission PDA, derived
-// from the fact table. Every permission event for a PDA lands in the fact table, so
-// max(slot) per permission_pk is where the per-account watch resumes.
+// from the fact table. Kept as the resume fallback for accounts indexed before the durable
+// account cursor existed; GetAccountCursors is authoritative once a cursor row is written.
 func (s *Store) GetHighWaterMarks(ctx context.Context) (map[string]HighWaterMark, error) {
 	conn, err := s.cfg.ClickHouse.Conn(ctx)
 	if err != nil {

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -19,16 +19,23 @@ import (
 )
 
 const (
-	// maxConcurrentFetches limits parallel getTransaction calls per refresh.
+	// maxConcurrentFetches limits in-flight getTransaction calls across the whole view
+	// via a shared semaphore: accounts drain concurrently, but the RPC never sees more
+	// than this many transaction fetches at once.
 	maxConcurrentFetches = 10
 	// maxSignaturesPerRequest is the Solana RPC page limit.
 	maxSignaturesPerRequest = 1000
-	// scanChunkSize is how many signatures the full-program backfill scan fetches,
-	// decodes, and durably writes before advancing the program scan cursor. Chunking
-	// (oldest-first) bounds how much work is lost if the backfill is cancelled — a
-	// full-history sweep that exceeds the Temporal activity timeout resumes from the last
+	// scanChunkSize is how many signatures the program backfill scan and the per-account
+	// drain decode and durably write before advancing their cursor. Chunking
+	// (oldest-first) bounds how much work is lost if a refresh is cancelled — a
+	// backlog that exceeds the Temporal activity timeout resumes from the last
 	// completed chunk instead of restarting from scratch.
 	scanChunkSize = 200
+	// drainBudgetMargin is how much of the refresh context's deadline the per-account
+	// drain leaves unspent when deciding to start another chunk: enough to decode,
+	// insert, and checkpoint that chunk. When less than this remains, the drain stops
+	// and the next refresh continues from the durable cursor.
+	drainBudgetMargin = 30 * time.Second
 	// permissionAccountType is the serviceability account_type discriminator (first byte
 	// of account data) for Permission accounts — AccountType::Permission = 15 in
 	// state/permission.rs. Used to enumerate Permission PDAs via getProgramAccounts.
@@ -74,6 +81,11 @@ type View struct {
 	store     *Store
 	refreshMu sync.Mutex
 
+	// decodeSem bounds in-flight getTransaction calls view-wide (see
+	// maxConcurrentFetches); per-chunk errgroup limits alone would multiply
+	// by the number of concurrently draining accounts.
+	decodeSem chan struct{}
+
 	readyOnce sync.Once
 	readyCh   chan struct{}
 
@@ -91,10 +103,11 @@ func NewView(cfg ViewConfig) (*View, error) {
 		return nil, fmt.Errorf("failed to create store: %w", err)
 	}
 	return &View{
-		log:     cfg.Logger,
-		cfg:     cfg,
-		store:   store,
-		readyCh: make(chan struct{}),
+		log:       cfg.Logger,
+		cfg:       cfg,
+		store:     store,
+		decodeSem: make(chan struct{}, maxConcurrentFetches),
+		readyCh:   make(chan struct{}),
 	}, nil
 }
 
@@ -159,8 +172,11 @@ func (v *View) safeRefresh(ctx context.Context) {
 //  2. per PDA, getSignaturesForAddress since that account's high-water mark and decode only
 //     those transactions.
 //
-// Because a Permission PDA is only ever referenced by permission instructions, this fetches
-// only permission transactions rather than the whole program's history. New grants are
+// This fetches only transactions touching Permission PDAs rather than the whole program's
+// history. Note a Permission PDA is not only referenced by permission-management
+// instructions: other serviceability instructions (e.g. multicast allowlist ops) reference
+// it too and decode to zero audit rows — which is why resume progress is tracked in a
+// durable per-account cursor rather than derived from indexed rows. New grants are
 // picked up once the PDA is discovered (its create tx references the account). The only gap
 // is an account created and deleted between two discovery polls (a deleted account no longer
 // appears in getProgramAccounts) — BackfillRefresh's full-history program scan is the
@@ -191,61 +207,77 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		return result, nil
 	}
 
-	// Resume each account from the newest slot already indexed for it. The fact table holds
-	// every permission event for a given PDA, so max(slot) per permission_pk is a sound
-	// per-account cursor (unlike a program-wide scan, which the fact table can't anchor).
+	// Resume each account from its durable cursor, falling back to the fact-derived
+	// high-water mark for accounts indexed before the cursor table existed. When both
+	// exist take the newer: the program-wide backfill can insert rows beyond the cursor.
 	hwms, err := v.store.GetHighWaterMarks(ctx)
 	if err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
 		return result, fmt.Errorf("get high water marks: %w", err)
 	}
+	cursors, err := v.store.GetAccountCursors(ctx)
+	if err != nil {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
+		return result, fmt.Errorf("get account cursors: %w", err)
+	}
+	resume := func(pk string) HighWaterMark {
+		cur, hasCur := cursors[pk]
+		if hwm, ok := hwms[pk]; ok && (!hasCur || hwm.Slot > cur.Slot) {
+			return hwm
+		}
+		return cur
+	}
 
-	// Persist each account's events as soon as it finishes fetching, rather than
-	// accumulating every account into one end-of-cycle insert. The per-account cursor is
-	// derived from the fact table (max(slot) per permission_pk), so committing an account
-	// immediately advances its cursor. If the refresh later times out — the Temporal activity
-	// has a bounded StartToCloseTimeout — the accounts already committed are not re-fetched
-	// next cycle. A single terminal batch instead discards the whole cycle's work on timeout
-	// and re-fetches it forever: a poison loop once the backlog exceeds one timeout window.
+	// Drain each account in durable oldest-first chunks (see drainAccount). A refresh cut
+	// short by the Temporal activity timeout keeps every committed chunk, so even a single
+	// account whose backlog exceeds one timeout window makes forward progress each cycle
+	// instead of re-fetching the same work forever: the poison-loop failure mode.
 	var (
 		mu            sync.Mutex
 		totalInserted int64
+		totalPending  int
 	)
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentFetches)
 	for _, pda := range pdas {
 		g.Go(func() error {
-			events, fetchErr := v.fetchAccountEvents(ctx, pda, hwms[pda.String()])
-			// Persist whatever decoded cleanly before surfacing any fetch error (idempotent
-			// via ReplacingMergeTree). A failed account isn't cursor-advanced past its
-			// un-indexed signatures, so it is simply re-fetched next refresh — no silent gap.
-			if len(events) > 0 {
-				if err := v.store.InsertEvents(ctx, events); err != nil {
-					return fmt.Errorf("insert permission events for %s: %w", pda.String(), err)
-				}
-				mu.Lock()
-				totalInserted += int64(len(events))
-				mu.Unlock()
-			}
-			if fetchErr != nil {
-				v.log.Warn("serviceability/permission-events: failed to fetch account",
-					"permission_pk", pda.String(), "error", fetchErr)
-				return fetchErr
+			inserted, pending, drainErr := v.drainAccount(ctx, pda, resume(pda.String()))
+			mu.Lock()
+			totalInserted += inserted
+			totalPending += pending
+			mu.Unlock()
+			if drainErr != nil {
+				v.log.Warn("serviceability/permission-events: failed to drain account",
+					"permission_pk", pda.String(), "error", drainErr)
+				return fmt.Errorf("drain account %s: %w", pda.String(), drainErr)
 			}
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
+	// Committed chunks are durable regardless of the refresh outcome — report them, and
+	// let freshness advance on partial progress (overstates by at most one cycle).
+	err = g.Wait()
+	result.RowsAffected = totalInserted
+	if totalInserted > 0 || err == nil {
+		fetchedAt := time.Now().UTC()
+		result.SourceMaxEventTS = &fetchedAt
+	}
+	if err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
 		return result, fmt.Errorf("refresh permission accounts: %w", err)
 	}
 
-	result.RowsAffected = totalInserted
-	fetchedAt := time.Now().UTC()
-	result.SourceMaxEventTS = &fetchedAt
-
 	v.markReady()
-	metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+	// "partial" = every account made progress but at least one stopped at the refresh
+	// budget with backlog left. A drain that stays partial forever is a stalled drain —
+	// the metric is what keeps that visible, since each cycle reports success.
+	if totalPending > 0 {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "partial").Inc()
+		v.log.Info("serviceability/permission-events: drain stopped at refresh budget",
+			"inserted", totalInserted, "pending_signatures", totalPending, "watched_accounts", len(pdas))
+	} else {
+		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "success").Inc()
+	}
 
 	if totalInserted > 0 {
 		v.log.Info("serviceability/permission-events: indexed new events",
@@ -378,16 +410,85 @@ func (v *View) discoverPermissionAccounts(ctx context.Context) ([]solana.PublicK
 	return pdas, nil
 }
 
-// fetchAccountEvents fetches all transactions touching a single Permission PDA newer than
-// its high-water mark and decodes their permission instructions. A Permission PDA is only
-// referenced by permission instructions, so every signature here yields audit rows.
-func (v *View) fetchAccountEvents(ctx context.Context, pda solana.PublicKey, hwm HighWaterMark) ([]PermissionEventRow, error) {
+// drainAccount incrementally indexes one Permission PDA's transaction history newer than
+// resume, oldest-first in chunks. Each fully-decoded chunk is persisted and the account's
+// durable cursor advanced before the next chunk starts, so a refresh cut short by
+// cancellation or the deadline budget re-does at most one chunk of work — an account whose
+// backlog exceeds one refresh window drains across cycles instead of poison-looping.
+// Returns the audit rows inserted (meaningful even alongside an error) and how many
+// signatures were left unprocessed.
+//
+// Signature pagination is O(remaining backlog) each refresh: getSignaturesForAddress pages
+// newest-first, so reaching the oldest unprocessed chunk requires paging everything newer
+// than the cursor. If pagination alone ever consumes the budget, the zero-progress error
+// below fires — a pagination-starved account is loud, never a silent no-op.
+func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume HighWaterMark) (inserted int64, pending int, err error) {
+	sigs, err := v.fetchAccountSignatures(ctx, pda, resume)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(sigs) == 0 {
+		return 0, 0, nil
+	}
+
+	// Reverse to oldest-first so the cursor advances monotonically as chunks commit; a
+	// partial drain then leaves the cursor at the newest fully-processed signature.
+	for i, j := 0, len(sigs)-1; i < j; i, j = i+1, j-1 {
+		sigs[i], sigs[j] = sigs[j], sigs[i]
+	}
+
+	for start := 0; start < len(sigs); start += scanChunkSize {
+		if err := ctx.Err(); err != nil {
+			return inserted, len(sigs) - start, err
+		}
+		// Stop when too little of the deadline remains to decode, insert, and checkpoint
+		// another chunk. Progress so far is committed, so stopping with progress is a
+		// success — the next refresh continues from the cursor. Stopping with none is an
+		// error so a persistently starved account escalates instead of no-op succeeding.
+		if deadline, ok := ctx.Deadline(); ok && deadline.Sub(v.cfg.Clock.Now()) < drainBudgetMargin {
+			if start == 0 {
+				return 0, len(sigs), fmt.Errorf("refresh budget exhausted before first chunk (%d signatures pending)", len(sigs))
+			}
+			v.log.Info("serviceability/permission-events: account drain stopping at refresh budget",
+				"permission_pk", pda.String(), "processed", start, "pending", len(sigs)-start)
+			return inserted, len(sigs) - start, nil
+		}
+
+		chunk := sigs[start:min(start+scanChunkSize, len(sigs))]
+		events, decodeErr := v.decodeChunk(ctx, chunk)
+		if decodeErr != nil {
+			// Decode order within a chunk is not cursor order: persisting a partially
+			// decoded chunk could advance the fact-derived high-water mark past
+			// never-decoded signatures — a silent, permanent gap. Drop the chunk's
+			// events; the cursor stays put and the chunk is re-fetched next refresh.
+			return inserted, len(sigs) - start, fmt.Errorf("decode transactions: %w", decodeErr)
+		}
+		if err := v.store.InsertEvents(ctx, events); err != nil {
+			return inserted, len(sigs) - start, fmt.Errorf("insert permission events: %w", err)
+		}
+		inserted += int64(len(events))
+
+		// Chunk is oldest-first, so its last element is the newest processed signature.
+		// The cursor must advance even when the chunk produced no rows: non-permission
+		// instructions also reference Permission PDAs, and a backlog of them would
+		// otherwise be re-fetched forever.
+		newest := chunk[len(chunk)-1]
+		cur := HighWaterMark{TxSignature: newest.Signature.String(), Slot: newest.Slot}
+		if err := v.store.SetAccountCursor(ctx, pda.String(), cur); err != nil {
+			return inserted, len(sigs) - start, fmt.Errorf("set account cursor: %w", err)
+		}
+	}
+	return inserted, 0, nil
+}
+
+// fetchAccountSignatures returns all signatures touching pda newer than resume, newest-first.
+func (v *View) fetchAccountSignatures(ctx context.Context, pda solana.PublicKey, resume HighWaterMark) ([]*rpc.TransactionSignature, error) {
 	var untilSig solana.Signature
-	if hwm.TxSignature != "" {
+	if resume.TxSignature != "" {
 		var err error
-		untilSig, err = solana.SignatureFromBase58(hwm.TxSignature)
+		untilSig, err = solana.SignatureFromBase58(resume.TxSignature)
 		if err != nil {
-			return nil, fmt.Errorf("invalid high water mark signature %q: %w", hwm.TxSignature, err)
+			return nil, fmt.Errorf("invalid resume cursor signature %q: %w", resume.TxSignature, err)
 		}
 	}
 
@@ -414,27 +515,20 @@ func (v *View) fetchAccountEvents(ctx context.Context, pda solana.PublicKey, hwm
 		allSigs = append(allSigs, page...)
 		beforeSig = page[len(page)-1].Signature
 	}
-	if len(allSigs) == 0 {
-		return nil, nil
-	}
-
-	var events []PermissionEventRow
-	for _, sig := range allSigs {
-		decoded, err := v.decodeTransaction(ctx, sig)
-		if err != nil {
-			// Fail the account so it is retried (cursor is derived from the fact table and
-			// therefore not advanced) rather than silently dropping the event.
-			return events, fmt.Errorf("decode transaction %s: %w", sig.Signature.String(), err)
-		}
-		events = append(events, decoded...)
-	}
-	return events, nil
+	return allSigs, nil
 }
 
 // decodeChunk fetches and decodes a batch of transactions concurrently. It returns the
 // events that decoded cleanly along with the first fetch/decode error encountered, if any.
 // All transactions are attempted even when one fails (no early cancellation) so a single
 // transient error doesn't discard the rest of the chunk's successfully decoded events.
+//
+// A finalized signature whose transaction the RPC cannot serve (rpc.ErrNotFound — pruned
+// or inconsistent upstream history) is skipped with a warning rather than failing the
+// chunk: retrying can never recover it, and failing would wedge the drain (and the
+// backfill, which advances past skipped signatures identically) at that point forever.
+// A skip is therefore a permanently missing audit row unless re-backfilled against an
+// archival node — the PermissionEventsSkippedTx metric is what keeps that loss visible.
 func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature) ([]PermissionEventRow, error) {
 	var (
 		mu        sync.Mutex
@@ -444,8 +538,23 @@ func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature
 	g.SetLimit(maxConcurrentFetches)
 	for _, sig := range sigs {
 		g.Go(func() error {
+			// The view-wide semaphore bounds total RPC pressure: without it, chunks
+			// draining in parallel across accounts would each fetch at the group limit.
+			select {
+			case v.decodeSem <- struct{}{}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			defer func() { <-v.decodeSem }()
+
 			events, err := v.decodeTransaction(ctx, sig)
 			if err != nil {
+				if errors.Is(err, rpc.ErrNotFound) {
+					metrics.PermissionEventsSkippedTx.Inc()
+					v.log.Warn("serviceability/permission-events: transaction unretrievable upstream, skipping",
+						"signature", sig.Signature.String(), "slot", sig.Slot, "error", err)
+					return nil
+				}
 				v.log.Warn("serviceability/permission-events: failed to decode transaction",
 					"signature", sig.Signature.String(), "error", err)
 				return err

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -420,8 +420,8 @@ func (v *View) discoverPermissionAccounts(ctx context.Context) ([]solana.PublicK
 //
 // Signature pagination is O(remaining backlog) each refresh: getSignaturesForAddress pages
 // newest-first, so reaching the oldest unprocessed chunk requires paging everything newer
-// than the cursor. If pagination alone ever consumes the budget, the zero-progress error
-// below fires — a pagination-starved account is loud, never a silent no-op.
+// than the cursor. Pagination checks the same deadline budget per page and fails fast when
+// it can't finish in time — a pagination-starved account is loud, never a silent no-op.
 func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume HighWaterMark) (inserted int64, pending int, err error) {
 	sigs, err := v.fetchAccountSignatures(ctx, pda, resume)
 	if err != nil {
@@ -498,6 +498,13 @@ func (v *View) fetchAccountSignatures(ctx context.Context, pda solana.PublicKey,
 	var allSigs []*rpc.TransactionSignature
 	var beforeSig solana.Signature
 	for {
+		// Pagination cost is O(remaining backlog) and yields nothing processable until it
+		// reaches the cursor (pages are newest-first, chunks drain oldest-first), so a
+		// backlog whose pagination alone fills the window must fail fast here rather than
+		// burn the whole activity before the zero-progress check.
+		if deadline, ok := ctx.Deadline(); ok && deadline.Sub(v.cfg.Clock.Now()) < drainBudgetMargin {
+			return nil, fmt.Errorf("refresh budget exhausted during signature pagination (%d signatures paged)", len(allSigs))
+		}
 		opts := &rpc.GetSignaturesForAddressOpts{Commitment: rpc.CommitmentFinalized, Limit: &limit}
 		if !untilSig.IsZero() {
 			opts.Until = untilSig

--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -36,6 +36,14 @@ const (
 	// insert, and checkpoint that chunk. When less than this remains, the drain stops
 	// and the next refresh continues from the durable cursor.
 	drainBudgetMargin = 30 * time.Second
+	// notFoundSkipSlotLag is how far below the newest fetched signature a not-found
+	// transaction must sit before it is skipped as pruned history. A getTransaction
+	// null near the tip is usually a load-balanced backend lagging finalization — a
+	// transient, recoverable miss that must fail the chunk (the un-advanced cursor
+	// retries it next refresh) rather than permanently skip an audit row. One this
+	// many slots back (~minutes of ledger time) is genuinely unretrievable and would
+	// wedge the drain forever if it kept failing.
+	notFoundSkipSlotLag = 300
 	// permissionAccountType is the serviceability account_type discriminator (first byte
 	// of account data) for Permission accounts — AccountType::Permission = 15 in
 	// state/permission.rs. Used to enumerate Permission PDAs via getProgramAccounts.
@@ -207,9 +215,13 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		return result, nil
 	}
 
-	// Resume each account from its durable cursor, falling back to the fact-derived
-	// high-water mark for accounts indexed before the cursor table existed. When both
-	// exist take the newer: the program-wide backfill can insert rows beyond the cursor.
+	// Resume each account from its durable cursor; the fact-derived high-water mark is
+	// only the fallback for accounts indexed before the cursor table existed. The cursor
+	// always wins once present — comparing slots would let stale fact rows (e.g. rows
+	// surviving a ledger reset, whose old slots exceed any new-ledger slot forever)
+	// permanently shadow the cursor and force a full re-page + re-decode every cycle.
+	// The bounded cost: after a program-wide backfill inserts rows beyond the cursor,
+	// one drain pass re-decodes that span (idempotent) and the cursor catches up.
 	hwms, err := v.store.GetHighWaterMarks(ctx)
 	if err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
@@ -221,11 +233,10 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		return result, fmt.Errorf("get account cursors: %w", err)
 	}
 	resume := func(pk string) HighWaterMark {
-		cur, hasCur := cursors[pk]
-		if hwm, ok := hwms[pk]; ok && (!hasCur || hwm.Slot > cur.Slot) {
-			return hwm
+		if cur, ok := cursors[pk]; ok {
+			return cur
 		}
-		return cur
+		return hwms[pk]
 	}
 
 	// Drain each account in durable oldest-first chunks (see drainAccount). A refresh cut
@@ -236,15 +247,20 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		mu            sync.Mutex
 		totalInserted int64
 		totalPending  int
+		frontier      time.Time // oldest committedTip among accounts left with a backlog
 	)
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentFetches)
 	for _, pda := range pdas {
 		g.Go(func() error {
-			inserted, pending, drainErr := v.drainAccount(ctx, pda, resume(pda.String()))
+			res, drainErr := v.drainAccount(ctx, pda, resume(pda.String()))
 			mu.Lock()
-			totalInserted += inserted
-			totalPending += pending
+			totalInserted += res.inserted
+			totalPending += res.pending
+			if res.pending > 0 && !res.committedTip.IsZero() &&
+				(frontier.IsZero() || res.committedTip.Before(frontier)) {
+				frontier = res.committedTip
+			}
 			mu.Unlock()
 			if drainErr != nil {
 				v.log.Warn("serviceability/permission-events: failed to drain account",
@@ -254,13 +270,18 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 			return nil
 		})
 	}
-	// Committed chunks are durable regardless of the refresh outcome — report them, and
-	// let freshness advance on partial progress (overstates by at most one cycle).
+	// Committed chunks are durable regardless of the refresh outcome — report them.
+	// Freshness must not overstate during a multi-cycle drain: with backlog pending,
+	// the honest frontier is the oldest committed chunk tip across backlogged accounts
+	// (their newest events stay unindexed until the drain converges), not "now".
 	err = g.Wait()
 	result.RowsAffected = totalInserted
-	if totalInserted > 0 || err == nil {
+	switch {
+	case err == nil && totalPending == 0:
 		fetchedAt := time.Now().UTC()
 		result.SourceMaxEventTS = &fetchedAt
+	case !frontier.IsZero():
+		result.SourceMaxEventTS = &frontier
 	}
 	if err != nil {
 		metrics.ViewRefreshTotal.WithLabelValues(metricSource, "error").Inc()
@@ -331,6 +352,13 @@ func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult,
 		return result, nil
 	}
 
+	// sigs is newest-first here, so sigs[0] is the scan tip; see drainAccount for the
+	// not-found age-gate rationale.
+	var skipNotFoundBelow uint64
+	if tip := sigs[0].Slot; tip > notFoundSkipSlotLag {
+		skipNotFoundBelow = tip - notFoundSkipSlotLag
+	}
+
 	// Reverse to oldest-first so the cursor advances monotonically as we checkpoint each
 	// chunk; a partial scan then leaves the cursor at the newest fully-indexed signature.
 	for i, j := 0, len(sigs)-1; i < j; i, j = i+1, j-1 {
@@ -345,7 +373,7 @@ func (v *View) BackfillRefresh(ctx context.Context) (ingestionlog.RefreshResult,
 		}
 		chunk := sigs[start:end]
 
-		events, decodeErr := v.decodeChunk(ctx, chunk)
+		events, decodeErr := v.decodeChunk(ctx, chunk, skipNotFoundBelow)
 
 		// Persist whatever decoded cleanly (idempotent via ReplacingMergeTree) before
 		// deciding whether to advance the cursor.
@@ -410,25 +438,44 @@ func (v *View) discoverPermissionAccounts(ctx context.Context) ([]solana.PublicK
 	return pdas, nil
 }
 
+// drainResult reports one account's drain outcome.
+type drainResult struct {
+	inserted int64
+	// pending is how many fetched signatures were left unprocessed (budget stop,
+	// cancellation, or a failed chunk).
+	pending int
+	// committedTip is the block time of the newest committed chunk's tail — the
+	// account's honest indexing frontier when pending > 0. Zero when no chunk
+	// committed this pass or the tail carried no block time.
+	committedTip time.Time
+}
+
 // drainAccount incrementally indexes one Permission PDA's transaction history newer than
 // resume, oldest-first in chunks. Each fully-decoded chunk is persisted and the account's
 // durable cursor advanced before the next chunk starts, so a refresh cut short by
 // cancellation or the deadline budget re-does at most one chunk of work — an account whose
 // backlog exceeds one refresh window drains across cycles instead of poison-looping.
-// Returns the audit rows inserted (meaningful even alongside an error) and how many
-// signatures were left unprocessed.
+// The returned result is meaningful even alongside an error.
 //
 // Signature pagination is O(remaining backlog) each refresh: getSignaturesForAddress pages
 // newest-first, so reaching the oldest unprocessed chunk requires paging everything newer
 // than the cursor. Pagination checks the same deadline budget per page and fails fast when
 // it can't finish in time — a pagination-starved account is loud, never a silent no-op.
-func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume HighWaterMark) (inserted int64, pending int, err error) {
+func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume HighWaterMark) (drainResult, error) {
+	var res drainResult
 	sigs, err := v.fetchAccountSignatures(ctx, pda, resume)
 	if err != nil {
-		return 0, 0, err
+		return res, err
 	}
 	if len(sigs) == 0 {
-		return 0, 0, nil
+		return res, nil
+	}
+
+	// sigs is newest-first here, so sigs[0] is the account's fetch tip: not-founds more
+	// than notFoundSkipSlotLag below it are pruned history, safe to skip.
+	var skipNotFoundBelow uint64
+	if tip := sigs[0].Slot; tip > notFoundSkipSlotLag {
+		skipNotFoundBelow = tip - notFoundSkipSlotLag
 	}
 
 	// Reverse to oldest-first so the cursor advances monotonically as chunks commit; a
@@ -439,34 +486,38 @@ func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume Hi
 
 	for start := 0; start < len(sigs); start += scanChunkSize {
 		if err := ctx.Err(); err != nil {
-			return inserted, len(sigs) - start, err
+			res.pending = len(sigs) - start
+			return res, err
 		}
 		// Stop when too little of the deadline remains to decode, insert, and checkpoint
 		// another chunk. Progress so far is committed, so stopping with progress is a
 		// success — the next refresh continues from the cursor. Stopping with none is an
 		// error so a persistently starved account escalates instead of no-op succeeding.
 		if deadline, ok := ctx.Deadline(); ok && deadline.Sub(v.cfg.Clock.Now()) < drainBudgetMargin {
+			res.pending = len(sigs) - start
 			if start == 0 {
-				return 0, len(sigs), fmt.Errorf("refresh budget exhausted before first chunk (%d signatures pending)", len(sigs))
+				return res, fmt.Errorf("refresh budget exhausted before first chunk (%d signatures pending)", len(sigs))
 			}
 			v.log.Info("serviceability/permission-events: account drain stopping at refresh budget",
-				"permission_pk", pda.String(), "processed", start, "pending", len(sigs)-start)
-			return inserted, len(sigs) - start, nil
+				"permission_pk", pda.String(), "processed", start, "pending", res.pending)
+			return res, nil
 		}
 
 		chunk := sigs[start:min(start+scanChunkSize, len(sigs))]
-		events, decodeErr := v.decodeChunk(ctx, chunk)
+		events, decodeErr := v.decodeChunk(ctx, chunk, skipNotFoundBelow)
 		if decodeErr != nil {
 			// Decode order within a chunk is not cursor order: persisting a partially
 			// decoded chunk could advance the fact-derived high-water mark past
 			// never-decoded signatures — a silent, permanent gap. Drop the chunk's
 			// events; the cursor stays put and the chunk is re-fetched next refresh.
-			return inserted, len(sigs) - start, fmt.Errorf("decode transactions: %w", decodeErr)
+			res.pending = len(sigs) - start
+			return res, fmt.Errorf("decode transactions: %w", decodeErr)
 		}
 		if err := v.store.InsertEvents(ctx, events); err != nil {
-			return inserted, len(sigs) - start, fmt.Errorf("insert permission events: %w", err)
+			res.pending = len(sigs) - start
+			return res, fmt.Errorf("insert permission events: %w", err)
 		}
-		inserted += int64(len(events))
+		res.inserted += int64(len(events))
 
 		// Chunk is oldest-first, so its last element is the newest processed signature.
 		// The cursor must advance even when the chunk produced no rows: non-permission
@@ -475,10 +526,14 @@ func (v *View) drainAccount(ctx context.Context, pda solana.PublicKey, resume Hi
 		newest := chunk[len(chunk)-1]
 		cur := HighWaterMark{TxSignature: newest.Signature.String(), Slot: newest.Slot}
 		if err := v.store.SetAccountCursor(ctx, pda.String(), cur); err != nil {
-			return inserted, len(sigs) - start, fmt.Errorf("set account cursor: %w", err)
+			res.pending = len(sigs) - start
+			return res, fmt.Errorf("set account cursor: %w", err)
+		}
+		if newest.BlockTime != nil {
+			res.committedTip = newest.BlockTime.Time().UTC()
 		}
 	}
-	return inserted, 0, nil
+	return res, nil
 }
 
 // fetchAccountSignatures returns all signatures touching pda newer than resume, newest-first.
@@ -530,13 +585,15 @@ func (v *View) fetchAccountSignatures(ctx context.Context, pda solana.PublicKey,
 // All transactions are attempted even when one fails (no early cancellation) so a single
 // transient error doesn't discard the rest of the chunk's successfully decoded events.
 //
-// A finalized signature whose transaction the RPC cannot serve (rpc.ErrNotFound — pruned
-// or inconsistent upstream history) is skipped with a warning rather than failing the
-// chunk: retrying can never recover it, and failing would wedge the drain (and the
-// backfill, which advances past skipped signatures identically) at that point forever.
-// A skip is therefore a permanently missing audit row unless re-backfilled against an
-// archival node — the PermissionEventsSkippedTx metric is what keeps that loss visible.
-func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature) ([]PermissionEventRow, error) {
+// A finalized signature whose transaction the RPC cannot serve (rpc.ErrNotFound) is
+// handled by age: below skipNotFoundBelow it is pruned history — skipped with a warning,
+// since retrying can never recover it and failing would wedge the drain (and the backfill,
+// which advances past skipped signatures identically) at that point forever; such a skip
+// is a permanently missing audit row unless re-backfilled against an archival node, kept
+// visible by the PermissionEventsSkippedTx metric. At or above the threshold the null is
+// most likely a load-balanced backend lagging finalization, so the chunk fails and the
+// un-advanced cursor retries the signature next refresh.
+func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature, skipNotFoundBelow uint64) ([]PermissionEventRow, error) {
 	var (
 		mu        sync.Mutex
 		allEvents []PermissionEventRow
@@ -557,10 +614,15 @@ func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature
 			events, err := v.decodeTransaction(ctx, sig)
 			if err != nil {
 				if errors.Is(err, rpc.ErrNotFound) {
-					metrics.PermissionEventsSkippedTx.Inc()
-					v.log.Warn("serviceability/permission-events: transaction unretrievable upstream, skipping",
-						"signature", sig.Signature.String(), "slot", sig.Slot, "error", err)
-					return nil
+					if sig.Slot < skipNotFoundBelow {
+						metrics.PermissionEventsSkippedTx.Inc()
+						v.log.Warn("serviceability/permission-events: transaction unretrievable upstream, skipping",
+							"signature", sig.Signature.String(), "slot", sig.Slot, "error", err)
+						return nil
+					}
+					v.log.Warn("serviceability/permission-events: transaction not found near tip, retrying next refresh",
+						"signature", sig.Signature.String(), "slot", sig.Slot)
+					return err
 				}
 				v.log.Warn("serviceability/permission-events: failed to decode transaction",
 					"signature", sig.Signature.String(), "error", err)

--- a/indexer/pkg/dz/serviceability/permissionevents/view_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view_test.go
@@ -25,20 +25,34 @@ var (
 	testPDA       = solana.MustPublicKeyFromBase58("9onLAjzQx38ajKMbyfPs5L2jXFRtioXJBsFZNduxc4jA")
 )
 
-// fakeRPC serves a single Permission PDA with a synthetic transaction history.
-// history is newest-first, mirroring getSignaturesForAddress. Until/Before/Limit
+// fakeRPC serves Permission PDAs with synthetic per-account transaction histories.
+// Each history is newest-first, mirroring getSignaturesForAddress. Until/Before/Limit
 // are honored like the real RPC. txErrs/txResults may only be mutated between
 // Refresh calls (decode goroutines read them concurrently).
 type fakeRPC struct {
 	pdas      []solana.PublicKey
-	history   []*solanarpc.TransactionSignature
+	histories map[solana.PublicKey][]*solanarpc.TransactionSignature
 	txResults map[solana.Signature]*solanarpc.GetTransactionResult
 	txErrs    map[solana.Signature]error
 
-	decodes  atomic.Int64
-	cancelAt int64 // if >0, the Nth GetTransaction call invokes cancel and fails
-	cancel   context.CancelFunc
-	onDecode func() // if set, invoked on every GetTransaction (e.g. to advance a fake clock)
+	decodes   atomic.Int64
+	cancelAt  int64 // if >0, the Nth GetTransaction call invokes cancel and fails
+	cancel    context.CancelFunc
+	onDecode  func() // if set, invoked on every GetTransaction (e.g. to advance a fake clock)
+	onSigPage func() // if set, invoked on every GetSignaturesForAddress page
+
+	inflight     atomic.Int64 // current concurrent GetTransaction calls
+	peakInflight atomic.Int64 // high-water mark of inflight
+}
+
+// notePeak records cur into peakInflight if it is a new high-water mark.
+func (f *fakeRPC) notePeak(cur int64) {
+	for {
+		peak := f.peakInflight.Load()
+		if cur <= peak || f.peakInflight.CompareAndSwap(peak, cur) {
+			return
+		}
+	}
 }
 
 func (f *fakeRPC) GetProgramAccountsWithOpts(ctx context.Context, program solana.PublicKey, opts *solanarpc.GetProgramAccountsOpts) (solanarpc.GetProgramAccountsResult, error) {
@@ -53,7 +67,10 @@ func (f *fakeRPC) GetSignaturesForAddressWithOpts(ctx context.Context, account s
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	hist := f.history
+	if f.onSigPage != nil {
+		f.onSigPage()
+	}
+	hist := f.histories[account]
 	if !opts.Until.IsZero() {
 		for i, e := range hist {
 			if e.Signature == opts.Until {
@@ -83,6 +100,8 @@ func (f *fakeRPC) GetTransaction(ctx context.Context, txSig solana.Signature, op
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	f.notePeak(f.inflight.Add(1))
+	defer f.inflight.Add(-1)
 	n := f.decodes.Add(1)
 	if f.onDecode != nil {
 		f.onDecode()
@@ -179,15 +198,23 @@ func buildTxResult(t *testing.T, ixData []byte) *solanarpc.GetTransactionResult 
 func newFakeRPC(t *testing.T, slots []uint64, ixData []byte) *fakeRPC {
 	t.Helper()
 	f := &fakeRPC{
-		pdas:      []solana.PublicKey{testPDA},
-		history:   newHistory(slots),
+		histories: make(map[solana.PublicKey][]*solanarpc.TransactionSignature),
 		txResults: make(map[solana.Signature]*solanarpc.GetTransactionResult, len(slots)),
 		txErrs:    make(map[solana.Signature]error),
 	}
+	f.addAccount(t, testPDA, slots, ixData)
+	return f
+}
+
+// addAccount registers another watched PDA with its own history. Slot ranges must not
+// overlap across accounts (mkSig derives signatures from slots).
+func (f *fakeRPC) addAccount(t *testing.T, pda solana.PublicKey, slots []uint64, ixData []byte) {
+	t.Helper()
+	f.pdas = append(f.pdas, pda)
+	f.histories[pda] = newHistory(slots)
 	for _, slot := range slots {
 		f.txResults[mkSig(slot)] = buildTxResult(t, ixData)
 	}
-	return f
 }
 
 func newTestView(t *testing.T, ch clickhouse.Client, rpc *fakeRPC) *View {
@@ -402,6 +429,62 @@ func TestLake_PermissionEvents_View_BudgetStopWithProgressResumesNextRefresh(t *
 	_, slot, found = accountCursor(t, ch, testPDA.String())
 	require.True(t, found)
 	require.Equal(t, total, slot)
+}
+
+// TestLake_PermissionEvents_View_PaginationRespectsBudget: signature pagination is
+// O(remaining backlog) and runs before any chunk work, so it must respect the deadline
+// budget too — otherwise a backlog whose pagination alone fills the window would burn
+// the whole activity every cycle before failing. It must fail fast, before any decode.
+func TestLake_PermissionEvents_View_PaginationRespectsBudget(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 10), rowlessIxData())
+	ch := testClient(t)
+
+	start := time.Now()
+	clock := clockwork.NewFakeClockAt(start)
+	// Each signature page consumes 20s of budget; deadline 45s out with a 30s margin
+	// means the second page's check sees 25s remaining and stops.
+	rpc.onSigPage = func() { clock.Advance(20 * time.Second) }
+
+	view, err := NewView(ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		Clock:           clock,
+		RPC:             rpc,
+		ProgramID:       testProgramID,
+		RefreshInterval: time.Second,
+		ClickHouse:      ch,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithDeadline(context.Background(), start.Add(45*time.Second))
+	defer cancel()
+	_, err = view.Refresh(ctx)
+	require.Error(t, err, "pagination that exhausts the budget must fail the account loudly")
+	require.ErrorContains(t, err, "pagination")
+	require.EqualValues(t, 0, rpc.decodes.Load(), "no decode work may start after pagination exhausts the budget")
+}
+
+// TestLake_PermissionEvents_View_BoundsConcurrentTransactionFetches: the view-wide
+// semaphore must cap in-flight getTransaction calls at maxConcurrentFetches even with
+// several accounts draining chunks concurrently — without it, nested per-chunk limits
+// multiply by the number of accounts (the 10×10=100 hazard).
+func TestLake_PermissionEvents_View_BoundsConcurrentTransactionFetches(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 250), rowlessIxData())
+	rpc.addAccount(t, solana.NewWallet().PublicKey(), seqSlots(1001, 1250), rowlessIxData())
+	rpc.addAccount(t, solana.NewWallet().PublicKey(), seqSlots(2001, 2250), rowlessIxData())
+	// Hold each fetch briefly so goroutines genuinely overlap.
+	rpc.onDecode = func() { time.Sleep(2 * time.Millisecond) }
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	_, err := view.Refresh(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 750, rpc.decodes.Load())
+	require.LessOrEqual(t, rpc.peakInflight.Load(), int64(maxConcurrentFetches),
+		"in-flight getTransaction calls must stay within the view-wide bound")
 }
 
 // TestLake_PermissionEvents_View_ResumesFromFactHighWaterMark guards the upgrade

--- a/indexer/pkg/dz/serviceability/permissionevents/view_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view_test.go
@@ -315,24 +315,86 @@ func TestLake_PermissionEvents_View_DrainProgressPersistsAcrossTimedOutRefreshes
 	require.EqualValues(t, 0, factRowCount(t, ch))
 }
 
-// TestLake_PermissionEvents_View_SkipsUnretrievableTransaction: a signature whose
-// transaction the RPC no longer serves (pruned history) is skipped with a warning
-// instead of wedging the account forever.
-func TestLake_PermissionEvents_View_SkipsUnretrievableTransaction(t *testing.T) {
+// TestLake_PermissionEvents_View_SkipsUnretrievableOldTransaction: a not-found
+// transaction far below the account's fetch tip is pruned history — skipped with a
+// warning instead of wedging the account forever.
+func TestLake_PermissionEvents_View_SkipsUnretrievableOldTransaction(t *testing.T) {
 	t.Parallel()
 
-	rpc := newFakeRPC(t, seqSlots(1, 5), createPermissionIxData())
-	delete(rpc.txResults, mkSig(3)) // fake returns solanarpc.ErrNotFound for it
+	slots := append([]uint64{1000}, seqSlots(10001, 10004)...)
+	rpc := newFakeRPC(t, slots, createPermissionIxData())
+	delete(rpc.txResults, mkSig(1000)) // fake returns solanarpc.ErrNotFound for it
 	ch := testClient(t)
 	view := newTestView(t, ch, rpc)
 
 	_, err := view.Refresh(context.Background())
-	require.NoError(t, err, "an unretrievable transaction must not fail the refresh")
+	require.NoError(t, err, "an old unretrievable transaction must not fail the refresh")
 	require.EqualValues(t, 4, factRowCount(t, ch))
 
 	_, slot, found := accountCursor(t, ch, testPDA.String())
 	require.True(t, found)
+	require.EqualValues(t, 10004, slot)
+}
+
+// TestLake_PermissionEvents_View_NearTipNotFoundFailsChunkAndRetries: a not-found
+// near the fetch tip is usually a load-balanced backend lagging finalization — a
+// transient null, not pruned history. Skipping it would advance the cursor past a
+// recoverable audit row permanently; the chunk must fail so the next refresh
+// retries, and the event must land once the transaction becomes retrievable.
+func TestLake_PermissionEvents_View_NearTipNotFoundFailsChunkAndRetries(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 5), createPermissionIxData())
+	tipTx := rpc.txResults[mkSig(5)]
+	delete(rpc.txResults, mkSig(5)) // near-tip null from a lagging backend
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	_, err := view.Refresh(context.Background())
+	require.Error(t, err, "a near-tip not-found must fail the chunk, not be skipped")
+	require.EqualValues(t, 0, factRowCount(t, ch))
+	_, _, found := accountCursor(t, ch, testPDA.String())
+	require.False(t, found, "cursor must not advance past a recoverable signature")
+
+	// The lagging backend catches up; nothing may have been lost.
+	rpc.txResults[mkSig(5)] = tipTx
+	_, err = view.Refresh(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 5, factRowCount(t, ch))
+	_, slot, found := accountCursor(t, ch, testPDA.String())
+	require.True(t, found)
 	require.EqualValues(t, 5, slot)
+}
+
+// TestLake_PermissionEvents_View_DurableCursorWinsOverStaleHighWaterMark: once a
+// durable cursor exists it must be the resume point even when fact rows carry higher
+// slots (a program-wide backfill wrote ahead, or pre-ledger-reset rows survive with
+// old high slots). Preferring the higher slot would let a stale high-water mark
+// shadow the cursor forever and re-page the account's full history every cycle.
+func TestLake_PermissionEvents_View_DurableCursorWinsOverStaleHighWaterMark(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(95, 110), createPermissionIxData())
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	ctx := context.Background()
+	require.NoError(t, view.store.SetAccountCursor(ctx, testPDA.String(),
+		HighWaterMark{TxSignature: mkSig(100).String(), Slot: 100}))
+	bt := time.Unix(1753200105, 0).UTC()
+	require.NoError(t, view.store.InsertEvents(ctx, []PermissionEventRow{{
+		EventTS:      bt,
+		TxSignature:  mkSig(105).String(),
+		Slot:         105,
+		PermissionPK: testPDA.String(),
+		EventType:    EventCreate,
+		Success:      1,
+	}}))
+
+	_, err := view.Refresh(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 10, rpc.decodes.Load(),
+		"resume must start at the durable cursor (slot 100), not the higher fact high-water mark")
 }
 
 // TestLake_PermissionEvents_View_FailedChunkKeepsCursorAndBackfillsOnRetry: a
@@ -410,10 +472,15 @@ func TestLake_PermissionEvents_View_BudgetStopWithProgressResumesNextRefresh(t *
 	// the chunk the fake clock has advanced 20s, so 25s < margin stops the drain.
 	ctx, cancel := context.WithDeadline(context.Background(), start.Add(45*time.Second))
 	defer cancel()
-	_, err = view.Refresh(ctx)
+	res, err := view.Refresh(ctx)
 	require.NoError(t, err, "budget stop after committed progress is a success, not an error")
 	require.EqualValues(t, scanChunkSize, rpc.decodes.Load(),
 		"only the first chunk may be decoded before the budget stop")
+	// Freshness must not overstate during a drain: with backlog pending, the source
+	// timestamp is the committed chunk's frontier (block time of slot 200), not now.
+	require.NotNil(t, res.SourceMaxEventTS)
+	require.True(t, res.SourceMaxEventTS.Equal(time.Unix(1753200000+int64(scanChunkSize), 0)),
+		"partial-progress freshness must be the committed frontier, got %v", res.SourceMaxEventTS)
 
 	_, slot, found := accountCursor(t, ch, testPDA.String())
 	require.True(t, found)

--- a/indexer/pkg/dz/serviceability/permissionevents/view_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view_test.go
@@ -1,0 +1,433 @@
+package permissionevents
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/jonboulle/clockwork"
+	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testProgramID = solana.MustPublicKeyFromBase58("DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb")
+	testFeePayer  = solana.MustPublicKeyFromBase58("BUtAWK4GaUV42YRp7jSHZhchspsshabn67HnBHnKxzsY")
+	testPDA       = solana.MustPublicKeyFromBase58("9onLAjzQx38ajKMbyfPs5L2jXFRtioXJBsFZNduxc4jA")
+)
+
+// fakeRPC serves a single Permission PDA with a synthetic transaction history.
+// history is newest-first, mirroring getSignaturesForAddress. Until/Before/Limit
+// are honored like the real RPC. txErrs/txResults may only be mutated between
+// Refresh calls (decode goroutines read them concurrently).
+type fakeRPC struct {
+	pdas      []solana.PublicKey
+	history   []*solanarpc.TransactionSignature
+	txResults map[solana.Signature]*solanarpc.GetTransactionResult
+	txErrs    map[solana.Signature]error
+
+	decodes  atomic.Int64
+	cancelAt int64 // if >0, the Nth GetTransaction call invokes cancel and fails
+	cancel   context.CancelFunc
+	onDecode func() // if set, invoked on every GetTransaction (e.g. to advance a fake clock)
+}
+
+func (f *fakeRPC) GetProgramAccountsWithOpts(ctx context.Context, program solana.PublicKey, opts *solanarpc.GetProgramAccountsOpts) (solanarpc.GetProgramAccountsResult, error) {
+	res := make(solanarpc.GetProgramAccountsResult, 0, len(f.pdas))
+	for _, pda := range f.pdas {
+		res = append(res, &solanarpc.KeyedAccount{Pubkey: pda})
+	}
+	return res, nil
+}
+
+func (f *fakeRPC) GetSignaturesForAddressWithOpts(ctx context.Context, account solana.PublicKey, opts *solanarpc.GetSignaturesForAddressOpts) ([]*solanarpc.TransactionSignature, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	hist := f.history
+	if !opts.Until.IsZero() {
+		for i, e := range hist {
+			if e.Signature == opts.Until {
+				hist = hist[:i]
+				break
+			}
+		}
+	}
+	if !opts.Before.IsZero() {
+		rest := hist[:0:0]
+		for i, e := range hist {
+			if e.Signature == opts.Before {
+				rest = hist[i+1:]
+				break
+			}
+		}
+		hist = rest
+	}
+	limit := len(hist)
+	if opts.Limit != nil && *opts.Limit < limit {
+		limit = *opts.Limit
+	}
+	return hist[:limit], nil
+}
+
+func (f *fakeRPC) GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	n := f.decodes.Add(1)
+	if f.onDecode != nil {
+		f.onDecode()
+	}
+	if f.cancelAt > 0 && n >= f.cancelAt {
+		f.cancel()
+		return nil, context.Canceled
+	}
+	if err, ok := f.txErrs[txSig]; ok {
+		return nil, err
+	}
+	res, ok := f.txResults[txSig]
+	if !ok {
+		return nil, solanarpc.ErrNotFound
+	}
+	return res, nil
+}
+
+// mkSig returns a deterministic distinct signature for a slot.
+func mkSig(slot uint64) solana.Signature {
+	var sig solana.Signature
+	binary.BigEndian.PutUint64(sig[:8], slot)
+	sig[8] = 1 // avoid the zero signature for slot 0
+	return sig
+}
+
+// newHistory builds a newest-first history of len(slots) entries. slots must be
+// ascending; entry i gets signature mkSig(slot) and a non-nil block time.
+func newHistory(slots []uint64) []*solanarpc.TransactionSignature {
+	out := make([]*solanarpc.TransactionSignature, 0, len(slots))
+	for i := len(slots) - 1; i >= 0; i-- {
+		slot := slots[i]
+		bt := solana.UnixTimeSeconds(1753200000 + int64(slot))
+		out = append(out, &solanarpc.TransactionSignature{
+			Signature: mkSig(slot),
+			Slot:      slot,
+			BlockTime: &bt,
+		})
+	}
+	return out
+}
+
+func seqSlots(from, to uint64) []uint64 {
+	out := make([]uint64, 0, to-from+1)
+	for s := from; s <= to; s++ {
+		out = append(out, s)
+	}
+	return out
+}
+
+// createPermissionIxData builds CreatePermission instruction data: variant 97,
+// user_payer pubkey, permissions mask (bit 0 set).
+func createPermissionIxData() []byte {
+	data := make([]byte, 49)
+	data[0] = variantCreatePermission
+	copy(data[1:33], testFeePayer[:])
+	data[33] = 1
+	return data
+}
+
+// rowlessIxData is a serviceability instruction that references the Permission
+// PDA but is not a permission-management variant (like the multicast allowlist
+// ops observed in prod), so it decodes to zero audit rows.
+func rowlessIxData() []byte {
+	return []byte{0x2a, 0, 0, 0}
+}
+
+// buildTxResult wraps a single-instruction transaction touching the PDA into a
+// base64 GetTransactionResult envelope, as the real RPC returns it.
+func buildTxResult(t *testing.T, ixData []byte) *solanarpc.GetTransactionResult {
+	t.Helper()
+	tx := &solana.Transaction{
+		Signatures: []solana.Signature{mkSig(1)},
+		Message: solana.Message{
+			Header:          solana.MessageHeader{NumRequiredSignatures: 1},
+			AccountKeys:     []solana.PublicKey{testFeePayer, testPDA, testProgramID},
+			RecentBlockhash: solana.Hash{},
+			Instructions: []solana.CompiledInstruction{{
+				ProgramIDIndex: 2,
+				Accounts:       []uint16{1},
+				Data:           solana.Base58(ixData),
+			}},
+		},
+	}
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	var env solanarpc.TransactionResultEnvelope
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, `[%q,"base64"]`, base64.StdEncoding.EncodeToString(raw)), &env))
+	return &solanarpc.GetTransactionResult{Transaction: &env}
+}
+
+// newFakeRPC serves the given slots for testPDA, all with the same instruction data.
+func newFakeRPC(t *testing.T, slots []uint64, ixData []byte) *fakeRPC {
+	t.Helper()
+	f := &fakeRPC{
+		pdas:      []solana.PublicKey{testPDA},
+		history:   newHistory(slots),
+		txResults: make(map[solana.Signature]*solanarpc.GetTransactionResult, len(slots)),
+		txErrs:    make(map[solana.Signature]error),
+	}
+	for _, slot := range slots {
+		f.txResults[mkSig(slot)] = buildTxResult(t, ixData)
+	}
+	return f
+}
+
+func newTestView(t *testing.T, ch clickhouse.Client, rpc *fakeRPC) *View {
+	t.Helper()
+	view, err := NewView(ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		Clock:           clockwork.NewRealClock(),
+		RPC:             rpc,
+		ProgramID:       testProgramID,
+		RefreshInterval: time.Second,
+		ClickHouse:      ch,
+	})
+	require.NoError(t, err)
+	return view
+}
+
+func factRowCount(t *testing.T, ch clickhouse.Client) uint64 {
+	t.Helper()
+	return queryUInt64(t, ch, `SELECT count() FROM fact_dz_permission_events`)
+}
+
+func factDistinctSlots(t *testing.T, ch clickhouse.Client) uint64 {
+	t.Helper()
+	return queryUInt64(t, ch, `SELECT uniqExact(slot) FROM fact_dz_permission_events`)
+}
+
+func queryUInt64(t *testing.T, ch clickhouse.Client, query string) uint64 {
+	t.Helper()
+	conn, err := ch.Conn(t.Context())
+	require.NoError(t, err)
+	rows, err := conn.Query(t.Context(), query)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var n uint64
+	require.NoError(t, rows.Scan(&n))
+	return n
+}
+
+// accountCursor reads the durable per-account cursor. found is false when no
+// cursor row has been written for the PDA yet.
+func accountCursor(t *testing.T, ch clickhouse.Client, pk string) (sig string, slot uint64, found bool) {
+	t.Helper()
+	conn, err := ch.Conn(t.Context())
+	require.NoError(t, err)
+	rows, err := conn.Query(t.Context(), `
+		SELECT argMax(last_tx_signature, (updated_at, last_slot)), argMax(last_slot, (updated_at, last_slot))
+		FROM dz_permission_events_account_cursor
+		WHERE permission_pk = ?
+		GROUP BY permission_pk
+	`, pk)
+	require.NoError(t, err)
+	defer rows.Close()
+	if !rows.Next() {
+		return "", 0, false
+	}
+	require.NoError(t, rows.Scan(&sig, &slot))
+	return sig, slot, true
+}
+
+// TestLake_PermissionEvents_View_DrainProgressPersistsAcrossTimedOutRefreshes is
+// the poison-loop regression: an account whose backlog exceeds one refresh window
+// must not have completed work re-fetched by the next refresh — even when its
+// transactions decode to zero audit rows (so the fact table cannot serve as the
+// cursor). Refresh #1 is cancelled mid-drain (as the Temporal activity deadline
+// does); refresh #2 must only process the remainder.
+func TestLake_PermissionEvents_View_DrainProgressPersistsAcrossTimedOutRefreshes(t *testing.T) {
+	t.Parallel()
+
+	total := uint64(2*scanChunkSize + 50)
+	rpc := newFakeRPC(t, seqSlots(1, total), rowlessIxData())
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	// Refresh #1: cancel once the drain is 50 decodes into the second chunk.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rpc.cancelAt = int64(scanChunkSize + 50)
+	rpc.cancel = cancel
+	_, err := view.Refresh(ctx)
+	require.Error(t, err, "cancelled mid-drain refresh should surface an error")
+
+	// Refresh #2: no cancellation. Only the un-committed remainder may be
+	// re-fetched; the first chunk's work must have been durably committed.
+	rpc.cancelAt = 0
+	rpc.decodes.Store(0)
+	_, err = view.Refresh(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, total-scanChunkSize, rpc.decodes.Load(),
+		"refresh #2 must resume after the committed chunk instead of re-fetching the whole backlog")
+
+	// The durable cursor sits at the newest signature and no audit rows exist
+	// (every transaction was row-less).
+	sig, slot, found := accountCursor(t, ch, testPDA.String())
+	require.True(t, found, "drain must leave a durable per-account cursor")
+	require.Equal(t, total, slot)
+	require.Equal(t, mkSig(total).String(), sig)
+	require.EqualValues(t, 0, factRowCount(t, ch))
+}
+
+// TestLake_PermissionEvents_View_SkipsUnretrievableTransaction: a signature whose
+// transaction the RPC no longer serves (pruned history) is skipped with a warning
+// instead of wedging the account forever.
+func TestLake_PermissionEvents_View_SkipsUnretrievableTransaction(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 5), createPermissionIxData())
+	delete(rpc.txResults, mkSig(3)) // fake returns solanarpc.ErrNotFound for it
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	_, err := view.Refresh(context.Background())
+	require.NoError(t, err, "an unretrievable transaction must not fail the refresh")
+	require.EqualValues(t, 4, factRowCount(t, ch))
+
+	_, slot, found := accountCursor(t, ch, testPDA.String())
+	require.True(t, found)
+	require.EqualValues(t, 5, slot)
+}
+
+// TestLake_PermissionEvents_View_FailedChunkKeepsCursorAndBackfillsOnRetry: a
+// transient decode failure mid-chunk must not persist a partial chunk. Decode
+// order is not cursor order, so inserting a partial chunk would advance the
+// fact-derived high-water mark past never-decoded older signatures — a silent,
+// permanent gap once the fault clears.
+func TestLake_PermissionEvents_View_FailedChunkKeepsCursorAndBackfillsOnRetry(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 10), createPermissionIxData())
+	rpc.txErrs[mkSig(5)] = errors.New("boom")
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	_, err := view.Refresh(context.Background())
+	require.Error(t, err)
+	require.EqualValues(t, 0, factRowCount(t, ch),
+		"a chunk that did not fully decode must not be persisted")
+
+	// Fault clears; every event must land — nothing skipped by a corrupted cursor.
+	delete(rpc.txErrs, mkSig(5))
+	_, err = view.Refresh(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 10, factRowCount(t, ch))
+	require.EqualValues(t, 10, factDistinctSlots(t, ch))
+}
+
+// TestLake_PermissionEvents_View_RefusesChunkWhenBudgetExhausted: when the
+// context deadline is too close to safely decode and commit a chunk, the drain
+// stops before starting one and reports an error (no silent no-op success).
+func TestLake_PermissionEvents_View_RefusesChunkWhenBudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(1, 3), rowlessIxData())
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	// Deadline closer than the drain budget margin: no chunk may start.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	defer cancel()
+	_, err := view.Refresh(ctx)
+	require.Error(t, err, "no-progress budget exhaustion must surface an error")
+	require.EqualValues(t, 0, rpc.decodes.Load(), "no transaction decode may start on an exhausted budget")
+}
+
+// TestLake_PermissionEvents_View_BudgetStopWithProgressResumesNextRefresh: when the
+// deadline budget runs out after at least one committed chunk, the refresh reports
+// success (the committed work is durable, stopping is the designed drain behavior)
+// and the next refresh continues from the cursor. Time is driven by a fake clock the
+// RPC advances per decode, so the stop point is deterministic.
+func TestLake_PermissionEvents_View_BudgetStopWithProgressResumesNextRefresh(t *testing.T) {
+	t.Parallel()
+
+	total := uint64(2 * scanChunkSize)
+	rpc := newFakeRPC(t, seqSlots(1, total), rowlessIxData())
+	ch := testClient(t)
+
+	start := time.Now()
+	clock := clockwork.NewFakeClockAt(start)
+	// Each decode advances the clock so the first chunk consumes 20s of budget.
+	rpc.onDecode = func() { clock.Advance(100 * time.Millisecond) }
+
+	view, err := NewView(ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		Clock:           clock,
+		RPC:             rpc,
+		ProgramID:       testProgramID,
+		RefreshInterval: time.Second,
+		ClickHouse:      ch,
+	})
+	require.NoError(t, err)
+
+	// Deadline 45s out: the first chunk's budget check sees 45s > margin (30s); after
+	// the chunk the fake clock has advanced 20s, so 25s < margin stops the drain.
+	ctx, cancel := context.WithDeadline(context.Background(), start.Add(45*time.Second))
+	defer cancel()
+	_, err = view.Refresh(ctx)
+	require.NoError(t, err, "budget stop after committed progress is a success, not an error")
+	require.EqualValues(t, scanChunkSize, rpc.decodes.Load(),
+		"only the first chunk may be decoded before the budget stop")
+
+	_, slot, found := accountCursor(t, ch, testPDA.String())
+	require.True(t, found)
+	require.EqualValues(t, scanChunkSize, slot, "cursor must sit at the committed chunk boundary")
+
+	// Next refresh (fresh deadline) drains the remainder.
+	rpc.decodes.Store(0)
+	ctx2, cancel2 := context.WithDeadline(context.Background(), clock.Now().Add(10*time.Minute))
+	defer cancel2()
+	_, err = view.Refresh(ctx2)
+	require.NoError(t, err)
+	require.EqualValues(t, total-scanChunkSize, rpc.decodes.Load())
+	_, slot, found = accountCursor(t, ch, testPDA.String())
+	require.True(t, found)
+	require.Equal(t, total, slot)
+}
+
+// TestLake_PermissionEvents_View_ResumesFromFactHighWaterMark guards the upgrade
+// path: an account indexed before the durable cursor existed resumes from the
+// fact table's high-water mark rather than re-fetching its full history.
+func TestLake_PermissionEvents_View_ResumesFromFactHighWaterMark(t *testing.T) {
+	t.Parallel()
+
+	rpc := newFakeRPC(t, seqSlots(95, 110), createPermissionIxData())
+	ch := testClient(t)
+	view := newTestView(t, ch, rpc)
+
+	// Seed one already-indexed event at slot 100, as the pre-cursor code left it.
+	bt := time.Unix(1753200100, 0).UTC()
+	require.NoError(t, view.store.InsertEvents(context.Background(), []PermissionEventRow{{
+		EventTS:      bt,
+		TxSignature:  mkSig(100).String(),
+		Slot:         100,
+		PermissionPK: testPDA.String(),
+		EventType:    EventCreate,
+		Success:      1,
+	}}))
+
+	_, err := view.Refresh(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 10, rpc.decodes.Load(),
+		"only signatures newer than the fact high-water mark may be fetched")
+	require.EqualValues(t, 11, factRowCount(t, ch))
+}

--- a/indexer/pkg/dzingest/backfill_permission_events.go
+++ b/indexer/pkg/dzingest/backfill_permission_events.go
@@ -11,7 +11,7 @@ import (
 
 // BackfillPermissionEventsInput configures the permission events backfill.
 type BackfillPermissionEventsInput struct {
-	Truncate bool // If true, truncate the fact table + scan cursor before backfilling.
+	Truncate bool // If true, truncate the fact table + scan/account cursors before backfilling.
 }
 
 // BackfillPermissionEventsWorkflow re-scans all serviceability transaction history
@@ -45,7 +45,10 @@ func BackfillPermissionEventsWorkflow(ctx temporalworkflow.Context, input Backfi
 	return nil
 }
 
-// TruncatePermissionEvents truncates the permission events fact table and its scan cursor.
+// TruncatePermissionEvents truncates the permission events fact table and both cursors.
+// The per-account cursor must reset with the fact table: left behind, it would sit
+// stale-newer than the re-derived high-water marks and make the steady-state watch skip
+// everything below it — a silent gap if the subsequent backfill is interrupted.
 func (a *Activities) TruncatePermissionEvents(ctx context.Context) error {
 	if a.PermissionEvents == nil {
 		return fmt.Errorf("permission events view not configured")
@@ -54,11 +57,14 @@ func (a *Activities) TruncatePermissionEvents(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get ClickHouse connection: %w", err)
 	}
-	if err := conn.Exec(ctx, "TRUNCATE TABLE fact_dz_permission_events"); err != nil {
-		return fmt.Errorf("truncate fact_dz_permission_events: %w", err)
-	}
-	if err := conn.Exec(ctx, "TRUNCATE TABLE dz_permission_events_scan_cursor"); err != nil {
-		return fmt.Errorf("truncate dz_permission_events_scan_cursor: %w", err)
+	for _, table := range []string{
+		"fact_dz_permission_events",
+		"dz_permission_events_scan_cursor",
+		"dz_permission_events_account_cursor",
+	} {
+		if err := conn.Exec(ctx, "TRUNCATE TABLE "+table); err != nil {
+			return fmt.Errorf("truncate %s: %w", table, err)
+		}
 	}
 	return nil
 }

--- a/indexer/pkg/dzingest/backfill_permission_events_test.go
+++ b/indexer/pkg/dzingest/backfill_permission_events_test.go
@@ -1,0 +1,81 @@
+package dzingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/jonboulle/clockwork"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPermissionRPC satisfies permissionevents.SolanaRPC; the truncate activity never
+// touches the RPC, it only needs a constructible view for its ClickHouse client.
+type stubPermissionRPC struct{}
+
+func (stubPermissionRPC) GetProgramAccountsWithOpts(context.Context, solana.PublicKey, *solanarpc.GetProgramAccountsOpts) (solanarpc.GetProgramAccountsResult, error) {
+	return nil, nil
+}
+
+func (stubPermissionRPC) GetSignaturesForAddressWithOpts(context.Context, solana.PublicKey, *solanarpc.GetSignaturesForAddressOpts) ([]*solanarpc.TransactionSignature, error) {
+	return nil, nil
+}
+
+func (stubPermissionRPC) GetTransaction(context.Context, solana.Signature, *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error) {
+	return nil, nil
+}
+
+// TestLake_DZIngest_TruncatePermissionEvents_ResetsFactAndCursors: the --truncate
+// recovery path must clear the fact table AND both cursors. A surviving account cursor
+// would sit stale-newer than the re-derived high-water marks and make the steady-state
+// watch silently skip everything below it after a reset.
+func TestLake_DZIngest_TruncatePermissionEvents_ResetsFactAndCursors(t *testing.T) {
+	t.Parallel()
+
+	ch := laketesting.NewClient(t, sharedDB)
+	view, err := permissionevents.NewView(permissionevents.ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		Clock:           clockwork.NewRealClock(),
+		RPC:             stubPermissionRPC{},
+		ProgramID:       solana.MustPublicKeyFromBase58("DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb"),
+		RefreshInterval: time.Second,
+		ClickHouse:      ch,
+	})
+	require.NoError(t, err)
+
+	conn, err := ch.Conn(t.Context())
+	require.NoError(t, err)
+	seeds := []string{
+		`INSERT INTO fact_dz_permission_events
+			(event_ts, ingested_at, tx_signature, slot, instruction_index, permission_pk, event_type)
+			VALUES (now(), now(), 'sig', 1, 0, 'pk', 'Create')`,
+		`INSERT INTO dz_permission_events_scan_cursor
+			(program_pk, last_tx_signature, last_slot, updated_at) VALUES ('prog', 'sig', 1, now())`,
+		`INSERT INTO dz_permission_events_account_cursor
+			(permission_pk, last_tx_signature, last_slot, updated_at) VALUES ('pk', 'sig', 1, now())`,
+	}
+	for _, seed := range seeds {
+		require.NoError(t, conn.Exec(t.Context(), seed))
+	}
+
+	a := &Activities{Log: laketesting.NewLogger(), PermissionEvents: view}
+	require.NoError(t, a.TruncatePermissionEvents(t.Context()))
+
+	for _, table := range []string{
+		"fact_dz_permission_events",
+		"dz_permission_events_scan_cursor",
+		"dz_permission_events_account_cursor",
+	} {
+		rows, err := conn.Query(t.Context(), "SELECT count() FROM "+table)
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		var n uint64
+		require.NoError(t, rows.Scan(&n))
+		require.NoError(t, rows.Close())
+		require.Zero(t, n, "table %s must be empty after truncate", table)
+	}
+}

--- a/indexer/pkg/dzingest/main_test.go
+++ b/indexer/pkg/dzingest/main_test.go
@@ -1,0 +1,25 @@
+package dzingest
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	clickhousetesting "github.com/malbeclabs/lake/indexer/pkg/clickhouse/testing"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+)
+
+var sharedDB *clickhousetesting.DB
+
+func TestMain(m *testing.M) {
+	log := laketesting.NewLogger()
+	var err error
+	sharedDB, err = clickhousetesting.NewDB(context.Background(), log, nil)
+	if err != nil {
+		log.Error("failed to create shared DB", "error", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedDB.Close()
+	os.Exit(code)
+}

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -21,7 +21,7 @@ var (
 	ViewRefreshTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "doublezero_data_indexer_view_refresh_total",
-			Help: "Total number of view refreshes",
+			Help: "Total number of view refreshes (status: success, partial, error, panic; partial = stopped at the refresh budget with backlog pending)",
 		},
 		[]string{"view_type", "status"},
 	)

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -41,6 +41,19 @@ var (
 		[]string{"status"},
 	)
 
+	// PermissionEventsSkippedTx counts transactions the permission-events indexer skipped
+	// because the RPC would not serve them (getTransaction not-found for a finalized,
+	// listed signature — pruned or inconsistent upstream history). Each skip is a
+	// potentially missing audit row that no automatic path recovers (the backfill skips
+	// them identically); a sustained non-zero rate means upstream retention is dropping
+	// events and a manual re-backfill against an archival node is warranted.
+	PermissionEventsSkippedTx = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_permission_events_skipped_tx_total",
+			Help: "Permission-events transactions skipped because the RPC could not serve them",
+		},
+	)
+
 	ViewRefreshDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "doublezero_data_indexer_view_refresh_duration_seconds",


### PR DESCRIPTION
## Summary of Changes
- Break the permission-events poison loop for single-account backlogs. Since 2026-07-22 21:07 UTC, testnet `RefreshPermissionEvents` timed out every cycle: one Permission PDA receives ~3 tx/s of `AddMulticastGroupSubAllowlist` instructions, which reference the PDA but are not permission-management ops, so they decode to zero audit rows. The fact-derived high-water mark could therefore never advance, and every 5-minute activity re-fetched the same (growing) backlog from scratch — #704 checkpointed per account, but couldn't make progress *within* an account, and its partial-persist fallback ran on the already-cancelled activity context so nothing landed.
- The steady-state watch now drains each account oldest-first in 200-signature chunks: decode a chunk concurrently, insert it, then advance a new durable per-account cursor (`dz_permission_events_account_cursor`) that moves through row-less transactions. A refresh cut short by cancellation or its deadline re-does at most one chunk of work. The cursor always wins over the fact-derived high-water mark once present (the hwm remains only as the pre-upgrade fallback) — comparing slots would let stale fact rows, e.g. surviving a ledger reset, shadow the cursor forever.
- A deadline budget stops starting new chunks within 30s of the activity deadline: stop-with-progress is a success (next cycle resumes from the cursor; reported via a new `partial` refresh status so a never-converging drain stays visible), stop-with-zero-progress is an error so a starved account escalates instead of no-op succeeding. Signature pagination — which is O(remaining backlog) and runs before any chunk work — checks the same budget per page and fails fast with a distinct error rather than burning the window first.
- A chunk that fails decode is dropped whole rather than partially persisted — decode order is not cursor order, so a partial-chunk insert could advance the fact-derived mark past never-decoded signatures, silently and permanently dropping audit rows (the previous code had this latent gap; a regression test now pins it).
- Not-found transactions are handled by age: a `getTransaction` null more than 300 slots below the account's fetch tip is pruned history — skipped with a warning and counted via `doublezero_data_indexer_permission_events_skipped_tx_total` instead of wedging the drain forever. Near the tip a null is usually a load-balanced backend lagging finalization (the retry client only retries transport failures, never null results), so the chunk fails and the un-advanced cursor retries the signature next refresh — no audit row is silently lost to a transient miss.
- `getTransaction` concurrency is bounded at 10 view-wide by a shared semaphore. Pre-PR per-account decode was sequential (effective peak 10); the chunked rework alone would have allowed up to 10 accounts × 10 fetches = 100 in flight — introduced and closed within this PR, now pinned by a regression test.
- During a multi-cycle drain, freshness (`source_max_event_ts`) advances to the oldest committed chunk frontier across backlogged accounts, not to `now` — a backlogged account's newest events stay unindexed until the drain converges.
- The admin `--truncate` recovery path now also resets the account cursor table; leaving it behind would make the steady-state watch resume from a stale cursor after a reset.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +305 / -95  | +210 |
| Tests        |     4 | +731 / -27  | +704 |
| Scaffolding  |     2 | +36  / -1   |  +35 |

Mostly new test coverage around a focused rework of the per-account drain path.

<details>
<summary>Key files (click to expand)</summary>

- [`indexer/pkg/dz/serviceability/permissionevents/view.go`](https://github.com/malbeclabs/lake/pull/706/files#diff-459842cd4012d0dffff4899fb743474d212ab8c0ad9bdeeb226cc0843a0066fa) — per-account fetch rebuilt as `drainAccount`: oldest-first chunked decode+insert+cursor checkpoint, budget-aware pagination and chunking, shared decode semaphore, age-gated not-found handling
- [`indexer/pkg/dz/serviceability/permissionevents/store.go`](https://github.com/malbeclabs/lake/pull/706/files#diff-186946680acee51d57959380f946a72d78c441db31b50d12e9b32c8b03ac8fc8) — durable per-account cursor read/write (`GetAccountCursors`/`SetAccountCursor`), tie-broken by `(updated_at, last_slot)`
- [`indexer/pkg/dzingest/backfill_permission_events.go`](https://github.com/malbeclabs/lake/pull/706/files#diff-e5f4720c4b8c9b48b0a3082d5cb351be90a7bb0b346b7b297bb548e909615b07) — `--truncate` also resets the account cursor table

</details>

## Testing Verification
- Twelve integration tests (testcontainers ClickHouse + fake Solana RPC); those pinning new behavior were verified failing first:
  - a backlog cancelled mid-drain resumes from the committed chunk instead of re-fetching everything, with the cursor advancing through row-less transactions (the exact prod failure mode)
  - a mid-chunk decode failure persists nothing and a retry backfills all events — the old code persisted a newest-first partial prefix and permanently skipped the older half
  - a near-tip not-found fails the chunk with nothing persisted, and the event lands once the lagging backend catches up; an old (pruned) not-found is skipped so the drain can't wedge
  - the durable cursor wins over a higher fact-derived high-water mark (backfill overshoot / ledger-reset remnants)
  - budget exhaustion with zero progress surfaces an error with no decode work started; budget stop after a committed chunk returns success with freshness clamped to the committed frontier, and the next refresh drains the remainder; pagination that exhausts the budget fails fast before any decode (deterministic via a fake clock advanced by the RPC stub)
  - peak in-flight `getTransaction` stays ≤ 10 with three accounts draining concurrently — validated to bite by temporarily bypassing the semaphore (peak observed: 30)
  - `TruncatePermissionEvents` clears the fact table and both cursor tables from seeded rows — validated to bite by temporarily dropping the account cursor from the truncate list
- Upgrade path covered: accounts indexed before the cursor table existed resume from the fact-derived high-water mark.
- Package suites run repeatedly with `-race`; full repo suite run with `-race` (surfaced a same-millisecond cursor-read tie in the new test, fixed with the `(updated_at, last_slot)` tie-break).
- Note for deploy: the new table is created by the existing migration flow (`--migrations-enable`). After rollout, the testnet whale (~10⁵ signatures and growing) drains at roughly 30–100 tx/s of decode, so the alert should quiet within a few refresh cycles' worth of drain; stopping the testnet spammer (`BUtAWK…` from 64.225.32.240) is a separate follow-up.
