### PR TITLE
indexer,api: parallelize msdp/mroute S3 scans and multicast-delivery queries

### DIFF
--- a/api/handlers/multicast_delivery_entity.go
+++ b/api/handlers/multicast_delivery_entity.go
@@ -17,7 +17,7 @@ import (
 
 const multicastDeliveryEntityCoverageNote = "Current observed route state is limited to devices reporting multicast forwarding telemetry; absence is not proof of packet loss."
 
-// The device multicast-delivery fan-out bounds its aggregate in-flight
+// The multicast-delivery fan-outs bound their aggregate in-flight
 // ClickHouse queries per env (across all concurrent requests). clickhouse-go
 // does not queue pool acquisitions: past DialTimeout (5s) an acquisition
 // fails with ErrAcquireConnTimeout, which is not a source-unavailable error
@@ -38,6 +38,40 @@ func multicastDeliveryQuerySemSize(maxOpenConns int) int {
 	}
 	return size
 }
+
+// multicastDeliveryFanout runs a multicast-delivery handler's independent
+// ClickHouse queries concurrently, each holding a slot in the request env's
+// semaphore.
+type multicastDeliveryFanout struct {
+	ctx context.Context
+	sem chan struct{}
+	wg  sync.WaitGroup
+}
+
+func (a *API) newMulticastDeliveryFanout(ctx context.Context) *multicastDeliveryFanout {
+	return &multicastDeliveryFanout{ctx: ctx, sem: a.multicastDeliveryQuerySem(ctx)}
+}
+
+func (f *multicastDeliveryFanout) spawn(fn func()) {
+	f.wg.Add(1)
+	go func() {
+		defer f.wg.Done()
+		select {
+		case f.sem <- struct{}{}:
+			defer func() { <-f.sem }()
+		case <-f.ctx.Done():
+			// No slot before the request deadline (or the handler already
+			// returned). Run fn anyway: with ctx done it fails fast with
+			// the context error, keeping error handling uniform instead of
+			// leaving its result vars zeroed as if the query succeeded.
+		}
+		fn()
+	}()
+}
+
+// wait blocks until every query spawned since the last wait has finished, so a
+// handler can Wait per stage.
+func (f *multicastDeliveryFanout) wait() { f.wg.Wait() }
 
 type multicastDeliveryEntityParams struct {
 	Groups         []string
@@ -107,24 +141,8 @@ func (a *API) GetDeviceMulticastDelivery(w http.ResponseWriter, r *http.Request)
 		sourceTimes                             map[string]time.Time
 		deviceErr, availableErr, sourceTimesErr error
 	)
-	var wg sync.WaitGroup
-	sem := a.multicastDeliveryQuerySem(ctx)
-	spawn := func(fn func()) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				// No slot before the request deadline (or the handler already
-				// returned). Run fn anyway: with ctx done it fails fast with
-				// the context error, keeping error handling uniform instead of
-				// leaving its result vars zeroed as if the query succeeded.
-			}
-			fn()
-		}()
-	}
+	fanout := a.newMulticastDeliveryFanout(ctx)
+	spawn := fanout.spawn
 	deviceDone := make(chan struct{})
 	go func() {
 		defer close(deviceDone)
@@ -138,7 +156,7 @@ func (a *API) GetDeviceMulticastDelivery(w http.ResponseWriter, r *http.Request)
 		writeMulticastDeliveryEntityError(w, deviceErr, "multicast device delivery query error", "device", pkOrCode)
 		return
 	}
