### PR TITLE
indexer: make telemetry latency fetch skips visible

### DIFF
--- a/indexer/pkg/dz/telemetry/latency/view.go
+++ b/indexer/pkg/dz/telemetry/latency/view.go
@@ -25,7 +25,9 @@ import (
 type fetchOutcome int
 
 const (
-	// fetchAbort means the worker is shutting down: stop, don't record anything.
+	// fetchAbort means the refresh context is done — worker shutdown or the refresh
+	// deadline — so stop and record nothing. Shutdown is not a collection failure and
+	// must not be counted as one.
 	fetchAbort fetchOutcome = iota
 	// fetchExpectedMiss means there is simply no telemetry account for this
 	// circuit/epoch. Routine and very common — not worth counting.
@@ -38,15 +40,30 @@ const (
 	fetchUnclassified
 )
 
-func classifyFetchErr(err error) fetchOutcome {
-	switch {
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+// classifyFetchErr decides what a sample-fetch error means. Shutdown is decided by
+// the context, never by the error's shape.
+//
+// The distinction matters because an http.Client timeout also satisfies
+// errors.Is(err, context.DeadlineExceeded) — verified: a Client.Timeout abort
+// produces "context deadline exceeded (Client.Timeout exceeded while awaiting
+// headers)" and errors.Is against context.DeadlineExceeded is true. Keying on the
+// error therefore read a slow endpoint as "we are shutting down" and returned from
+// the worker goroutine, which sits before the append of everything already collected
+// for that circuit — so a timeout silently discarded the earlier epochs' samples
+// while the refresh still reported a clean cycle.
+//
+// With the context as the authority, a live context means the fetch genuinely failed:
+// it is counted, logged, and the circuit resumes from its stored max sample index next
+// refresh. Only a cancelled or expired context aborts, and the loop's own
+// select-on-ctx.Done already handles that case first.
+func classifyFetchErr(ctx context.Context, err error) fetchOutcome {
+	if ctx.Err() != nil {
 		return fetchAbort
-	case errors.Is(err, telemetry.ErrAccountNotFound):
-		return fetchExpectedMiss
-	default:
-		return fetchUnclassified
 	}
+	if errors.Is(err, telemetry.ErrAccountNotFound) {
+		return fetchExpectedMiss
+	}
+	return fetchUnclassified
 }
 
 type TelemetryRPC interface {

--- a/indexer/pkg/dz/telemetry/latency/view.go
+++ b/indexer/pkg/dz/telemetry/latency/view.go
@@ -19,6 +19,36 @@ import (
 	"github.com/malbeclabs/lake/utils/pkg/logger"
 )
 
+// fetchOutcome classifies a telemetry sample-fetch error. Both the device-link
+// and internet-metro fan-outs need the same three-way split, so it lives here
+// rather than being spelled out (and drifting) at each call site.
+type fetchOutcome int
+
+const (
+	// fetchAbort means the worker is shutting down: stop, don't record anything.
+	fetchAbort fetchOutcome = iota
+	// fetchExpectedMiss means there is simply no telemetry account for this
+	// circuit/epoch. Routine and very common — not worth counting.
+	fetchExpectedMiss
+	// fetchUnclassified is any other error. Skipping it is safe (each circuit
+	// resumes from its own stored max sample index, so the next refresh re-fetches
+	// what this one missed) but it MUST be counted and logged: the refresh still
+	// reports success, so an uncounted skip lets a persistently failing circuit
+	// under-collect indefinitely with no signal anywhere.
+	fetchUnclassified
+)
+
+func classifyFetchErr(err error) fetchOutcome {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return fetchAbort
+	case errors.Is(err, telemetry.ErrAccountNotFound):
+		return fetchExpectedMiss
+	default:
+		return fetchUnclassified
+	}
+}
+
 type TelemetryRPC interface {
 	GetDeviceLatencySamplesTail(ctx context.Context, originDevicePK, targetDevicePK, linkPK solana.PublicKey, epoch uint64, existingMaxIdx int) (*telemetry.DeviceLatencySamplesHeader, int, []uint32, error)
 	GetInternetLatencySamples(ctx context.Context, dataProviderName string, originLocationPK, targetLocationPK, agentPK solana.PublicKey, epoch uint64) (*telemetry.InternetLatencySamples, error)

--- a/indexer/pkg/dz/telemetry/latency/view.go
+++ b/indexer/pkg/dz/telemetry/latency/view.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -291,4 +292,17 @@ func (v *View) WaitReady(ctx context.Context) error {
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled while waiting for telemetry view: %w", ctx.Err())
 	}
+}
+
+// noteSkip records a skipped fetch for the per-refresh summary. Both fan-outs call it
+// from the same place, the arm that counts an unclassified error, so the two cannot
+// drift: a previous version of this accounting sat in the wrong branch on one path and
+// silenced that path's summary entirely.
+//
+// It stores a copy of err rather than the caller's variable, so the retained error
+// cannot be affected by later loop iterations.
+func noteSkip(count *atomic.Int64, first *atomic.Pointer[error], err error) {
+	count.Add(1)
+	e := err
+	first.CompareAndSwap(nil, &e)
 }

--- a/indexer/pkg/dz/telemetry/latency/view.go
+++ b/indexer/pkg/dz/telemetry/latency/view.go
@@ -32,30 +32,33 @@ const (
 	// fetchExpectedMiss means there is simply no telemetry account for this
 	// circuit/epoch. Routine and very common — not worth counting.
 	fetchExpectedMiss
-	// fetchUnclassified is any other error. Skipping it is safe (each circuit
-	// resumes from its own stored max sample index, so the next refresh re-fetches
-	// what this one missed) but it MUST be counted and logged: the refresh still
-	// reports success, so an uncounted skip lets a persistently failing circuit
-	// under-collect indefinitely with no signal anywhere.
+	// fetchUnclassified is any other error. The circuit resumes from its own stored
+	// max sample index, so the next refresh re-fetches what this one missed — but only
+	// while the epoch is still in the fetch window (current and current-1). Past that,
+	// roughly two days, only the admin backfill recovers it. So the skip must be
+	// counted and logged: the refresh still reports success, and an uncounted skip lets
+	// a failing circuit under-collect with no signal anywhere.
 	fetchUnclassified
 )
 
-// classifyFetchErr decides what a sample-fetch error means. Shutdown is decided by
-// the context, never by the error's shape.
+// classifyFetchErr decides what a sample-fetch error means. The context decides
+// shutdown, never the error's shape.
 //
-// The distinction matters because an http.Client timeout also satisfies
-// errors.Is(err, context.DeadlineExceeded) — verified: a Client.Timeout abort
-// produces "context deadline exceeded (Client.Timeout exceeded while awaiting
-// headers)" and errors.Is against context.DeadlineExceeded is true. Keying on the
-// error therefore read a slow endpoint as "we are shutting down" and returned from
-// the worker goroutine, which sits before the append of everything already collected
-// for that circuit — so a timeout silently discarded the earlier epochs' samples
-// while the refresh still reported a clean cycle.
+// The invariant: an http.Client timeout also satisfies
+// errors.Is(err, context.DeadlineExceeded). Keying the abort on the error therefore
+// reads a slow endpoint as shutdown and returns from the worker goroutine, and that
+// return sits before the append of everything already collected for the circuit. The
+// refresh still reports success, so the cycle looks clean with a hole in it.
 //
-// With the context as the authority, a live context means the fetch genuinely failed:
-// it is counted, logged, and the circuit resumes from its stored max sample index next
-// refresh. Only a cancelled or expired context aborts, and the loop's own
-// select-on-ctx.Done already handles that case first.
+// This has not fired in production. The deployed client timeout and the activity
+// StartToCloseTimeout are both 5 minutes and the HTTP request starts later, so the
+// context always expired first and the abort was genuine. It bites as soon as the
+// client timeout drops below the activity deadline, which the SDK bump in #757 does
+// (10s), or when Refresh runs from a context with no deadline.
+//
+// A live context therefore means the fetch genuinely failed: count it, log it, and let
+// the circuit resume from its stored max sample index. Only a cancelled or expired
+// context aborts, and the loop's own select on ctx.Done handles that first.
 func classifyFetchErr(ctx context.Context, err error) fetchOutcome {
 	if ctx.Err() != nil {
 		return fetchAbort

--- a/indexer/pkg/dz/telemetry/latency/view_device.go
+++ b/indexer/pkg/dz/telemetry/latency/view_device.go
@@ -3,15 +3,14 @@ package dztelemlatency
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
-	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 )
 
 type DeviceLinkLatencySample struct {
@@ -123,13 +122,18 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 
 						hdr, startIdx, tail, err := v.cfg.TelemetryRPC.GetDeviceLatencySamplesTail(ctx, originPK, targetPK, linkPK, epoch, existingMaxIdx)
 						if err != nil {
-							if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+							switch classifyFetchErr(err) {
+							case fetchAbort:
 								return
-							}
-							if errors.Is(err, telemetry.ErrAccountNotFound) {
+							case fetchExpectedMiss:
+								continue
+							default:
+								metrics.TelemetryFetchSkipped.WithLabelValues("device_link").Inc()
+								v.log.Warn("telemetry/device-link: sample fetch failed, skipping until next refresh",
+									"origin_device_pk", originDevicePK, "target_device_pk", targetDevicePK,
+									"link_pk", linkPKStr, "epoch", epoch, "error", err)
 								continue
 							}
-							continue
 						}
 						if hdr == nil {
 							continue

--- a/indexer/pkg/dz/telemetry/latency/view_device.go
+++ b/indexer/pkg/dz/telemetry/latency/view_device.go
@@ -135,12 +135,11 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 								v.log.Debug("telemetry/device-link: sample fetch failed, skipping until next refresh",
 									"origin_device_pk", originDevicePK, "target_device_pk", targetDevicePK,
 									"link_pk", linkPKStr, "epoch", epoch, "error", err)
+								noteSkip(&skipped, &firstSkipErr, err)
 								continue
 							}
 						}
 						if hdr == nil {
-							skipped.Add(1)
-							firstSkipErr.CompareAndSwap(nil, &err)
 							continue
 						}
 

--- a/indexer/pkg/dz/telemetry/latency/view_device.go
+++ b/indexer/pkg/dz/telemetry/latency/view_device.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -52,6 +53,8 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 	var allSamples []DeviceLinkLatencySample
 	var allHeaders []DeviceLinkLatencySampleHeader
 	var samplesMu sync.Mutex
+	var skipped atomic.Int64
+	var firstSkipErr atomic.Pointer[error]
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, v.cfg.MaxConcurrency)
 	linksProcessed := 0
@@ -128,14 +131,16 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 							case fetchExpectedMiss:
 								continue
 							default:
-								metrics.TelemetryFetchSkipped.WithLabelValues("device_link").Inc()
-								v.log.Warn("telemetry/device-link: sample fetch failed, skipping until next refresh",
+								metrics.TelemetryFetchSkipped.WithLabelValues(v.cfg.DZEnv, "device_link").Inc()
+								v.log.Debug("telemetry/device-link: sample fetch failed, skipping until next refresh",
 									"origin_device_pk", originDevicePK, "target_device_pk", targetDevicePK,
 									"link_pk", linkPKStr, "epoch", epoch, "error", err)
 								continue
 							}
 						}
 						if hdr == nil {
+							skipped.Add(1)
+							firstSkipErr.CompareAndSwap(nil, &err)
 							continue
 						}
 
@@ -193,6 +198,18 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 
 done:
 	wg.Wait()
+
+	// One line per refresh, not per fetch. A skipped circuit is re-fetched next refresh
+	// while its epoch is still in the window, so the count matters more than any single
+	// failure. Per-fetch detail is at Debug.
+	if n := skipped.Load(); n > 0 {
+		var first error
+		if ptr := firstSkipErr.Load(); ptr != nil {
+			first = *ptr
+		}
+		v.log.Warn("telemetry/device-link: sample fetches skipped, retried next refresh",
+			"skipped", n, "first_error", first)
+	}
 
 	// Append new samples to table (instead of replacing)
 	if len(allSamples) > 0 {

--- a/indexer/pkg/dz/telemetry/latency/view_device.go
+++ b/indexer/pkg/dz/telemetry/latency/view_device.go
@@ -122,7 +122,7 @@ func (v *View) refreshDeviceLinkTelemetrySamples(ctx context.Context, devices []
 
 						hdr, startIdx, tail, err := v.cfg.TelemetryRPC.GetDeviceLatencySamplesTail(ctx, originPK, targetPK, linkPK, epoch, existingMaxIdx)
 						if err != nil {
-							switch classifyFetchErr(err) {
+							switch classifyFetchErr(ctx, err) {
 							case fetchAbort:
 								return
 							case fetchExpectedMiss:

--- a/indexer/pkg/dz/telemetry/latency/view_internet.go
+++ b/indexer/pkg/dz/telemetry/latency/view_internet.go
@@ -154,8 +154,7 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 								v.log.Debug("telemetry/internet-metro: sample fetch failed, skipping until next refresh",
 									"origin_metro_pk", originMetroPK, "target_metro_pk", targetMetroPK,
 									"data_provider", dataProvider, "epoch", epoch, "error", err)
-								skipped.Add(1)
-								firstSkipErr.CompareAndSwap(nil, &err)
+								noteSkip(&skipped, &firstSkipErr, err)
 								continue
 							}
 						}

--- a/indexer/pkg/dz/telemetry/latency/view_internet.go
+++ b/indexer/pkg/dz/telemetry/latency/view_internet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -47,6 +48,8 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 	var allSamples []InternetMetroLatencySample
 	var allHeaders []InternetMetroLatencySampleHeader
 	var samplesMu sync.Mutex
+	var skipped atomic.Int64
+	var firstSkipErr atomic.Pointer[error]
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, v.cfg.MaxConcurrency)
 	metrosProcessed := 0
@@ -147,10 +150,12 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 							case fetchExpectedMiss:
 								continue
 							default:
-								metrics.TelemetryFetchSkipped.WithLabelValues("internet_metro").Inc()
-								v.log.Warn("telemetry/internet-metro: sample fetch failed, skipping until next refresh",
+								metrics.TelemetryFetchSkipped.WithLabelValues(v.cfg.DZEnv, "internet_metro").Inc()
+								v.log.Debug("telemetry/internet-metro: sample fetch failed, skipping until next refresh",
 									"origin_metro_pk", originMetroPK, "target_metro_pk", targetMetroPK,
 									"data_provider", dataProvider, "epoch", epoch, "error", err)
+								skipped.Add(1)
+								firstSkipErr.CompareAndSwap(nil, &err)
 								continue
 							}
 						}
@@ -210,6 +215,16 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 
 done:
 	wg.Wait()
+
+	// One line per refresh, not per fetch. See view_device.go.
+	if n := skipped.Load(); n > 0 {
+		var first error
+		if ptr := firstSkipErr.Load(); ptr != nil {
+			first = *ptr
+		}
+		v.log.Warn("telemetry/internet-metro: sample fetches skipped, retried next refresh",
+			"skipped", n, "first_error", first)
+	}
 
 	// Append new samples to table (instead of replacing)
 	if len(allSamples) > 0 {

--- a/indexer/pkg/dz/telemetry/latency/view_internet.go
+++ b/indexer/pkg/dz/telemetry/latency/view_internet.go
@@ -2,7 +2,6 @@ package dztelemlatency
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -12,6 +11,7 @@ import (
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 	dzsvc "github.com/malbeclabs/lake/indexer/pkg/dz/serviceability"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 )
 
 type InternetMetroLatencySample struct {
@@ -141,13 +141,18 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 
 						samples, err := v.cfg.TelemetryRPC.GetInternetLatencySamples(ctx, dataProvider, originPK, targetPK, v.cfg.InternetLatencyAgentPK, epoch)
 						if err != nil {
-							if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+							switch classifyFetchErr(err) {
+							case fetchAbort:
 								return
-							}
-							if errors.Is(err, telemetry.ErrAccountNotFound) {
+							case fetchExpectedMiss:
+								continue
+							default:
+								metrics.TelemetryFetchSkipped.WithLabelValues("internet_metro").Inc()
+								v.log.Warn("telemetry/internet-metro: sample fetch failed, skipping until next refresh",
+									"origin_metro_pk", originMetroPK, "target_metro_pk", targetMetroPK,
+									"data_provider", dataProvider, "epoch", epoch, "error", err)
 								continue
 							}
-							continue
 						}
 
 						metroHasSamples = true

--- a/indexer/pkg/dz/telemetry/latency/view_internet.go
+++ b/indexer/pkg/dz/telemetry/latency/view_internet.go
@@ -141,7 +141,7 @@ func (v *View) refreshInternetMetroLatencySamples(ctx context.Context, metros []
 
 						samples, err := v.cfg.TelemetryRPC.GetInternetLatencySamples(ctx, dataProvider, originPK, targetPK, v.cfg.InternetLatencyAgentPK, epoch)
 						if err != nil {
-							switch classifyFetchErr(err) {
+							switch classifyFetchErr(ctx, err) {
 							case fetchAbort:
 								return
 							case fetchExpectedMiss:

--- a/indexer/pkg/dz/telemetry/latency/view_test.go
+++ b/indexer/pkg/dz/telemetry/latency/view_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1989,4 +1992,110 @@ func TestLake_TelemetryLatency_View_TimeoutKeepsEarlierEpochSamples(t *testing.T
 
 	after := testutil.ToFloat64(metrics.TelemetryFetchSkipped.WithLabelValues(env, "device_link"))
 	require.Greater(t, after, before, "the skipped fetch must be counted under dz_env=%s", env)
+}
+
+// capturingHandler records the records a logger emits, so a test can assert on log
+// output as well as on metrics. The bug this exists for was invisible to a
+// counter-only assertion: the accounting for the per-refresh summary sat in the wrong
+// branch, so the counter still moved and the summary WARN never fired.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// find returns the first record at the given level whose message contains msg.
+func (h *capturingHandler) find(level slog.Level, msg string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level == level && strings.Contains(r.Message, msg) {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+// TestLake_TelemetryLatency_View_SkippedFetchesReachOneWarn asserts the operator-facing
+// half of the skip accounting: a skipped fetch must produce exactly one WARN for the
+// refresh, carrying the count and a real error.
+//
+// Asserting the counter is not enough. The accounting that feeds this summary once sat in
+// a branch that only runs when err == nil, so the counter moved, the summary never fired,
+// and device-link fetch failures reached no WARN at all. Every metric assertion still
+// passed.
+func TestLake_TelemetryLatency_View_SkippedFetchesReachOneWarn(t *testing.T) {
+	t.Parallel()
+
+	db := testClient(t)
+	svcView, originPK, targetPK, linkPKPubKey := latencyFixture(t, db)
+
+	capture := &capturingHandler{}
+	injected := errors.New("Too many requests for a specific RPC call")
+
+	rpc := &mockTelemetryRPCWithIncrementalSamples{
+		getSamplesFunc: func(o, tgt, l solana.PublicKey, epoch uint64, existingMaxIdx int) (*telemetry.DeviceLatencySamplesHeader, int, []uint32, error) {
+			if o != originPK || tgt != targetPK || l != linkPKPubKey {
+				return nil, 0, nil, telemetry.ErrAccountNotFound
+			}
+			return nil, 0, nil, injected
+		},
+	}
+
+	view, err := NewView(ViewConfig{
+		Logger:                 slog.New(capture),
+		Clock:                  clockwork.NewFakeClock(),
+		TelemetryRPC:           rpc,
+		EpochRPC:               &mockEpochRPCWithEpoch{epoch: 100},
+		MaxConcurrency:         32,
+		InternetLatencyAgentPK: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+		InternetDataProviders:  []string{"test-provider"},
+		ClickHouse:             db,
+		Serviceability:         svcView,
+		RefreshInterval:        time.Second,
+		DZEnv:                  "fixture-env",
+	})
+	require.NoError(t, err)
+
+	_, err = view.Refresh(context.Background())
+	require.NoError(t, err)
+
+	rec, ok := capture.find(slog.LevelWarn, "sample fetches skipped")
+	require.True(t, ok, "no summary WARN was emitted for a skipped fetch; "+
+		"the per-fetch line is Debug, so without this the failure is invisible at WARN")
+
+	var skipped int64
+	var firstErr string
+	rec.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "skipped":
+			skipped = a.Value.Int64()
+		case "first_error":
+			firstErr = a.Value.String()
+		}
+		return true
+	})
+	require.Positive(t, skipped, "the summary WARN must carry a non-zero skip count")
+	require.Contains(t, firstErr, "Too many requests",
+		"the summary WARN must carry the real first error, not <nil>")
+
+	// Exactly one summary line per source per refresh, not one per fetch.
+	capture.mu.Lock()
+	var warns int
+	for _, r := range capture.records {
+		if r.Level == slog.LevelWarn && strings.Contains(r.Message, "sample fetches skipped") {
+			warns++
+		}
+	}
+	capture.mu.Unlock()
+	require.Equal(t, 1, warns, "expected one summary WARN for device-link, got %d", warns)
 }

--- a/indexer/pkg/dz/telemetry/latency/view_test.go
+++ b/indexer/pkg/dz/telemetry/latency/view_test.go
@@ -2,6 +2,7 @@ package dztelemlatency
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -1739,4 +1740,40 @@ func TestLake_TelemetryLatency_View_AgentVersionCommit(t *testing.T) {
 		require.Equal(t, "", storedVersion, "zero-value AgentVersion should produce empty string")
 		require.Equal(t, "", storedCommit, "zero-value AgentCommit should produce empty string")
 	})
+}
+
+// TestLake_TelemetryLatency_ClassifyFetchErr pins which sample-fetch errors are
+// counted as skips. Both fan-outs drop a failed circuit and let the next refresh
+// re-fetch it, which is safe but silent — the refresh still reports success. The
+// counter is the only signal that a circuit is not being collected, so an error
+// class landing in the wrong bucket either hides a real outage (unclassified
+// treated as expected) or floods the counter with routine misses.
+func TestLake_TelemetryLatency_ClassifyFetchErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want fetchOutcome
+	}{
+		{"context canceled", context.Canceled, fetchAbort},
+		{"deadline exceeded", context.DeadlineExceeded, fetchAbort},
+		{"wrapped cancel", fmt.Errorf("fetch tail: %w", context.Canceled), fetchAbort},
+
+		{"no telemetry account", telemetry.ErrAccountNotFound, fetchExpectedMiss},
+		{"wrapped no account", fmt.Errorf("epoch 42: %w", telemetry.ErrAccountNotFound), fetchExpectedMiss},
+
+		// Everything else must be counted — these are the cases that used to vanish.
+		{"rpc throttle", errors.New("Too many requests for a specific RPC call"), fetchUnclassified},
+		{"service unavailable", errors.New("Service unavailable, please try again later."), fetchUnclassified},
+		{"connection reset", errors.New("read tcp 10.0.0.1:8899: connection reset by peer"), fetchUnclassified},
+		{"decode failure", errors.New("failed to deserialize account data"), fetchUnclassified},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, classifyFetchErr(tt.err))
+		})
+	}
 }

--- a/indexer/pkg/dz/telemetry/latency/view_test.go
+++ b/indexer/pkg/dz/telemetry/latency/view_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse/dataset"
 	mcpgeoip "github.com/malbeclabs/lake/indexer/pkg/geoip"
+	"github.com/malbeclabs/lake/indexer/pkg/metrics"
 	laketesting "github.com/malbeclabs/lake/utils/pkg/testing"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
@@ -1807,4 +1809,184 @@ func TestLake_TelemetryLatency_ClassifyFetchErr(t *testing.T) {
 			}
 		})
 	}
