### PR TITLE
deps: bump doublezero SDK to get working RPC retry classification

### DIFF
--- a/admin/internal/admin/backfill_device_link_latency.go
+++ b/admin/internal/admin/backfill_device_link_latency.go
@@ -52,8 +52,16 @@ func BackfillDeviceLinkLatency(
 	}
 	defer chDB.Close()
 
-	// Create RPC clients
-	dzRPCClient := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// Resolved here rather than at first use: it sizes the connection pool below.
+	maxConcurrency := cfg.MaxConcurrency
+	if maxConcurrency <= 0 {
+		maxConcurrency = defaultBackfillMaxConcurrency
+	}
+
+	// Create RPC clients. Pool sized to the backfill fan-out: the SDK's per-request
+	// timeout includes time queued for a connection, so a smaller pool turns a slow
+	// backend into terminal timeouts rather than slow successes.
+	dzRPCClient := rpc.New(networkConfig.LedgerPublicRPCURL, rpc.Options{MaxConnsPerHost: maxConcurrency})
 	defer dzRPCClient.Close()
 
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
@@ -142,11 +150,6 @@ func BackfillDeviceLinkLatency(
 		fmt.Printf("No epochs available to backfill.\n")
 		fmt.Printf("To backfill specific epochs, use --start-epoch and --end-epoch flags.\n")
 		return nil
-	}
-
-	maxConcurrency := cfg.MaxConcurrency
-	if maxConcurrency <= 0 {
-		maxConcurrency = defaultBackfillMaxConcurrency
 	}
 
 	fmt.Printf("Backfill Device Link Latency\n")

--- a/admin/internal/admin/backfill_internet_metro_latency.go
+++ b/admin/internal/admin/backfill_internet_metro_latency.go
@@ -48,8 +48,16 @@ func BackfillInternetMetroLatency(
 	}
 	defer chDB.Close()
 
-	// Create RPC clients
-	dzRPCClient := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// Resolved here rather than at first use: it sizes the connection pool below.
+	maxConcurrency := cfg.MaxConcurrency
+	if maxConcurrency <= 0 {
+		maxConcurrency = defaultBackfillMaxConcurrency
+	}
+
+	// Create RPC clients. Pool sized to the backfill fan-out: the SDK's per-request
+	// timeout includes time queued for a connection, so a smaller pool turns a slow
+	// backend into terminal timeouts rather than slow successes.
+	dzRPCClient := rpc.New(networkConfig.LedgerPublicRPCURL, rpc.Options{MaxConnsPerHost: maxConcurrency})
 	defer dzRPCClient.Close()
 
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
@@ -138,11 +146,6 @@ func BackfillInternetMetroLatency(
 		fmt.Printf("No epochs available to backfill.\n")
 		fmt.Printf("To backfill specific epochs, use --start-epoch and --end-epoch flags.\n")
 		return nil
-	}
-
-	maxConcurrency := cfg.MaxConcurrency
-	if maxConcurrency <= 0 {
-		maxConcurrency = defaultBackfillMaxConcurrency
 	}
 
 	fmt.Printf("Backfill Internet Metro Latency\n")

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/lmittmann/tint v1.1.3
-	github.com/malbeclabs/doublezero v0.8.1-0.20260724204114-f7981ab6f7a3
+	github.com/malbeclabs/doublezero v0.8.1-0.20260728210138-d904a1969083
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/mr-tron/base58 v1.3.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/malbeclabs/doublezero v0.8.1-0.20260724204114-f7981ab6f7a3 h1:67hJvUmdRNtXcW2BbUCBrH6kANhOL6tlqsg3lYD1Akk=
 github.com/malbeclabs/doublezero v0.8.1-0.20260724204114-f7981ab6f7a3/go.mod h1:TIfH1zvFiSLdeSNVr6HM7LbwNfkZXlHSTiDWdNpxE80=
+github.com/malbeclabs/doublezero v0.8.1-0.20260728210138-d904a1969083 h1:iBYx+Czk20vq7065s5nIqBjuTxdoG5B6+H+/aTfwurw=
+github.com/malbeclabs/doublezero v0.8.1-0.20260728210138-d904a1969083/go.mod h1:TIfH1zvFiSLdeSNVr6HM7LbwNfkZXlHSTiDWdNpxE80=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -333,7 +333,17 @@ func run() error {
 		}()
 	}
 