-	wg.Wait()
+	fanout.wait()
 
 	if availableErr != nil {
 		writeMulticastDeliveryEntityError(w, availableErr, "multicast device delivery sources query error", "device", pkOrCode)
@@ -196,7 +214,7 @@ func (a *API) GetDeviceMulticastDelivery(w http.ResponseWriter, r *http.Request)
 	spawn(func() {
 		endpointHealthItems, endpointHealthTotal, endpointHealthCounts, endpointErr = a.queryDeviceMulticastEndpointHealth(ctx, device, params)
 	})
-	wg.Wait()
+	fanout.wait()
 
 	if available[multicastDeliveryMrouteView] && mrouteErr != nil {
 		if !multicastDeliverySourceErr(mrouteErr) {
@@ -341,38 +359,77 @@ func (a *API) GetLinkMulticastDelivery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Same two-stage fan-out, semaphore, and error-ordering rationale as
+	// GetDeviceMulticastDelivery above: the link lookup gates the rest and
+	// stays ungated so a 404 stays fast, then the queries that depend only on
+	// it run concurrently. Sequentially, these queries each scan the same
+	// view chains and their wall times accumulated to the 30s request deadline
+	// on loaded runners. Related-group health needs the group rows, so it
+	// chains behind the groups query inside one slot rather than forming a
+	// third stage; its one caller-visible fallback (groups unavailable) is
+	// handled below, where the OIF rows it needs exist.
 	now := time.Now().UTC()
-	link, err := a.queryMulticastDeliveryLink(ctx, pkOrCode)
-	if err != nil {
-		writeMulticastDeliveryEntityError(w, err, "multicast link delivery query error", "link", pkOrCode)
-		return
-	}
 
-	available, err := a.queryMulticastDeliverySources(ctx)
-	if err != nil {
-		writeMulticastDeliveryEntityError(w, err, "multicast link delivery sources query error", "link", pkOrCode)
+	var (
+		link                                  MulticastDeliveryLink
+		available                             map[string]bool
+		sourceTimes                           map[string]time.Time
+		linkErr, availableErr, sourceTimesErr error
+	)
+	fanout := a.newMulticastDeliveryFanout(ctx)
+	linkDone := make(chan struct{})
+	go func() {
+		defer close(linkDone)
+		link, linkErr = a.queryMulticastDeliveryLink(ctx, pkOrCode)
+	}()
+	fanout.spawn(func() { available, availableErr = a.queryMulticastDeliverySources(ctx) })
+	fanout.spawn(func() { sourceTimes, sourceTimesErr = a.queryMulticastDeliverySourceIngestTimes(ctx) })
+
+	<-linkDone
+	if linkErr != nil {
+		writeMulticastDeliveryEntityError(w, linkErr, "multicast link delivery query error", "link", pkOrCode)
 		return
 	}
-	sourceTimes, err := a.queryMulticastDeliverySourceIngestTimes(ctx)
-	if err != nil {
-		writeMulticastDeliveryEntityError(w, err, "multicast link delivery freshness query error", "link", pkOrCode)
+	fanout.wait()
+
+	if availableErr != nil {
+		writeMulticastDeliveryEntityError(w, availableErr, "multicast link delivery sources query error", "link", pkOrCode)
+		return
+	}
+	if sourceTimesErr != nil {
+		writeMulticastDeliveryEntityError(w, sourceTimesErr, "multicast link delivery freshness query error", "link", pkOrCode)
 		return
 	}
 
 	branches := []MulticastDeliveryLinkBranch{}
 	var oifTimes []time.Time
 	var branchTotal int
+	var branchErr error
+	var groups, groupsWithHealth []MulticastDeliveryEntityGroup
+	var relatedHealthCounts MulticastEntityHealthStatusCounts
+	var groupErr, healthErr error
+
 	if available[multicastDeliveryOIFView] {
-		branches, oifTimes, branchTotal, err = a.queryMulticastLinkDeliveryBranches(ctx, link, params)
-		if err != nil {
-			if !multicastDeliverySourceErr(err) {
-				writeMulticastDeliveryEntityError(w, err, "multicast link branches query error", "link", pkOrCode)
-				return
-			}
-			available[multicastDeliveryOIFView] = false
-			branches = []MulticastDeliveryLinkBranch{}
-			oifTimes = nil
+		fanout.spawn(func() {
+			branches, oifTimes, branchTotal, branchErr = a.queryMulticastLinkDeliveryBranches(ctx, link, params)
+		})
+	}
+	fanout.spawn(func() {
+		groups, groupErr = a.queryMulticastLinkDeliveryGroups(ctx, link, params)
+		if groupErr == nil {
+			groupsWithHealth, relatedHealthCounts, healthErr = a.queryLinkRelatedGroupHealth(ctx, groups)
 		}
+	})
+	fanout.wait()
+
+	if branchErr != nil {
+		if !multicastDeliverySourceErr(branchErr) {
+			writeMulticastDeliveryEntityError(w, branchErr, "multicast link branches query error", "link", pkOrCode)
+			return
+		}
+		available[multicastDeliveryOIFView] = false
+		branches = []MulticastDeliveryLinkBranch{}
+		oifTimes = nil
 	}
 
 	freshnessAvailable := copyMulticastDeliveryAvailability(available)
@@ -389,15 +446,14 @@ func (a *API) GetLinkMulticastDelivery(w http.ResponseWriter, r *http.Request) {
 	for _, branch := range branches {
 		oifs = append(oifs, branch.MulticastDeliveryOIF)
 	}
-	groups, groupErr := a.queryMulticastLinkDeliveryGroups(ctx, link, params)
 	if groupErr != nil {
 		if !multicastDeliverySourceErr(groupErr) {
 			writeMulticastDeliveryEntityError(w, groupErr, "multicast link groups query error", "link", pkOrCode)
 			return
 		}
 		groups = buildMulticastEntityGroups(nil, oifs)
+		groupsWithHealth, relatedHealthCounts, healthErr = a.queryLinkRelatedGroupHealth(ctx, groups)
 	}
-	groupsWithHealth, relatedHealthCounts, healthErr := a.queryLinkRelatedGroupHealth(ctx, groups)
 	if healthErr != nil {
 		if !multicastDeliverySourceErr(healthErr) {
 			writeMulticastDeliveryEntityError(w, healthErr, "multicast link related health query error", "link", pkOrCode)

--- a/api/handlers/multicast_delivery_entity_test.go
+++ b/api/handlers/multicast_delivery_entity_test.go
@@ -79,7 +79,7 @@ func TestDeviceMulticastDelivery_EmptyState(t *testing.T) {
 
 	rr, resp := deviceMulticastDeliveryRequest(api, "dev-ams1", "")
 
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	assert.True(t, resp.SourceAvailable)
 	assert.Equal(t, "dev-ams1", resp.Device.PK)
 	assert.Zero(t, resp.Summary.GroupCount)
@@ -102,7 +102,7 @@ func TestDeviceMulticastDelivery_ObservedStateAndPagination(t *testing.T) {
 
 	rr, resp := deviceMulticastDeliveryRequest(api, "dev-ams1", "limit=1")
 
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	assert.True(t, resp.SourceAvailable)
 	assert.Equal(t, "fresh", resp.Freshness.Mroute.Status)
 	assert.Equal(t, 1, resp.Summary.GroupCount)
@@ -180,7 +180,7 @@ func TestLinkMulticastDelivery_ObservedStateAndDirectionFilter(t *testing.T) {
 
 	rr, resp := linkMulticastDeliveryRequest(api, "link-ams-nyc", "")
 
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	assert.True(t, resp.SourceAvailable)
 	assert.Equal(t, "link-ams-nyc", resp.Link.PK)
 	assert.Equal(t, 1, resp.BranchTotal)
@@ -195,7 +195,7 @@ func TestLinkMulticastDelivery_ObservedStateAndDirectionFilter(t *testing.T) {
 	assert.Greater(t, resp.Summary.RelatedGroupHealthCounts.Total, uint64(0))
 
 	rr, filtered := linkMulticastDeliveryRequest(api, "link-ams-nyc", "direction=z_to_a")
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
 	assert.Zero(t, filtered.BranchTotal)
 	assert.Empty(t, filtered.Branches)
 }

--- a/api/testing/clickhouse.go
+++ b/api/testing/clickhouse.go
@@ -252,6 +252,21 @@ func SetupClickHouseForTest(t *testing.T, db *ClickHouseDB) (driver.Conn, string
 	return testConn, databaseName
 }
 
+// skipTemplateTable reports whether a system.tables row in the template
+// database should be excluded when cloning its schema.
+//
+// Dot-prefixed names are ClickHouse internals, never part of the migrated
+// schema. A materialized view's own CREATE recreates its ".inner_id.<uuid>"
+// storage table, so cloning that row is at best redundant. It is also unsafe:
+// dz_device_interface_ips is a REFRESHABLE materialized view, so the template
+// database — which outlives every test — rebuilds it into a transient
+// ".tmp.inner_id.<uuid>" table once a minute and swaps it in. A clone whose
+// system.tables read lands inside that window sees the transient row with an
+// empty create_table_query and fails with "code: 62, Empty query".
+func skipTemplateTable(name string) bool {
+	return name == "goose_db_version" || strings.HasPrefix(name, ".")
+}
+
 // SetupClickHouseWithMigrationsForTest creates a per-test ClickHouse database
 // with full schema migrations and returns the direct connection and database name.
 func SetupClickHouseWithMigrationsForTest(t *testing.T, db *ClickHouseDB) (driver.Conn, string) {
@@ -285,7 +300,7 @@ func SetupClickHouseWithMigrationsForTest(t *testing.T, db *ClickHouseDB) (drive
 	for rows.Next() {
 		var name, engineFull, createQuery string
 		require.NoError(t, rows.Scan(&name, &engineFull, &createQuery))
-		if name == "goose_db_version" {
+		if skipTemplateTable(name) {
 			continue
 		}
 		cloneQuery := strings.Replace(createQuery, fmt.Sprintf("%s.", templateDB), fmt.Sprintf("%s.", databaseName), -1)

--- a/api/testing/clickhouse_test.go
+++ b/api/testing/clickhouse_test.go
@@ -1,0 +1,27 @@
+package apitesting
+
+import "testing"
+
+func TestSkipTemplateTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		skip  bool
+	}{
+		{"migrated table", "dz_devices", false},
+		{"materialized view", "dz_device_interface_ips", false},
+		{"goose bookkeeping", "goose_db_version", true},
+		{"mv inner table", ".inner_id.5d0a2c83-2f3e-43fd-b81d-40a97a87f610", true},
+		{"named mv inner table", ".inner.some_view", true},
+		// Transient rebuild target of a REFRESHABLE materialized view: its
+		// create_table_query is empty, so cloning it fails with "Empty query".
+		{"refresh swap temp table", ".tmp.inner_id.5d0a2c83-2f3e-43fd-b81d-40a97a87f610", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skipTemplateTable(tt.table); got != tt.skip {
+				t.Errorf("skipTemplateTable(%q) = %v, want %v", tt.table, got, tt.skip)
+			}
+		})
+	}
+}

--- a/indexer/pkg/dz/mroute/source_minio_test.go
+++ b/indexer/pkg/dz/mroute/source_minio_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,6 +22,7 @@ import (
 	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
 
 	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 )
 
 // TestS3Source_FetchLatest_MinIO is layer C: round-trip the source against a
@@ -153,8 +155,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	}
 
 	t.Run("device set and ordering follow the listing, work runs concurrently", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumps, err := src.FetchLatest(ctx)
 		require.NoError(t, err)
@@ -172,8 +174,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	})
 
 	t.Run("transient mid-walk failure is retried and the walk completes", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failFirst: 1}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failFirst: 1}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumps, err := src.FetchLatest(ctx)
 		require.NoError(t, err)
@@ -182,8 +184,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	})
 
 	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failAll: true}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failAll: true}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumps, err := src.FetchLatest(ctx)
 		require.Error(t, err, "a partial device set would tombstone the missing devices")
@@ -197,43 +199,104 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 
 		ft := &faultTransport{
 			base:    http.DefaultTransport,
+			devices: pubkeys,
 			target:  pubkeys[7],
 			failAll: true,
 			onFail:  cancel,
 		}
-		src := mio.newSource(t, bucket, ft)
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumps, err := src.FetchLatest(cancelCtx)
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Nil(t, dumps)
 		assert.Equal(t, 1, ft.matched(), "retrying a cancelled context is pointless")
 	})
+
+	t.Run("no S3 calls are issued after the walk aborts", func(t *testing.T) {
+		// pubkeys[0] is in the first batch, so it aborts the group while the other
+		// in-flight devices are still held in delay and the rest have not started.
+		ft := &faultTransport{
+			base:    http.DefaultTransport,
+			devices: pubkeys,
+			target:  pubkeys[0],
+			failAll: true,
+			delay:   2 * time.Second,
+		}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		_, err := src.FetchLatest(ctx)
+		require.Error(t, err)
+		assert.LessOrEqual(t, ft.devicesReached(), maxConcurrentFetches,
+			"devices that had not started must not reach S3 once the group is cancelled")
+	})
+
+	t.Run("device with no snapshot in the lookback window is dropped and logged", func(t *testing.T) {
+		const staleBucket = "doublezero-stale-state-collect"
+		_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(staleBucket)})
+		require.NoError(t, err)
+
+		const freshPK = "DzPkFresh11111111111111111111111111111111111"
+		const stalePK = "DzPkStale22222222222222222222222222222222222"
+		mio.putSnapshot(t, staleBucket, freshPK, now, body)
+		mio.putSnapshot(t, staleBucket, stalePK, now.AddDate(0, 0, -5), body)
+
+		var logs bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		src := mio.newSource(t, staleBucket, http.DefaultTransport, log)
+
+		dumps, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+		require.Len(t, dumps, 1)
+		assert.Equal(t, freshPK, dumps[0].DevicePubkey)
+		// The drop tombstones the device under MissingMeansDeleted, so it must
+		// not be silent.
+		assert.Contains(t, logs.String(), stalePK)
+	})
 }
 
-// faultTransport injects failures into the S3 calls whose URL mentions a target
-// device pubkey, so tests can drive the per-device retry path deterministically.
-// It also records peak concurrent requests.
+// faultTransport attributes each S3 call to a device by pubkey and injects
+// failures for one target device, so tests can drive the per-device retry path
+// deterministically. It also records peak concurrency and which devices were
+// reached at all.
 type faultTransport struct {
-	base http.RoundTripper
+	base    http.RoundTripper
+	devices []string // pubkeys used to attribute a request to a device
 
 	// target is the device pubkey whose requests fail; empty fails nothing.
 	target    string
-	failFirst int  // fail this many matching requests, then pass through
-	failAll   bool // fail every matching request
+	failFirst int           // fail this many target requests, then pass through
+	failAll   bool          // fail every target request
+	delay     time.Duration // held on non-target requests, to keep the fan-out busy
 	onFail    func()
 
 	mu       sync.Mutex
 	inflight int
 	peak     int
 	matches  int
+	seen     map[string]struct{}
 }
 
 func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.String()
+
 	f.mu.Lock()
 	f.inflight++
 	f.peak = max(f.peak, f.inflight)
+	var device string
+	for _, pk := range f.devices {
+		if strings.Contains(url, pk) {
+			device = pk
+			break
+		}
+	}
+	if device != "" {
+		if f.seen == nil {
+			f.seen = map[string]struct{}{}
+		}
+		f.seen[device] = struct{}{}
+	}
 	fail := false
-	if f.target != "" && strings.Contains(req.URL.String(), f.target) {
+	if device != "" && device == f.target {
 		f.matches++
 		fail = f.failAll || f.matches <= f.failFirst
 	}
@@ -252,6 +315,13 @@ func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// dberror classifies this as connectivity, i.e. transient.
 		return nil, errors.New("connection reset by peer")
 	}
+	if f.delay > 0 && device != "" && device != f.target {
+		select {
+		case <-time.After(f.delay):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
 	return f.base.RoundTrip(req)
 }
 
@@ -266,6 +336,13 @@ func (f *faultTransport) matched() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.matches
+}
+
+// devicesReached returns how many distinct devices issued at least one request.
+func (f *faultTransport) devicesReached() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.seen)
 }
 
 // minioBackend is a MinIO container plus a raw S3 client for populating it.