+}
+
+// latencyFixture builds the serviceability state the latency views read: two activated
+// devices joined by one WAN link, refreshed into ClickHouse. It returns the view and the
+// circuit's three pubkeys. Nine tests in this file inline the same block; new tests
+// should call this rather than add a tenth copy.
+func latencyFixture(t *testing.T, db clickhouse.Client) (*dzsvc.View, solana.PublicKey, solana.PublicKey, solana.PublicKey) {
+	t.Helper()
+	devicePK1 := [32]byte{1, 2, 3, 4}
+	devicePK2 := [32]byte{5, 6, 7, 8}
+	linkPK := [32]byte{9, 10, 11, 12}
+	contributorPK := [32]byte{13, 14, 15, 16}
+	metroPK := [32]byte{17, 18, 19, 20}
+	ownerPubkey := [32]byte{21, 22, 23, 24}
+	publicIP1 := [4]byte{192, 168, 1, 1}
+	publicIP2 := [4]byte{192, 168, 1, 2}
+	tunnelNet := [5]byte{10, 0, 0, 0, 24}
+
+	svcMockRPC := &MockServiceabilityRPC{
+		getProgramDataFunc: func(ctx context.Context) (*serviceability.ProgramData, error) {
+			return &serviceability.ProgramData{
+				Contributors: []serviceability.Contributor{
+					{
+						PubKey: contributorPK,
+						Owner:  ownerPubkey,
+						Code:   "CONTRIB",
+					},
+				},
+				Devices: []serviceability.Device{
+					{
+						PubKey:            devicePK1,
+						Owner:             ownerPubkey,
+						Status:            serviceability.DeviceStatusActivated,
+						DeviceType:        serviceability.DeviceDeviceTypeHybrid,
+						Code:              "DEV1",
+						PublicIp:          publicIP1,
+						ContributorPubKey: contributorPK,
+						ExchangePubKey:    metroPK,
+					},
+					{
+						PubKey:            devicePK2,
+						Owner:             ownerPubkey,
+						Status:            serviceability.DeviceStatusActivated,
+						DeviceType:        serviceability.DeviceDeviceTypeHybrid,
+						Code:              "DEV2",
+						PublicIp:          publicIP2,
+						ContributorPubKey: contributorPK,
+						ExchangePubKey:    metroPK,
+					},
+				},
+				Links: []serviceability.Link{
+					{
+						PubKey:            linkPK,
+						Owner:             ownerPubkey,
+						Status:            serviceability.LinkStatusActivated,
+						Code:              "LINK1",
+						TunnelNet:         tunnelNet,
+						ContributorPubKey: contributorPK,
+						SideAPubKey:       devicePK1,
+						SideZPubKey:       devicePK2,
+						SideAIfaceName:    "eth0",
+						SideZIfaceName:    "eth1",
+						LinkType:          serviceability.LinkLinkTypeWAN,
+						DelayNs:           1000000,
+						JitterNs:          50000,
+					},
+				},
+				Exchanges: []serviceability.Exchange{
+					{PubKey: metroPK, Code: "METRO1", Name: "Test Metro"},
+				},
+			}, nil
+		},
+	}
+
+	geoipStore, err := newMockGeoIPStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { geoipStore.db.Close() })
+
+	svcView, err := dzsvc.NewView(dzsvc.ViewConfig{
+		Logger:            laketesting.NewLogger(),
+		Clock:             clockwork.NewFakeClock(),
+		ServiceabilityRPC: svcMockRPC,
+		RefreshInterval:   time.Second,
+		ClickHouse:        db,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = svcView.Refresh(ctx)
+	require.NoError(t, err)
+
+	// Set up telemetry RPC to return samples with NextSampleIndex
+	originPK := solana.PublicKeyFromBytes(devicePK1[:])
+	targetPK := solana.PublicKeyFromBytes(devicePK2[:])
+	linkPKPubKey := solana.PublicKeyFromBytes(linkPK[:])
+	return svcView, originPK, targetPK, linkPKPubKey
+}
+
+// TestLake_TelemetryLatency_View_TimeoutKeepsEarlierEpochSamples asserts the classifier
+// change at the call site, which the pure-function test cannot reach.
+//
+// epochsToFetch is current-first, so epoch N is fetched before N-1. A fetch error that
+// looks like context.DeadlineExceeded, which every http.Client timeout does, used to
+// return from the worker goroutine. That return sits before the append, so epoch N's
+// samples were already in hand and got discarded, and the refresh still reported
+// success.
+//
+// Reverting view_device.go to the error-shape branch must fail this test. No other mock
+// in this file returns a non-nil fetch error, so before this the call-site behaviour was
+// never exercised at all.
+func TestLake_TelemetryLatency_View_TimeoutKeepsEarlierEpochSamples(t *testing.T) {
+	t.Parallel()
+
+	const env = "fixture-env"
+	db := testClient(t)
+	svcView, originPK, targetPK, linkPKPubKey := latencyFixture(t, db)
+
+	// A real Client.Timeout error, so this keeps matching whatever net/http returns.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+	_, timeoutErr := (&http.Client{Timeout: 20 * time.Millisecond}).Get(srv.URL)
+	require.Error(t, timeoutErr)
+	require.True(t, errors.Is(timeoutErr, context.DeadlineExceeded),
+		"precondition: the injected error must look like context.DeadlineExceeded")
+
+	startTsMicro := uint64(time.Now().Add(-1 * time.Hour).UnixMicro())
+	rpc := &mockTelemetryRPCWithIncrementalSamples{
+		getSamplesFunc: func(o, tgt, l solana.PublicKey, epoch uint64, existingMaxIdx int) (*telemetry.DeviceLatencySamplesHeader, int, []uint32, error) {
+			if o != originPK || tgt != targetPK || l != linkPKPubKey {
+				return nil, 0, nil, telemetry.ErrAccountNotFound
+			}
+			if epoch == 99 {
+				return nil, 0, nil, timeoutErr
+			}
+			return &telemetry.DeviceLatencySamplesHeader{
+				StartTimestampMicroseconds:   startTsMicro,
+				SamplingIntervalMicroseconds: 100_000,
+				NextSampleIndex:              3,
+			}, 0, []uint32{5000, 6000, 7000}, nil
+		},
+	}
+
+	view, err := NewView(ViewConfig{
+		Logger:                 laketesting.NewLogger(),
+		Clock:                  clockwork.NewFakeClock(),
+		TelemetryRPC:           rpc,
+		EpochRPC:               &mockEpochRPCWithEpoch{epoch: 100},
+		MaxConcurrency:         32,
+		InternetLatencyAgentPK: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+		InternetDataProviders:  []string{"test-provider"},
+		ClickHouse:             db,
+		Serviceability:         svcView,
+		RefreshInterval:        time.Second,
+		DZEnv:                  env,
+	})
+	require.NoError(t, err)
+
+	before := testutil.ToFloat64(metrics.TelemetryFetchSkipped.WithLabelValues(env, "device_link"))
+
+	ctx := context.Background()
+	_, err = view.Refresh(ctx)
+	require.NoError(t, err, "one circuit timing out must not fail the refresh")
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	rows, err := conn.Query(ctx, "SELECT count() FROM fact_dz_device_link_latency WHERE epoch = 100")
+	require.NoError(t, err)
+	require.True(t, rows.Next())
+	var n uint64
+	require.NoError(t, rows.Scan(&n))
+	rows.Close()
+	require.EqualValues(t, 3, n,
+		"epoch 100's samples were collected before epoch 99 timed out and must still be written; "+
+			"0 means the timeout was read as shutdown and the goroutine returned before the append")
+
+	after := testutil.ToFloat64(metrics.TelemetryFetchSkipped.WithLabelValues(env, "device_link"))
+	require.Greater(t, after, before, "the skipped fetch must be counted under dz_env=%s", env)
 }

--- a/indexer/pkg/dz/telemetry/latency/view_test.go
+++ b/indexer/pkg/dz/telemetry/latency/view_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1742,38 +1744,67 @@ func TestLake_TelemetryLatency_View_AgentVersionCommit(t *testing.T) {
 	})
 }
 
