### PR TITLE
rollup: fail a backfill that skipped a chunk instead of reporting success

### DIFF
--- a/indexer/pkg/rollup/workflow.go
+++ b/indexer/pkg/rollup/workflow.go
@@ -1,6 +1,8 @@
 package rollup
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"go.temporal.io/sdk/log"
@@ -65,7 +67,10 @@ func ComputeRollupWorkflow(ctx temporalworkflow.Context, iteration int) error {
 			WindowEnd:   now,
 		}
 
-		runIteration(ctx, log, esc, window)
+		// The live loop must keep running: a bucket stays in the overlap window
+		// (rollupWindow) for several iterations, so a failed cycle gets another
+		// chance on its own. The escalator already logged it.
+		_ = runIteration(ctx, log, esc, window)
 
 		iteration++
 
@@ -79,20 +84,27 @@ func ComputeRollupWorkflow(ctx temporalworkflow.Context, iteration int) error {
 	return temporalworkflow.NewContinueAsNewError(ctx, ComputeRollupWorkflow, 0)
 }
 
-// runIteration executes one rollup cycle. Errors are logged, not returned,
-// so the workflow loop continues on failure.
-func runIteration(ctx temporalworkflow.Context, log log.Logger, esc *lakelogger.Escalator, window BackfillChunkInput) {
-	err := temporalworkflow.ExecuteActivity(ctx, (*Activities).RollupLinks, window).Get(ctx, nil)
-	if err != nil && ctx.Err() != nil {
-		return // workflow context done; the error is just the cancellation
+// runIteration executes one rollup cycle. Errors are logged via the escalator,
+// which owns the paging decision, and also returned so a caller that must not
+// silently skip a window can act on them. The live loop discards the return and
+// continues; the backfill records it (see BackfillRollupWorkflow).
+//
+// A cancellation is reported as ctx.Err() rather than an activity failure: the
+// window did not fail, the workflow is shutting down.
+func runIteration(ctx temporalworkflow.Context, log log.Logger, esc *lakelogger.Escalator, window BackfillChunkInput) error {
+	linkErr := temporalworkflow.ExecuteActivity(ctx, (*Activities).RollupLinks, window).Get(ctx, nil)
+	if linkErr != nil && ctx.Err() != nil {
+		return ctx.Err() // workflow context done; the error is just the cancellation
 	}
-	esc.Observe(log, "link_rollup", "link rollup failed", err, "window_start", window.WindowStart, "window_end", window.WindowEnd)
+	esc.Observe(log, "link_rollup", "link rollup failed", linkErr, "window_start", window.WindowStart, "window_end", window.WindowEnd)
 
-	err = temporalworkflow.ExecuteActivity(ctx, (*Activities).RollupDeviceInterfaces, window).Get(ctx, nil)
-	if err != nil && ctx.Err() != nil {
-		return
+	intfErr := temporalworkflow.ExecuteActivity(ctx, (*Activities).RollupDeviceInterfaces, window).Get(ctx, nil)
+	if intfErr != nil && ctx.Err() != nil {
+		return ctx.Err()
 	}
-	esc.Observe(log, "device_interface_rollup", "device interface rollup failed", err, "window_start", window.WindowStart, "window_end", window.WindowEnd)
+	esc.Observe(log, "device_interface_rollup", "device interface rollup failed", intfErr, "window_start", window.WindowStart, "window_end", window.WindowEnd)
+
+	return errors.Join(linkErr, intfErr)
 }
 
 // BackfillRollupWorkflow processes historical data in time chunks.
@@ -131,6 +143,16 @@ func BackfillRollupWorkflow(ctx temporalworkflow.Context, input BackfillInput) e
 		log.Info("capped backfill end time to avoid live rollup overlap", "end_time", endTime)
 	}
 
+	// A backfill is a one-shot pass: unlike the live rollup there is no overlap
+	// window and no later cycle to recompute a window that failed. Advancing past
+	// a failed chunk therefore leaves a permanent hole in the rollups. Collect the
+	// failures instead — keep going so one bad window doesn't abandon the rest of
+	// the range, then fail with the windows to re-run. Re-running is safe: both
+	// rollup tables are ReplacingMergeTree keyed on the bucket, so recomputing a
+	// window is idempotent.
+	var failed []BackfillChunkInput
+	totalChunks := 0
+
 	chunkStart := input.StartTime
 	for chunkStart.Before(endTime) {
 		chunkEnd := chunkStart.Add(input.ChunkSize)
@@ -144,9 +166,24 @@ func BackfillRollupWorkflow(ctx temporalworkflow.Context, input BackfillInput) e
 			SourceDatabase: input.SourceDatabase,
 		}
 
-		runIteration(ctx, log, esc, chunk)
+		totalChunks++
+		if err := runIteration(ctx, log, esc, chunk); err != nil {
+			if ctx.Err() != nil {
+				return err // shutting down, not a chunk failure
+			}
+			failed = append(failed, chunk)
+		}
 
 		chunkStart = chunkEnd
+	}
+
+	if len(failed) > 0 {
+		// Each failure was already logged with its window by the escalator, so this
+		// carries the summary and the range to re-run rather than repeating them.
+		return fmt.Errorf("backfill incomplete: %d of %d chunks failed, leaving gaps between %s and %s; re-run the backfill over the failed windows (each is logged with window_start/window_end)",
+			len(failed), totalChunks,
+			failed[0].WindowStart.Format(time.RFC3339),
+			failed[len(failed)-1].WindowEnd.Format(time.RFC3339))
 	}
 
 	return nil

--- a/indexer/pkg/rollup/workflow_test.go
+++ b/indexer/pkg/rollup/workflow_test.go
@@ -1,0 +1,104 @@
+package rollup
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// backfillChunkStarts returns the WindowStart of every chunk a backfill over
+// [start, start+span) with the given chunk size will produce.
+func backfillChunkStarts(start time.Time, span, chunkSize time.Duration) []time.Time {
+	var out []time.Time
+	for t := start; t.Before(start.Add(span)); t = t.Add(chunkSize) {
+		out = append(out, t)
+	}
+	return out
+}
+
+// TestBackfillRollupWorkflow_FailedChunkMustNotBeSilentlySkipped is the
+// permanent-gap regression. The chunk loop advanced chunkStart unconditionally
+// after runIteration swallowed the activity error, so a transient failure on one
+// chunk left a hole in the backfilled rollups that nothing ever recomputes — and
+// the workflow returned nil, reporting a complete backfill.
+//
+// A backfill is a one-shot operation with no later pass to catch a missed window,
+// so an incomplete run must fail loudly enough that an operator knows to re-run
+// the affected ranges. (Re-running is safe: both rollup tables are
+// ReplacingMergeTree keyed on the bucket, so recomputing a window is idempotent.)
+//
+// The live ComputeRollupWorkflow is deliberately unaffected — it must keep
+// looping on failure, and its overlap window gives each bucket several chances.
+func TestBackfillRollupWorkflow_FailedChunkMustNotBeSilentlySkipped(t *testing.T) {
+	const chunkSize = time.Hour
+	// Well in the past so the live-overlap cap never trims the range.
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	span := 3 * chunkSize
+
+	chunkStarts := backfillChunkStarts(start, span, chunkSize)
+	require.Len(t, chunkStarts, 3, "test needs three chunks to prove the middle one is skipped")
+	failWindow := chunkStarts[1]
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	a := &Activities{}
+	env.RegisterActivity(a)
+
+	// The middle chunk fails; the ones on either side succeed.
+	isFailWindow := mock.MatchedBy(func(in BackfillChunkInput) bool {
+		return in.WindowStart.Equal(failWindow)
+	})
+	env.OnActivity(a.RollupLinks, mock.Anything, isFailWindow).
+		Return(0, errors.New("clickhouse connection reset by peer"))
+	env.OnActivity(a.RollupLinks, mock.Anything, mock.Anything).Return(1, nil)
+	env.OnActivity(a.RollupDeviceInterfaces, mock.Anything, mock.Anything).Return(1, nil)
+
+	env.ExecuteWorkflow(BackfillRollupWorkflow, BackfillInput{
+		StartTime: start,
+		EndTime:   start.Add(span),
+		ChunkSize: chunkSize,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err,
+		"a backfill that skipped a chunk must not report success — the window is a permanent gap")
+	require.Contains(t, err.Error(), "incomplete",
+		"the error must say the backfill was incomplete so an operator re-runs it")
+	require.Contains(t, err.Error(), failWindow.Format(time.RFC3339),
+		"the error must name the window to re-run, got: %v", err)
+	// Exactly one chunk failed: the surrounding chunks must still have been
+	// processed, so one bad window doesn't abandon the rest of the range. Without
+	// this the test would also pass if every chunk failed.
+	require.Contains(t, err.Error(), "1 of 3 chunks failed",
+		"only the middle chunk should fail; the others must still run, got: %v", err)
+}
+
+// TestBackfillRollupWorkflow_AllChunksSucceedReportsSuccess pins the other side:
+// the failure path above must not make a clean backfill look broken.
+func TestBackfillRollupWorkflow_AllChunksSucceedReportsSuccess(t *testing.T) {
+	const chunkSize = time.Hour
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	a := &Activities{}
+	env.RegisterActivity(a)
+	env.OnActivity(a.RollupLinks, mock.Anything, mock.Anything).Return(1, nil)
+	env.OnActivity(a.RollupDeviceInterfaces, mock.Anything, mock.Anything).Return(1, nil)
+
+	env.ExecuteWorkflow(BackfillRollupWorkflow, BackfillInput{
+		StartTime: start,
+		EndTime:   start.Add(3 * chunkSize),
+		ChunkSize: chunkSize,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}


### PR DESCRIPTION
## Summary

- `BackfillRollupWorkflow` advanced `chunkStart` unconditionally after `runIteration` swallowed the activity error, so a transient failure on one chunk left a **permanent hole** in the backfilled rollups — nothing ever recomputes it — and the workflow returned `nil`, reporting a complete backfill.
- Failed chunks are now collected and the workflow fails with the count and the range to re-run. The loop keeps going, so one bad window doesn't abandon the rest of the range.
- `runIteration` now returns the activity error in addition to logging it via the escalator. The **live** `ComputeRollupWorkflow` discards the return and keeps looping, unchanged — its overlap window (`rollupWindow`) gives each bucket several chances, so swallowing is correct there. The backfill has no such second pass, which is the whole difference.
- A cancellation is reported as `ctx.Err()` rather than a chunk failure, so shutdown doesn't get recorded as a gap.

## Why the backfill is different from the live rollup

The live rollup recomputes a sliding window every 30s, so a bucket that fails one cycle is retried on the next several. The backfill is a single pass over a historical range: a window it skips is never revisited by anything. Silently skipping it while reporting success is the worst of both — the data is missing and nobody knows.

Re-running is safe: `link_rollup_5m` and `device_interface_rollup_5m` are both `ReplacingMergeTree(ingested_at)` ordered by the bucket key, so recomputing a window is idempotent. The error message says so.

No ERROR log is added here — the escalator already logged each chunk failure with its `window_start`/`window_end`, and this is a manually-triggered workflow whose error Temporal surfaces to the operator. A second alert-bearing line would page on-call for a hand-run backfill.

## Testing Verification

- Adds the package's first workflow-level tests (`workflow_test.go`); previously only the activities had coverage.
- `FailedChunkMustNotBeSilentlySkipped` — three chunks with the middle one failing. Asserts the workflow errors, that the message names the failed window so an operator can re-run it, and that it reports `1 of 3 chunks failed` — the last assertion is what stops the test passing for the wrong reason if *every* chunk fails instead.
- Confirmed the test fails on the pre-change code (`An error is expected but got nil`) and passes after, by stashing only the `workflow.go` change.
- `AllChunksSucceedReportsSuccess` pins the other side: the new failure path must not make a clean backfill look broken.
- `go test -race` green on `indexer/pkg/rollup`.

## Found by

An audit of every batch path in the indexer for the invariant *item-failure handling must match how the resume point is derived*. Sibling PR #754 fixes the same family in the escrow-events indexer (a skipped signature dragged the fact-derived high-water mark past itself).