@@ -336,7 +413,7 @@ func (m *minioBackend) putSnapshot(t *testing.T, bucket, pubkey string, ts time.
 // newSource builds an S3Source whose HTTP calls go through rt. The AWS SDK's own
 // retryer is disabled so request counts reflect only the source's retry layer;
 // in production the SDK retryer sits underneath and can only help.
-func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper) *S3Source {
+func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper, log *slog.Logger) *S3Source {
 	t.Helper()
 	awsCfg, err := config.LoadDefaultConfig(t.Context(),
 		config.WithRegion("us-east-1"),
@@ -350,7 +427,7 @@ func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripp
 		o.HTTPClient = &http.Client{Transport: rt}
 		o.Retryer = aws.NopRetryer{}
 	})
-	return &S3Source{client: client, bucket: bucket, lookbackDays: 3}
+	return &S3Source{client: client, log: log, bucket: bucket, lookbackDays: 3}
 }
 
 // buildStateIngestKey reproduces the key pattern from the telemetry

--- a/indexer/pkg/dz/mroute/source_minio_test.go
+++ b/indexer/pkg/dz/mroute/source_minio_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -183,6 +184,26 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 		assert.Greater(t, ft.matched(), 1, "the failed device should have been retried")
 	})
 
+	t.Run("transient failure listing devices is retried and the walk completes", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, failListFirst: 1}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		dumps, err := src.FetchLatest(ctx)
+		require.NoError(t, err, "a blip listing devices must not abort the cycle")
+		require.Len(t, dumps, deviceCount)
+		assert.Greater(t, ft.listAttempts(), 1, "the device listing should have been retried")
+	})
+
+	t.Run("persistent listing failure aborts with bounded retries", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, failListFirst: math.MaxInt}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		dumps, err := src.FetchLatest(ctx)
+		require.Error(t, err)
+		assert.Nil(t, dumps)
+		assert.Equal(t, deviceFetchRetry.MaxAttempts, ft.listAttempts(), "retries must be bounded")
+	})
+
 	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
 		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failAll: true}
 		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
@@ -269,11 +290,16 @@ type faultTransport struct {
 	delay     time.Duration // held on non-target requests, to keep the fan-out busy
 	onFail    func()
 
-	mu       sync.Mutex
-	inflight int
-	peak     int
-	matches  int
-	seen     map[string]struct{}
+	// failListFirst fails this many device-listing requests, then passes them
+	// through. The listing runs before the fan-out, so no pubkey identifies it.
+	failListFirst int
+
+	mu        sync.Mutex
+	inflight  int
+	peak      int
+	matches   int
+	listCalls int
+	seen      map[string]struct{}
 }
 
 func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -299,6 +325,13 @@ func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if device != "" && device == f.target {
 		f.matches++
 		fail = f.failAll || f.matches <= f.failFirst
+	}
+	// Every request the source issues either names a device or is the
+	// device-prefix listing: newSource pins region and credentials statically,
+	// so the SDK makes no discovery calls of its own.
+	if device == "" {
+		f.listCalls++
+		fail = f.listCalls <= f.failListFirst
 	}
 	f.mu.Unlock()
 
@@ -336,6 +369,13 @@ func (f *faultTransport) matched() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.matches
+}
+
+// listAttempts returns how many device-listing requests the transport saw.
+func (f *faultTransport) listAttempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listCalls
 }
 
 // devicesReached returns how many distinct devices issued at least one request.

--- a/indexer/pkg/dz/mroute/source_minio_test.go
+++ b/indexer/pkg/dz/mroute/source_minio_test.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,31 +39,10 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 	}
 
 	ctx := t.Context()
-
-	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = ctr.Terminate(termCtx)
-	})
-
-	endpoint, err := ctr.ConnectionString(ctx)
-	require.NoError(t, err)
-
-	// Build a raw S3 client pointed at MinIO so we can pre-populate the bucket.
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
-	)
-	require.NoError(t, err)
-	rawS3 := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String("http://" + endpoint)
-		o.UsePathStyle = true
-	})
+	mio := startMinIO(t)
 
 	const bucket = "doublezero-mainnet-beta-state-collect"
-	_, err = rawS3.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 	require.NoError(t, err)
 
 	// Use today's UTC date so the source's 3-day lookback finds everything.
@@ -87,35 +71,20 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		key := buildStateIngestKey(f.pubkey, f.ts)
-		body, err := json.Marshal(statecollect.Envelope{
-			Metadata: statecollect.Metadata{
-				Kind:      SnapshotKind,
-				Timestamp: f.ts.UTC().Format(time.RFC3339),
-				Device:    f.pubkey,
-			},
-			Data: json.RawMessage(f.body),
-		})
-		require.NoError(t, err)
-		_, err = rawS3.PutObject(ctx, &s3.PutObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-			Body:   bytes.NewReader(body),
-		})
-		require.NoError(t, err, "put %s", key)
+		mio.putSnapshot(t, bucket, f.pubkey, f.ts, f.body)
 	}
 
 	// Construct the S3Source pointed at MinIO. The Source uses the default
 	// AWS credential chain; t.Setenv injects static creds so it picks them up.
-	t.Setenv("AWS_ACCESS_KEY_ID", ctr.Username)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", ctr.Password)
+	t.Setenv("AWS_ACCESS_KEY_ID", mio.username)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", mio.password)
 	t.Setenv("AWS_SESSION_TOKEN", "")
 	t.Setenv("AWS_REGION", "us-east-1")
 
 	src, err := NewS3Source(ctx, S3SourceConfig{
 		Bucket:       bucket,
 		Region:       "us-east-1",
-		EndpointURL:  "http://" + endpoint,
+		EndpointURL:  mio.endpoint,
 		LookbackDays: 3,
 	})
 	require.NoError(t, err)
@@ -153,6 +122,235 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 		assert.Equal(t, "10.0.0.5", entries[0].SourceAddress)
 		assert.Equal(t, "ME", entries[0].RouteFlags)
 	})