-// TestLake_TelemetryLatency_ClassifyFetchErr pins which sample-fetch errors are
-// counted as skips. Both fan-outs drop a failed circuit and let the next refresh
-// re-fetch it, which is safe but silent — the refresh still reports success. The
-// counter is the only signal that a circuit is not being collected, so an error
-// class landing in the wrong bucket either hides a real outage (unclassified
-// treated as expected) or floods the counter with routine misses.
+// TestLake_TelemetryLatency_ClassifyFetchErr pins that shutdown is decided by the
+// context, not by the error's shape.
+//
+// The regression this guards: an http.Client timeout also satisfies
+// errors.Is(err, context.DeadlineExceeded), so classifying on the error read a slow
+// endpoint as shutdown and returned from the worker goroutine — before the append of
+// everything already collected for that circuit. A timeout therefore discarded earlier
+// epochs' samples silently, with the refresh still reporting a clean cycle.
 func TestLake_TelemetryLatency_ClassifyFetchErr(t *testing.T) {
 	t.Parallel()
 
+	// The exact error an http.Client timeout produces. Constructed rather than
+	// hand-written so it keeps matching whatever net/http actually returns.
+	clientTimeout := func() error {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(500 * time.Millisecond)
+		}))
+		defer srv.Close()
+		_, err := (&http.Client{Timeout: 20 * time.Millisecond}).Get(srv.URL)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.DeadlineExceeded),
+			"precondition: a Client.Timeout abort must look like context.DeadlineExceeded, "+
+				"otherwise this test is not exercising the bug")
+		return err
+	}()
+
+	live := context.Background()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	tests := []struct {
 		name string
+		ctx  context.Context
 		err  error
 		want fetchOutcome
 	}{
-		{"context canceled", context.Canceled, fetchAbort},
-		{"deadline exceeded", context.DeadlineExceeded, fetchAbort},
-		{"wrapped cancel", fmt.Errorf("fetch tail: %w", context.Canceled), fetchAbort},
+		// The regression: live context, timeout-shaped error => a real failure to count,
+		// not a shutdown to swallow.
+		{"client timeout on a live context", live, clientTimeout, fetchUnclassified},
+		{"bare deadline exceeded on a live context", live, context.DeadlineExceeded, fetchUnclassified},
 
-		{"no telemetry account", telemetry.ErrAccountNotFound, fetchExpectedMiss},
-		{"wrapped no account", fmt.Errorf("epoch 42: %w", telemetry.ErrAccountNotFound), fetchExpectedMiss},
+		// Genuine shutdown, whatever the error looks like.
+		{"cancelled context", cancelled, errors.New("read tcp: connection reset by peer"), fetchAbort},
+		{"cancelled context with timeout error", cancelled, clientTimeout, fetchAbort},
+		{"cancelled context with no account", cancelled, telemetry.ErrAccountNotFound, fetchAbort},
 
-		// Everything else must be counted — these are the cases that used to vanish.
-		{"rpc throttle", errors.New("Too many requests for a specific RPC call"), fetchUnclassified},
-		{"service unavailable", errors.New("Service unavailable, please try again later."), fetchUnclassified},
-		{"connection reset", errors.New("read tcp 10.0.0.1:8899: connection reset by peer"), fetchUnclassified},
-		{"decode failure", errors.New("failed to deserialize account data"), fetchUnclassified},
+		// Expected miss: no telemetry account for this circuit/epoch. Routine, uncounted.
+		{"no telemetry account", live, telemetry.ErrAccountNotFound, fetchExpectedMiss},
+		{"wrapped no account", live, fmt.Errorf("epoch 42: %w", telemetry.ErrAccountNotFound), fetchExpectedMiss},
+
+		// Everything else is counted.
+		{"rpc throttle", live, errors.New("Too many requests for a specific RPC call"), fetchUnclassified},
+		{"connection reset", live, errors.New("read tcp 10.0.0.1:8899: connection reset by peer"), fetchUnclassified},
+		{"decode failure", live, errors.New("failed to deserialize account data"), fetchUnclassified},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, classifyFetchErr(tt.err))
+			if got := classifyFetchErr(tt.ctx, tt.err); got != tt.want {
+				t.Errorf("classifyFetchErr() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -55,19 +55,26 @@ var (
 	)
 
 	// TelemetryFetchSkipped counts telemetry sample fetches the latency indexer
-	// dropped on an unclassified RPC error. The drop itself is safe — each circuit
-	// resumes from its own stored max sample index, so the next refresh re-fetches
-	// what this one missed — but nothing else records it: the activity still reports
-	// success, so without this counter a circuit (or a throttled subset) can
-	// under-collect indefinitely with no signal at all. Expected conditions
-	// (no telemetry account for a circuit/epoch, worker shutdown) are not counted.
-	// A sustained non-zero rate means a subset of circuits is not being collected.
+	// dropped on an unclassified RPC error, by env and source.
+	//
+	// A skip is recoverable only while its epoch stays in the fetch window, which is
+	// the current epoch and the one before it. Past that, roughly two days, nothing
+	// re-fetches it and only the admin backfill can recover the samples. So a rising
+	// rate is time-limited, not merely cosmetic.
+	//
+	// Nothing else records these skips: the refresh still reports success, so without
+	// this counter a circuit that keeps failing under-collects with no signal. See
+	// classifyFetchErr in indexer/pkg/dz/telemetry/latency for what counts as a skip.
+	//
+	// dz_env is required because one indexer process serves mainnet, devnet and testnet
+	// together. Without it a devnet blip and a real mainnet under-collect are the same
+	// series, and an operator who mutes the first also mutes the second.
 	TelemetryFetchSkipped = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "doublezero_data_indexer_telemetry_fetch_skipped_total",
-			Help: "Telemetry sample fetches skipped on an unclassified RPC error, by source",
+			Help: "Telemetry sample fetches skipped on an unclassified RPC error, by env and source.",
 		},
