### PR TITLE
indexer: anchor telemetry-usage catch-up cap at maxTime so ingest advances past ~1h stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Non-actionable failures no longer log at ERROR (which pages on-call): indexer view refreshes and ingest workflows escalate WARN→ERROR only on sustained consecutive failures; slack, agent, and worker log sites classify transient and client-caused errors as WARN; probe-write, optional-listener, and shutdown-cleanup failures demote to WARN (#696)
 - `dberror` moved from `api/handlers/dberror` to `utils/pkg/dberror` so all services can share transient-error classification (#696)
 
+### Fixed
+
+- Indexer interface-counter data (`fact_dz_device_interface_counters`) is no longer permanently ~1h stale: the telemetry-usage catch-up cap is now anchored at `maxTime` (the ingest watermark) instead of `queryStart`, which had made the cap equal the 5m re-read overlap so an incremental refresh could never query past `maxTime` — every cycle re-read only rows that dedup out and inserted nothing, and `max(event_ts)` sawtoothed ~1h behind `now()`. Steady state now ingests the overlap plus one chunk (~10m, 2 Flux queries) and advances every refresh. `RefreshTelemetryUsage` gets a dedicated 10m activity `StartToCloseTimeout` (was the shared 5m) to bound the two-query worst case plus ClickHouse work, preventing the #665/#671 timeout loop. The post-downtime catch-up memory bound is unchanged (#708)
+
 ### Added
 
 - Shared `utils/pkg/logger` helpers: transient-aware `logger.Error`/`logger.Warn` and consecutive-failure `logger.Escalator`; logging-level convention documented in CLAUDE.md (#696)

--- a/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
+++ b/indexer/pkg/dz/telemetry/usage/flux_influx_client.go
@@ -21,8 +21,11 @@ type FluxInfluxDBClient struct {
 
 // defaultFluxHTTPTimeout is the HTTP client timeout for Flux queries.
 // The influxdb-client-go/v2 default is 20s which is too short for pivot queries
-// over a 1-hour window of interface counter data. The Temporal activity
-// StartToCloseTimeout is 5 minutes, so 4 minutes gives a comfortable margin.
+// over a 1-hour window of interface counter data. A steady-state telemetry-usage
+// refresh runs 2 chunked queries (overlap re-read + one new chunk), so ~8m of
+// Flux worst case; RefreshTelemetryUsage runs under a dedicated 10m
+// StartToCloseTimeout (see dzingest/workflow.go) that leaves margin for that
+// plus the ClickHouse work.
 const defaultFluxHTTPTimeout = 4 * time.Minute
 
 // NewFluxInfluxDBClient creates a new InfluxDB client that uses Flux queries.

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -530,8 +530,13 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 		v.log.Warn("telemetry/usage: no data returned from influxdb query", "from", queryStart, "to", now)
 		// Nothing to insert, so no persistence to wait on. Merge end-of-window
 		// baselines (a no-op when the window was genuinely empty) and advance the
-		// watermark: nothing changed through queryEnd, so the cached last-known
-		// values still hold there and the next refresh can cache-hit.
+		// baseline-cache watermark: nothing changed through queryEnd, so the
+		// cached last-known values still hold there and the next refresh can
+		// cache-hit. Note this advances only the cache watermark, not maxTime
+		// (nothing was written): while a data gap longer than QueryChunk sits at
+		// maxTime, the incremental window stays pinned at [maxTime-overlap,
+		// maxTime+chunk) returning zero new rows, until maxTime ages out of
+		// QueryWindow and the "data too old" branch skips past the gap.
 		v.updateBaselineCache(endBaselines, queryEnd)
 		v.readyOnce.Do(func() {
 			close(v.readyCh)

--- a/indexer/pkg/dz/telemetry/usage/view.go
+++ b/indexer/pkg/dz/telemetry/usage/view.go
@@ -234,24 +234,30 @@ const refreshOverlap = 5 * time.Minute
 // event_ts against the watermark (see queryBaselineCountersFromClickHouse).
 const baselineCacheMaxLag = 15 * time.Minute
 
-// maxCatchupChunks bounds a single refresh to maxCatchupChunks × QueryChunk of
-// data. After downtime maxTime can fall behind the query window, making one
-// refresh span the entire window at once; capping it spreads the catch-up over
-// successive refreshes (maxTime advances after each) so peak memory stays near
-// steady state.
+// maxCatchupChunks bounds how much NEW data (past maxTime) a single refresh
+// ingests: maxCatchupChunks × QueryChunk. After downtime maxTime can fall
+// behind the query window, making one refresh span the entire window at once;
+// capping it spreads the catch-up over successive refreshes (maxTime advances
+// after each) so peak memory stays near steady state.
 //
-// The cap must also keep each refresh inside the dzingest activity's
-// StartToCloseTimeout (5m). Each chunk is a separate Flux query bounded only by
-// the client's per-request HTTP timeout (defaultFluxHTTPTimeout, 4m); the Flux
-// query does not abort on the activity context deadline, so a 3-chunk (15m)
-// window can spend up to ~12m in InfluxDB alone. In prod this overran the 5m
-// deadline (observed >10m on both mainnet-beta and testnet), so ctx was already
-// expired by the time InsertInterfaceUsage ran — every catch-up refresh failed,
-// maxTime never advanced, and the window stayed pinned at the cap (an
-// unrecoverable loop; the overrun also spawned a doomed second Temporal attempt
-// that failed instantly on the already-expired ctx). One chunk caps each
-// refresh at a single <=4m query, leaving room for the insert inside the 5m
-// deadline so maxTime advances every cycle.
+// The cap is anchored at maxTime, not queryStart (see Refresh). In steady state
+// queryStart = maxTime − refreshOverlap, so the ingested span is the overlap
+// plus one chunk (~10m) = 2 Flux queries per refresh: one re-reading the
+// overlap (dedups out) and one ingesting the new chunk. maxTime advances one
+// chunk per refresh.
+//
+// The cap must keep each refresh inside the dzingest activity's
+// StartToCloseTimeout. Each chunk is a separate Flux query bounded only by the
+// client's per-request HTTP timeout (defaultFluxHTTPTimeout, 4m); the Flux
+// query does not abort on the activity context deadline, so the 2-query steady
+// state can spend up to ~8m in InfluxDB alone. RefreshTelemetryUsage runs under
+// a dedicated 10m StartToCloseTimeout (see dzingest/workflow.go) that bounds
+// this worst case plus the ClickHouse dedup/baseline/insert work, so ctx is not
+// already expired when InsertInterfaceUsage runs and maxTime advances every
+// cycle. (History: a 3-chunk/15m span under the old 5m deadline overran on both
+// mainnet-beta and testnet — ctx expired before the insert, every catch-up
+// refresh failed, and the window stayed pinned at the cap in an unrecoverable
+// loop.)
 const maxCatchupChunks = 1
 
 type View struct {
@@ -486,9 +492,24 @@ func (v *View) Refresh(ctx context.Context) (ingestionlog.RefreshResult, error) 
 	// never advanced and every restart re-ran the same giant query. Capping the
 	// span lets a large catch-up proceed across successive refreshes (maxTime
 	// advances after each), keeping peak memory near steady state.
+	//
+	// Anchor the cap at the start of NEW data (maxTime), not queryStart.
+	// queryStart sits refreshOverlap (5m) behind maxTime to re-read late
+	// arrivals; anchoring the cap there made queryEnd = queryStart + 5m =
+	// maxTime, so an incremental refresh could never query past maxTime — it
+	// only re-read rows that dedup out and ingest stalled ~1h behind (#708).
+	// Anchoring at maxTime makes the steady-state span overlap + one chunk
+	// (~10m, 2 Flux queries) so maxTime advances every cycle. When maxTime is
+	// nil or older than queryStart (initial / "data too old"), newDataStart
+	// falls back to queryStart and the cap behaves as before — one chunk from
+	// the window start, preserving the post-downtime memory bound.
+	newDataStart := queryStart
+	if maxTime != nil && maxTime.After(newDataStart) {
+		newDataStart = *maxTime
+	}
 	queryEnd := now
-	if maxCatchup := v.cfg.QueryChunk * maxCatchupChunks; maxCatchup > 0 && queryEnd.Sub(queryStart) > maxCatchup {
-		queryEnd = queryStart.Add(maxCatchup)
+	if maxCatchup := v.cfg.QueryChunk * maxCatchupChunks; maxCatchup > 0 && queryEnd.Sub(newDataStart) > maxCatchup {
+		queryEnd = newDataStart.Add(maxCatchup)
 		v.log.Info("telemetry/usage: capping catch-up window to bound memory",
 			"queryStart", queryStart.UTC(), "queryEnd", queryEnd.UTC(), "target", now.UTC())
 	}

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -1468,3 +1468,175 @@ func TestLake_TelemetryUsage_View_convertRowsToUsage(t *testing.T) {
 		require.Equal(t, int64(1000200-1000100), *usage[2].InOctetsDelta) // 100, not 500200
 	})
 }
+
+// captureIntfCounterWindows returns a View whose InfluxDB mock records the
+// [start, end) of every QueryIntfCounters sub-query so tests can assert the
+// span a refresh actually queried. The mock returns no rows, so Refresh
+// completes without exercising the convert/insert path (not what these tests
+// cover).
+func captureIntfCounterWindows(t *testing.T, clock clockwork.Clock, chunk time.Duration) (*View, *[][2]time.Time) {
+	t.Helper()
+	windows := &[][2]time.Time{}
+	influx := &mockInfluxDBClient{
+		queryIntfCountersFunc: func(_ context.Context, s, e time.Time) ([]map[string]any, error) {
+			*windows = append(*windows, [2]time.Time{s, e})
+			return nil, nil
+		},
+	}
+	view, err := NewView(ViewConfig{
+		Logger:          laketesting.NewLogger(),
+		Clock:           clock,
+		ClickHouse:      testClient(t),
+		InfluxDB:        influx,
+		Bucket:          "test-bucket",
+		RefreshInterval: time.Second,
+		QueryWindow:     time.Hour,
+		QueryChunk:      chunk,
+	})
+	require.NoError(t, err)
+	return view, windows
+}
+
+// seedMaxTime inserts a single interface-counter row at event_ts=ts so the next
+// refresh reads ts as maxTime (the ingest watermark).
+func seedMaxTime(t *testing.T, v *View, ts time.Time) {
+	t.Helper()
+	dev, intf := "seed-device", "eth0"
+	err := v.store.InsertInterfaceUsage(context.Background(), []InterfaceUsage{{
+		Time:     ts.UTC(),
+		DevicePK: &dev,
+		Intf:     &intf,
+	}})
+	require.NoError(t, err)
+}
+
+// span returns the overall [start, end) covered by the recorded sub-query
+// windows (first start, last end).
+func span(t *testing.T, windows [][2]time.Time) (time.Time, time.Time) {
+	t.Helper()
+	require.NotEmpty(t, windows, "expected at least one InfluxDB sub-query")
+	return windows[0][0], windows[len(windows)-1][1]
+}
+
+// Regression for #708: an incremental refresh (maxTime inside the query window)
+// must query PAST maxTime, not stop at it. The catch-up cap is anchored at
+// maxTime, so the span is refreshOverlap behind maxTime plus one QueryChunk of
+// new data. On the buggy code the cap was anchored at queryStart (= maxTime −
+// overlap) and equalled the overlap, so queryEnd landed exactly at maxTime and
+// no new data was ever ingested.
+func TestLake_TelemetryUsage_View_Refresh_IncrementalQueriesPastMaxTime(t *testing.T) {
+	t.Parallel()
+
+	const chunk = 5 * time.Minute
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+	maxTime := now.Add(-30 * time.Minute) // well inside the 1h window
+
+	view, windows := captureIntfCounterWindows(t, clock, chunk)
+	seedMaxTime(t, view, maxTime)
+
+	_, err := view.Refresh(t.Context())
+	require.NoError(t, err)
+
+	start, end := span(t, *windows)
+	require.Equal(t, maxTime.Add(-refreshOverlap).UTC(), start.UTC(),
+		"refresh must re-read the overlap behind maxTime")
+	require.Equal(t, maxTime.Add(chunk).UTC(), end.UTC(),
+		"refresh must query one chunk PAST maxTime (the #708 regression)")
+	require.True(t, end.After(maxTime), "queryEnd must advance past maxTime")
+	// overlap + one chunk = 2 chunk-sized sub-queries.
+	require.Len(t, *windows, 2)
+}
+
+// Steady state must step forward one chunk per refresh — the sawtooth is gone
+// and progress is monotonic. Re-seeding the watermark to the prior queryEnd
+// stands in for the insert that advances maxTime in production.
+func TestLake_TelemetryUsage_View_Refresh_SteadyStateAdvancesOneChunk(t *testing.T) {
+	t.Parallel()
+
+	const chunk = 5 * time.Minute
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+	maxTime := now.Add(-40 * time.Minute)
+
+	view, windows := captureIntfCounterWindows(t, clock, chunk)
+	seedMaxTime(t, view, maxTime)
+
+	_, err := view.Refresh(t.Context())
+	require.NoError(t, err)
+	_, end1 := span(t, *windows)
+	require.Equal(t, maxTime.Add(chunk).UTC(), end1.UTC())
+
+	// Simulate the insert advancing the watermark to the first refresh's end.
+	*windows = nil
+	seedMaxTime(t, view, end1)
+
+	_, err = view.Refresh(t.Context())
+	require.NoError(t, err)
+	_, end2 := span(t, *windows)
+	require.Equal(t, end1.Add(chunk).UTC(), end2.UTC(), "each refresh advances exactly one chunk")
+	require.True(t, end2.After(end1), "progress must be monotonic")
+}
+
+// The catch-up cap (the #665 memory bound) is preserved when maxTime is older
+// than the query window or absent: the span starts at the window start and
+// covers exactly one chunk, regardless of how far behind maxTime is.
+func TestLake_TelemetryUsage_View_Refresh_CatchupCapPreserved(t *testing.T) {
+	t.Parallel()
+
+	const chunk = 5 * time.Minute
+
+	t.Run("maxTime older than query window", func(t *testing.T) {
+		t.Parallel()
+		clock := clockwork.NewFakeClock()
+		now := clock.Now()
+		windowStart := now.Add(-time.Hour)
+
+		view, windows := captureIntfCounterWindows(t, clock, chunk)
+		seedMaxTime(t, view, now.Add(-90*time.Minute)) // outside the window
+
+		_, err := view.Refresh(t.Context())
+		require.NoError(t, err)
+
+		start, end := span(t, *windows)
+		require.Equal(t, windowStart.UTC(), start.UTC(), "catch-up starts at the window start")
+		require.Equal(t, windowStart.Add(chunk).UTC(), end.UTC(), "catch-up ingests exactly one chunk")
+		require.Len(t, *windows, 1)
+	})
+
+	t.Run("empty table", func(t *testing.T) {
+		t.Parallel()
+		clock := clockwork.NewFakeClock()
+		now := clock.Now()
+		windowStart := now.Add(-time.Hour)
+
+		view, windows := captureIntfCounterWindows(t, clock, chunk)
+
+		_, err := view.Refresh(t.Context())
+		require.NoError(t, err)
+
+		start, end := span(t, *windows)
+		require.Equal(t, windowStart.UTC(), start.UTC())
+		require.Equal(t, windowStart.Add(chunk).UTC(), end.UTC())
+	})
+}
+
+// When maxTime + QueryChunk is beyond now, the refresh must clamp queryEnd to
+// now rather than overshooting into the future.
+func TestLake_TelemetryUsage_View_Refresh_UncappedTailClampsToNow(t *testing.T) {
+	t.Parallel()
+
+	const chunk = 5 * time.Minute
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+	maxTime := now.Add(-3 * time.Minute) // maxTime + 5m chunk > now
+
+	view, windows := captureIntfCounterWindows(t, clock, chunk)
+	seedMaxTime(t, view, maxTime)
+
+	_, err := view.Refresh(t.Context())
+	require.NoError(t, err)
+
+	_, end := span(t, *windows)
+	require.Equal(t, now.UTC(), end.UTC(), "queryEnd must clamp to now, never past it")
+}

--- a/indexer/pkg/dz/telemetry/usage/view_test.go
+++ b/indexer/pkg/dz/telemetry/usage/view_test.go
@@ -1530,7 +1530,8 @@ func TestLake_TelemetryUsage_View_Refresh_IncrementalQueriesPastMaxTime(t *testi
 	const chunk = 5 * time.Minute
 	clock := clockwork.NewFakeClock()
 	now := clock.Now()
-	maxTime := now.Add(-30 * time.Minute) // well inside the 1h window
+	// event_ts is DateTime64(3); align the seed so it round-trips exactly.
+	maxTime := now.Add(-30 * time.Minute).Truncate(time.Millisecond) // well inside the 1h window
 
 	view, windows := captureIntfCounterWindows(t, clock, chunk)
 	seedMaxTime(t, view, maxTime)
@@ -1557,7 +1558,8 @@ func TestLake_TelemetryUsage_View_Refresh_SteadyStateAdvancesOneChunk(t *testing
 	const chunk = 5 * time.Minute
 	clock := clockwork.NewFakeClock()
 	now := clock.Now()
-	maxTime := now.Add(-40 * time.Minute)
+	// event_ts is DateTime64(3); align the seed so it round-trips exactly.
+	maxTime := now.Add(-40 * time.Minute).Truncate(time.Millisecond)
 
 	view, windows := captureIntfCounterWindows(t, clock, chunk)
 	seedMaxTime(t, view, maxTime)

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -23,6 +23,19 @@ const (
 	// at ~2s resolution so indexing every minute keeps data reasonably fresh.
 	telemUsageEveryN = 1
 
+	// telemUsageStartToCloseTimeout is the dedicated activity deadline for
+	// RefreshTelemetryUsage, larger than the shared 5m. A steady-state refresh
+	// runs 2 Flux queries (overlap re-read + one new chunk, see
+	// dztelemusage.maxCatchupChunks), each bounded by defaultFluxHTTPTimeout
+	// (4m) and not aborting on the activity ctx, so the worst case is ~8m of
+	// InfluxDB plus the ClickHouse dedup/baseline/insert work; 10m bounds that.
+	// A shorter deadline would expire before the insert on slow InfluxDB and pin
+	// maxTime in a retry loop (the #665/#671 failure mode). (The rare InfluxDB
+	// baseline fallback adds up to 120s before the chunked read; on that path
+	// the deadline is tight, but it needs a cache miss plus 0 ClickHouse
+	// baselines and the next cycle recovers.)
+	telemUsageStartToCloseTimeout = 10 * time.Minute
+
 	// permissionEventsEveryN controls how often the permission audit refresh runs.
 	// Serviceability permission changes are sporadic, so at the 60s base interval this
 	// runs every ~5 minutes — enough freshness for an audit page while avoiding a
@@ -82,19 +95,19 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		msdpSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncMSDP)
 		graphSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncGraph)
 
-		// Telemetry usage runs less frequently (~5 minutes). It needs a longer
-		// StartToCloseTimeout than the shared 5m: a steady-state refresh runs 2
-		// Flux queries (overlap re-read + one new chunk, see maxCatchupChunks),
-		// each bounded by defaultFluxHTTPTimeout (4m) and not aborting on the
-		// activity deadline, so the worst case is ~8m of InfluxDB plus the
-		// ClickHouse dedup/baseline/insert work. 10m bounds that; a shorter
-		// deadline would expire before the insert on slow InfluxDB and pin
-		// maxTime in a retry loop (the #665/#671 failure mode).
+		// Telemetry usage runs every iteration (~1 minute) but under a dedicated
+		// longer deadline (telemUsageStartToCloseTimeout) because a refresh now
+		// runs 2 Flux queries. Use MaximumAttempts: 1, not the shared retry
+		// policy: the workflow reschedules this activity every iteration, so a
+		// Temporal retry adds no recovery a re-run wouldn't — while a 10m×3
+		// retry chain would block the whole ingest loop for up to ~30m and stack
+		// attempts on refreshMu behind a first attempt whose Flux query ignores
+		// the expired ctx. One attempt keeps the worst-case loop stall at 10m.
 		var telemUsageFuture temporalworkflow.Future
 		if iteration%telemUsageEveryN == 0 {
 			telemUsageCtx := temporalworkflow.WithActivityOptions(ctx, temporalworkflow.ActivityOptions{
-				StartToCloseTimeout: 10 * time.Minute,
-				RetryPolicy:         actOpts.RetryPolicy,
+				StartToCloseTimeout: telemUsageStartToCloseTimeout,
+				RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
 			})
 			telemUsageFuture = temporalworkflow.ExecuteActivity(telemUsageCtx, (*Activities).RefreshTelemetryUsage)
 		}

--- a/indexer/pkg/dzingest/workflow.go
+++ b/indexer/pkg/dzingest/workflow.go
@@ -82,10 +82,21 @@ func DZIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 		msdpSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncMSDP)
 		graphSyncFuture := temporalworkflow.ExecuteActivity(ctx, (*Activities).SyncGraph)
 
-		// Telemetry usage runs less frequently (~5 minutes).
+		// Telemetry usage runs less frequently (~5 minutes). It needs a longer
+		// StartToCloseTimeout than the shared 5m: a steady-state refresh runs 2
+		// Flux queries (overlap re-read + one new chunk, see maxCatchupChunks),
+		// each bounded by defaultFluxHTTPTimeout (4m) and not aborting on the
+		// activity deadline, so the worst case is ~8m of InfluxDB plus the
+		// ClickHouse dedup/baseline/insert work. 10m bounds that; a shorter
+		// deadline would expire before the insert on slow InfluxDB and pin
+		// maxTime in a retry loop (the #665/#671 failure mode).
 		var telemUsageFuture temporalworkflow.Future
 		if iteration%telemUsageEveryN == 0 {
-			telemUsageFuture = temporalworkflow.ExecuteActivity(ctx, (*Activities).RefreshTelemetryUsage)
+			telemUsageCtx := temporalworkflow.WithActivityOptions(ctx, temporalworkflow.ActivityOptions{
+				StartToCloseTimeout: 10 * time.Minute,
+				RetryPolicy:         actOpts.RetryPolicy,
+			})
+			telemUsageFuture = temporalworkflow.ExecuteActivity(telemUsageCtx, (*Activities).RefreshTelemetryUsage)
 		}
 
 		// Permission audit events run less frequently (~5 minutes); changes are sporadic.


### PR DESCRIPTION
## Summary of Changes
* Anchor the telemetry-usage catch-up cap at `maxTime` (the ingest watermark) instead of `queryStart`, so incremental refreshes query past `maxTime` and `fact_dz_device_interface_counters` stops being permanently ~1h stale.
* The cap had equalled the 5m re-read overlap (`queryStart = maxTime − overlap`, cap = `QueryChunk × maxCatchupChunks` = 5m → `queryEnd = maxTime`), so every incremental refresh re-read only rows that dedup out and inserted nothing; `max(event_ts)` sawtoothed ~3,450–3,800s behind `now()`.
* Give `RefreshTelemetryUsage` a dedicated 10m activity `StartToCloseTimeout` with `MaximumAttempts: 1` — steady state now runs 2 Flux queries (~8m worst case) which no longer fits the shared 5m deadline; a single attempt avoids a ~30m loop stall since the workflow reschedules every iteration anyway.
* Fixes #708

## Testing Verification
* Added regression tests in `dztelemusage` (fake clock + per-test ClickHouse + InfluxDB mock capturing query spans): incremental refresh queries one chunk past `maxTime` (fails on `main`); steady state advances exactly one chunk per refresh (monotonic, no sawtooth); catch-up cap preserved for out-of-window/empty `maxTime` (the #665 memory bound); near-`now` tail clamps `queryEnd` to `now`.
* Post-deploy: `now() − max(event_ts)` on `fact_dz_device_interface_counters` should drop from ~3,500–3,800s to single-digit minutes and stay flat; `doublezero_data_indexer_clickhouse_baseline_query_total` should remain ~restarts-only (confirms no #702 baseline-cache interaction).
* Note: ClickHouse-backed tests require Docker and were not run locally (no Docker daemon in the dev environment); they run in CI. Build, `go vet`, and `golangci-lint` pass on the changed packages.

## Note on review deviation
The approved plan kept the existing retry policy; the architecture review flagged that `MaximumAttempts: 3` × the new 10m deadline widens the worst-case ingest-loop stall to ~30m (from ~15m) with no benefit, since `telemUsageEveryN = 1` reschedules the activity every ~1 minute. Reduced to `MaximumAttempts: 1`, which also keeps a hung Flux query from stacking attempts on `refreshMu`. The pre-existing zero-rows gap-stall (Medium, self-heals when `maxTime` ages out of the window) is documented in-code but not otherwise changed — out of scope for this fix.