+}
+
+// TestS3Source_FetchLatest_FanOut covers the parallel per-device fan-out against
+// MinIO: result ordering, the bounded retry of transient failures, and the
+// all-or-nothing abort that protects the MissingMeansDeleted contract in
+// Store.Sync.
+func TestS3Source_FetchLatest_FanOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MinIO integration test in -short mode")
+	}
+
+	ctx := t.Context()
+	mio := startMinIO(t)
+
+	const bucket = "doublezero-fanout-state-collect"
+	_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+
+	// Enough devices that the fan-out saturates maxConcurrentFetches. Pubkeys are
+	// zero-padded so generation order is also lexicographic (= S3 listing order).
+	const deviceCount = 25
+	body := `{"vrfs":{"default":{"sparseMode":{"groups":{}},"bidirectional":{"groups":{}}}}}`
+	now := time.Now().UTC()
+	pubkeys := make([]string, 0, deviceCount)
+	for i := range deviceCount {
+		pk := fmt.Sprintf("DzPkFanOut%02d111111111111111111111111111111", i)
+		pubkeys = append(pubkeys, pk)
+		mio.putSnapshot(t, bucket, pk, now, body)
+	}
+
+	t.Run("device set and ordering follow the listing, work runs concurrently", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport}
+		src := mio.newSource(t, bucket, ft)
+
+		dumps, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+
+		got := make([]string, 0, deviceCount)
+		for _, d := range dumps {
+			got = append(got, d.DevicePubkey)
+		}
+		// Ordering is what the serial walk produced: S3 listing order.
+		assert.Equal(t, pubkeys, got)
+
+		peak := ft.peakInflight()
+		assert.Greater(t, peak, 1, "per-device reads should overlap")
+		assert.LessOrEqual(t, peak, maxConcurrentFetches, "fan-out must stay under the limit")
+	})
+
+	t.Run("transient mid-walk failure is retried and the walk completes", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failFirst: 1}
+		src := mio.newSource(t, bucket, ft)
+
+		dumps, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+		require.Len(t, dumps, deviceCount)
+		assert.Greater(t, ft.matched(), 1, "the failed device should have been retried")
+	})
+
+	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failAll: true}
+		src := mio.newSource(t, bucket, ft)
+
+		dumps, err := src.FetchLatest(ctx)
+		require.Error(t, err, "a partial device set would tombstone the missing devices")
+		assert.Nil(t, dumps)
+		assert.Equal(t, deviceFetchRetry.MaxAttempts, ft.matched(), "retries must be bounded")
+	})
+
+	t.Run("cancelled context aborts without exhausting retries", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ft := &faultTransport{
+			base:    http.DefaultTransport,
+			target:  pubkeys[7],
+			failAll: true,
+			onFail:  cancel,
+		}
+		src := mio.newSource(t, bucket, ft)
+
+		dumps, err := src.FetchLatest(cancelCtx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, dumps)
+		assert.Equal(t, 1, ft.matched(), "retrying a cancelled context is pointless")
+	})
+}
+
+// faultTransport injects failures into the S3 calls whose URL mentions a target
+// device pubkey, so tests can drive the per-device retry path deterministically.
+// It also records peak concurrent requests.
+type faultTransport struct {
+	base http.RoundTripper
+
+	// target is the device pubkey whose requests fail; empty fails nothing.
+	target    string
+	failFirst int  // fail this many matching requests, then pass through
+	failAll   bool // fail every matching request
+	onFail    func()
+
+	mu       sync.Mutex
+	inflight int
+	peak     int
+	matches  int
+}
+
+func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.inflight++
+	f.peak = max(f.peak, f.inflight)
+	fail := false
+	if f.target != "" && strings.Contains(req.URL.String(), f.target) {
+		f.matches++
+		fail = f.failAll || f.matches <= f.failFirst
+	}
+	f.mu.Unlock()
+
+	defer func() {
+		f.mu.Lock()
+		f.inflight--
+		f.mu.Unlock()
+	}()
+
+	if fail {
+		if f.onFail != nil {
+			f.onFail()
+		}
+		// dberror classifies this as connectivity, i.e. transient.
+		return nil, errors.New("connection reset by peer")
+	}
+	return f.base.RoundTrip(req)
+}
+
+func (f *faultTransport) peakInflight() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.peak
+}
+
+// matched returns how many requests for the target device the transport saw.
+func (f *faultTransport) matched() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.matches
+}
+
+// minioBackend is a MinIO container plus a raw S3 client for populating it.
+type minioBackend struct {
+	endpoint string
+	username string
+	password string
+	client   *s3.Client
+}
+
+// startMinIO boots a MinIO container for the calling test.
+func startMinIO(t *testing.T) *minioBackend {
+	t.Helper()
+	ctx := t.Context()
+
+	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = ctr.Terminate(termCtx)
+	})
+
+	endpoint, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
+	)
+	require.NoError(t, err)
+
+	mio := &minioBackend{
+		endpoint: "http://" + endpoint,
+		username: ctr.Username,
+		password: ctr.Password,
+	}
+	mio.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(mio.endpoint)
+		o.UsePathStyle = true
+	})
+	return mio
+}
+
+// putSnapshot uploads one envelope-wrapped snapshot at the key layout the
+// state-ingest server writes.
+func (m *minioBackend) putSnapshot(t *testing.T, bucket, pubkey string, ts time.Time, rawJSON string) {
+	t.Helper()
+	body, err := json.Marshal(statecollect.Envelope{
+		Metadata: statecollect.Metadata{
+			Kind:      SnapshotKind,
+			Timestamp: ts.UTC().Format(time.RFC3339),
+			Device:    pubkey,
+		},
+		Data: json.RawMessage(rawJSON),
+	})
+	require.NoError(t, err)
+
+	key := buildStateIngestKey(pubkey, ts)
+	_, err = m.client.PutObject(t.Context(), &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(body),
+	})
+	require.NoError(t, err, "put %s", key)
+}
+
+// newSource builds an S3Source whose HTTP calls go through rt. The AWS SDK's own
+// retryer is disabled so request counts reflect only the source's retry layer;
+// in production the SDK retryer sits underneath and can only help.
+func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper) *S3Source {
+	t.Helper()
+	awsCfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(m.username, m.password, "")),
+	)
+	require.NoError(t, err)
+
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(m.endpoint)
+		o.UsePathStyle = true
+		o.HTTPClient = &http.Client{Transport: rt}
+		o.Retryer = aws.NopRetryer{}
+	})
+	return &S3Source{client: client, bucket: bucket, lookbackDays: 3}
 }
 
 // buildStateIngestKey reproduces the key pattern from the telemetry

--- a/indexer/pkg/dz/mroute/source_s3.go
+++ b/indexer/pkg/dz/mroute/source_s3.go
@@ -11,9 +11,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 )
+
+// maxConcurrentFetches bounds in-flight per-device S3 reads, matching the limit
+// used by the serviceability and shreds views.
+const maxConcurrentFetches = 10
+
+// deviceFetchRetry bounds per-device retries for transient S3 failures. The fetch
+// is all-or-nothing (see Store.Sync), so without a retry one blip among the
+// hundreds of calls a cycle makes aborts the whole thing. dberror.IsTransient
+// treats context errors as non-transient, so a cancelled activity aborts
+// immediately rather than retrying into its deadline.
+var deviceFetchRetry = dberror.RetryConfig{
+	MaxAttempts: 3,
+	BaseBackoff: 100 * time.Millisecond,
+	MaxBackoff:  time.Second,
+}
 
 // SnapshotKind is the state-collect kind name for mroute dumps. It matches the
 // key used by the telemetry state-ingest server when it presigns the
@@ -100,14 +117,49 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 	}
 
 	now := time.Now().UTC()
-	var dumps []*Dump
-	for _, pubkey := range devices {
+
+	// Per-device reads are independent. Collect by device index so the result
+	// order tracks the device listing regardless of completion order.
+	perDevice := make([]*Dump, len(devices))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentFetches)
+	for i, pubkey := range devices {
+		g.Go(func() error {
+			dump, err := s.fetchDevice(gctx, pubkey, now)
+			if err != nil {
+				return err
+			}
+			perDevice[i] = dump
+			return nil
+		})
+	}
+	// One failed device aborts the whole fetch: Store.Sync writes with
+	// MissingMeansDeleted=true, so returning a partial device set would
+	// tombstone the missing devices' prior state.
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	dumps := make([]*Dump, 0, len(perDevice))
+	for _, d := range perDevice {
+		if d != nil {
+			dumps = append(dumps, d)
+		}
+	}
+	return dumps, nil
+}
+
+// fetchDevice reads the latest snapshot for one device, retrying transient S3
+// failures. A nil Dump with a nil error means the device has no snapshot in the
+// lookback window.
+func (s *S3Source) fetchDevice(ctx context.Context, pubkey string, now time.Time) (*Dump, error) {
+	return dberror.Retry(ctx, deviceFetchRetry, func() (*Dump, error) {
 		key, keyTS, err := s.latestKeyForDevice(ctx, pubkey, now)
 		if err != nil {
 			return nil, err
 		}
 		if key == "" {
-			continue
+			return nil, nil
 		}
 		body, err := s.getObject(ctx, key)
 		if err != nil {
@@ -136,15 +188,14 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 			}
 		}
 
-		dumps = append(dumps, &Dump{
+		return &Dump{
 			FetchedAt:    time.Now().UTC(),
 			SnapshotTS:   snapTS,
 			DevicePubkey: devicePK,
 			RawJSON:      env.Data,
 			FileName:     key,
-		})
-	}
-	return dumps, nil
+		}, nil
+	})
 }
 
 // listDevicePubkeys uses delimiter listing to enumerate the device=<pubkey>

--- a/indexer/pkg/dz/mroute/source_s3.go
+++ b/indexer/pkg/dz/mroute/source_s3.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -48,6 +49,9 @@ type S3SourceConfig struct {
 	// finding the latest per device. Three covers clock skew and the
 	// midnight-UTC boundary; tests can shorten this.
 	LookbackDays int
+
+	// Logger is optional; it defaults to slog.Default().
+	Logger *slog.Logger
 }
 
 // S3Source implements Source against an S3 bucket populated by the telemetry
