### PR TITLE
logging: classify bare rate-limit messages as transient

### DIFF
--- a/utils/pkg/dberror/dberror.go
+++ b/utils/pkg/dberror/dberror.go
@@ -120,7 +120,9 @@ func Classify(err error) ErrorType {
 	// 429 or a gRPC service returning ResourceExhausted, like InfluxDB).
 	// These are transient and self-healing — worth retrying, not worth paging on.
 	rateLimitPatterns := []string{
-		"rate limited",
+		// Broad on purpose: covers "rate limited", "rate limits exceeded" (rpcpool's
+		// 429 body), and "rate limiting" — an error mentioning rate limits is a throttle.
+		"rate limit",
 		"too many requests",
 		"status 429",
 		"request too large",

--- a/utils/pkg/dberror/dberror_test.go
+++ b/utils/pkg/dberror/dberror_test.go
@@ -27,6 +27,12 @@ func TestClassifyAndIsTransient(t *testing.T) {
 		// "request too large" prefix — both must classify as transient rate limits.
 		{"influxdb resources exhausted plural", errors.New("Resources exhausted: Heap exhausted"), dberror.ErrorTypeRateLimit, true},
 		{"influxdb request too large", errors.New("request too large: Error running series plans for namespace 'x': Resources exhausted: Heap exhausted"), dberror.ErrorTypeRateLimit, true},
+		// rpcpool 429 as surfaced by the jsonrpc client's dump formatting: neither
+		// "rate limited" nor "status 429" substring-matches it, but it is plainly a
+		// transient throttle (observed from the DZ ledger RPC during the 2026-07-23
+		// permission-events drain).
+		{"rpcpool connection rate limit", errors.New("get transaction: (*jsonrpc.RPCError)(0xc003100330)({\n Code: (int) 429,\n Message: (string) (len=31) \"Connection rate limits exceeded\",\n Data: (interface {}) <nil>\n})"), dberror.ErrorTypeRateLimit, true},
+		{"rate limiting variant", errors.New("upstream is rate limiting requests"), dberror.ErrorTypeRateLimit, true},
 
 		// The actual prod CH-connection-drop errors we saw — must be transient.
 		{"ch read packet reset", errors.New("query processing: failed to read packet from 52.4.220.199:9440 (conn_id=492): read: connection reset by peer"), dberror.ErrorTypeConnectivity, true},


### PR DESCRIPTION
## Summary of Changes
- Broaden `dberror`'s rate-limit pattern from `"rate limited"` to `"rate limit"`, so messages like rpcpool's HTTP 429 body — `Connection rate limits exceeded`, surfaced through the jsonrpc client's error dump where neither `"rate limited"` nor `"status 429"` substring-match — classify as `ErrorTypeRateLimit`/transient. The broader pattern also covers `"rate limiting"`.
- Why it matters: transient classification selects the lenient escalation threshold (10 consecutive failures) instead of the strict one (3), so a throttled-but-progressing loop logs WARN rather than paging on-call. Observed during the 2026-07-23 testnet permission-events drain (#706): a mid-drain 429 from the DZ ledger RPC classified as Unknown and would have escalated as if actionable.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net |
|--------------|-------|-------------|-----|
| Core logic   |     1 | +3 / -1     |  +2 |
| Tests        |     1 | +6 / -0     |  +6 |

One pattern broadened, pinned by table-test cases.

## Testing Verification
- New table cases (verified failing first) assert `Classify` → `ErrorTypeRateLimit` and `IsTransient` → true for the exact prod error text (jsonrpc dump format with `Connection rate limits exceeded`) and a `"rate limiting"` variant; existing cases confirm `"rate limited"` and `"status 429"` still classify unchanged.
- `utils/...` suite passes with `-race`.
