### PR TITLE
indexer: stop transient rollup/permission-events blips from paging

### DIFF
--- a/indexer/pkg/dz/serviceability/permissionevents/view.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view.go
@@ -14,6 +14,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
 	"github.com/malbeclabs/lake/indexer/pkg/metrics"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 	"github.com/malbeclabs/lake/utils/pkg/logger"
 	"golang.org/x/sync/errgroup"
 )
@@ -622,7 +623,12 @@ func (v *View) decodeChunk(ctx context.Context, sigs []*rpc.TransactionSignature
 					}
 					v.log.Warn("serviceability/permission-events: transaction not found near tip, retrying next refresh",
 						"signature", sig.Signature.String(), "slot", sig.Slot)
-					return err
+					// Mark transient: this near-tip null is a load-balanced backend
+					// lagging finalization and self-heals on retry, so escalation
+					// should use the higher transient threshold rather than paging
+					// after a few consecutive refreshes. Still unwraps to
+					// rpc.ErrNotFound for any upstream errors.Is checks.
+					return fmt.Errorf("%w (%w)", err, dberror.ErrTransient)
 				}
 				v.log.Warn("serviceability/permission-events: failed to decode transaction",
 					"signature", sig.Signature.String(), "error", err)

--- a/indexer/pkg/dz/serviceability/permissionevents/view_test.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/view_test.go
@@ -15,6 +15,7 @@ import (
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/jonboulle/clockwork"
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -352,6 +353,12 @@ func TestLake_PermissionEvents_View_NearTipNotFoundFailsChunkAndRetries(t *testi
 
 	_, err := view.Refresh(context.Background())
 	require.Error(t, err, "a near-tip not-found must fail the chunk, not be skipped")
+	// The failure is transient-by-design (a lagging backend that self-heals),
+	// so it must classify as transient — the activity escalator then pages at
+	// the higher transient threshold instead of after a few refreshes — while
+	// still unwrapping to the original not-found cause.
+	require.True(t, dberror.IsTransient(err), "near-tip not-found must be classified transient")
+	require.True(t, errors.Is(err, solanarpc.ErrNotFound), "error must still unwrap to ErrNotFound")
 	require.EqualValues(t, 0, factRowCount(t, ch))
 	_, _, found := accountCursor(t, ch, testPDA.String())
 	require.False(t, found, "cursor must not advance past a recoverable signature")

--- a/indexer/pkg/dzingest/dzingest.go
+++ b/indexer/pkg/dzingest/dzingest.go
@@ -27,6 +27,7 @@ import (
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 )
 
 // Config configures the DZ ingest worker.
@@ -176,7 +177,34 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
+	// The periodic DZ ingest activities return nil to Temporal (see
+	// activities.refresh), so they never reach this "Activity error." log. The
+	// manual backfill activities do return their error, and BackfillRefresh
+	// shares the permission-events near-tip not-found gate — a transient-by-
+	// design condition (dberror.ErrTransient) that would otherwise page an
+	// attended backfill. Demote transient causes to WARN; non-transient
+	// failures still log ERROR. Mirrors the rollup worker's temporalLogger.
+	if msg == "Activity error." && isTransientActivityError(keyvals) {
+		l.log.Warn(msg, keyvals...)
+		return
+	}
 	l.log.Error(msg, keyvals...)
+}
+
+// isTransientActivityError reports whether Temporal's activity-error keyvals
+// carry an Error that dberror classifies as transient (a self-healing upstream
+// blip, or one explicitly marked with dberror.ErrTransient). At the "Activity
+// error." log site the Error keyval is the raw error the activity returned.
+func isTransientActivityError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			return dberror.IsTransient(err)
+		}
+	}
+	return false
 }
 
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing

--- a/indexer/pkg/rollup/logger_test.go
+++ b/indexer/pkg/rollup/logger_test.go
@@ -1,0 +1,64 @@
+package rollup
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// capturingHandler records the level of the last log record it handled.
+type capturingHandler struct{ last slog.Level }
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.last = r.Level
+	return nil
+}
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestTemporalLoggerErrorLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		err  error
+		want slog.Level
+	}{
+		{
+			name: "transient activity error demoted to warn",
+			msg:  "Activity error.",
+			err:  errors.New("link latency query: query processing: failed to read first block packet from 52.4.220.199:9440 (conn_id=15): read: EOF"),
+			want: slog.LevelWarn,
+		},
+		{
+			name: "non-transient activity error stays error",
+			msg:  "Activity error.",
+			err:  errors.New("Code: 62. DB::Exception: Syntax error"),
+			want: slog.LevelError,
+		},
+		{
+			name: "context cancellation demoted to warn",
+			msg:  "Activity error.",
+			err:  context.Canceled,
+			want: slog.LevelWarn,
+		},
+		{
+			name: "transient error under a different message stays error",
+			msg:  "some other failure",
+			err:  errors.New("read: EOF"),
+			want: slog.LevelError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &capturingHandler{}
+			l := &temporalLogger{log: slog.New(h)}
+			l.Error(tt.msg, "Error", tt.err)
+			require.Equal(t, tt.want, h.last)
+		})
+	}
+}

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 )
@@ -175,6 +176,15 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
+	// Temporal logs "Activity error." at ERROR on every failed attempt,
+	// including non-final ones the activity's retry policy will recover. A
+	// transient cause (ClickHouse connection blip, timeout) self-heals on
+	// retry, so demote to WARN; a sustained failure still pages via the
+	// workflow-side Escalator once retries are exhausted across iterations.
+	if msg == "Activity error." && isTransientActivityError(keyvals) {
+		l.log.Warn(msg, keyvals...)
+		return
+	}
 	l.log.Error(msg, keyvals...)
 }
 
@@ -194,6 +204,23 @@ func hasBenignTaskProcessingError(keyvals []any) bool {
 				strings.Contains(msg, "grpc: the client connection is closing") {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// isTransientActivityError reports whether Temporal's activity-error keyvals
+// carry an Error that dberror classifies as transient (a self-healing upstream
+// blip the activity's retry policy will recover). The Error value arrives
+// wrapped in the SDK's ApplicationError, but dberror.Classify matches on the
+// unwrapped message string, so a connectivity/timeout cause still classifies.
+func isTransientActivityError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			return dberror.IsTransient(err)
 		}
 	}
 	return false

--- a/indexer/pkg/rollup/rollup.go
+++ b/indexer/pkg/rollup/rollup.go
@@ -211,9 +211,11 @@ func hasBenignTaskProcessingError(keyvals []any) bool {
 
 // isTransientActivityError reports whether Temporal's activity-error keyvals
 // carry an Error that dberror classifies as transient (a self-healing upstream
-// blip the activity's retry policy will recover). The Error value arrives
-// wrapped in the SDK's ApplicationError, but dberror.Classify matches on the
-// unwrapped message string, so a connectivity/timeout cause still classifies.
+// blip the activity's retry policy will recover). At the "Activity error." log
+// site the Error keyval is the raw error the activity returned (conversion to
+// the SDK's ApplicationError happens afterward). dberror.Classify matches on
+// the message string, so classification would also hold if a converted error
+// ever appeared here.
 func isTransientActivityError(keyvals []any) bool {
 	for i := 0; i+1 < len(keyvals); i += 2 {
 		if keyvals[i] != "Error" {

--- a/indexer/pkg/solingest/logger_test.go
+++ b/indexer/pkg/solingest/logger_test.go
@@ -1,0 +1,64 @@
+package solingest
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// capturingHandler records the level of the last log record it handled.
+type capturingHandler struct{ last slog.Level }
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.last = r.Level
+	return nil
+}
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestTemporalLoggerErrorLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		err  error
+		want slog.Level
+	}{
+		{
+			name: "transient activity error demoted to warn",
+			msg:  "Activity error.",
+			err:  errors.New("solana refresh: query processing: failed to read first block packet from 52.4.220.199:9440 (conn_id=15): read: EOF"),
+			want: slog.LevelWarn,
+		},
+		{
+			name: "non-transient activity error stays error",
+			msg:  "Activity error.",
+			err:  errors.New("Code: 62. DB::Exception: Syntax error"),
+			want: slog.LevelError,
+		},
+		{
+			name: "context cancellation demoted to warn",
+			msg:  "Activity error.",
+			err:  context.Canceled,
+			want: slog.LevelWarn,
+		},
+		{
+			name: "transient error under a different message stays error",
+			msg:  "some other failure",
+			err:  errors.New("read: EOF"),
+			want: slog.LevelError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &capturingHandler{}
+			l := &temporalLogger{log: slog.New(h)}
+			l.Error(tt.msg, "Error", tt.err)
+			require.Equal(t, tt.want, h.last)
+		})
+	}
+}

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
 	"github.com/malbeclabs/lake/indexer/pkg/sol"
 	"github.com/malbeclabs/lake/indexer/pkg/validatorsapp"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 )
 
 // Config configures the Solana ingest worker.