@@ -56,6 +60,7 @@ type S3SourceConfig struct {
 //	<KeyPrefix>/snapshots/<SnapshotKind>/device=<pubkey>/date=YYYY-MM-DD/hour=HH/<ts>.json
 type S3Source struct {
 	client       *s3.Client
+	log          *slog.Logger
 	bucket       string
 	keyPrefix    string // already stripped of trailing slash; empty when no prefix
 	lookbackDays int
@@ -75,6 +80,10 @@ func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
 		cfg.LookbackDays = 3
 	}
 
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
 	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region))
 	if err != nil {
 		return nil, fmt.Errorf("mroute: load AWS config: %w", err)
@@ -91,6 +100,7 @@ func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
 
 	return &S3Source{
 		client:       s3.NewFromConfig(awsCfg, clientOpts...),
+		log:          cfg.Logger,
 		bucket:       cfg.Bucket,
 		keyPrefix:    strings.TrimRight(cfg.KeyPrefix, "/"),
 		lookbackDays: cfg.LookbackDays,
@@ -125,6 +135,13 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 	g.SetLimit(maxConcurrentFetches)
 	for i, pubkey := range devices {
 		g.Go(func() error {
+			// errgroup still invokes every function queued behind SetLimit
+			// after the group context is cancelled. The AWS SDK rejects the
+			// call on a cancelled context anyway; returning here makes the
+			// skip explicit instead of relying on that.
+			if err := gctx.Err(); err != nil {
+				return err
+			}
 			dump, err := s.fetchDevice(gctx, pubkey, now)
 			if err != nil {
 				return err
@@ -135,16 +152,28 @@ func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
 	}
 	// One failed device aborts the whole fetch: Store.Sync writes with
 	// MissingMeansDeleted=true, so returning a partial device set would
-	// tombstone the missing devices' prior state.
+	// tombstone the devices whose reads failed.
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
 	dumps := make([]*Dump, 0, len(perDevice))
-	for _, d := range perDevice {
-		if d != nil {
-			dumps = append(dumps, d)
+	var stale []string
+	for i, d := range perDevice {
+		if d == nil {
+			stale = append(stale, devices[i])
+			continue
 		}
+		dumps = append(dumps, d)
+	}
+	// A device whose prefix exists but holds no snapshot in the lookback window
+	// is dropped here, and MissingMeansDeleted=true then tombstones its rows.
+	// That is the intended outcome for a device that stopped uploading — its
+	// state is no longer current — but it is the one path where rows disappear
+	// without an error, so name the devices rather than let them vanish.
+	if len(stale) > 0 {
+		s.log.Warn("mroute: devices have no snapshot in the lookback window, their prior state will be tombstoned",
+			"lookback_days", s.lookbackDays, "count", len(stale), "devices", strings.Join(stale, ","))
 	}
 	return dumps, nil
 }

--- a/indexer/pkg/dz/mroute/source_s3.go
+++ b/indexer/pkg/dz/mroute/source_s3.go
@@ -22,11 +22,13 @@ import (
 // used by the serviceability and shreds views.
 const maxConcurrentFetches = 10
 
-// deviceFetchRetry bounds per-device retries for transient S3 failures. The fetch
-// is all-or-nothing (see Store.Sync), so without a retry one blip among the
-// hundreds of calls a cycle makes aborts the whole thing. dberror.IsTransient
-// treats context errors as non-transient, so a cancelled activity aborts
-// immediately rather than retrying into its deadline.
+// deviceFetchRetry bounds retries for transient S3 failures, covering both the
+// device listing and each per-device read. The fetch is all-or-nothing (see
+// Store.Sync), so without a retry one blip among the hundreds of calls a cycle
+// makes aborts the whole thing — and nothing above retries either, since
+// Activities.refresh returns nil to Temporal. dberror.IsTransient treats
+// context errors as non-transient, so a cancelled activity aborts immediately
+// rather than retrying into its deadline.
 var deviceFetchRetry = dberror.RetryConfig{
 	MaxAttempts: 3,
 	BaseBackoff: 100 * time.Millisecond,
@@ -121,7 +123,9 @@ func (s *S3Source) snapshotsPrefix() string {
 // window. Each S3 object is a statecollect.Envelope; this method unwraps
 // it so callers receive only the inner Arista JSON in Dump.RawJSON.
 func (s *S3Source) FetchLatest(ctx context.Context) ([]*Dump, error) {
-	devices, err := s.listDevicePubkeys(ctx)
+	devices, err := dberror.Retry(ctx, deviceFetchRetry, func() ([]string, error) {
+		return s.listDevicePubkeys(ctx)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/pkg/dz/msdp/source_minio_test.go
+++ b/indexer/pkg/dz/msdp/source_minio_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,6 +22,7 @@ import (
 	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
 
 	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
 )
 
 // TestS3Source_FetchLatest_MinIO is layer C for MSDP: round-trip the
@@ -152,8 +154,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	}
 
 	t.Run("device set and ordering follow the listing, work runs concurrently", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumpsByKind, err := src.FetchLatest(ctx)
 		require.NoError(t, err)
@@ -171,8 +173,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	})
 
 	t.Run("transient mid-walk failure is retried and the walk completes", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failFirst: 1}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failFirst: 1}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumpsByKind, err := src.FetchLatest(ctx)
 		require.NoError(t, err)
@@ -181,8 +183,8 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 	})
 
 	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
-		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failAll: true}
-		src := mio.newSource(t, bucket, ft)
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failAll: true}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumpsByKind, err := src.FetchLatest(ctx)
 		require.Error(t, err, "a partial device set would tombstone the missing devices")
@@ -196,43 +198,104 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 
 		ft := &faultTransport{
 			base:    http.DefaultTransport,
+			devices: pubkeys,
 			target:  pubkeys[7],
 			failAll: true,
 			onFail:  cancel,
 		}
-		src := mio.newSource(t, bucket, ft)
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
 
 		dumpsByKind, err := src.FetchLatest(cancelCtx)
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Nil(t, dumpsByKind)
 		assert.Equal(t, 1, ft.matched(), "retrying a cancelled context is pointless")
 	})
+
+	t.Run("no S3 calls are issued after the walk aborts", func(t *testing.T) {
+		// pubkeys[0] is in the first batch, so it aborts the group while the other
+		// in-flight devices are still held in delay and the rest have not started.
+		ft := &faultTransport{
+			base:    http.DefaultTransport,
+			devices: pubkeys,
+			target:  pubkeys[0],
+			failAll: true,
+			delay:   2 * time.Second,
+		}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		_, err := src.FetchLatest(ctx)
+		require.Error(t, err)
+		assert.LessOrEqual(t, ft.devicesReached(), maxConcurrentFetches,
+			"devices that had not started must not reach S3 once the group is cancelled")
+	})
+
+	t.Run("device with no snapshot in the lookback window is dropped and logged", func(t *testing.T) {
+		const staleBucket = "doublezero-stale-state-collect"
+		_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(staleBucket)})
+		require.NoError(t, err)
+
+		const freshPK = "DzPkFresh11111111111111111111111111111111111"
+		const stalePK = "DzPkStale22222222222222222222222222222222222"
+		mio.putSnapshot(t, staleBucket, SnapshotKindSummary, freshPK, now, body)
+		mio.putSnapshot(t, staleBucket, SnapshotKindSummary, stalePK, now.AddDate(0, 0, -5), body)
+
+		var logs bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		src := mio.newSource(t, staleBucket, http.DefaultTransport, log)
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+		require.Len(t, dumpsByKind[SnapshotKindSummary], 1)
+		assert.Equal(t, freshPK, dumpsByKind[SnapshotKindSummary][0].DevicePubkey)
+		// The drop tombstones the device under MissingMeansDeleted, so it must
+		// not be silent.
+		assert.Contains(t, logs.String(), stalePK)
+	})
 }
 
-// faultTransport injects failures into the S3 calls whose URL mentions a target
-// device pubkey, so tests can drive the per-device retry path deterministically.
-// It also records peak concurrent requests.
+// faultTransport attributes each S3 call to a device by pubkey and injects
+// failures for one target device, so tests can drive the per-device retry path
+// deterministically. It also records peak concurrency and which devices were
+// reached at all.
 type faultTransport struct {
-	base http.RoundTripper
+	base    http.RoundTripper
+	devices []string // pubkeys used to attribute a request to a device
 
 	// target is the device pubkey whose requests fail; empty fails nothing.
 	target    string
-	failFirst int  // fail this many matching requests, then pass through
-	failAll   bool // fail every matching request
+	failFirst int           // fail this many target requests, then pass through
+	failAll   bool          // fail every target request
+	delay     time.Duration // held on non-target requests, to keep the fan-out busy
 	onFail    func()
 
 	mu       sync.Mutex
 	inflight int
 	peak     int
 	matches  int
+	seen     map[string]struct{}
 }
 
 func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.String()
+
 	f.mu.Lock()
 	f.inflight++
 	f.peak = max(f.peak, f.inflight)
+	var device string
+	for _, pk := range f.devices {
+		if strings.Contains(url, pk) {
+			device = pk
+			break
+		}
+	}
+	if device != "" {
+		if f.seen == nil {
+			f.seen = map[string]struct{}{}
+		}
+		f.seen[device] = struct{}{}
+	}
 	fail := false
-	if f.target != "" && strings.Contains(req.URL.String(), f.target) {
+	if device != "" && device == f.target {
 		f.matches++
 		fail = f.failAll || f.matches <= f.failFirst
 	}
@@ -251,6 +314,13 @@ func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// dberror classifies this as connectivity, i.e. transient.
 		return nil, errors.New("connection reset by peer")
 	}
+	if f.delay > 0 && device != "" && device != f.target {
+		select {
+		case <-time.After(f.delay):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
 	return f.base.RoundTrip(req)
 }
 
@@ -265,6 +335,13 @@ func (f *faultTransport) matched() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.matches
+}
+
+// devicesReached returns how many distinct devices issued at least one request.
+func (f *faultTransport) devicesReached() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.seen)
 }
 
 // minioBackend is a MinIO container plus a raw S3 client for populating it.
@@ -335,7 +412,7 @@ func (m *minioBackend) putSnapshot(t *testing.T, bucket, kind, pubkey string, ts
 // newSource builds an S3Source whose HTTP calls go through rt. The AWS SDK's own
 // retryer is disabled so request counts reflect only the source's retry layer;
 // in production the SDK retryer sits underneath and can only help.
-func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper) *S3Source {
+func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper, log *slog.Logger) *S3Source {
 	t.Helper()
 	awsCfg, err := config.LoadDefaultConfig(t.Context(),
 		config.WithRegion("us-east-1"),
@@ -349,7 +426,7 @@ func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripp
 		o.HTTPClient = &http.Client{Transport: rt}
 		o.Retryer = aws.NopRetryer{}
 	})
-	return &S3Source{client: client, bucket: bucket, lookbackDays: 3}
+	return &S3Source{client: client, log: log, bucket: bucket, lookbackDays: 3}
 }
 
 // buildStateIngestKey reproduces the key pattern from the telemetry

--- a/indexer/pkg/dz/msdp/source_minio_test.go
+++ b/indexer/pkg/dz/msdp/source_minio_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -182,6 +183,28 @@ func TestS3Source_FetchLatest_FanOut(t *testing.T) {
 		assert.Greater(t, ft.matched(), 1, "the failed device should have been retried")
 	})
 