-		[]string{"source"},
+		[]string{"dz_env", "source"},
 	)
 
 	ViewRefreshDuration = promauto.NewHistogramVec(

--- a/indexer/pkg/metrics/metrics.go
+++ b/indexer/pkg/metrics/metrics.go
@@ -54,6 +54,22 @@ var (
 		},
 	)
 
+	// TelemetryFetchSkipped counts telemetry sample fetches the latency indexer
+	// dropped on an unclassified RPC error. The drop itself is safe — each circuit
+	// resumes from its own stored max sample index, so the next refresh re-fetches
+	// what this one missed — but nothing else records it: the activity still reports
+	// success, so without this counter a circuit (or a throttled subset) can
+	// under-collect indefinitely with no signal at all. Expected conditions
+	// (no telemetry account for a circuit/epoch, worker shutdown) are not counted.
+	// A sustained non-zero rate means a subset of circuits is not being collected.
+	TelemetryFetchSkipped = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_data_indexer_telemetry_fetch_skipped_total",
+			Help: "Telemetry sample fetches skipped on an unclassified RPC error, by source",
+		},
+		[]string{"source"},
+	)
+
 	ViewRefreshDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "doublezero_data_indexer_view_refresh_duration_seconds",


### PR DESCRIPTION
## Summary

- Every per-circuit RPC error in the device-link and internet-metro fan-outs hit a bare `continue` — no log, no metric, no counter. The circuit was dropped and the activity reported success.
- Dropping is genuinely **safe** here: each circuit resumes from its own stored max sample index, so the next refresh re-fetches what this one missed. This is not data loss. It is a pure observability hole — a circuit failing persistently, or a throttled subset, under-collects indefinitely with nothing anywhere to say so.
- Unclassified fetch errors now increment `doublezero_data_indexer_telemetry_fetch_skipped_total{source}` and log at WARN with the circuit and epoch.
- Expected conditions stay uncounted and unchanged: worker shutdown, and no telemetry account for a circuit/epoch (routine and very common — counting it would bury the signal).
- The three-way classification was written out identically at both call sites. It now lives in one `classifyFetchErr` so the two cannot drift apart.

WARN, not ERROR: a single skipped circuit self-heals next refresh and is not actionable on its own. The counter is what makes a *sustained* rate visible, which is the actionable condition.

## Why this is separate from the other audit PRs

The sibling PRs (#754 escrow events, #755 rollup backfill) fix real data loss — a resume point that advances past work that was never done. This path gets that part right; the only thing wrong is that nobody can see it happening. No data is at risk, so it ships last.

## Testing Verification

- `ClassifyFetchErr` table test covers all three outcomes including wrapped errors: cancel/deadline → abort, `ErrAccountNotFound` → expected miss, and the cases that used to vanish silently (RPC throttle, service-unavailable, connection reset, decode failure) → counted.
- The classification is what the test pins deliberately: an error class landing in the wrong bucket either hides a real outage (unclassified treated as expected) or floods the counter with routine misses. Both are silent failures of the fix itself.
- `go test -race` green on `dz/telemetry/...`.

## Found by

An audit of every batch path in the indexer for the invariant *item-failure handling must match how the resume point is derived*. This path satisfies the invariant; it just did so invisibly.