-	dzRPCClient := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// The connection pool must match the fan-out that shares this client. The SDK's
+	// per-request timeout bounds total wall time, queue wait included, so a pool
+	// smaller than the fan-out turns one slow backend into terminal timeouts: 64
+	// goroutines through 9 connections is ~7 waves, making each request's wall time
+	// roughly 7x the server's service time, and a timed-out request is not retried
+	// (isRetryableJSONRPC rejects context errors before any other check).
+	//
+	// This does not increase exposure to the endpoint's rate limits, which are counted
+	// per method per source IP over a rolling window: the same requests land in the
+	// window either way, just less spread out.
+	dzRPCClient := rpc.New(networkConfig.LedgerPublicRPCURL, rpc.Options{MaxConnsPerHost: *maxConcurrencyFlag})
 	defer dzRPCClient.Close()
 	serviceabilityClient := serviceability.New(dzRPCClient, networkConfig.ServiceabilityProgramID)
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)
@@ -998,7 +1008,8 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	}
 	secondaryIngestionLog := ingestionlog.NewWriter(secondaryChConn, log)
 
-	dzRPCClient := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// Pool sized to this network's fan-out; see the primary path for why.
+	dzRPCClient := rpc.New(networkConfig.LedgerPublicRPCURL, rpc.Options{MaxConnsPerHost: cfg.maxConcurrency})
 	defer dzRPCClient.Close()
 	serviceabilityClient := serviceability.New(dzRPCClient, networkConfig.ServiceabilityProgramID)
 	telemetryClient := telemetry.New(log, dzRPCClient, nil, networkConfig.TelemetryProgramID)

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/malbeclabs/doublezero/tools/maxmind/pkg/metrodb"
 	"github.com/malbeclabs/doublezero/tools/solana/pkg/rpc"
 	"github.com/malbeclabs/lake/indexer/pkg/clickhouse"
+	"github.com/malbeclabs/lake/indexer/pkg/dz/serviceability/permissionevents"
 	dztelemusage "github.com/malbeclabs/lake/indexer/pkg/dz/telemetry/usage"
 	"github.com/malbeclabs/lake/indexer/pkg/dzingest"
 	"github.com/malbeclabs/lake/indexer/pkg/indexer"