+	t.Run("transient failure listing devices is retried and the walk completes", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, failListFirst: 1}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.NoError(t, err, "a blip listing devices must not abort the cycle")
+		require.Len(t, dumpsByKind[SnapshotKindSummary], deviceCount)
+		// One listing per kind plus the retried one.
+		assert.Greater(t, ft.listAttempts(), len(snapshotKinds), "the device listing should have been retried")
+	})
+
+	t.Run("persistent listing failure aborts with bounded retries", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, failListFirst: math.MaxInt}
+		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.Error(t, err)
+		assert.Nil(t, dumpsByKind)
+		// Aborts on the first kind's listing, so no further kind is attempted.
+		assert.Equal(t, deviceFetchRetry.MaxAttempts, ft.listAttempts(), "retries must be bounded")
+	})
+
 	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
 		ft := &faultTransport{base: http.DefaultTransport, devices: pubkeys, target: pubkeys[7], failAll: true}
 		src := mio.newSource(t, bucket, ft, laketesting.NewLogger())
@@ -268,11 +291,16 @@ type faultTransport struct {
 	delay     time.Duration // held on non-target requests, to keep the fan-out busy
 	onFail    func()
 
-	mu       sync.Mutex
-	inflight int
-	peak     int
-	matches  int
-	seen     map[string]struct{}
+	// failListFirst fails this many device-listing requests, then passes them
+	// through. Each kind lists before its fan-out, so no pubkey identifies one.
+	failListFirst int
+
+	mu        sync.Mutex
+	inflight  int
+	peak      int
+	matches   int
+	listCalls int
+	seen      map[string]struct{}
 }
 
 func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -298,6 +326,13 @@ func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if device != "" && device == f.target {
 		f.matches++
 		fail = f.failAll || f.matches <= f.failFirst
+	}
+	// Every request the source issues either names a device or is a
+	// device-prefix listing: newSource pins region and credentials statically,
+	// so the SDK makes no discovery calls of its own.
+	if device == "" {
+		f.listCalls++
+		fail = f.listCalls <= f.failListFirst
 	}
 	f.mu.Unlock()
 
@@ -335,6 +370,14 @@ func (f *faultTransport) matched() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.matches
+}
+
+// listAttempts returns how many device-listing requests the transport saw,
+// summed across kinds.
+func (f *faultTransport) listAttempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listCalls
 }
 
 // devicesReached returns how many distinct devices issued at least one request.

--- a/indexer/pkg/dz/msdp/source_minio_test.go
+++ b/indexer/pkg/dz/msdp/source_minio_test.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,30 +35,10 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 	}
 
 	ctx := t.Context()
-
-	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = ctr.Terminate(termCtx)
-	})
-
-	endpoint, err := ctr.ConnectionString(ctx)
-	require.NoError(t, err)
-
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
-	)
-	require.NoError(t, err)
-	rawS3 := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String("http://" + endpoint)
-		o.UsePathStyle = true
-	})
+	mio := startMinIO(t)
 
 	const bucket = "doublezero-mainnet-beta-state-collect"
-	_, err = rawS3.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 	require.NoError(t, err)
 
 	now := time.Now().UTC()
@@ -77,33 +62,18 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 	}
 
 	for _, u := range uploads {
-		key := buildStateIngestKey(u.kind, u.pubkey, now)
-		body, err := json.Marshal(statecollect.Envelope{
-			Metadata: statecollect.Metadata{
-				Kind:      u.kind,
-				Timestamp: now.UTC().Format(time.RFC3339),
-				Device:    u.pubkey,
-			},
-			Data: json.RawMessage(u.body),
-		})
-		require.NoError(t, err)
-		_, err = rawS3.PutObject(ctx, &s3.PutObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-			Body:   bytes.NewReader(body),
-		})
-		require.NoError(t, err, "put %s", key)
+		mio.putSnapshot(t, bucket, u.kind, u.pubkey, now, u.body)
 	}
 
-	t.Setenv("AWS_ACCESS_KEY_ID", ctr.Username)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", ctr.Password)
+	t.Setenv("AWS_ACCESS_KEY_ID", mio.username)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", mio.password)
 	t.Setenv("AWS_SESSION_TOKEN", "")
 	t.Setenv("AWS_REGION", "us-east-1")
 
 	src, err := NewS3Source(ctx, S3SourceConfig{
 		Bucket:       bucket,
 		Region:       "us-east-1",
-		EndpointURL:  "http://" + endpoint,
+		EndpointURL:  mio.endpoint,
 		LookbackDays: 3,
 	})
 	require.NoError(t, err)
@@ -151,6 +121,235 @@ func TestS3Source_FetchLatest_MinIO(t *testing.T) {
 		require.Len(t, sa, 1)
 		assert.Equal(t, SACacheStatusAccepted, sa[0].Status)
 	})
+}
+
+// TestS3Source_FetchLatest_FanOut covers the parallel per-device fan-out against
+// MinIO: result ordering, the bounded retry of transient failures, and the
+// all-or-nothing abort that protects the MissingMeansDeleted contract in
+// Store.Sync.
+func TestS3Source_FetchLatest_FanOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MinIO integration test in -short mode")
+	}
+
+	ctx := t.Context()
+	mio := startMinIO(t)
+
+	const bucket = "doublezero-fanout-state-collect"
+	_, err := mio.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+
+	// Enough devices that the fan-out saturates maxConcurrentFetches. Pubkeys are
+	// zero-padded so generation order is also lexicographic (= S3 listing order).
+	const deviceCount = 25
+	body := `{"peerList":[{"peerIpAddress":"172.16.0.1","state":"established","saCount":1,"resetCount":0}]}`
+	now := time.Now().UTC()
+	pubkeys := make([]string, 0, deviceCount)
+	for i := range deviceCount {
+		pk := fmt.Sprintf("DzPkFanOut%02d111111111111111111111111111111", i)
+		pubkeys = append(pubkeys, pk)
+		mio.putSnapshot(t, bucket, SnapshotKindSummary, pk, now, body)
+	}
+
+	t.Run("device set and ordering follow the listing, work runs concurrently", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport}
+		src := mio.newSource(t, bucket, ft)
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+
+		got := make([]string, 0, deviceCount)
+		for _, d := range dumpsByKind[SnapshotKindSummary] {
+			got = append(got, d.DevicePubkey)
+		}
+		// Ordering is what the serial walk produced: S3 listing order.
+		assert.Equal(t, pubkeys, got)
+
+		peak := ft.peakInflight()
+		assert.Greater(t, peak, 1, "per-device reads should overlap")
+		assert.LessOrEqual(t, peak, maxConcurrentFetches, "fan-out must stay under the limit")
+	})
+
+	t.Run("transient mid-walk failure is retried and the walk completes", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failFirst: 1}
+		src := mio.newSource(t, bucket, ft)
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.NoError(t, err)
+		require.Len(t, dumpsByKind[SnapshotKindSummary], deviceCount)
+		assert.Greater(t, ft.matched(), 1, "the failed device should have been retried")
+	})
+
+	t.Run("persistent device failure aborts the whole fetch", func(t *testing.T) {
+		ft := &faultTransport{base: http.DefaultTransport, target: pubkeys[7], failAll: true}
+		src := mio.newSource(t, bucket, ft)
+
+		dumpsByKind, err := src.FetchLatest(ctx)
+		require.Error(t, err, "a partial device set would tombstone the missing devices")
+		assert.Nil(t, dumpsByKind)
+		assert.Equal(t, deviceFetchRetry.MaxAttempts, ft.matched(), "retries must be bounded")
+	})
+
+	t.Run("cancelled context aborts without exhausting retries", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ft := &faultTransport{
+			base:    http.DefaultTransport,
+			target:  pubkeys[7],
+			failAll: true,
+			onFail:  cancel,
+		}
+		src := mio.newSource(t, bucket, ft)
+
+		dumpsByKind, err := src.FetchLatest(cancelCtx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, dumpsByKind)
+		assert.Equal(t, 1, ft.matched(), "retrying a cancelled context is pointless")
+	})
+}
+
+// faultTransport injects failures into the S3 calls whose URL mentions a target
+// device pubkey, so tests can drive the per-device retry path deterministically.
+// It also records peak concurrent requests.
+type faultTransport struct {
+	base http.RoundTripper
+
+	// target is the device pubkey whose requests fail; empty fails nothing.
+	target    string
+	failFirst int  // fail this many matching requests, then pass through
+	failAll   bool // fail every matching request
+	onFail    func()
+
+	mu       sync.Mutex
+	inflight int
+	peak     int
+	matches  int
+}
+
+func (f *faultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.inflight++
+	f.peak = max(f.peak, f.inflight)
+	fail := false
+	if f.target != "" && strings.Contains(req.URL.String(), f.target) {
+		f.matches++
+		fail = f.failAll || f.matches <= f.failFirst
+	}
+	f.mu.Unlock()
+
+	defer func() {
+		f.mu.Lock()
+		f.inflight--
+		f.mu.Unlock()
+	}()
+
+	if fail {
+		if f.onFail != nil {
+			f.onFail()
+		}
+		// dberror classifies this as connectivity, i.e. transient.
+		return nil, errors.New("connection reset by peer")
+	}
+	return f.base.RoundTrip(req)
+}
+
+func (f *faultTransport) peakInflight() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.peak
+}
+
+// matched returns how many requests for the target device the transport saw.
+func (f *faultTransport) matched() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.matches
+}
+
+// minioBackend is a MinIO container plus a raw S3 client for populating it.
+type minioBackend struct {
+	endpoint string
+	username string
+	password string
+	client   *s3.Client
+}
+
+// startMinIO boots a MinIO container for the calling test.
+func startMinIO(t *testing.T) *minioBackend {
+	t.Helper()
+	ctx := t.Context()
+
+	ctr, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = ctr.Terminate(termCtx)
+	})
+
+	endpoint, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(ctr.Username, ctr.Password, "")),
+	)
+	require.NoError(t, err)
+
+	mio := &minioBackend{
+		endpoint: "http://" + endpoint,
+		username: ctr.Username,
+		password: ctr.Password,
+	}
+	mio.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(mio.endpoint)
+		o.UsePathStyle = true
+	})
+	return mio
+}
+
+// putSnapshot uploads one envelope-wrapped snapshot at the key layout the
+// state-ingest server writes.
+func (m *minioBackend) putSnapshot(t *testing.T, bucket, kind, pubkey string, ts time.Time, rawJSON string) {
+	t.Helper()
+	body, err := json.Marshal(statecollect.Envelope{
+		Metadata: statecollect.Metadata{
+			Kind:      kind,
+			Timestamp: ts.UTC().Format(time.RFC3339),
+			Device:    pubkey,
+		},
+		Data: json.RawMessage(rawJSON),
+	})
+	require.NoError(t, err)
+
+	key := buildStateIngestKey(kind, pubkey, ts)
+	_, err = m.client.PutObject(t.Context(), &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(body),
+	})
+	require.NoError(t, err, "put %s", key)
+}
+
+// newSource builds an S3Source whose HTTP calls go through rt. The AWS SDK's own
+// retryer is disabled so request counts reflect only the source's retry layer;
+// in production the SDK retryer sits underneath and can only help.
+func (m *minioBackend) newSource(t *testing.T, bucket string, rt http.RoundTripper) *S3Source {
+	t.Helper()
+	awsCfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(m.username, m.password, "")),
+	)
+	require.NoError(t, err)
+
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(m.endpoint)
+		o.UsePathStyle = true
+		o.HTTPClient = &http.Client{Transport: rt}
+		o.Retryer = aws.NopRetryer{}
+	})
+	return &S3Source{client: client, bucket: bucket, lookbackDays: 3}
 }
 
 // buildStateIngestKey reproduces the key pattern from the telemetry