@@ -143,7 +144,34 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 		l.log.Warn(msg, keyvals...)
 		return
 	}
+	// Temporal logs "Activity error." at ERROR on every failed attempt,
+	// including non-final ones the activity's retry policy will recover. These
+	// activities write to ClickHouse and return their errors to Temporal, so a
+	// transient connection blip (a native-TLS read: EOF from ClickHouse Cloud)
+	// self-heals on retry but still trips the aggregate level="ERR" pager.
+	// Demote to WARN; sustained failure still surfaces via the ingestion log.
+	// Mirrors the rollup worker's temporalLogger.
+	if msg == "Activity error." && isTransientActivityError(keyvals) {
+		l.log.Warn(msg, keyvals...)
+		return
+	}
 	l.log.Error(msg, keyvals...)
+}
+
+// isTransientActivityError reports whether Temporal's activity-error keyvals
+// carry an Error that dberror classifies as transient (a self-healing upstream
+// blip the activity's retry policy will recover). At the "Activity error." log
+// site the Error keyval is the raw error the activity returned.
+func isTransientActivityError(keyvals []any) bool {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if keyvals[i] != "Error" {
+			continue
+		}
+		if err, ok := keyvals[i+1].(error); ok {
+			return dberror.IsTransient(err)
+		}
+	}
+	return false
 }
 
 // hasBenignTaskProcessingError reports whether Temporal's "Task processing