@@ -353,7 +354,11 @@ func run() error {
 	// reads serviceability transaction history (getSignaturesForAddress + getTransaction).
 	// Retrying client so a transient RPC error on getTransaction doesn't drop a
 	// permission event from the audit trail (the refresh fails and retries instead).
-	permissionEventsRawRPC := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// Pool sized to this view's own peak, which is higher than it looks: concurrent
+	// account drains paginate signatures while decodeSem separately caps in-flight
+	// getTransaction, and the two overlap.
+	permissionEventsRawRPC := rpc.New(networkConfig.LedgerPublicRPCURL,
+		rpc.Options{MaxConnsPerHost: permissionevents.MaxConcurrentRPCRequests})
 
 	// Shreds subscription client (mainnet-beta and testnet only, not devnet).
 	// Mainnet uses Solana proper RPC; testnet uses the DZ ledger RPC.
@@ -1018,7 +1023,11 @@ func startSecondaryNetwork(ctx context.Context, log *slog.Logger, env string, cf
 	// Raw Solana RPC on the DZ ledger for the permission-events audit indexer.
 	// Retrying client so a transient RPC error on getTransaction doesn't drop a
 	// permission event from the audit trail (the refresh fails and retries instead).
-	permissionEventsRawRPC := rpc.NewWithRetries(networkConfig.LedgerPublicRPCURL, nil)
+	// Pool sized to this view's own peak, which is higher than it looks: concurrent
+	// account drains paginate signatures while decodeSem separately caps in-flight
+	// getTransaction, and the two overlap.
+	permissionEventsRawRPC := rpc.New(networkConfig.LedgerPublicRPCURL,
+		rpc.Options{MaxConnsPerHost: permissionevents.MaxConcurrentRPCRequests})
 
 	// Shreds subscription client (testnet only, not devnet).
 	var shredsClient *shreds.Client

--- a/indexer/cmd/indexer/rpcpool_test.go
+++ b/indexer/cmd/indexer/rpcpool_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/solana/pkg/rpc"
+)
+
+// TestLedgerClientPoolMatchesFanOut pins the relationship between the RPC connection
+// pool and the concurrency that shares the client.
+//
+// The SDK's per-request timeout bounds total wall time including time queued waiting
+// for a free connection, not just the server's service time. So a pool smaller than
+// the fan-out multiplies each request's wall time by the number of waves: with the
+// SDK's default pool of 9 and this repo's default concurrency of 64, a request's wall
+// time is roughly 7x service time. Under the SDK's old 5-minute default that was
+// invisible; at 10s a merely slow backend produces terminal timeouts — and a timed-out
+// request is not retried, because isRetryableJSONRPC rejects context errors before any
+// other check.
+//
+// The backend delay here is deliberately well inside the 10s budget on its own but far
+// outside it once multiplied by an unsized pool.
+func TestLedgerClientPoolMatchesFanOut(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fanOut       = defaultMaxConcurrency
+		serviceTime  = 150 * time.Millisecond
+		perReqBudget = 10 * time.Second // the SDK default this test is defending
+	)
+
+	var inFlight, peak int64
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		inFlight++
+		if inFlight > peak {
+			peak = inFlight
+		}
+		mu.Unlock()
+		time.Sleep(serviceTime)
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"jsonrpc":"2.0","result":"ok","id":1}`)
+	}))
+	defer srv.Close()
+
+	// The real constructor, configured the way main.go configures it.
+	client := rpc.New(srv.URL, rpc.Options{MaxConnsPerHost: fanOut})
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	errs := make(chan error, fanOut)
+	var wg sync.WaitGroup
+	start := time.Now()
+	for range fanOut {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := client.GetHealth(ctx)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	close(errs)
+
+	var timeouts, others int
+	for err := range errs {
+		switch {
+		case err == nil:
+		case errors.Is(err, context.DeadlineExceeded):
+			timeouts++
+		default:
+			others++
+		}
+	}
+
+	if timeouts != 0 {
+		t.Errorf("%d/%d requests timed out at %s service time — the pool is not sized for the fan-out",
+			timeouts, fanOut, serviceTime)
+	}
+	if others != 0 {
+		t.Errorf("%d/%d requests failed for a non-timeout reason", others, fanOut)
+	}
+	// The discriminating assertion. Timeouts alone do not distinguish a sized pool
+	// from an unsized one at a short service time — 64 requests through 9 connections
+	// is ~8 waves, which at 150ms still lands inside the 10s budget. What always
+	// differs is how many requests reach the server at once: a sized pool puts the
+	// whole fan-out in flight, an unsized one caps it at the pool size. Asserting that
+	// is fast and exact, where asserting timeouts needs a service time slow enough to
+	// blow the budget (>1.25s) and so a test that runs for over ten seconds.
+	if peak < int64(fanOut) {
+		t.Errorf("peak server concurrency %d < fan-out %d: requests queued behind the connection pool, "+
+			"so each one's wall time is a multiple of service time and counts against the same %s budget",
+			peak, fanOut, perReqBudget)
+	}
+	t.Logf("fanOut=%d serviceTime=%s elapsed=%s peakServerConcurrency=%d", fanOut, serviceTime, elapsed, peak)
+}

--- a/indexer/pkg/dz/serviceability/permissionevents/rpc.go
+++ b/indexer/pkg/dz/serviceability/permissionevents/rpc.go
@@ -18,3 +18,15 @@ type SolanaRPC interface {
 
 // Compile-time check that *rpc.Client satisfies SolanaRPC.
 var _ SolanaRPC = (*rpc.Client)(nil)
+
+// MaxConcurrentRPCRequests is the peak number of in-flight HTTP requests this view
+// makes, so a client serving it can size its connection pool to match. Time queued
+// waiting for a free connection counts against the client's per-request timeout, so a
+// pool below this turns a slow endpoint into terminal timeouts rather than slow
+// successes.
+//
+// Two independent limits add up. Up to maxConcurrentFetches accounts drain at once, and
+// each one paginates getSignaturesForAddress itself, ungated. Separately, decodeSem caps
+// in-flight getTransaction at maxConcurrentFetches across the whole view. Signature
+// pagination and transaction decoding therefore overlap.
+const MaxConcurrentRPCRequests = 2 * maxConcurrentFetches


### PR DESCRIPTION
## Summary

One-line `go.mod` bump, but it is the closest thing to a root-cause fix for the permission-events throttle incident. **On the SDK version we are running, an RPCPool 429 is not retryable at all** — every cycle got exactly one attempt and aborted.

Two independent reasons, both fixed upstream:

**1. Retry classification is dead code.** The pinned version tests retryability with interface assertions:

```go
type hasStatusCode interface{ StatusCode() int }
type hasCode interface{ Code() int }
```

`jsonrpc.RPCError` and `jsonrpc.HTTPError` expose `Code` as a **struct field, not a method**, so `errors.As` matches neither. The newer version reads the codes off the concrete types and says so explicitly:

> Both expose their code as a struct field, not a method, so an interface assertion on `StatusCode()`/`Code()` matches nothing in production — that was the bug that made every Go ledger reader give up after one attempt on RPCPool's 503s.

**2. The message fallback does not cover it either.** Pinned list includes `"rate limited"`; the actual error reads `"Too many requests for a specific RPC call"`. `"too many requests"` and `"service unavailable"` are both added in the newer version.

Which explains the shape of the incident precisely: runs failing in 8–14 seconds, nowhere near any budget, for 4.5 hours.

## Also in the bump

- **Jittered backoff** — `d/2 + rand.N(d/2+1)`, added so *"the ~60 doublezerod hosts and dozen services reading the same ledger endpoint do not retry in lockstep and re-spike an endpoint that is already shedding load."*
- **Per-request timeout 5m → 10s.** The pinned client uses `defaultTimeout = 5 * time.Minute` for the HTTP client, dial, and idle timeout alike, so one hung request can stall a drain goroutine for five minutes.
- **`doublezero_solana_rpc_retries_total{method}`** and **`_retries_exhausted_total{method}`**. Every other DoubleZero service already publishes these — `telemetry-state-ingest`, `controller`, `devices`, `doublezero_client`, `internet_latency_collector`, `monitor`, `device-health-oracle`. lake published neither, which is why a 4.5-hour sustained throttle produced no RPC-layer signal: two ERROR log lines and a staleness alert were the entire evidence base. Note that no `getTransaction` series exists from *any* service — lake is the only consumer of it, and the only one not reporting.
- Non-idempotent methods (`sendTransaction`, `requestAirdrop`) are now never retried regardless of options.

## Review surface

Narrower than a four-day version jump suggests. Of the nine SDK packages lake imports, **six are byte-identical**:

| package | changed |
|---|---|
| `config` | — |
| `controlplane/telemetry/pkg/config` | — |
| `sdk/geolocation/go` | — |
| `smartcontract/sdk/go/serviceability` | — |
| `smartcontract/sdk/go/telemetry` | — |
| `tools/maxmind/pkg/{geoip,metrodb}` | — |
| `tools/solana/pkg/jsonrpc` | retry.go, + metrics.go |
| `tools/solana/pkg/rpc` | retry.go |
| `sdk/shreds/go` | rpc.go, state.go |

`sdk/shreds/go` is the one worth a look beyond the RPC layer, since `rpc.go` and `state.go` both changed.

## Testing Verification

- Full `go test ./indexer/...` suite run against the bump. One failure, `TestHealthMulticastUserRate` in `dz/mroute` — confirmed **pre-existing** by running it on `main` without the bump and getting the identical ClickHouse error (`code: 27, Cannot parse input: expected '(' before: '-- grp-rate-gap: …'` — a `--` comment inside a `VALUES` list in `health_multicast_user_rate_test.go:42`). Unrelated to this change, but it means that package has no working local coverage right now.
- Builds clean across `indexer`, `api`, `utils`, `admin`. No source changes required — `go.mod` and `go.sum` only.

## Relationship to #753

#753 (graceful stop on throttle + request pacing) is still correct and still wanted, but its description overstates the deployed retry behavior — I have posted a correction there. The two are complementary: this PR makes a throttled request actually get retried, #753 makes a cycle bank its committed work when retries do run out, and #753's pacing keeps us from tripping the limit in the first place. **This one should land first**, or at least alongside.