--- a/indexer/pkg/dz/msdp/source_s3.go
+++ b/indexer/pkg/dz/msdp/source_s3.go
@@ -22,11 +22,13 @@ import (
 // used by the serviceability and shreds views.
 const maxConcurrentFetches = 10
 
-// deviceFetchRetry bounds per-device retries for transient S3 failures. The fetch
-// is all-or-nothing (see Store.Sync), so without a retry one blip among the
-// hundreds of calls a cycle makes aborts the whole thing. dberror.IsTransient
-// treats context errors as non-transient, so a cancelled activity aborts
-// immediately rather than retrying into its deadline.
+// deviceFetchRetry bounds retries for transient S3 failures, covering both the
+// per-kind device listing and each per-device read. The fetch is all-or-nothing
+// (see Store.Sync), so without a retry one blip among the hundreds of calls a
+// cycle makes aborts the whole thing — and nothing above retries either, since
+// Activities.refresh returns nil to Temporal. dberror.IsTransient treats
+// context errors as non-transient, so a cancelled activity aborts immediately
+// rather than retrying into its deadline.
 var deviceFetchRetry = dberror.RetryConfig{
 	MaxAttempts: 3,
 	BaseBackoff: 100 * time.Millisecond,
@@ -134,7 +136,9 @@ func (s *S3Source) FetchLatest(ctx context.Context) (map[string][]*Dump, error) 
 }
 
 func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time.Time) ([]*Dump, error) {
-	devices, err := s.listDevicePubkeys(ctx, kind)
+	devices, err := dberror.Retry(ctx, deviceFetchRetry, func() ([]string, error) {
+		return s.listDevicePubkeys(ctx, kind)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/pkg/dz/msdp/source_s3.go
+++ b/indexer/pkg/dz/msdp/source_s3.go
@@ -11,9 +11,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/malbeclabs/lake/indexer/pkg/dz/statecollect"
+	"github.com/malbeclabs/lake/utils/pkg/dberror"
 )
+
+// maxConcurrentFetches bounds in-flight per-device S3 reads, matching the limit
+// used by the serviceability and shreds views.
+const maxConcurrentFetches = 10
+
+// deviceFetchRetry bounds per-device retries for transient S3 failures. The fetch
+// is all-or-nothing (see Store.Sync), so without a retry one blip among the
+// hundreds of calls a cycle makes aborts the whole thing. dberror.IsTransient
+// treats context errors as non-transient, so a cancelled activity aborts
+// immediately rather than retrying into its deadline.
+var deviceFetchRetry = dberror.RetryConfig{
+	MaxAttempts: 3,
+	BaseBackoff: 100 * time.Millisecond,
+	MaxBackoff:  time.Second,
+}
 
 // snapshotKinds lists the state-collect kinds this package consumes.
 // `ip-msdp-sa-cache` is intentionally absent — the `*-rejected` variant
@@ -111,14 +128,48 @@ func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time
 	if err != nil {
 		return nil, err
 	}
-	var dumps []*Dump
-	for _, pubkey := range devices {
+	// Per-device reads are independent. Collect by device index so the result
+	// order tracks the device listing regardless of completion order.
+	perDevice := make([]*Dump, len(devices))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentFetches)
+	for i, pubkey := range devices {
+		g.Go(func() error {
+			dump, err := s.fetchDevice(gctx, kind, pubkey, now)
+			if err != nil {
+				return err
+			}
+			perDevice[i] = dump
+			return nil
+		})
+	}
+	// One failed device aborts the whole kind: Store.Sync writes with
+	// MissingMeansDeleted=true, so returning a partial device set would
+	// tombstone the missing devices' prior state.
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	dumps := make([]*Dump, 0, len(perDevice))
+	for _, d := range perDevice {
+		if d != nil {
+			dumps = append(dumps, d)
+		}
+	}
+	return dumps, nil
+}
+
+// fetchDevice reads the latest snapshot for one device, retrying transient S3
+// failures. A nil Dump with a nil error means the device has no snapshot in the
+// lookback window.
+func (s *S3Source) fetchDevice(ctx context.Context, kind, pubkey string, now time.Time) (*Dump, error) {
+	return dberror.Retry(ctx, deviceFetchRetry, func() (*Dump, error) {
 		key, keyTS, err := s.latestKeyForDevice(ctx, kind, pubkey, now)
 		if err != nil {
 			return nil, err
 		}
 		if key == "" {
-			continue
+			return nil, nil
 		}
 		body, err := s.getObject(ctx, key)
 		if err != nil {
@@ -145,16 +196,15 @@ func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time
 			}
 		}
 
-		dumps = append(dumps, &Dump{
+		return &Dump{
 			Kind:         kind,
 			FetchedAt:    time.Now().UTC(),
 			SnapshotTS:   snapTS,
 			DevicePubkey: devicePK,
 			RawJSON:      env.Data,
 			FileName:     key,
-		})
-	}
-	return dumps, nil
+		}, nil
+	})
 }
 
 func (s *S3Source) listDevicePubkeys(ctx context.Context, kind string) ([]string, error) {

--- a/indexer/pkg/dz/msdp/source_s3.go
+++ b/indexer/pkg/dz/msdp/source_s3.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -50,6 +51,9 @@ type S3SourceConfig struct {
 	KeyPrefix    string
 	EndpointURL  string
 	LookbackDays int
+
+	// Logger is optional; it defaults to slog.Default().
+	Logger *slog.Logger
 }
 
 // S3Source implements Source against an S3 bucket populated by the
@@ -58,6 +62,7 @@ type S3SourceConfig struct {
 // each MSDP kind in turn.
 type S3Source struct {
 	client       *s3.Client
+	log          *slog.Logger
 	bucket       string
 	keyPrefix    string
 	lookbackDays int
@@ -76,6 +81,10 @@ func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
 		cfg.LookbackDays = 3
 	}
 
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
 	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region))
 	if err != nil {
 		return nil, fmt.Errorf("msdp: load AWS config: %w", err)
@@ -92,6 +101,7 @@ func NewS3Source(ctx context.Context, cfg S3SourceConfig) (*S3Source, error) {
 
 	return &S3Source{
 		client:       s3.NewFromConfig(awsCfg, clientOpts...),
+		log:          cfg.Logger,
 		bucket:       cfg.Bucket,
 		keyPrefix:    strings.TrimRight(cfg.KeyPrefix, "/"),
 		lookbackDays: cfg.LookbackDays,
@@ -135,6 +145,13 @@ func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time
 	g.SetLimit(maxConcurrentFetches)
 	for i, pubkey := range devices {
 		g.Go(func() error {
+			// errgroup still invokes every function queued behind SetLimit
+			// after the group context is cancelled. The AWS SDK rejects the
+			// call on a cancelled context anyway; returning here makes the
+			// skip explicit instead of relying on that.
+			if err := gctx.Err(); err != nil {
+				return err
+			}
 			dump, err := s.fetchDevice(gctx, kind, pubkey, now)
 			if err != nil {
 				return err
@@ -145,16 +162,28 @@ func (s *S3Source) fetchLatestForKind(ctx context.Context, kind string, now time
 	}
 	// One failed device aborts the whole kind: Store.Sync writes with
 	// MissingMeansDeleted=true, so returning a partial device set would
-	// tombstone the missing devices' prior state.
+	// tombstone the devices whose reads failed.
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
 	dumps := make([]*Dump, 0, len(perDevice))
-	for _, d := range perDevice {
-		if d != nil {
-			dumps = append(dumps, d)
+	var stale []string
+	for i, d := range perDevice {
+		if d == nil {
+			stale = append(stale, devices[i])
+			continue
 		}
+		dumps = append(dumps, d)
+	}
+	// A device whose prefix exists but holds no snapshot in the lookback window
+	// is dropped here, and MissingMeansDeleted=true then tombstones its rows.
+	// That is the intended outcome for a device that stopped uploading — its
+	// state is no longer current — but it is the one path where rows disappear
+	// without an error, so name the devices rather than let them vanish.
+	if len(stale) > 0 {
+		s.log.Warn("msdp: devices have no snapshot in the lookback window, their prior state will be tombstoned",
+			"kind", kind, "lookback_days", s.lookbackDays, "count", len(stale), "devices", strings.Join(stale, ","))
 	}
 	return dumps, nil
 }

--- a/indexer/pkg/dzingest/activities.go
+++ b/indexer/pkg/dzingest/activities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	dzgeoloc "github.com/malbeclabs/lake/indexer/pkg/dz/geolocation"
 	dzgraph "github.com/malbeclabs/lake/indexer/pkg/dz/graph"
@@ -17,6 +18,7 @@ import (
 	dztelemlatency "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/latency"
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 	"github.com/malbeclabs/lake/indexer/pkg/ingestionlog"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 	"github.com/malbeclabs/lake/utils/pkg/logger"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -225,14 +227,14 @@ func (a *Activities) SyncIPMroute(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncIPMroute", a.Network)
 		return nil
 	}
-	return a.refresh(ctx, "SyncIPMroute", func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "SyncIPMroute", a.observeSync("mroute", func() (ingestionlog.RefreshResult, error) {
 		var result ingestionlog.RefreshResult
 		dumps, err := a.MrouteSource.FetchLatest(ctx)
 		if err != nil {
 			return result, fmt.Errorf("mroute fetch: %w", err)
 		}
 		return result, a.MrouteStore.Sync(ctx, dumps)
-	})
+	}))
 }
 
 // SyncMSDP fetches per-device `show ip msdp ...` snapshots from S3
@@ -244,14 +246,37 @@ func (a *Activities) SyncMSDP(ctx context.Context) error {
 		a.IngestionLog.WrapSkipped(ctx, "dzingest", "SyncMSDP", a.Network)
 		return nil
 	}
-	return a.refresh(ctx, "SyncMSDP", func() (ingestionlog.RefreshResult, error) {
+	return a.refresh(ctx, "SyncMSDP", a.observeSync("msdp", func() (ingestionlog.RefreshResult, error) {
 		var result ingestionlog.RefreshResult
 		dumps, err := a.MSDPSource.FetchLatest(ctx)
 		if err != nil {
 			return result, fmt.Errorf("msdp fetch: %w", err)
 		}
 		return result, a.MSDPStore.Sync(ctx, dumps)
-	})
+	}))
+}
+
+// observeSync records the view-refresh metrics and a duration log line for the
+// state-collect syncs. Unlike the other activities, these have no view layer of
+// their own to report from, so without this their runtime — and the headroom
+// left under the activity's StartToCloseTimeout — is invisible outside the
+// ingestion log table.
+func (a *Activities) observeSync(viewType string, fn func() (ingestionlog.RefreshResult, error)) func() (ingestionlog.RefreshResult, error) {
+	return func() (ingestionlog.RefreshResult, error) {
+		start := time.Now()
+		result, err := fn()
+		duration := time.Since(start)
+
+		status := "success"
+		if err != nil {
+			status = "error"
+		}
+		metrics.ViewRefreshTotal.WithLabelValues(viewType, status).Inc()
+		metrics.ViewRefreshDuration.WithLabelValues(viewType).Observe(duration.Seconds())
+		a.Log.Info(viewType+": sync completed", "duration", duration.String(), "status", status)
+
+		return result, err
+	}
 }
 
 func (a *Activities) fetchISISData(ctx context.Context) ([]isis.LSP, error) {

--- a/indexer/pkg/indexer/indexer.go
+++ b/indexer/pkg/indexer/indexer.go
@@ -282,6 +282,7 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 			Region:      cfg.MrouteS3Region,
 			KeyPrefix:   cfg.MrouteS3KeyPrefix,
 			EndpointURL: cfg.MrouteS3EndpointURL,
+			Logger:      cfg.Logger,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create mroute S3 source: %w", err)
@@ -308,6 +309,7 @@ func New(ctx context.Context, cfg Config) (*Indexer, error) {
 			Region:      cfg.MSDPS3Region,
 			KeyPrefix:   cfg.MSDPS3KeyPrefix,
 			EndpointURL: cfg.MSDPS3EndpointURL,
+			Logger:      cfg.Logger,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create MSDP S3 source: %w", err)


### PR DESCRIPTION
## Summary of Changes

- **The msdp/mroute S3 walks now fan out.** They read devices serially — ~1,200 sequential round trips per MSDP cycle, ~400 for mroute — inside one 5m activity timeout. Prod mainnet-beta `SyncMSDP` averaged 155s (max 190s, 63% of the deadline) and staging had started aborting whole cycles on single transient S3 blips. Reads now run under `errgroup` + `SetLimit(10)`, collected by device index so ordering still follows the S3 listing.
- **Every S3 call in the walk retries**, the device listing included, bounded at 3 attempts and gated on `dberror.IsTransient` so a cancelled activity aborts rather than retrying into its deadline. Nothing above covers this: `Activities.refresh` returns nil to Temporal, so the workflow's `MaximumAttempts` never applies to these activities.
- **The all-or-nothing abort is unchanged** — a partial device set would tombstone every device whose read failed. Devices with an S3 prefix but no snapshot in the lookback window are now named in a WARN rather than dropped silently.
- **`view_type=msdp|mroute` on the refresh counter and duration histogram**, so the predicted effect (MSDP ~155s → ~20s, mroute ~57s → ~8s) is checkable after deploy rather than assumed.
- **`GetLinkMulticastDelivery` becomes a two-stage fan-out.** Its six sequential queries over the same `enriched_ip_mroute_oifs` and health view chains overran the handler's 30s deadline in CI. Error precedence, source-unavailable downgrades, and response shape are unchanged.
- **The test template-DB clone skips ClickHouse internals.** `dz_device_interface_ips` is a REFRESHABLE materialized view, so the long-lived template DB rebuilds it into a transient `.tmp.inner_id.<uuid>` table every minute; a clone whose `system.tables` read landed in that window died with `code: 62, Empty query`.

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net   |
|--------------|-------|---------------|-------|
| Tests        |     4 | +748 / -87    |  +661 |
| Core logic   |     3 | +280 / -57    |  +223 |
| Scaffolding  |     3 | +47 / -5      |   +42 |
| **Total**    |    10 | +1075 / -149  |  +926 |

Three concurrency rewrites carrying most of the risk, behind roughly 2.5x their weight in tests.

<details>
<summary>Key files (click to expand)</summary>

- [`api/handlers/multicast_delivery_entity.go`](https://github.com/malbeclabs/lake/pull/744/files#diff-53c4554235bcf03c0235d7eecb420f6427b15de3a360f380cda5eb651b11a29b) — link handler two-stage fan-out; shared spawn/semaphore extracted to `multicastDeliveryFanout`
- [`indexer/pkg/dz/mroute/source_s3.go`](https://github.com/malbeclabs/lake/pull/744/files#diff-4630e62195f6688098893fea2c22ceec727eec37eeb974a69256ffd919dfa11e) — per-device fan-out, retry on listing and per-device reads, stale-device WARN
- [`indexer/pkg/dz/msdp/source_s3.go`](https://github.com/malbeclabs/lake/pull/744/files#diff-36ca940360154671dfe6a001a013e36c56fea411c520e308fefd86de713570ee) — same, per snapshot kind
- [`indexer/pkg/dzingest/activities.go`](https://github.com/malbeclabs/lake/pull/744/files#diff-a2351b69fbbb5752bb5e678ef261f2d1da4e9294f7230534ccb29f76b388147a) — `observeSync` wrapper adding refresh metrics and a duration log line
- [`api/testing/clickhouse.go`](https://github.com/malbeclabs/lake/pull/744/files#diff-3f95e724029ee98315a41802e66b76489d40101859345ed48b4c0094312ab3c6) — `skipTemplateTable` excludes dot-prefixed internals from the clone

</details>

## Testing Verification

- `TestS3Source_FetchLatest_FanOut` in both packages, MinIO-backed with a fault-injecting `http.RoundTripper`: a first-request failure on a device *or on the device listing* is retried and the walk still returns the full device set; a persistent failure aborts after exactly `MaxAttempts` requests; a failure that also cancels the context returns `context.Canceled` after one attempt, with no not-yet-started device reaching S3; 25 devices return in listing order with peak in-flight above 1 and at most 10.
- `TestSkipTemplateTable` pins the clone filter, including the exact `.tmp.inner_id.<uuid>` name from the CI failure, and runs without a container.
- Docker is unavailable in my environment, so CI runs the container-backed tests rather than me. The link handler went from a 500 after 31.9s to passing in 15.9s.

## Follow-up

Collapsing the three per-device lookback LISTs into one LIST at the `device=` prefix would cut round trips a further ~3x. Left out: it changes scan semantics, and concurrency already restores ample headroom.