--- a/indexer/pkg/solingest/solingest.go
+++ b/indexer/pkg/solingest/solingest.go
@@ -149,8 +149,11 @@ func (l *temporalLogger) Error(msg string, keyvals ...any) {
 	// activities write to ClickHouse and return their errors to Temporal, so a
 	// transient connection blip (a native-TLS read: EOF from ClickHouse Cloud)
 	// self-heals on retry but still trips the aggregate level="ERR" pager.
-	// Demote to WARN; sustained failure still surfaces via the ingestion log.
-	// Mirrors the rollup worker's temporalLogger.
+	// Demote to WARN; a sustained failure still pages via the workflow-side
+	// Escalator, which observes the frequent activities (solana/geoip/
+	// validatorsapp) enough times per run to reach its threshold, and observes
+	// the once-per-run block production activity at a dedicated threshold of 1
+	// (see workflow.go). Mirrors the rollup worker's temporalLogger.
 	if msg == "Activity error." && isTransientActivityError(keyvals) {
 		l.log.Warn(msg, keyvals...)
 		return

--- a/indexer/pkg/solingest/workflow.go
+++ b/indexer/pkg/solingest/workflow.go
@@ -48,6 +48,15 @@ func SolIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	// to ErrorAfter-1 iterations across the boundary — fine at threshold 3;
 	// revisit before raising the threshold.
 	esc := &logger.Escalator{TransientErrorAfter: logger.DefaultErrorAfter}
+
+	// Block production runs once per ~hourly run (blockProductionEveryN ==
+	// continueAsNewThreshold, so only at iteration 0), and esc is workflow-local
+	// and recreated on every ContinueAsNew — so its block_production count can
+	// never exceed 1 and the default threshold of 3 is unreachable. A block
+	// production failure that survived Temporal's in-activity retries is already
+	// sustained, so escalate it at 1 to preserve pre-PR paging (the per-attempt
+	// "Activity error." lines that used to page are now demoted to WARN).
+	bpEsc := &logger.Escalator{ErrorAfter: 1, TransientErrorAfter: 1}
 	var err error
 
 	actOpts := temporalworkflow.ActivityOptions{
@@ -91,7 +100,7 @@ func SolIngestWorkflow(ctx temporalworkflow.Context, iteration int) error {
 			if err != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
-			esc.Observe(log, "block_production", "block production refresh failed", err)
+			bpEsc.Observe(log, "block_production", "block production refresh failed", err)
 		}
 		if validatorsAppFuture != nil {
 			err = validatorsAppFuture.Get(ctx, nil)

--- a/utils/pkg/dberror/dberror.go
+++ b/utils/pkg/dberror/dberror.go
@@ -18,6 +18,15 @@ var eofRe = regexp.MustCompile(`\beof\b`)
 // errors.Join or fmt.Errorf("...: %w", ErrTransient)) when the caller knows a
 // failure is self-healing but its message wouldn't be classified as transient
 // by Classify — for example an expected, retryable upstream miss.
+//
+// Two limits, both of which fail safe (page sooner rather than suppress):
+//   - IsTransient checks context.Canceled/DeadlineExceeded before this marker,
+//     so wrapping a context error with ErrTransient does not make it transient.
+//   - The marker does not survive Temporal's failure serialization: after the
+//     ErrorToFailure/FailureToError round-trip errors.Is(reconstructed,
+//     ErrTransient) is false, so it cannot classify an error that reaches a
+//     caller across an activity boundary. Use it where the wrapped error is
+//     inspected in-process (e.g. before an activity returns nil to Temporal).
 var ErrTransient = errors.New("transient error")
 
 // ErrorType classifies database errors for appropriate handling.

--- a/utils/pkg/dberror/dberror.go
+++ b/utils/pkg/dberror/dberror.go
@@ -13,6 +13,13 @@ import (
 // eofRe matches "eof" as a standalone word in a lowercased error message.
 var eofRe = regexp.MustCompile(`\beof\b`)
 
+// ErrTransient is a sentinel that explicitly marks an error as transient for
+// IsTransient, independent of its message. Wrap a return with it (e.g. via
+// errors.Join or fmt.Errorf("...: %w", ErrTransient)) when the caller knows a
+// failure is self-healing but its message wouldn't be classified as transient
+// by Classify — for example an expected, retryable upstream miss.
+var ErrTransient = errors.New("transient error")
+
 // ErrorType classifies database errors for appropriate handling.
 type ErrorType int
 
@@ -40,6 +47,12 @@ func IsTransient(err error) bool {
 	// Context errors are not transient (user cancelled or deadline exceeded)
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
+	}
+
+	// An explicit ErrTransient marker overrides message-based classification:
+	// the caller already knows the failure is self-healing.
+	if errors.Is(err, ErrTransient) {
+		return true
 	}
 
 	errType := Classify(err)

--- a/utils/pkg/dberror/dberror_test.go
+++ b/utils/pkg/dberror/dberror_test.go
@@ -3,6 +3,7 @@ package dberror_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/malbeclabs/lake/utils/pkg/dberror"
@@ -52,4 +53,19 @@ func TestClassifyAndIsTransient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsTransientSentinel(t *testing.T) {
+	// The explicit ErrTransient marker makes IsTransient true even when the
+	// message alone would classify as non-transient (e.g. a not-found miss).
+	notFound := errors.New("get transaction: not found")
+	require.False(t, dberror.IsTransient(notFound), "plain not-found is not transient")
+
+	wrapped := fmt.Errorf("%w (%w)", notFound, dberror.ErrTransient)
+	require.True(t, dberror.IsTransient(wrapped), "not-found wrapped with ErrTransient is transient")
+	require.True(t, errors.Is(wrapped, dberror.ErrTransient), "wrapped unwraps to ErrTransient")
+	require.True(t, errors.Is(wrapped, notFound), "wrapped still unwraps to the original cause")
+
+	// The marker does not override a genuine context cancellation.
+	require.False(t, dberror.IsTransient(context.Canceled))
 }


### PR DESCRIPTION
## Summary

Two prod indexer ERROR lines overnight (2026-07-24) each tripped the aggregate "Lake Indexer: Errors (prod)" Grafana pager (which fires on *any* `level="ERR"` line) and self-resolved within ~5 minutes. Both were transient, self-healing conditions that shouldn't log at ERROR. This is alert-noise reduction, aligned with the logging-levels guidance in `CLAUDE.md` (transient/not-found/lifecycle conditions log WARN, not ERR).

- **RollupLinks (devnet):** a native-TLS `read: EOF` from ClickHouse Cloud (`:9440`) during the link-latency query. The activity auto-retries (Temporal `MaximumAttempts: 3`) and self-heals, but the Temporal SDK worker logs `Activity error.` at ERROR on the non-final `Attempt=1`. `temporalLogger.Error` now demotes to WARN when the carried error is transient (`dberror.IsTransient`), mirroring the existing context-cancellation demotion. Sustained failure still pages via the workflow-side `Escalator`. This is a recurring class (same EOF-from-`:9440` hit `timing statswriter` on 2026-05-29).
- **RefreshPermissionEvents (testnet):** a `getTransaction` null near an account's fetch tip — transient by design (a load-balanced backend lagging finalization; the un-advanced cursor retries next refresh, per #706). It propagated as a plain `rpc.ErrNotFound`, which `dberror.Classify` files as `Unknown`, so the activity escalator paged at the strict threshold (3 refreshes, ~15 min) instead of the transient threshold (10, ~50 min) used for other self-healing causes. The near-tip return is now marked transient via a new `dberror.ErrTransient` sentinel (still unwrapping to `rpc.ErrNotFound`). The old/pruned skip branch is unchanged.

## Follow-up (out of scope)

The near-tip age-gate (`skipNotFoundBelow`) is derived from the account's own newest signature (`sigs[0].Slot`). On a **low-traffic** PDA whose tip never advances, a genuinely-unretrievable near-tip null (e.g. a sig lost across a testnet ledger reset) would never age into the skip branch and would keep failing — now paging every ~50 min instead of ~15. No evidence this happened in the incident (both errors self-resolved). A durable fix would age-gate against ledger/wall-clock time or bound the retries before skipping; worth a separate change if it recurs.

## Testing Verification

- `dberror.IsTransient` returns true for an error wrapping `ErrTransient` and remains false for a plain not-found; the wrapped error still `errors.Is` its original cause. (unit test, passing)
- Extended the existing `NearTipNotFoundFailsChunkAndRetries` view test to assert the returned error is now `dberror.IsTransient` and still unwraps to `rpc.ErrNotFound`; the old/pruned skip path is unchanged.
- New rollup logger test: `temporalLogger.Error` with `"Activity error."` carrying an EOF/connectivity error logs WARN, a non-transient activity error stays ERROR, context cancellation stays WARN, and a transient error under a *different* message stays ERROR.
- Note: the `rollup` and `permissionevents` test packages need a ClickHouse testcontainer (`TestMain`), which was unavailable in the authoring environment (no Docker); those tests compile and are expected to run in CI. `dberror` tests, `go vet`, and `golangci-lint` (0 issues) all pass locally.
