### PR TITLE
api,web: customer route latency page

### DIFF
--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -1687,15 +1687,20 @@ func (a *API) GetMetroConnectivity(w http.ResponseWriter, r *http.Request) {
 
 // MetroPathLatency represents path-based latency between two metros
 type MetroPathLatency struct {
-	FromMetroPK       string   `json:"fromMetroPK"`
-	FromMetroCode     string   `json:"fromMetroCode"`
-	ToMetroPK         string   `json:"toMetroPK"`
-	ToMetroCode       string   `json:"toMetroCode"`
-	PathLatencyMs     float64  `json:"pathLatencyMs"`     // Sum of link metrics along path (in ms)
-	HopCount          int      `json:"hopCount"`          // Number of hops
-	BottleneckBwGbps  float64  `json:"bottleneckBwGbps"`  // Min bandwidth along path (Gbps)
-	InternetLatencyMs float64  `json:"internetLatencyMs"` // Internet latency for comparison (0 if not available)
-	ImprovementPct    *float64 `json:"improvementPct"`    // Improvement vs internet (nil if no internet data)
+	FromMetroPK        string   `json:"fromMetroPK"`
+	FromMetroCode      string   `json:"fromMetroCode"`
+	ToMetroPK          string   `json:"toMetroPK"`
+	ToMetroCode        string   `json:"toMetroCode"`
+	PathLatencyMs      float64  `json:"pathLatencyMs"`      // Contracted: sum of link metrics along path (ms)
+	MeasuredLatencyMs  float64  `json:"measuredLatencyMs"`  // Observed: sum of per-hop rollup RTT (ms)
+	MeasuredP95Ms      float64  `json:"measuredP95Ms"`      // Sum of per-hop p95 (conservative; percentiles are not additive)
+	MeasuredJitterMs   float64  `json:"measuredJitterMs"`   // Sum of per-hop avg jitter (ms)
+	PartiallyCommitted bool     `json:"partiallyCommitted"` // true when a hop lacked samples and measured fell back to contracted
+	PathMetros         []string `json:"pathMetros"`         // metros traversed, e.g. ["tyo","fra","lon"]
+	HopCount           int      `json:"hopCount"`
+	BottleneckBwGbps   float64  `json:"bottleneckBwGbps"`
+	InternetLatencyMs  float64  `json:"internetLatencyMs"`
+	ImprovementPct     *float64 `json:"improvementPct"` // vs internet, computed from measured latency
 }
 
 // MetroPathLatencyResponse is the response for the metro path latency endpoint
@@ -1737,7 +1742,7 @@ func (a *API) GetMetroPathLatency(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
-	response, err := a.FetchMetroPathLatencyData(ctx, optimize)
+	response, err := a.FetchMetroPathLatencyData(ctx, optimize, 0)
 	if err != nil {
 		logError("metro path latency error", "error", err)
 		writeJSON(w, MetroPathLatencyResponse{Optimize: optimize, Paths: []MetroPathLatency{}, Error: err.Error()})
@@ -1749,7 +1754,7 @@ func (a *API) GetMetroPathLatency(w http.ResponseWriter, r *http.Request) {
 
 // FetchMetroPathLatencyData fetches metro path latency data for the given optimization strategy.
 // Used by both the handler and the cache.
-func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string) (*MetroPathLatencyResponse, error) {
+func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string, window time.Duration) (*MetroPathLatencyResponse, error) {
 	start := time.Now()
 
 	g, err := a.loadTopologyGraph(ctx, "")
@@ -1765,31 +1770,52 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string) (*
 	// Compute best paths between all metro pairs using in-memory Dijkstra
 	metroPaths := computeMetroPairPaths(g)
 
+	measured, err := a.linkMeasuredMap(ctx, window)
+	if err != nil {
+		return nil, fmt.Errorf("loading measured link latency: %w", err)
+	}
+
 	// Build map of metro paths
 	pathMap := make(map[string]*MetroPathLatency)
 	for _, mp := range metroPaths {
+		mRtt, mP95, mJitter, partial := sumMeasuredAlongPath(mp.Path.Nodes, measured, mp.Path.TotalMetric)
+		metros := pathMetroCodes(mp.Path.Nodes, g)
 		path := &MetroPathLatency{
-			FromMetroPK:      mp.FromMetroPK,
-			FromMetroCode:    mp.FromMetroCode,
-			ToMetroPK:        mp.ToMetroPK,
-			ToMetroCode:      mp.ToMetroCode,
-			PathLatencyMs:    float64(mp.Path.TotalMetric) / 1000.0, // Convert microseconds to milliseconds
-			HopCount:         mp.HopCount,
-			BottleneckBwGbps: float64(mp.BottleneckBps) / 1e9, // Convert bps to Gbps
+			FromMetroPK:        mp.FromMetroPK,
+			FromMetroCode:      mp.FromMetroCode,
+			ToMetroPK:          mp.ToMetroPK,
+			ToMetroCode:        mp.ToMetroCode,
+			PathLatencyMs:      float64(mp.Path.TotalMetric) / 1000.0, // Convert microseconds to milliseconds
+			MeasuredLatencyMs:  mRtt,
+			MeasuredP95Ms:      mP95,
+			MeasuredJitterMs:   mJitter,
+			PartiallyCommitted: partial,
+			PathMetros:         metros,
+			HopCount:           mp.HopCount,
+			BottleneckBwGbps:   float64(mp.BottleneckBps) / 1e9, // Convert bps to Gbps
 		}
 
 		// Store in map for both directions
 		key1 := mp.FromMetroCode + ":" + mp.ToMetroCode
 		key2 := mp.ToMetroCode + ":" + mp.FromMetroCode
 		pathMap[key1] = path
+		reversed := make([]string, len(metros))
+		for i, c := range metros {
+			reversed[len(metros)-1-i] = c
+		}
 		pathMap[key2] = &MetroPathLatency{
-			FromMetroPK:      mp.ToMetroPK,
-			FromMetroCode:    mp.ToMetroCode,
-			ToMetroPK:        mp.FromMetroPK,
-			ToMetroCode:      mp.FromMetroCode,
-			PathLatencyMs:    path.PathLatencyMs,
-			HopCount:         path.HopCount,
-			BottleneckBwGbps: path.BottleneckBwGbps,
+			FromMetroPK:        mp.ToMetroPK,
+			FromMetroCode:      mp.ToMetroCode,
+			ToMetroPK:          mp.FromMetroPK,
+			ToMetroCode:        mp.FromMetroCode,
+			PathLatencyMs:      path.PathLatencyMs,
+			MeasuredLatencyMs:  path.MeasuredLatencyMs,
+			MeasuredP95Ms:      path.MeasuredP95Ms,
+			MeasuredJitterMs:   path.MeasuredJitterMs,
+			PartiallyCommitted: path.PartiallyCommitted,
+			PathMetros:         reversed,
+			HopCount:           path.HopCount,
+			BottleneckBwGbps:   path.BottleneckBwGbps,
 		}
 	}
 
@@ -1824,15 +1850,23 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string) (*
 			key2 := metro2 + ":" + metro1
 			if p, ok := pathMap[key1]; ok {
 				p.InternetLatencyMs = avgRttMs
-				if avgRttMs > 0 && p.PathLatencyMs > 0 {
-					pct := (avgRttMs - p.PathLatencyMs) / avgRttMs * 100
+				basis := p.MeasuredLatencyMs
+				if basis <= 0 {
+					basis = p.PathLatencyMs
+				}
+				if avgRttMs > 0 && basis > 0 {
+					pct := (avgRttMs - basis) / avgRttMs * 100
 					p.ImprovementPct = &pct
 				}
 			}
 			if p, ok := pathMap[key2]; ok {
 				p.InternetLatencyMs = avgRttMs
-				if avgRttMs > 0 && p.PathLatencyMs > 0 {
-					pct := (avgRttMs - p.PathLatencyMs) / avgRttMs * 100
+				basis := p.MeasuredLatencyMs
+				if basis <= 0 {
+					basis = p.PathLatencyMs
+				}
+				if avgRttMs > 0 && basis > 0 {
+					pct := (avgRttMs - basis) / avgRttMs * 100
 					p.ImprovementPct = &pct
 				}
 			}
@@ -3226,4 +3260,47 @@ func pathMetroCodes(nodes []string, g *kspGraph) []string {
 		out = append(out, info.MetroCode)
 	}
 	return out
+}
+
+// linkMeasuredMap returns observed per-link latency keyed by "devicePK:devicePK"
+// in both directions, over the given window (0 defaults to 24h).
+func (a *API) linkMeasuredMap(ctx context.Context, window time.Duration) (map[string]linkMeasured, error) {
+	if window <= 0 {
+		window = 24 * time.Hour
+	}
+	query := `
+		SELECT
+			l.side_a_pk,
+			l.side_z_pk,
+			round(sum(r.a_avg_rtt_us * r.a_samples + r.z_avg_rtt_us * r.z_samples) / greatest(sum(r.a_samples + r.z_samples), 1) / 1000.0, 3) AS avg_rtt_ms,
+			round(sum(r.a_p95_rtt_us * r.a_samples + r.z_p95_rtt_us * r.z_samples) / greatest(sum(r.a_samples + r.z_samples), 1) / 1000.0, 3) AS p95_rtt_ms,
+			round(sum(r.a_avg_jitter_us * r.a_samples + r.z_avg_jitter_us * r.z_samples) / greatest(sum(r.a_samples + r.z_samples), 1) / 1000.0, 3) AS avg_jitter_ms,
+			sum(r.a_samples + r.z_samples) AS sample_count
+		FROM dz_links_current l
+		JOIN link_rollup_5m r FINAL ON l.pk = r.link_pk
+		WHERE r.bucket_ts >= now() - toIntervalSecond($1)
+		  AND l.side_a_pk != ''
+		  AND l.side_z_pk != ''
+		GROUP BY l.side_a_pk, l.side_z_pk
+	`
+	rows, err := a.envDB(ctx).Query(ctx, query, int64(window.Seconds()))
+	if err != nil {
+		return nil, fmt.Errorf("linkMeasuredMap query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]linkMeasured)
+	for rows.Next() {
+		var sideA, sideZ string
+		var d linkMeasured
+		if err := rows.Scan(&sideA, &sideZ, &d.AvgRttMs, &d.P95RttMs, &d.AvgJitterMs, &d.SampleCount); err != nil {
+			return nil, fmt.Errorf("linkMeasuredMap scan: %w", err)
+		}
+		out[sideA+":"+sideZ] = d
+		out[sideZ+":"+sideA] = d
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("linkMeasuredMap rows: %w", err)
+	}
+	return out, nil
 }

--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -3176,3 +3176,54 @@ func (a *API) GetMetroDevicePaths(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, response)
 }
+
+// linkMeasured holds observed latency for one link over the query window.
+type linkMeasured struct {
+	AvgRttMs    float64
+	P95RttMs    float64
+	AvgJitterMs float64
+	SampleCount uint64
+}
+
+// sumMeasuredAlongPath accumulates observed per-hop latency across the device
+// sequence Dijkstra selected. Returns partial=true when any hop lacks rollup
+// samples, in which case every returned value falls back to the contracted
+// figure for the whole path — a partial sum would understate the route, which
+// is the dangerous direction for a customer-facing number.
+//
+// p95 is a sum of per-hop p95s, which overestimates the true end-to-end p95
+// (percentiles are not additive). That bias is conservative for DoubleZero, so
+// it is the safe approximation to publish.
+func sumMeasuredAlongPath(nodes []string, m map[string]linkMeasured, committedUs uint32) (rtt, p95, jitter float64, partial bool) {
+	if len(nodes) < 2 {
+		return float64(committedUs) / 1000.0, 0, 0, true
+	}
+	for i := 1; i < len(nodes); i++ {
+		data, ok := m[nodes[i-1]+":"+nodes[i]]
+		if !ok || data.SampleCount == 0 {
+			return float64(committedUs) / 1000.0, 0, 0, true
+		}
+		rtt += data.AvgRttMs
+		p95 += data.P95RttMs
+		jitter += data.AvgJitterMs
+	}
+	return rtt, p95, jitter, false
+}
+
+// pathMetroCodes reduces a device path to the metros it traverses, collapsing
+// consecutive devices in the same metro. This is what the UI renders as
+// "tyo — fra — lon" so a reader can audit the composed figure.
+func pathMetroCodes(nodes []string, g *kspGraph) []string {
+	out := make([]string, 0, len(nodes))
+	for _, pk := range nodes {
+		info, ok := g.Nodes[pk]
+		if !ok || info.MetroCode == "" {
+			continue
+		}
+		if len(out) > 0 && out[len(out)-1] == info.MetroCode {
+			continue
+		}
+		out = append(out, info.MetroCode)
+	}
+	return out
+}

--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -1702,7 +1702,14 @@ type MetroPathLatency struct {
 	InternetLatencyMs  float64  `json:"internetLatencyMs"`
 	InternetP95Ms      float64  `json:"internetP95Ms"`    // 95th percentile of internet samples (ms)
 	InternetJitterMs   float64  `json:"internetJitterMs"` // mean |IPDV| of internet samples (ms)
-	ImprovementPct     *float64 `json:"improvementPct"`   // vs internet, computed from measured latency
+	ImprovementPct     *float64 `json:"improvementPct"`   // vs internet, from contracted PathLatencyMs
+	// MeasuredImprovementPct is the same comparison against MeasuredLatencyMs.
+	// It is a separate field rather than a change of basis on ImprovementPct
+	// because the internal path-latency page displays contracted figures beside
+	// that badge; measured and contracted differ by up to tens of milliseconds,
+	// so one basis cannot serve both pages without one of them showing a
+	// percentage that cannot be reproduced from any number next to it.
+	MeasuredImprovementPct *float64 `json:"measuredImprovementPct"`
 }
 
 // MetroPathLatencyResponse is the response for the metro path latency endpoint
@@ -1862,13 +1869,17 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string, wi
 				p.InternetLatencyMs = avgRttMs
 				p.InternetP95Ms = p95RttMs
 				p.InternetJitterMs = jitterMs
-				basis := p.MeasuredLatencyMs
-				if basis <= 0 {
-					basis = p.PathLatencyMs
-				}
-				if avgRttMs > 0 && basis > 0 {
-					pct := (avgRttMs - basis) / avgRttMs * 100
+				if avgRttMs > 0 && p.PathLatencyMs > 0 {
+					pct := (avgRttMs - p.PathLatencyMs) / avgRttMs * 100
 					p.ImprovementPct = &pct
+				}
+				measuredBasis := p.MeasuredLatencyMs
+				if measuredBasis <= 0 {
+					measuredBasis = p.PathLatencyMs
+				}
+				if avgRttMs > 0 && measuredBasis > 0 {
+					pct := (avgRttMs - measuredBasis) / avgRttMs * 100
+					p.MeasuredImprovementPct = &pct
 				}
 			}
 		}

--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -1827,7 +1827,7 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string, wi
 			least(ma.code, mz.code) AS metro1,
 			greatest(ma.code, mz.code) AS metro2,
 			round(avg(f.rtt_us) / 1000.0, 2) AS avg_rtt_ms,
-			round(quantile(0.95)(f.rtt_us) / 1000.0, 2) AS p95_rtt_ms,
+			round(quantileExact(0.95)(f.rtt_us) / 1000.0, 2) AS p95_rtt_ms,
 			-- ipdv_us is nullable; avg skips nulls and yields NULL over an
 			-- all-null group. Fold that to 0 here so the column stays Float64 and
 			-- an unmeasured pair reads as absent rather than failing the scan.

--- a/api/handlers/isis.go
+++ b/api/handlers/isis.go
@@ -1700,7 +1700,9 @@ type MetroPathLatency struct {
 	HopCount           int      `json:"hopCount"`
 	BottleneckBwGbps   float64  `json:"bottleneckBwGbps"`
 	InternetLatencyMs  float64  `json:"internetLatencyMs"`
-	ImprovementPct     *float64 `json:"improvementPct"` // vs internet, computed from measured latency
+	InternetP95Ms      float64  `json:"internetP95Ms"`    // 95th percentile of internet samples (ms)
+	InternetJitterMs   float64  `json:"internetJitterMs"` // mean |IPDV| of internet samples (ms)
+	ImprovementPct     *float64 `json:"improvementPct"`   // vs internet, computed from measured latency
 }
 
 // MetroPathLatencyResponse is the response for the metro path latency endpoint
@@ -1824,7 +1826,12 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string, wi
 		SELECT
 			least(ma.code, mz.code) AS metro1,
 			greatest(ma.code, mz.code) AS metro2,
-			round(avg(f.rtt_us) / 1000.0, 2) AS avg_rtt_ms
+			round(avg(f.rtt_us) / 1000.0, 2) AS avg_rtt_ms,
+			round(quantile(0.95)(f.rtt_us) / 1000.0, 2) AS p95_rtt_ms,
+			-- ipdv_us is nullable; avg skips nulls and yields NULL over an
+			-- all-null group. Fold that to 0 here so the column stays Float64 and
+			-- an unmeasured pair reads as absent rather than failing the scan.
+			round(ifNull(avg(abs(f.ipdv_us)), 0) / 1000.0, 3) AS jitter_ms
 		FROM fact_dz_internet_metro_latency f
 		JOIN dz_metros_current ma ON f.origin_metro_pk = ma.pk
 		JOIN dz_metros_current mz ON f.target_metro_pk = mz.pk
@@ -1841,26 +1848,20 @@ func (a *API) FetchMetroPathLatencyData(ctx context.Context, optimize string, wi
 		defer rows.Close()
 		for rows.Next() {
 			var metro1, metro2 string
-			var avgRttMs float64
-			if err := rows.Scan(&metro1, &metro2, &avgRttMs); err != nil {
+			var avgRttMs, p95RttMs, jitterMs float64
+			if err := rows.Scan(&metro1, &metro2, &avgRttMs, &p95RttMs, &jitterMs); err != nil {
 				return nil, fmt.Errorf("failed to scan internet latency row: %w", err)
 			}
-			// Update both directions in pathMap
-			key1 := metro1 + ":" + metro2
-			key2 := metro2 + ":" + metro1
-			if p, ok := pathMap[key1]; ok {
-				p.InternetLatencyMs = avgRttMs
-				basis := p.MeasuredLatencyMs
-				if basis <= 0 {
-					basis = p.PathLatencyMs
+			// The pair is stored under both orderings and the internet figures are
+			// direction-agnostic, so both entries get the same values.
+			for _, key := range [2]string{metro1 + ":" + metro2, metro2 + ":" + metro1} {
+				p, ok := pathMap[key]
+				if !ok {
+					continue
 				}
-				if avgRttMs > 0 && basis > 0 {
-					pct := (avgRttMs - basis) / avgRttMs * 100
-					p.ImprovementPct = &pct
-				}
-			}
-			if p, ok := pathMap[key2]; ok {
 				p.InternetLatencyMs = avgRttMs
+				p.InternetP95Ms = p95RttMs
+				p.InternetJitterMs = jitterMs
 				basis := p.MeasuredLatencyMs
 				if basis <= 0 {
 					basis = p.PathLatencyMs

--- a/api/handlers/isis_ksp.go
+++ b/api/handlers/isis_ksp.go
@@ -493,6 +493,15 @@ func computeMetroPairPaths(g *kspGraph) []metroPairPath {
 	metroCodes := make([]string, 0, len(metroDevices))
 	for code := range metroDevices {
 		metroCodes = append(metroCodes, code)
+		// The device lists were built by ranging a Go map, so their order is
+		// random per call. Equal-cost paths are common (many links share a
+		// committed RTT), and the tie-break below keeps whichever candidate it
+		// saw first — so without this sort the chosen ECMP arm varies per call.
+		// That used to be harmless because tied paths have identical metrics,
+		// but the measured figures and the sparkline are derived from the
+		// specific device sequence, and are computed by two independent calls
+		// to this function. Sorting makes both land on the same arm.
+		slices.Sort(metroDevices[code])
 	}
 	slices.Sort(metroCodes)
 

--- a/api/handlers/isis_measured_path_test.go
+++ b/api/handlers/isis_measured_path_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import "testing"
+
+func TestSumMeasuredAlongPath(t *testing.T) {
+	m := map[string]linkMeasured{
+		"a:b": {AvgRttMs: 8.57, P95RttMs: 8.9, AvgJitterMs: 0.02, SampleCount: 100},
+		"b:a": {AvgRttMs: 8.57, P95RttMs: 8.9, AvgJitterMs: 0.02, SampleCount: 100},
+		"b:c": {AvgRttMs: 64.24, P95RttMs: 65.1, AvgJitterMs: 0.05, SampleCount: 100},
+		"c:b": {AvgRttMs: 64.24, P95RttMs: 65.1, AvgJitterMs: 0.05, SampleCount: 100},
+	}
+
+	t.Run("sums every hop when all are measured", func(t *testing.T) {
+		rtt, p95, jitter, partial := sumMeasuredAlongPath([]string{"a", "b", "c"}, m, 99999)
+		if partial {
+			t.Fatalf("expected fully measured, got partial")
+		}
+		if diff := rtt - 72.81; diff > 0.001 || diff < -0.001 {
+			t.Errorf("rtt = %v, want 72.81", rtt)
+		}
+		if diff := p95 - 74.0; diff > 0.001 || diff < -0.001 {
+			t.Errorf("p95 = %v, want 74.0", p95)
+		}
+		if diff := jitter - 0.07; diff > 0.001 || diff < -0.001 {
+			t.Errorf("jitter = %v, want 0.07", jitter)
+		}
+	})
+
+	// A hop with no rollup samples must fall back to the contracted figure for the
+	// whole path and flag it, rather than silently reporting a short sum. MIA<->DFW
+	// is a live example: committed 27.61ms with zero measured samples.
+	t.Run("falls back to committed and flags when a hop is unmeasured", func(t *testing.T) {
+		rtt, _, _, partial := sumMeasuredAlongPath([]string{"a", "b", "zz"}, m, 27610)
+		if !partial {
+			t.Fatalf("expected partial=true when a hop has no samples")
+		}
+		if diff := rtt - 27.61; diff > 0.001 || diff < -0.001 {
+			t.Errorf("rtt = %v, want committed fallback 27.61", rtt)
+		}
+	})
+
+	t.Run("single-node path is not measurable", func(t *testing.T) {
+		_, _, _, partial := sumMeasuredAlongPath([]string{"a"}, m, 1000)
+		if !partial {
+			t.Errorf("expected partial=true for a path with no hops")
+		}
+	})
+}
+
+func TestPathMetroCodes(t *testing.T) {
+	g := &kspGraph{Nodes: map[string]kspNodeInfo{
+		"d1": {MetroCode: "tyo"},
+		"d2": {MetroCode: "tyo"}, // second device in the same metro
+		"d3": {MetroCode: "fra"},
+		"d4": {MetroCode: "lon"},
+	}}
+
+	t.Run("collapses consecutive devices in the same metro", func(t *testing.T) {
+		got := pathMetroCodes([]string{"d1", "d2", "d3", "d4"}, g)
+		want := []string{"tyo", "fra", "lon"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("skips devices missing from the graph", func(t *testing.T) {
+		got := pathMetroCodes([]string{"d1", "zz", "d4"}, g)
+		if len(got) != 2 || got[0] != "tyo" || got[1] != "lon" {
+			t.Errorf("got %v, want [tyo lon]", got)
+		}
+	})
+}

--- a/api/handlers/route_series.go
+++ b/api/handlers/route_series.go
@@ -1,0 +1,222 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// maxRouteSeriesPairs bounds the sparkline query. The customer-facing page shows
+// a handful of routes; this keeps the uncached query cheap.
+const maxRouteSeriesPairs = 10
+
+// RouteSeriesPoint is one hourly bucket of the DZ-vs-internet comparison.
+type RouteSeriesPoint struct {
+	TS         time.Time `json:"ts"`
+	DZMs       float64   `json:"dzMs"`
+	InternetMs float64   `json:"internetMs"`
+}
+
+// RouteSeries is the 7-day history for one metro pair.
+type RouteSeries struct {
+	FromMetroCode string             `json:"fromMetroCode"`
+	ToMetroCode   string             `json:"toMetroCode"`
+	Points        []RouteSeriesPoint `json:"points"`
+}
+
+// RouteSeriesResponse is the response for the route series endpoint.
+type RouteSeriesResponse struct {
+	Series []RouteSeries `json:"series"`
+	Error  string        `json:"error,omitempty"`
+}
+
+// parseRoutePairs turns "tyo-lon,fra-lon" into normalized metro-code pairs,
+// ordered lexicographically to match the least/greatest convention used by the
+// latency tables.
+func parseRoutePairs(raw string) ([][2]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("pairs is required")
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) > maxRouteSeriesPairs {
+		return nil, fmt.Errorf("at most %d pairs allowed, got %d", maxRouteSeriesPairs, len(parts))
+	}
+	out := make([][2]string, 0, len(parts))
+	for _, p := range parts {
+		ab := strings.Split(strings.ToLower(strings.TrimSpace(p)), "-")
+		if len(ab) != 2 || ab[0] == "" || ab[1] == "" {
+			return nil, fmt.Errorf("malformed pair %q, want <metro>-<metro>", p)
+		}
+		if ab[0] == ab[1] {
+			return nil, fmt.Errorf("pair %q has identical metros", p)
+		}
+		if ab[0] > ab[1] {
+			ab[0], ab[1] = ab[1], ab[0]
+		}
+		out = append(out, [2]string{ab[0], ab[1]})
+	}
+	return out, nil
+}
+
+// GetRouteSeries returns 7 days of hourly DZ-vs-internet latency for the
+// requested metro pairs. Not page-cached: it serves a small, user-chosen set.
+func (a *API) GetRouteSeries(w http.ResponseWriter, r *http.Request) {
+	pairs, err := parseRoutePairs(r.URL.Query().Get("pairs"))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, RouteSeriesResponse{Series: []RouteSeries{}, Error: err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	resp, err := a.FetchRouteSeries(ctx, pairs)
+	if err != nil {
+		logError("route series error", "error", err)
+		writeJSON(w, RouteSeriesResponse{Series: []RouteSeries{}, Error: err.Error()})
+		return
+	}
+	writeJSON(w, resp)
+}
+
+// FetchRouteSeries builds the hourly series for each requested pair. The DZ side
+// sums per-hop rollup RTT per bucket along the path Dijkstra selected; the
+// internet side comes straight from fact_dz_internet_metro_latency.
+func (a *API) FetchRouteSeries(ctx context.Context, pairs [][2]string) (*RouteSeriesResponse, error) {
+	g, err := a.loadTopologyGraph(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("loading topology graph: %w", err)
+	}
+
+	// Map each requested pair to the device sequence of its best path.
+	pathByPair := make(map[string][]string)
+	for _, mp := range computeMetroPairPaths(g) {
+		a1, b1 := mp.FromMetroCode, mp.ToMetroCode
+		if a1 > b1 {
+			a1, b1 = b1, a1
+		}
+		pathByPair[a1+"-"+b1] = mp.Path.Nodes
+	}
+
+	// Hourly measured RTT per link.
+	linkQuery := `
+		SELECT
+			toStartOfHour(r.bucket_ts) AS ts,
+			l.side_a_pk,
+			l.side_z_pk,
+			sum(r.a_avg_rtt_us * r.a_samples + r.z_avg_rtt_us * r.z_samples) / greatest(sum(r.a_samples + r.z_samples), 1) / 1000.0 AS rtt_ms
+		FROM dz_links_current l
+		JOIN link_rollup_5m r FINAL ON l.pk = r.link_pk
+		WHERE r.bucket_ts >= now() - INTERVAL 7 DAY
+		  AND l.side_a_pk != '' AND l.side_z_pk != ''
+		GROUP BY ts, l.side_a_pk, l.side_z_pk
+	`
+	linkRows, err := a.envDB(ctx).Query(ctx, linkQuery)
+	if err != nil {
+		return nil, fmt.Errorf("route series link query: %w", err)
+	}
+	defer linkRows.Close()
+
+	// hourly[ts]["devA:devB"] = rtt
+	hourly := make(map[time.Time]map[string]float64)
+	for linkRows.Next() {
+		var ts time.Time
+		var sideA, sideZ string
+		var rtt float64
+		if err := linkRows.Scan(&ts, &sideA, &sideZ, &rtt); err != nil {
+			return nil, fmt.Errorf("route series link scan: %w", err)
+		}
+		ts = ts.UTC()
+		if hourly[ts] == nil {
+			hourly[ts] = make(map[string]float64)
+		}
+		hourly[ts][sideA+":"+sideZ] = rtt
+		hourly[ts][sideZ+":"+sideA] = rtt
+	}
+	if err := linkRows.Err(); err != nil {
+		return nil, fmt.Errorf("route series link rows: %w", err)
+	}
+
+	// Hourly internet RTT per metro pair.
+	inetQuery := `
+		SELECT
+			toStartOfHour(f.event_ts) AS ts,
+			least(ma.code, mz.code) AS m1,
+			greatest(ma.code, mz.code) AS m2,
+			avg(f.rtt_us) / 1000.0 AS rtt_ms
+		FROM fact_dz_internet_metro_latency f
+		JOIN dz_metros_current ma ON f.origin_metro_pk = ma.pk
+		JOIN dz_metros_current mz ON f.target_metro_pk = mz.pk
+		WHERE f.event_ts >= now() - INTERVAL 7 DAY
+		  AND ma.code != mz.code
+		GROUP BY ts, m1, m2
+	`
+	inetRows, err := a.envDB(ctx).Query(ctx, inetQuery)
+	if err != nil {
+		return nil, fmt.Errorf("route series internet query: %w", err)
+	}
+	defer inetRows.Close()
+
+	// inet["m1-m2"][ts] = rtt
+	inet := make(map[string]map[time.Time]float64)
+	for inetRows.Next() {
+		var ts time.Time
+		var m1, m2 string
+		var rtt float64
+		if err := inetRows.Scan(&ts, &m1, &m2, &rtt); err != nil {
+			return nil, fmt.Errorf("route series internet scan: %w", err)
+		}
+		key := m1 + "-" + m2
+		if inet[key] == nil {
+			inet[key] = make(map[time.Time]float64)
+		}
+		inet[key][ts.UTC()] = rtt
+	}
+	if err := inetRows.Err(); err != nil {
+		return nil, fmt.Errorf("route series internet rows: %w", err)
+	}
+
+	// Emit one point per hour across the window, oldest first.
+	end := time.Now().UTC().Truncate(time.Hour)
+	resp := &RouteSeriesResponse{Series: make([]RouteSeries, 0, len(pairs))}
+	for _, pair := range pairs {
+		key := pair[0] + "-" + pair[1]
+		nodes := pathByPair[key]
+		series := RouteSeries{
+			FromMetroCode: pair[0],
+			ToMetroCode:   pair[1],
+			Points:        make([]RouteSeriesPoint, 0, 168),
+		}
+		for i := 167; i >= 0; i-- {
+			ts := end.Add(-time.Duration(i) * time.Hour)
+			pt := RouteSeriesPoint{TS: ts}
+			if links := hourly[ts]; links != nil && len(nodes) >= 2 {
+				var sum float64
+				complete := true
+				for h := 1; h < len(nodes); h++ {
+					v, ok := links[nodes[h-1]+":"+nodes[h]]
+					if !ok {
+						complete = false
+						break
+					}
+					sum += v
+				}
+				// A bucket missing any hop is left at zero rather than reported
+				// short — the frontend renders gaps as breaks in the line.
+				if complete {
+					pt.DZMs = sum
+				}
+			}
+			if m := inet[key]; m != nil {
+				pt.InternetMs = m[ts]
+			}
+			series.Points = append(series.Points, pt)
+		}
+		resp.Series = append(resp.Series, series)
+	}
+	return resp, nil
+}

--- a/api/handlers/route_series.go
+++ b/api/handlers/route_series.go
@@ -95,6 +95,10 @@ func (a *API) GetRouteSeries(w http.ResponseWriter, r *http.Request) {
 	resp, err := a.FetchRouteSeries(ctx, pairs)
 	if err != nil {
 		logError("route series error", "error", err)
+		// Must not be a 200: the client renders an empty series as "no history",
+		// so a backend failure returned with a success status reads to a customer
+		// as "DoubleZero has no measurements for this route".
+		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, RouteSeriesResponse{Series: []RouteSeries{}, Error: err.Error()})
 		return
 	}

--- a/api/handlers/route_series.go
+++ b/api/handlers/route_series.go
@@ -61,6 +61,24 @@ func parseRoutePairs(raw string) ([][2]string, error) {
 	return out, nil
 }
 
+// sumHopsAtBucket returns the summed RTT across every hop in nodes, and ok=false
+// when any hop is missing from links — callers must report zero rather than a
+// short sum, which would understate the route.
+func sumHopsAtBucket(nodes []string, links map[string]float64) (float64, bool) {
+	if len(nodes) < 2 {
+		return 0, false
+	}
+	var sum float64
+	for h := 1; h < len(nodes); h++ {
+		v, ok := links[nodes[h-1]+":"+nodes[h]]
+		if !ok {
+			return 0, false
+		}
+		sum += v
+	}
+	return sum, true
+}
+
 // GetRouteSeries returns 7 days of hourly DZ-vs-internet latency for the
 // requested metro pairs. Not page-cached: it serves a small, user-chosen set.
 func (a *API) GetRouteSeries(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +123,7 @@ func (a *API) FetchRouteSeries(ctx context.Context, pairs [][2]string) (*RouteSe
 	// Hourly measured RTT per link.
 	linkQuery := `
 		SELECT
-			toStartOfHour(r.bucket_ts) AS ts,
+			toStartOfHour(r.bucket_ts, 'UTC') AS ts,
 			l.side_a_pk,
 			l.side_z_pk,
 			sum(r.a_avg_rtt_us * r.a_samples + r.z_avg_rtt_us * r.z_samples) / greatest(sum(r.a_samples + r.z_samples), 1) / 1000.0 AS rtt_ms
@@ -144,7 +162,7 @@ func (a *API) FetchRouteSeries(ctx context.Context, pairs [][2]string) (*RouteSe
 	// Hourly internet RTT per metro pair.
 	inetQuery := `
 		SELECT
-			toStartOfHour(f.event_ts) AS ts,
+			toStartOfHour(f.event_ts, 'UTC') AS ts,
 			least(ma.code, mz.code) AS m1,
 			greatest(ma.code, mz.code) AS m2,
 			avg(f.rtt_us) / 1000.0 AS rtt_ms
@@ -194,20 +212,10 @@ func (a *API) FetchRouteSeries(ctx context.Context, pairs [][2]string) (*RouteSe
 		for i := 167; i >= 0; i-- {
 			ts := end.Add(-time.Duration(i) * time.Hour)
 			pt := RouteSeriesPoint{TS: ts}
-			if links := hourly[ts]; links != nil && len(nodes) >= 2 {
-				var sum float64
-				complete := true
-				for h := 1; h < len(nodes); h++ {
-					v, ok := links[nodes[h-1]+":"+nodes[h]]
-					if !ok {
-						complete = false
-						break
-					}
-					sum += v
-				}
+			if links := hourly[ts]; links != nil {
 				// A bucket missing any hop is left at zero rather than reported
 				// short — the frontend renders gaps as breaks in the line.
-				if complete {
+				if sum, ok := sumHopsAtBucket(nodes, links); ok {
 					pt.DZMs = sum
 				}
 			}

--- a/api/handlers/route_series_test.go
+++ b/api/handlers/route_series_test.go
@@ -45,3 +45,40 @@ func TestParseRoutePairs(t *testing.T) {
 		}
 	})
 }
+
+func TestSumHopsAtBucket(t *testing.T) {
+	t.Run("sums correctly when all hops are present", func(t *testing.T) {
+		nodes := []string{"a", "b", "c"}
+		links := map[string]float64{
+			"a:b": 1.5,
+			"b:c": 2.5,
+		}
+		sum, ok := sumHopsAtBucket(nodes, links)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if sum != 4.0 {
+			t.Errorf("sum = %v, want 4.0", sum)
+		}
+	})
+
+	t.Run("reports not-ok when a hop is missing", func(t *testing.T) {
+		nodes := []string{"a", "b", "c"}
+		links := map[string]float64{
+			"a:b": 1.5,
+			// "b:c" missing
+		}
+		if _, ok := sumHopsAtBucket(nodes, links); ok {
+			t.Error("expected ok=false for a missing hop")
+		}
+	})
+
+	t.Run("reports not-ok for a path with fewer than 2 nodes", func(t *testing.T) {
+		if _, ok := sumHopsAtBucket([]string{"a"}, map[string]float64{}); ok {
+			t.Error("expected ok=false for a path with fewer than 2 nodes")
+		}
+		if _, ok := sumHopsAtBucket(nil, map[string]float64{}); ok {
+			t.Error("expected ok=false for a nil path")
+		}
+	})
+}

--- a/api/handlers/route_series_test.go
+++ b/api/handlers/route_series_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import "testing"
+
+func TestParseRoutePairs(t *testing.T) {
+	t.Run("parses and normalizes direction", func(t *testing.T) {
+		got, err := parseRoutePairs("tyo-lon,FRA-lon")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d pairs, want 2", len(got))
+		}
+		// Normalized so metro codes are lexicographically ordered, matching the
+		// least/greatest convention the internet-latency tables use.
+		if got[0] != [2]string{"lon", "tyo"} {
+			t.Errorf("got[0] = %v, want [lon tyo]", got[0])
+		}
+		if got[1] != [2]string{"fra", "lon"} {
+			t.Errorf("got[1] = %v, want [fra lon]", got[1])
+		}
+	})
+
+	t.Run("rejects empty input", func(t *testing.T) {
+		if _, err := parseRoutePairs(""); err == nil {
+			t.Error("expected error for empty pairs")
+		}
+	})
+
+	t.Run("rejects a malformed pair", func(t *testing.T) {
+		if _, err := parseRoutePairs("tyolon"); err == nil {
+			t.Error("expected error for pair without a separator")
+		}
+	})
+
+	t.Run("rejects a self-pair", func(t *testing.T) {
+		if _, err := parseRoutePairs("lon-lon"); err == nil {
+			t.Error("expected error for identical metros")
+		}
+	})
+
+	t.Run("caps the pair count", func(t *testing.T) {
+		if _, err := parseRoutePairs("a-b,c-d,e-f,g-h,i-j,k-l,m-n,o-p,q-r,s-t,u-v"); err == nil {
+			t.Error("expected error for more than 10 pairs")
+		}
+	})
+}

--- a/api/main.go
+++ b/api/main.go
@@ -693,6 +693,7 @@ func main() {
 			r.Get("/api/topology/simulate-link-addition", api.GetSimulateLinkAddition)
 			r.Get("/api/topology/metro-connectivity", api.GetMetroConnectivity)
 			r.Get("/api/topology/metro-path-latency", api.GetMetroPathLatency)
+			r.Get("/api/topology/route-series", api.GetRouteSeries)
 			r.Get("/api/topology/metro-path-detail", api.GetMetroPathDetail)
 			r.Get("/api/topology/metro-paths", api.GetMetroPaths)
 			r.Get("/api/topology/metro-device-paths", api.GetMetroDevicePaths)

--- a/api/worker/workflow.go
+++ b/api/worker/workflow.go
@@ -311,7 +311,7 @@ func (a *Activities) RefreshCaches(ctx context.Context, cycle int) error {
 	for _, strategy := range metroPathLatencyStrategies {
 		g.Go(func() error {
 			a.refresh(gctx, "metro path latency:"+strategy, "metro_path_latency:"+strategy, func(ctx context.Context) (any, error) {
-				return a.API.FetchMetroPathLatencyData(ctx, strategy)
+				return a.API.FetchMetroPathLatencyData(ctx, strategy, 0)
 			}, shuttingDown, errBatchDeadline)
 			return nil
 		})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ import { RedundancyReportPage } from '@/components/redundancy-report-page'
 import { MetroConnectivityPage } from '@/components/metro-connectivity-page'
 import { DzVsInternetPage } from '@/components/dz-vs-internet-page'
 import { PathLatencyPage } from '@/components/path-latency-page'
+import { RoutesPage } from '@/components/routes-page'
 import { LinkLatencyPage } from '@/pages/link-latency-page'
 import { TrafficPage } from '@/pages/traffic-page'
 import { TrafficDashboardPage } from '@/pages/traffic-dashboard-page'
@@ -659,6 +660,7 @@ function AppContent() {
             <Route path="/performance/dz-vs-internet" element={<DzVsInternetPage />} />
             <Route path="/performance/link-latency" element={<LinkLatencyPage />} />
             <Route path="/performance/path-latency" element={<PathLatencyPage />} />
+            <Route path="/performance/routes" element={<RoutesPage />} />
 
             {/* Traffic routes */}
             <Route path="/traffic" element={<Navigate to="/traffic/overview" replace />} />

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_CELLS,
   MAX_CITIES,
   cellFor,
+  cellPairKey,
   formatCells,
   formatCities,
   isComparable,
@@ -420,10 +421,33 @@ describe('parseCells', () => {
     expect(requested).toBe(2)
   })
 
-  it('folds two cells that resolve to one pair through their anchors', () => {
-    // Ohio anchors at Chicago by default, so ohio-lon and chi-lon are one route.
-    const { cells } = parseCells('ohio-lon,lon-ohio', [...cities, { id: 'chi' }])
-    expect(cells).toEqual([{ from: 'ohio', to: 'lon' }])
+  // The anchor a location carries has to reach the pair key, or the grid cell
+  // reads pit-lon while the card under it reads chi-lon, under one heading. The
+  // default anchor cannot show this: it would still fold if the anchor were
+  // dropped entirely, so the assertion is on a non-default one.
+  it('threads each location’s own anchor into the pair a cell names', () => {
+    const cells: SelectedCity[] = [{ id: 'ohio', anchor: 'pit' }, { id: 'lon' }]
+    expect(cellPairKey({ from: 'ohio', to: 'lon' }, cells)).toBe('lon-pit')
+    expect(cellPairKey({ from: 'ohio', to: 'lon' }, [{ id: 'ohio' }, { id: 'lon' }])).toBe('chi-lon')
+    expect(parseCells('ohio-lon', cells).cells).toEqual([{ from: 'ohio', to: 'lon' }])
+  })
+
+  // An off-net location on-ramped at a metro that is also in the mesh is that
+  // metro: one route, one card, however the reader reaches it.
+  it('folds an off-net cell onto its on-ramp metro cell', () => {
+    const withChi: SelectedCity[] = [...cities, { id: 'chi' }]
+    expect(cellPairKey({ from: 'ohio', to: 'lon' }, withChi)).toBe('chi-lon')
+    expect(parseCells('ohio-lon,chi-lon', withChi).cells).toEqual([{ from: 'ohio', to: 'lon' }])
+  })
+
+  // The anchor belongs to the location, once, in ?cities=. Half-honouring it
+  // here would render CHI under a URL that says PIT.
+  it('refuses a cell token carrying an anchor rather than applying a different one', () => {
+    const withAnchor: SelectedCity[] = [{ id: 'ohio', anchor: 'chi' }, { id: 'lon' }]
+    const { cells, requested } = parseCells('ohio@pit-lon', withAnchor)
+    expect(cells).toEqual([])
+    // Counted, so the shortfall is stated rather than silently absent.
+    expect(requested).toBe(1)
   })
 
   it('drops a malformed token instead of coercing it', () => {

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { pairKeyOf, resolveRoute } from './routes-page'
+
+describe('resolveRoute', () => {
+  it('keys an on-net route lexicographically, whichever way round it was picked', () => {
+    expect(resolveRoute({ from: 'tyo', to: 'lon' }).pairKey).toBe('lon-tyo')
+    expect(resolveRoute({ from: 'lon', to: 'tyo' }).pairKey).toBe('lon-tyo')
+  })
+
+  // The property Task 6 verifies: both the DoubleZero and the public-internet
+  // figures are looked up with this single key, so switching the on-ramp moves
+  // both sides together and they cannot come from different anchors.
+  it('folds an off-net anchor into the pair key', () => {
+    expect(resolveRoute({ from: 'ohio', to: 'lon' }).pairKey).toBe('chi-lon')
+    expect(resolveRoute({ from: 'ohio', to: 'lon', fromAnchor: 'pit' }).pairKey).toBe('lon-pit')
+  })
+
+  it('reports Zurich as unavailable with its note and no key', () => {
+    const r = resolveRoute({ from: 'zurich', to: 'lon' })
+    expect(r.unavailable).toBe(true)
+    expect(r.pairKey).toBeNull()
+    expect(r.notes[0]).toContain('no presence in Zurich')
+  })
+
+  it('reports an anchor that collides with the other endpoint as unavailable', () => {
+    expect(resolveRoute({ from: 'ohio', to: 'chi' }).unavailable).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(pairKeyOf('TYO', 'lon')).toBe('lon-tyo')
+    expect(resolveRoute({ from: 'LON', to: 'lon' }).unavailable).toBe(true)
+  })
+})

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MAX_CELLS,
   MAX_CITIES,
   cellFor,
+  formatCells,
   formatCities,
+  isComparable,
+  isToggleGesture,
   meshPairs,
   orientPath,
   pairKeyOf,
+  parseCells,
   parseCities,
   resolveRoute,
   routeFigures,
   shadeFor,
   summariseMatrix,
+  toggleCell,
 } from './routes-page'
-import type { MatrixCell } from './routes-page'
+import type { MatrixCell, SelectedCity } from './routes-page'
 import type { MetroPathLatency } from '@/lib/api'
 
 /** A fully-measured route; individual tests override the fields they care about. */
@@ -390,5 +396,133 @@ describe('parseCities case folding', () => {
     expect(resolveRoute({ from: cities[2].id, to: 'lon', fromAnchor: cities[2].anchor }).pairKey).toBe(
       'lon-pit',
     )
+  })
+})
+
+describe('parseCells', () => {
+  const cities: SelectedCity[] = [{ id: 'lon' }, { id: 'tyo' }, { id: 'fra' }, { id: 'ohio' }]
+
+  it('round-trips a comparison set', () => {
+    const { cells, requested } = parseCells('lon-tyo,fra-ohio', cities)
+    expect(cells).toEqual([
+      { from: 'lon', to: 'tyo' },
+      { from: 'fra', to: 'ohio' },
+    ])
+    expect(requested).toBe(2)
+    expect(formatCells(cells)).toBe('lon-tyo,fra-ohio')
+  })
+
+  // The matrix is symmetric, so the mirrored cell is the same route. Two cards
+  // would report one pair's figures twice under two headings.
+  it('folds a mirrored cell onto the route it names, keeping the first orientation', () => {
+    const { cells, requested } = parseCells('lon-tyo,tyo-lon', cities)
+    expect(cells).toEqual([{ from: 'lon', to: 'tyo' }])
+    expect(requested).toBe(2)
+  })
+
+  it('folds two cells that resolve to one pair through their anchors', () => {
+    // Ohio anchors at Chicago by default, so ohio-lon and chi-lon are one route.
+    const { cells } = parseCells('ohio-lon,lon-ohio', [...cities, { id: 'chi' }])
+    expect(cells).toEqual([{ from: 'ohio', to: 'lon' }])
+  })
+
+  it('drops a malformed token instead of coercing it', () => {
+    const { cells, requested } = parseCells('lon-tyo,lon-tyo-fra,,fra-lon', cities)
+    expect(cells).toEqual([
+      { from: 'lon', to: 'tyo' },
+      { from: 'fra', to: 'lon' },
+    ])
+    expect(requested).toBe(3)
+  })
+
+  it('drops a cell naming a location outside the mesh', () => {
+    expect(parseCells('lon-sao,lon-tyo', cities).cells).toEqual([{ from: 'lon', to: 'tyo' }])
+  })
+
+  // Nothing to compare: Zurich has no committed coverage, and a cell whose ends
+  // resolve to one metro is not a route.
+  it('drops a cell with nothing to compare', () => {
+    const withZurich: SelectedCity[] = [...cities, { id: 'zurich' }, { id: 'chi' }]
+    expect(parseCells('lon-zurich', withZurich).cells).toEqual([])
+    expect(parseCells('ohio-chi', withZurich).cells).toEqual([])
+    expect(parseCells('lon-lon', withZurich).cells).toEqual([])
+  })
+
+  it('caps the set at the pairs one series request accepts, and says it asked for more', () => {
+    const many: SelectedCity[] = Array.from({ length: MAX_CELLS + 2 }, (_, i) => ({ id: `m${i}` }))
+    const raw = many.slice(1).map((c) => `m0-${c.id}`).join(',')
+    const { cells, requested } = parseCells(raw, many)
+    expect(cells).toHaveLength(MAX_CELLS)
+    expect(requested).toBe(MAX_CELLS + 1)
+    expect(requested).toBeGreaterThan(cells.length)
+  })
+
+  it('is empty for a missing param', () => {
+    expect(parseCells(null, cities)).toEqual({ cells: [], requested: 0 })
+  })
+})
+
+describe('toggleCell', () => {
+  const cities: SelectedCity[] = [{ id: 'lon' }, { id: 'tyo' }, { id: 'fra' }]
+
+  it('adds a cell that is not in the set', () => {
+    expect(toggleCell([], { from: 'lon', to: 'tyo' }, cities)).toEqual([{ from: 'lon', to: 'tyo' }])
+  })
+
+  it('removes the route when its mirror is toggled', () => {
+    const set = [{ from: 'lon', to: 'tyo' }]
+    expect(toggleCell(set, { from: 'tyo', to: 'lon' }, cities)).toEqual([])
+  })
+
+  it('keeps the orientation of the cells already in the set', () => {
+    const set = [{ from: 'lon', to: 'tyo' }]
+    expect(toggleCell(set, { from: 'fra', to: 'lon' }, cities)).toEqual([
+      { from: 'lon', to: 'tyo' },
+      { from: 'fra', to: 'lon' },
+    ])
+  })
+
+  it('refuses to grow past the cap', () => {
+    const many: SelectedCity[] = Array.from({ length: MAX_CELLS + 2 }, (_, i) => ({ id: `m${i}` }))
+    const full = many.slice(1, MAX_CELLS + 1).map((c) => ({ from: 'm0', to: c.id }))
+    expect(full).toHaveLength(MAX_CELLS)
+    const extra = { from: 'm0', to: `m${MAX_CELLS + 1}` }
+    expect(toggleCell(full, extra, many)).toBe(full)
+    // Still lets one already in the set out, which is how a user makes room.
+    expect(toggleCell(full, full[0], many)).toHaveLength(MAX_CELLS - 1)
+  })
+
+  it('ignores a cell with nothing to compare', () => {
+    const withZurich: SelectedCity[] = [...cities, { id: 'zurich' }]
+    const set = [{ from: 'lon', to: 'tyo' }]
+    expect(toggleCell(set, { from: 'lon', to: 'zurich' }, withZurich)).toBe(set)
+  })
+})
+
+describe('isComparable', () => {
+  it('opens a cell that carries figures', () => {
+    expect(isComparable({ kind: 'improvement', pct: 20, savedMs: 40 })).toBe(true)
+    expect(isComparable({ kind: 'withheld' })).toBe(true)
+  })
+
+  it('refuses a cell with nothing to compare, and one whose state is not known yet', () => {
+    expect(isComparable({ kind: 'unavailable', note: null })).toBe(false)
+    expect(isComparable({ kind: 'no-path' })).toBe(false)
+    expect(isComparable({ kind: 'not-measured' })).toBe(false)
+    expect(isComparable({ kind: 'loading' })).toBe(false)
+    expect(isComparable({ kind: 'error' })).toBe(false)
+    expect(isComparable({ kind: 'diagonal' })).toBe(false)
+  })
+})
+
+describe('isToggleGesture', () => {
+  // One gesture for all three: a matrix has no linear range for Shift to extend,
+  // so distinguishing them would only punish reaching for the wrong modifier.
+  it('treats meta, ctrl and shift alike, and a plain click as a plain click', () => {
+    const plain = { metaKey: false, ctrlKey: false, shiftKey: false }
+    expect(isToggleGesture(plain)).toBe(false)
+    expect(isToggleGesture({ ...plain, metaKey: true })).toBe(true)
+    expect(isToggleGesture({ ...plain, ctrlKey: true })).toBe(true)
+    expect(isToggleGesture({ ...plain, shiftKey: true })).toBe(true)
   })
 })

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -1,5 +1,66 @@
 import { describe, expect, it } from 'vitest'
-import { orientPath, pairKeyOf, resolveRoute } from './routes-page'
+import { orientPath, pairKeyOf, resolveRoute, routeFigures } from './routes-page'
+import type { MetroPathLatency } from '@/lib/api'
+
+/** A fully-measured route; individual tests override the fields they care about. */
+function latency(over: Partial<MetroPathLatency> = {}): MetroPathLatency {
+  return {
+    fromMetroPK: 'p1',
+    fromMetroCode: 'tyo',
+    toMetroPK: 'p2',
+    toMetroCode: 'lon',
+    pathLatencyMs: 200,
+    measuredLatencyMs: 210.5,
+    measuredP95Ms: 220.25,
+    measuredJitterMs: 0.029,
+    partiallyCommitted: false,
+    pathMetros: ['tyo', 'fra', 'lon'],
+    hopCount: 3,
+    bottleneckBwGbps: 100,
+    internetLatencyMs: 259.76,
+    internetP95Ms: 272.06,
+    internetJitterMs: 2.568,
+    improvementPct: 23,
+    measuredImprovementPct: 19,
+    ...over,
+  }
+}
+
+describe('routeFigures', () => {
+  it('shows every figure on a fully-measured route', () => {
+    const f = routeFigures(latency())
+    expect(f.tiles.map((t) => [t.label, t.value])).toEqual([
+      ['DoubleZero mean', '210.50 ms'],
+      ['DoubleZero p95', '220.25 ms'],
+      // 3 dp: 2 dp would flatten a typical sub-0.1 ms jitter to one significant figure.
+      ['DoubleZero jitter', '0.029 ms'],
+      ['Internet mean', '259.76 ms'],
+      ['Internet p95', '272.06 ms'],
+      ['Internet jitter', '2.568 ms'],
+    ])
+    expect(f.improvementPct).toBe(19)
+    expect(f.footnote).toBeNull()
+  })
+
+  // The mean is a commitment on these routes, so it must be labelled as one, and
+  // an improvement computed from it must not be shown at all.
+  it('marks the mean as contracted and withholds improvement when partiallyCommitted', () => {
+    const f = routeFigures(latency({ partiallyCommitted: true, measuredP95Ms: 0, measuredJitterMs: 0 }))
+    expect(f.tiles[0]).toEqual({ label: 'DoubleZero mean (contracted)', value: '210.50 ms' })
+    expect(f.tiles[1].value).toBeNull()
+    expect(f.tiles[2].value).toBeNull()
+    expect(f.improvementPct).toBeNull()
+    expect(f.footnote).toContain('withheld')
+  })
+
+  // The internet side carries no partiallyCommitted-style flag, so 0 is the only
+  // signal that a figure is absent. It must never print as "0.00 ms".
+  it('renders an unmeasured internet figure as absent, not as zero', () => {
+    const f = routeFigures(latency({ internetP95Ms: 0, internetJitterMs: 0 }))
+    expect(f.tiles[4].value).toBeNull()
+    expect(f.tiles[5].value).toBeNull()
+  })
+})
 
 describe('orientPath', () => {
   // The API emits both directions of a pair and builds its slice from a Go map,
@@ -43,6 +104,17 @@ describe('resolveRoute', () => {
 
   it('reports an anchor that collides with the other endpoint as unavailable', () => {
     expect(resolveRoute({ from: 'ohio', to: 'chi' }).unavailable).toBe(true)
+  })
+
+  // Reachable only by URL. The cancellation argument in the Ohio note is false
+  // here — the two access legs differ — so the route must be refused, not shown
+  // with the note printed twice.
+  it('refuses a route with the same off-net endpoint at both ends', () => {
+    const r = resolveRoute({ from: 'ohio', to: 'ohio', fromAnchor: 'pit', toAnchor: 'chi' })
+    expect(r.unavailable).toBe(true)
+    expect(r.pairKey).toBeNull()
+    expect(r.notes).toHaveLength(1)
+    expect(r.notes[0]).toContain('both ends')
   })
 
   it('is case-insensitive', () => {

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -9,6 +9,7 @@ import {
   parseCities,
   resolveRoute,
   routeFigures,
+  shadeFor,
   summariseMatrix,
 } from './routes-page'
 import type { MatrixCell } from './routes-page'
@@ -305,5 +306,89 @@ describe('summariseMatrix', () => {
     const s = summariseMatrix([{ label: 'DUB↔FRA', cell: improvement(-4, -2) }])
     expect(s.avgPct).toBe(-4)
     expect(s.best?.pct).toBe(-4)
+  })
+})
+
+describe('summariseMatrix pending and failed', () => {
+  // The cell-level rule, one layer up: a request that failed must not total to
+  // "0 pairs where DoubleZero has a path", which reads to a customer as
+  // DoubleZero carrying none of their routes.
+  it('counts a failed pair as failed, never as a pair without a path', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: { kind: 'error' } },
+      { label: 'DUB↔FRA', cell: { kind: 'error' } },
+    ])
+    expect(s.failed).toBe(2)
+    expect(s.pending).toBe(0)
+    expect(s.withPath).toBe(0)
+    expect(s.avgPct).toBeNull()
+    expect(s.best).toBeNull()
+  })
+
+  it('counts a pending pair as pending, and keeps it out of every total', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: { kind: 'loading' } },
+      { label: 'DUB↔FRA', cell: { kind: 'loading' } },
+    ])
+    expect(s.pending).toBe(2)
+    expect(s.failed).toBe(0)
+    expect(s.withPath).toBe(0)
+  })
+
+  // A part-loaded grid still has an unknown in it, so the caller has something
+  // to gate on even when some pairs did resolve.
+  it('reports the unknowns alongside the pairs that did resolve', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: { kind: 'improvement', pct: 20, savedMs: 40 } },
+      { label: 'DUB↔FRA', cell: { kind: 'error' } },
+      { label: 'DUB↔LON', cell: { kind: 'loading' } },
+    ])
+    expect(s.pairs).toBe(3)
+    expect(s.withPath).toBe(1)
+    expect(s.failed).toBe(1)
+    expect(s.pending).toBe(1)
+  })
+
+  it('reports no unknowns on a fully resolved grid', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: { kind: 'improvement', pct: 20, savedMs: 40 } },
+      { label: 'DUB↔ZRH', cell: { kind: 'unavailable', note: null } },
+    ])
+    expect(s.pending).toBe(0)
+    expect(s.failed).toBe(0)
+  })
+})
+
+describe('shadeFor', () => {
+  // A route DoubleZero makes slower must never be shaded as a win.
+  it('shades a slower or level route away from the green ramp', () => {
+    expect(shadeFor(-0.1)).toContain('red')
+    expect(shadeFor(0)).toContain('red')
+    expect(shadeFor(0.1)).toContain('emerald')
+  })
+
+  it('deepens with the improvement and never lightens', () => {
+    const weights = [0.1, 9.9, 10, 19.9, 20, 29.9, 30, 39.9, 40, 100].map((pct) =>
+      Number(shadeFor(pct).split('/')[1]),
+    )
+    for (let i = 1; i < weights.length; i++) {
+      expect(weights[i]).toBeGreaterThanOrEqual(weights[i - 1])
+    }
+    expect(weights[weights.length - 1]).toBeGreaterThan(weights[0])
+  })
+})
+
+describe('parseCities case folding', () => {
+  // An inbox or a hand edit that uppercases a shared link must not turn an
+  // off-net location into an unknown metro code, whose row would then read
+  // "no path" — asserting DoubleZero cannot reach a place it has only ever said
+  // it does not serve.
+  it('folds an uppercased token back onto its off-net endpoint', () => {
+    const { cities } = parseCities('LON,ZURICH,Ohio@PIT')
+    expect(cities).toEqual([{ id: 'lon' }, { id: 'zurich' }, { id: 'ohio', anchor: 'pit' }])
+    expect(resolveRoute({ from: cities[1].id, to: 'lon' }).notes[0]).toContain('Zurich')
+    expect(resolveRoute({ from: cities[2].id, to: 'lon', fromAnchor: cities[2].anchor }).pairKey).toBe(
+      'lon-pit',
+    )
   })
 })

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { pairKeyOf, resolveRoute } from './routes-page'
+import { orientPath, pairKeyOf, resolveRoute } from './routes-page'
+
+describe('orientPath', () => {
+  // The API emits both directions of a pair and builds its slice from a Go map,
+  // so an undirected lookup returns either one at random. The displayed path must
+  // still read from the origin the customer picked, on every load.
+  it('keeps a path that already starts at the route origin', () => {
+    expect(orientPath(['tyo', 'fra', 'lon'], 'tyo', 'tyo')).toEqual(['tyo', 'fra', 'lon'])
+  })
+
+  it('reverses a path that arrived the other way round', () => {
+    expect(orientPath(['lon', 'fra', 'tyo'], 'lon', 'tyo')).toEqual(['tyo', 'fra', 'lon'])
+  })
+
+  it('compares case-insensitively and does not mutate the input', () => {
+    const path = ['TYO', 'fra', 'lon']
+    expect(orientPath(path, 'TYO', 'tyo')).toEqual(['TYO', 'fra', 'lon'])
+    expect(path).toEqual(['TYO', 'fra', 'lon'])
+  })
+})
 
 describe('resolveRoute', () => {
   it('keys an on-net route lexicographically, whichever way round it was picked', () => {

--- a/web/src/components/routes-page.test.ts
+++ b/web/src/components/routes-page.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { orientPath, pairKeyOf, resolveRoute, routeFigures } from './routes-page'
+import {
+  MAX_CITIES,
+  cellFor,
+  formatCities,
+  meshPairs,
+  orientPath,
+  pairKeyOf,
+  parseCities,
+  resolveRoute,
+  routeFigures,
+  summariseMatrix,
+} from './routes-page'
+import type { MatrixCell } from './routes-page'
 import type { MetroPathLatency } from '@/lib/api'
 
 /** A fully-measured route; individual tests override the fields they care about. */
@@ -59,6 +71,23 @@ describe('routeFigures', () => {
     const f = routeFigures(latency({ internetP95Ms: 0, internetJitterMs: 0 }))
     expect(f.tiles[4].value).toBeNull()
     expect(f.tiles[5].value).toBeNull()
+  })
+
+  it('reports the milliseconds saved on a fully-measured route', () => {
+    const f = routeFigures(latency())
+    expect(f.internetMeasured).toBe(true)
+    expect(f.savedMs).toBeCloseTo(49.26, 5)
+  })
+
+  // The saving is the improvement in another unit, so it must be withheld
+  // wherever the percentage is — a matrix cell and a KPI card read it directly.
+  it('withholds the saving whenever the improvement is withheld', () => {
+    expect(routeFigures(latency({ partiallyCommitted: true })).savedMs).toBeNull()
+    expect(routeFigures(latency({ internetLatencyMs: 0 })).savedMs).toBeNull()
+  })
+
+  it('reports an internet side with no samples as unmeasured', () => {
+    expect(routeFigures(latency({ internetLatencyMs: 0 })).internetMeasured).toBe(false)
   })
 })
 
@@ -120,5 +149,161 @@ describe('resolveRoute', () => {
   it('is case-insensitive', () => {
     expect(pairKeyOf('TYO', 'lon')).toBe('lon-tyo')
     expect(resolveRoute({ from: 'LON', to: 'lon' }).unavailable).toBe(true)
+  })
+})
+
+describe('parseCities', () => {
+  it('parses a plain list and round-trips it', () => {
+    const { cities, requested } = parseCities('dub,fra,lon')
+    expect(cities).toEqual([{ id: 'dub' }, { id: 'fra' }, { id: 'lon' }])
+    expect(requested).toBe(3)
+    expect(formatCities(cities)).toBe('dub,fra,lon')
+  })
+
+  it('carries an off-net anchor through the token', () => {
+    const { cities } = parseCities('lon,ohio@pit')
+    expect(cities[1]).toEqual({ id: 'ohio', anchor: 'pit' })
+    expect(formatCities(cities)).toBe('lon,ohio@pit')
+  })
+
+  // Same rule as parseRouteToken: a corrupted shared link drops the token rather
+  // than rendering a plausible-but-wrong location.
+  it('drops a malformed token instead of coercing it', () => {
+    const { cities, requested } = parseCities('lon,ohio@,@pit,fra')
+    expect(cities).toEqual([{ id: 'lon' }, { id: 'fra' }])
+    // requested still counts them, so the page can say the selection shrank.
+    expect(requested).toBe(4)
+  })
+
+  it('folds a repeated location, because a city cannot hold two anchors in one grid', () => {
+    const { cities, requested } = parseCities('lon,LON,ohio@pit,ohio@chi')
+    expect(cities).toEqual([{ id: 'lon' }, { id: 'ohio', anchor: 'pit' }])
+    expect(requested).toBe(4)
+  })
+
+  it('caps the selection and reports that it asked for more', () => {
+    const raw = Array.from({ length: MAX_CITIES + 3 }, (_, i) => `m${i}`).join(',')
+    const { cities, requested } = parseCities(raw)
+    expect(cities).toHaveLength(MAX_CITIES)
+    expect(requested).toBe(MAX_CITIES + 3)
+  })
+
+  it('is empty for a missing param', () => {
+    expect(parseCities(null)).toEqual({ cities: [], requested: 0 })
+  })
+})
+
+describe('meshPairs', () => {
+  it('enumerates every unordered pair once, in axis order', () => {
+    expect(meshPairs(['a', 'b', 'c'])).toEqual([
+      ['a', 'b'],
+      ['a', 'c'],
+      ['b', 'c'],
+    ])
+  })
+
+  it('has no pairs below two locations', () => {
+    expect(meshPairs(['a'])).toEqual([])
+    expect(meshPairs([])).toEqual([])
+  })
+
+  it('grows quadratically, which is why the selection is capped', () => {
+    expect(meshPairs(Array.from({ length: 6 }, (_, i) => i))).toHaveLength(15)
+  })
+})
+
+describe('cellFor', () => {
+  const route = resolveRoute({ from: 'tyo', to: 'lon' })
+
+  it('states the improvement and the saving on a measured pair', () => {
+    expect(cellFor(route, latency(), false, false)).toEqual({
+      kind: 'improvement',
+      pct: 19,
+      savedMs: 259.76 - 210.5,
+    })
+  })
+
+  // Three separate facts. A request failure reported as "no path" would tell a
+  // customer DoubleZero cannot reach between two of its own metros.
+  it('separates a failed request from a pending one and from a genuine absence', () => {
+    expect(cellFor(route, null, true, true)).toEqual({ kind: 'error' })
+    expect(cellFor(route, null, true, false)).toEqual({ kind: 'loading' })
+    expect(cellFor(route, null, false, false)).toEqual({ kind: 'no-path' })
+  })
+
+  it('keeps figures it already holds when a background refetch fails', () => {
+    expect(cellFor(route, latency(), false, true).kind).toBe('improvement')
+  })
+
+  it('marks a pair with no public-internet samples as unmeasured', () => {
+    expect(cellFor(route, latency({ internetLatencyMs: 0 }), false, false)).toEqual({
+      kind: 'not-measured',
+    })
+  })
+
+  // Distinct from 'not-measured': there is an internet figure here, it is the
+  // DoubleZero side that is a commitment rather than an observation.
+  it('withholds rather than fabricating on a partiallyCommitted route', () => {
+    expect(cellFor(route, latency({ partiallyCommitted: true }), false, false)).toEqual({
+      kind: 'withheld',
+    })
+  })
+
+  it('reports Zurich as unavailable with its note, at every column', () => {
+    const cell = cellFor(resolveRoute({ from: 'zurich', to: 'lon' }), null, false, false)
+    expect(cell.kind).toBe('unavailable')
+    expect(cell.kind === 'unavailable' && cell.note).toContain('no presence in Zurich')
+  })
+})
+
+describe('summariseMatrix', () => {
+  const improvement = (pct: number, savedMs: number | null): MatrixCell => ({
+    kind: 'improvement',
+    pct,
+    savedMs,
+  })
+
+  it('counts pairs, averages the measured ones, and names the best', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: improvement(44, 115) },
+      { label: 'DUB↔FRA', cell: improvement(20, 35) },
+      { label: 'DUB↔ZRH', cell: { kind: 'unavailable', note: null } },
+    ])
+    expect(s.pairs).toBe(3)
+    expect(s.withPath).toBe(2)
+    expect(s.avgPct).toBe(32)
+    expect(s.avgSavedMs).toBe(75)
+    expect(s.best).toEqual({ label: 'LON↔TYO', kind: 'improvement', pct: 44, savedMs: 115 })
+  })
+
+  // The point of the whole suppression chain: a contracted route is carried by
+  // DoubleZero, and that is all the KPI cards may say about it.
+  it('lets a withheld route count as carried but not move any average', () => {
+    const s = summariseMatrix([
+      { label: 'LON↔TYO', cell: improvement(20, 40) },
+      { label: 'FRA↔OHIO', cell: { kind: 'withheld' } },
+      { label: 'DUB↔FRA', cell: { kind: 'not-measured' } },
+    ])
+    expect(s.withPath).toBe(3)
+    expect(s.avgPct).toBe(20)
+    expect(s.avgSavedMs).toBe(40)
+    expect(s.best?.label).toBe('LON↔TYO')
+  })
+
+  it('averages nothing rather than zero when no pair is comparable', () => {
+    const s = summariseMatrix([
+      { label: 'DUB↔ZRH', cell: { kind: 'unavailable', note: null } },
+      { label: 'DUB↔FRA', cell: { kind: 'no-path' } },
+    ])
+    expect(s.withPath).toBe(0)
+    expect(s.avgPct).toBeNull()
+    expect(s.avgSavedMs).toBeNull()
+    expect(s.best).toBeNull()
+  })
+
+  it('reports a slower route honestly rather than hiding it', () => {
+    const s = summariseMatrix([{ label: 'DUB↔FRA', cell: improvement(-4, -2) }])
+    expect(s.avgPct).toBe(-4)
+    expect(s.best?.pct).toBe(-4)
   })
 })

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -1,17 +1,19 @@
 /* eslint-disable react-refresh/only-export-components */
 // Customer-facing route latency page. Deliberately separate from the internal
-// /performance/path-latency matrix: this one answers "how much faster is my
-// route", so it shows a handful of user-chosen routes with their measured
-// figures and a shareable URL, not an all-pairs grid.
-import { useCallback, useMemo, useState } from 'react'
+// /performance/path-latency matrix: that one grids every metro pair on the
+// network, this one grids only the locations a customer picked and answers
+// "how much faster is my mesh", with a shareable URL.
+import { useCallback, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router-dom'
-import { ArrowRight, Loader2, Plus, Route as RouteIcon, X } from 'lucide-react'
+import { ArrowRight, Loader2, Route as RouteIcon, X } from 'lucide-react'
 import { fetchFacilitiesByMetro, fetchMetroPathLatency, fetchMetros, fetchRouteSeries } from '@/lib/api'
 import type { MetroPathLatency } from '@/lib/api'
 import {
   OFF_NET_ENDPOINTS,
+  formatCityToken,
   formatRouteToken,
+  parseCityToken,
   parseRouteToken,
   resolveEndpoint,
 } from '@/lib/route-anchors'
@@ -20,8 +22,12 @@ import { PageHeader } from '@/components/page-header'
 import { ErrorState } from '@/components/ui/error-state'
 import { cn } from '@/lib/utils'
 
-/** Matches maxRouteSeriesPairs on the route-series endpoint. */
-const MAX_ROUTES = 10
+/**
+ * Presentational cap. The mesh is quadratic — 12 locations is 66 pairs, which is
+ * about as much as a reader can still scan. It is not the route-series cap: the
+ * series is fetched for the selected cell alone, one pair at a time.
+ */
+export const MAX_CITIES = 12
 
 // Copied rather than exported from path-latency-page.tsx: that page is a
 // separate, internal artefact and must not grow an export surface for this one.
@@ -122,6 +128,14 @@ export const CONTRACTED_NOTE =
 export type RouteFigures = {
   tiles: { label: string; value: string | null }[]
   improvementPct: number | null
+  /**
+   * Milliseconds saved against the public internet. Null wherever the
+   * improvement is withheld, so a matrix cell and a KPI card cannot print a
+   * saving for a route whose percentage we refuse to state.
+   */
+  savedMs: number | null
+  /** False when the public internet has no samples for this pair in the window. */
+  internetMeasured: boolean
   footnote: string | null
 }
 
@@ -145,6 +159,8 @@ export type RouteFigures = {
  */
 export function routeFigures(l: MetroPathLatency): RouteFigures {
   const partial = l.partiallyCommitted
+  const internetMeasured = l.internetLatencyMs > 0
+  const improvementPct = partial ? null : l.measuredImprovementPct
   return {
     tiles: [
       {
@@ -157,7 +173,12 @@ export function routeFigures(l: MetroPathLatency): RouteFigures {
       { label: 'Internet p95', value: orAbsent(l.internetP95Ms) },
       { label: 'Internet jitter', value: orAbsent(l.internetJitterMs, 3) },
     ],
-    improvementPct: partial ? null : l.measuredImprovementPct,
+    improvementPct,
+    savedMs:
+      improvementPct !== null && internetMeasured && l.measuredLatencyMs > 0
+        ? l.internetLatencyMs - l.measuredLatencyMs
+        : null,
+    internetMeasured,
     footnote: partial ? CONTRACTED_NOTE : null,
   }
 }
@@ -174,6 +195,146 @@ export function routeFigures(l: MetroPathLatency): RouteFigures {
  */
 export function orientPath(pathMetros: string[], apiFrom: string, routeFrom: string): string[] {
   return apiFrom.toLowerCase() === routeFrom.toLowerCase() ? pathMetros : [...pathMetros].reverse()
+}
+
+// --- Matrix model ----------------------------------------------------------
+
+/** A location the customer picked, with the on-ramp chosen for it if it is off-net. */
+export type SelectedCity = { id: string; anchor?: string }
+
+/**
+ * Reads the `?cities=` list. Returns how many tokens the link asked for as well
+ * as the ones kept, because a malformed token is dropped and a repeat is folded:
+ * the recipient of a shared link must be told the selection shrank rather than
+ * quietly seeing a smaller mesh than the sender.
+ */
+export function parseCities(raw: string | null): { cities: SelectedCity[]; requested: number } {
+  if (!raw) return { cities: [], requested: 0 }
+  const tokens = raw.split(',').filter(Boolean)
+  const seen = new Set<string>()
+  const cities: SelectedCity[] = []
+  for (const token of tokens) {
+    const parsed = parseCityToken(token)
+    if (!parsed) continue
+    const key = parsed.id.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    cities.push(parsed)
+  }
+  return { cities: cities.slice(0, MAX_CITIES), requested: tokens.length }
+}
+
+export function formatCities(cities: SelectedCity[]): string {
+  return cities.map((c) => formatCityToken(c.id, c.anchor)).join(',')
+}
+
+/** Every unordered pair of a selection, each once — the mesh the KPI cards sum over. */
+export function meshPairs<T>(items: T[]): [T, T][] {
+  const out: [T, T][] = []
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) out.push([items[i], items[j]])
+  }
+  return out
+}
+
+/**
+ * What one cell of the mesh states.
+ *
+ * The four ways a cell can hold no percentage are four different facts, and a
+ * customer reading the grid will ask which one applies, so none of them
+ * collapse into a shared blank:
+ *
+ *  - `unavailable` — the location has no committed DoubleZero coverage (Zurich),
+ *    or both ends resolve to one metro. Carries the note that says which.
+ *  - `no-path` — DoubleZero cannot route between the two metros.
+ *  - `not-measured` — the public internet had no samples for the pair.
+ *  - `withheld` — `partiallyCommitted`; a percentage here would compare a
+ *    commitment against a measurement.
+ *
+ * `loading` and `error` are separate again: a failed request must never render
+ * as DoubleZero having no route.
+ */
+export type MatrixCell =
+  | { kind: 'diagonal' }
+  | { kind: 'unavailable'; note: string | null }
+  | { kind: 'loading' }
+  | { kind: 'error' }
+  | { kind: 'no-path' }
+  | { kind: 'not-measured' }
+  | { kind: 'withheld' }
+  | { kind: 'improvement'; pct: number; savedMs: number | null }
+
+/**
+ * Classifies one cell. Every suppression decision is read off `routeFigures` —
+ * the cell re-derives none of them, so the grid and the card below it cannot
+ * disagree about what counts as a measurement.
+ */
+export function cellFor(
+  resolved: ResolvedRoute,
+  latency: MetroPathLatency | null,
+  pending: boolean,
+  error: boolean,
+): MatrixCell {
+  if (resolved.unavailable) return { kind: 'unavailable', note: resolved.notes[0] ?? null }
+  // Guarded on !latency so a failed background refetch does not blank figures we hold.
+  if (!latency && error) return { kind: 'error' }
+  if (!latency && pending) return { kind: 'loading' }
+  if (!latency) return { kind: 'no-path' }
+
+  const figures = routeFigures(latency)
+  if (!figures.internetMeasured) return { kind: 'not-measured' }
+  if (figures.improvementPct === null) return { kind: 'withheld' }
+  return { kind: 'improvement', pct: figures.improvementPct, savedMs: figures.savedMs }
+}
+
+export type MatrixSummary = {
+  pairs: number
+  /** Pairs DoubleZero carries, measured or not. */
+  withPath: number
+  avgSavedMs: number | null
+  avgPct: number | null
+  best: { label: string; pct: number; savedMs: number | null } | null
+}
+
+/**
+ * Totals for the KPI cards. Only `improvement` cells carry a percentage, so a
+ * withheld or unmeasured pair moves no average and can never be the best route —
+ * it is counted as carried by DoubleZero, which is a fact, and nothing more.
+ */
+export function summariseMatrix(entries: { label: string; cell: MatrixCell }[]): MatrixSummary {
+  const improved = entries.flatMap((e) =>
+    e.cell.kind === 'improvement' ? [{ label: e.label, ...e.cell }] : [],
+  )
+  const saved = improved.map((e) => e.savedMs).filter((ms): ms is number => ms !== null)
+  const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null)
+
+  return {
+    pairs: entries.length,
+    withPath: entries.filter((e) =>
+      ['improvement', 'withheld', 'not-measured'].includes(e.cell.kind),
+    ).length,
+    avgSavedMs: mean(saved),
+    avgPct: mean(improved.map((e) => e.pct)),
+    best: improved.reduce<MatrixSummary['best']>(
+      (best, e) => (best === null || e.pct > best.pct ? e : best),
+      null,
+    ),
+  }
+}
+
+/**
+ * Cell shading, by improvement rather than by absolute latency: 25 metros carry
+ * activated links and the graph is connected, so DoubleZero carrying a route is
+ * the norm across the mesh and shading that fact would spend the whole range on
+ * a constant.
+ */
+export function shadeFor(pct: number): string {
+  if (pct <= 0) return 'bg-red-500/20'
+  if (pct < 10) return 'bg-emerald-500/10'
+  if (pct < 20) return 'bg-emerald-500/20'
+  if (pct < 30) return 'bg-emerald-500/30'
+  if (pct < 40) return 'bg-emerald-500/45'
+  return 'bg-emerald-500/60'
 }
 
 /** One measured figure, or an em dash when the figure is absent. */
@@ -310,7 +471,7 @@ function RouteCard({
           )}
           <button
             onClick={onRemove}
-            aria-label="Remove route"
+            aria-label="Clear selected route"
             className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             <X className="h-4 w-4" />
@@ -431,29 +592,33 @@ export function RoutesPage() {
   // --- URL state -----------------------------------------------------------
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const { routes, truncated } = useMemo(() => {
-    const raw = searchParams.get('routes')
-    if (!raw) return { routes: [] as SelectedRoute[], truncated: false }
-    // parseRouteToken returns null for a malformed token. Drop those rather than
-    // coercing — a corrupted shared link must not render as a plausible-but-wrong
-    // route, which is the same failure the Zurich N/A rule exists to prevent.
-    const parsed = raw
-      .split(',')
-      .filter(Boolean)
-      .map(parseRouteToken)
-      .filter((r): r is NonNullable<ReturnType<typeof parseRouteToken>> => r !== null)
-    // Truncation is reported, not silent: otherwise the recipient of a shared
-    // link sees a different set of routes than the sender and cannot tell.
-    return { routes: parsed.slice(0, MAX_ROUTES), truncated: parsed.length > MAX_ROUTES }
-  }, [searchParams])
+  // parseCities drops a malformed or repeated token rather than coercing it, and
+  // reports how many the link asked for so a shrunken selection can be stated.
+  const { cities, requested } = useMemo(
+    () => parseCities(searchParams.get('cities')),
+    [searchParams],
+  )
 
-  const setRoutes = useCallback(
-    (next: SelectedRoute[]) => {
-      const tokens = next.map((r) => formatRouteToken(r.from, r.to, r.fromAnchor, r.toAnchor))
-      // Replace the whole param so a shared link reproduces the view exactly, and
+  const selectedCell = useMemo(() => {
+    const parsed = parseRouteToken(searchParams.get('cell') ?? '')
+    if (!parsed) return null
+    // A cell naming a location outside the mesh is dropped on the same rule: a
+    // shared link must not open on a pair this grid does not show.
+    const inMesh = (id: string) => cities.some((c) => c.id.toLowerCase() === id.toLowerCase())
+    if (!inMesh(parsed.from) || !inMesh(parsed.to)) return null
+    if (parsed.from.toLowerCase() === parsed.to.toLowerCase()) return null
+    return { from: parsed.from, to: parsed.to }
+  }, [searchParams, cities])
+
+  const setUrl = useCallback(
+    (nextCities: SelectedCity[], cell: { from: string; to: string } | null) => {
+      const params: Record<string, string> = {}
+      if (nextCities.length) params.cities = formatCities(nextCities)
+      if (cell) params.cell = formatRouteToken(cell.from, cell.to)
+      // Replace the whole query so a shared link reproduces the view exactly, and
       // replace the history entry so Back leaves the page rather than walking
-      // back through every intermediate route list.
-      setSearchParams(tokens.length ? { routes: tokens.join(',') } : {}, { replace: true })
+      // back through every intermediate selection.
+      setSearchParams(params, { replace: true })
     },
     [setSearchParams],
   )
@@ -480,30 +645,8 @@ export function RoutesPage() {
   })
 
   // The endpoint also returns 200 with an `error` body on a backend failure, so
-  // check both. Either way the card must not fall through to "no path".
+  // check both. Either way a cell must not fall through to "no path".
   const latencyError = Boolean(latencyQueryError) || Boolean(latencyData?.error)
-
-  const resolved = useMemo(() => routes.map(resolveRoute), [routes])
-
-  const pairKeys = useMemo(
-    () => [...new Set(resolved.map((r) => r.pairKey).filter((k): k is string => k !== null))],
-    [resolved],
-  )
-
-  const {
-    data: seriesData,
-    isPending: seriesIsPending,
-    error: seriesQueryError,
-  } = useQuery({
-    queryKey: ['route-series', pairKeys.join(',')],
-    queryFn: () => fetchRouteSeries(pairKeys),
-    enabled: pairKeys.length > 0,
-    staleTime: 300000,
-  })
-
-  // A disabled query reports isPending, so gate on there being something to fetch.
-  const seriesError = Boolean(seriesQueryError) || Boolean(seriesData?.error)
-  const seriesPending = pairKeys.length > 0 && seriesIsPending && !seriesError
 
   const latencyByPair = useMemo(() => {
     const map = new Map<string, MetroPathLatency>()
@@ -512,17 +655,6 @@ export function RoutesPage() {
     }
     return map
   }, [latencyData])
-
-  const seriesByPair = useMemo(() => {
-    const map = new Map<string, { dz: number[]; internet: number[] }>()
-    for (const s of seriesData?.series ?? []) {
-      map.set(pairKeyOf(s.fromMetroCode, s.toMetroCode), {
-        dz: s.points.map((p) => p.dzMs),
-        internet: s.points.map((p) => p.internetMs),
-      })
-    }
-    return map
-  }, [seriesData])
 
   const metros = useMemo(() => metroData?.items ?? [], [metroData])
 
@@ -546,25 +678,137 @@ export function RoutesPage() {
     [metroByCode],
   )
 
-  // --- Selection -----------------------------------------------------------
-  const [origin, setOrigin] = useState('')
-  const [destination, setDestination] = useState('')
+  // --- Mesh ----------------------------------------------------------------
 
-  const atLimit = routes.length >= MAX_ROUTES
-  const canAdd = Boolean(origin) && Boolean(destination) && origin !== destination && !atLimit
-
-  const addRoute = useCallback(() => {
-    if (!canAdd) return
-    setRoutes([...routes, { from: origin, to: destination }])
-  }, [canAdd, routes, origin, destination, setRoutes])
-
-  const options = useMemo(
-    () => ({
-      onNet: metros.map((m) => ({ value: m.code, label: `${m.name} (${m.code.toUpperCase()})` })),
-      offNet: OFF_NET_ENDPOINTS.map((e) => ({ value: e.id, label: e.label })),
-    }),
-    [metros],
+  // Axes are alphabetical by city name, matching the picker, so a reader can find
+  // a location in the grid without first learning the order it was added in.
+  const axis = useMemo(
+    () => [...cities].sort((a, b) => labelFor(a.id).localeCompare(labelFor(b.id))),
+    [cities, labelFor],
   )
+
+  const grid = useMemo(
+    () =>
+      axis.map((row, i) =>
+        axis.map((col, j) => {
+          if (i === j) {
+            return { resolved: null, cell: { kind: 'diagonal' } as MatrixCell }
+          }
+          // Row is the origin and column the destination, which is the direction
+          // the reader is scanning — orientPath in the card below uses it.
+          const resolved = resolveRoute({
+            from: row.id,
+            to: col.id,
+            fromAnchor: row.anchor,
+            toAnchor: col.anchor,
+          })
+          const latency = resolved.pairKey ? (latencyByPair.get(resolved.pairKey) ?? null) : null
+          return { resolved, cell: cellFor(resolved, latency, latencyPending, latencyError) }
+        }),
+      ),
+    [axis, latencyByPair, latencyPending, latencyError],
+  )
+
+  const summary = useMemo(
+    () =>
+      summariseMatrix(
+        meshPairs(axis.map((_, i) => i)).map(([i, j]) => ({
+          label: `${shortLabel(axis[i].id)}↔${shortLabel(axis[j].id)}`,
+          cell: grid[i][j].cell,
+        })),
+      ),
+    [axis, grid],
+  )
+
+  const selectedIndex = useMemo(() => {
+    if (!selectedCell) return null
+    const at = (id: string) => axis.findIndex((c) => c.id.toLowerCase() === id.toLowerCase())
+    const i = at(selectedCell.from)
+    const j = at(selectedCell.to)
+    return i < 0 || j < 0 || i === j ? null : { i, j }
+  }, [selectedCell, axis])
+
+  const selected = selectedIndex ? grid[selectedIndex.i][selectedIndex.j].resolved : null
+  const selectedLatency = selected?.pairKey ? (latencyByPair.get(selected.pairKey) ?? null) : null
+
+  // Fetched one pair at a time, for the selected cell only: the grid shows no
+  // sparklines, so the route-series cap of 10 pairs is never approached.
+  const selectedPairKey = selected?.pairKey ?? null
+  const {
+    data: seriesData,
+    isPending: seriesIsPending,
+    error: seriesQueryError,
+  } = useQuery({
+    queryKey: ['route-series', selectedPairKey],
+    queryFn: () => fetchRouteSeries([selectedPairKey as string]),
+    enabled: selectedPairKey !== null,
+    staleTime: 300000,
+  })
+
+  // A disabled query reports isPending, so gate on there being something to fetch.
+  const seriesError = Boolean(seriesQueryError) || Boolean(seriesData?.error)
+  const seriesPending = selectedPairKey !== null && seriesIsPending && !seriesError
+
+  const series = useMemo(() => {
+    const s = (seriesData?.series ?? []).find(
+      (x) => pairKeyOf(x.fromMetroCode, x.toMetroCode) === selectedPairKey,
+    )
+    if (!s) return null
+    return { dz: s.points.map((p) => p.dzMs), internet: s.points.map((p) => p.internetMs) }
+  }, [seriesData, selectedPairKey])
+
+  // --- Selection -----------------------------------------------------------
+  const atLimit = cities.length >= MAX_CITIES
+
+  const addCity = useCallback(
+    (id: string) => {
+      if (!id || atLimit) return
+      setUrl([...cities, { id }], selectedCell)
+    },
+    [atLimit, cities, selectedCell, setUrl],
+  )
+
+  const removeCity = useCallback(
+    (id: string) => {
+      const gone = (other: string) => other.toLowerCase() === id.toLowerCase()
+      const stillShown =
+        selectedCell && !gone(selectedCell.from) && !gone(selectedCell.to) ? selectedCell : null
+      setUrl(
+        cities.filter((c) => !gone(c.id)),
+        stillShown,
+      )
+    },
+    [cities, selectedCell, setUrl],
+  )
+
+  // One anchor per city rather than per route: the same city cannot sensibly have
+  // two on-ramps in one grid, and both sides of every pair it appears in move
+  // together, so the customer's access leg still cancels.
+  const setAnchor = useCallback(
+    (id: string, anchor: string) => {
+      setUrl(
+        cities.map((c) => (c.id === id ? { ...c, anchor } : c)),
+        selectedCell,
+      )
+    },
+    [cities, selectedCell, setUrl],
+  )
+
+  const options = useMemo(() => {
+    const chosen = new Set(cities.map((c) => c.id.toLowerCase()))
+    // Sorted by the label, which leads with the city name — a reader looking for
+    // Dublin should not have to know it is DUB.
+    const byLabel = (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label)
+    return {
+      onNet: metros
+        .filter((m) => !chosen.has(m.code.toLowerCase()))
+        .map((m) => ({ value: m.code, label: `${m.name} (${m.code.toUpperCase()})` }))
+        .sort(byLabel),
+      offNet: OFF_NET_ENDPOINTS.filter((e) => !chosen.has(e.id.toLowerCase()))
+        .map((e) => ({ value: e.id, label: e.label }))
+        .sort(byLabel),
+    }
+  }, [metros, cities])
 
   if (metrosError) {
     return (
@@ -583,11 +827,11 @@ export function RoutesPage() {
         <PageHeader icon={RouteIcon} title="Route Latency" />
 
         <p className="mt-2 text-sm text-muted-foreground">
-          Round-trip latency between metros, measured over the DoubleZero network and the public
-          internet.
+          DoubleZero against the public internet, across your locations. Pick the locations you
+          care about and every route between them is compared.
         </p>
         <p className="mt-1 text-xs text-muted-foreground max-w-4xl">
-          Figures cover the last 24 hours; the spark lines show the last 7 days by the
+          Figures cover the last 24 hours; the selected route also shows the last 7 days by the
           hour. The public-internet figures are measured end to end. The DoubleZero p95 and jitter
           are sums of each hop&apos;s own p95 and mean jitter — percentiles and jitter do not add,
           so those two figures are higher than what a packet actually sees. The bias runs against
@@ -595,117 +839,362 @@ export function RoutesPage() {
         </p>
 
         {/* Selection */}
-        <div className="flex flex-wrap items-end gap-2 mt-4">
+        <div className="flex flex-wrap items-center gap-2 mt-4">
           <EndpointSelect
-            label="Origin"
-            value={origin}
-            onChange={setOrigin}
+            value=""
+            onChange={addCity}
             options={options}
             loading={metrosLoading}
+            disabled={atLimit}
           />
-          <EndpointSelect
-            label="Destination"
-            value={destination}
-            onChange={setDestination}
-            options={options}
-            loading={metrosLoading}
-          />
-          <button
-            onClick={addRoute}
-            disabled={!canAdd}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-border bg-background hover:bg-muted/50 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <Plus className="h-3 w-3" />
-            Add route
-          </button>
-          {(atLimit || truncated) && (
-            <span className="text-xs text-muted-foreground pb-1.5">
-              Showing the maximum of {MAX_ROUTES} routes
-              {truncated ? '; this link asked for more.' : '. Remove one to add another.'}
+          {/* Chips follow the axis order, so the picker, the chips and the grid all
+              read alphabetically. */}
+          {axis.map((c) => {
+            const offNet = OFF_NET_ENDPOINTS.find((e) => e.id === c.id)
+            return (
+              <span
+                key={c.id}
+                className="flex items-center gap-2 pl-2.5 pr-1 py-1 text-xs border border-border rounded-md bg-muted/40"
+              >
+                {labelFor(c.id)}
+                {offNet && offNet.candidateAnchors.length > 0 && (
+                  <AnchorPicker
+                    candidates={offNet.candidateAnchors}
+                    value={resolveEndpoint(c.id, c.anchor).metroCode}
+                    onChange={(a) => setAnchor(c.id, a)}
+                  />
+                )}
+                <button
+                  onClick={() => removeCity(c.id)}
+                  aria-label={`Remove ${labelFor(c.id)}`}
+                  className="p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            )
+          })}
+          {(atLimit || requested > cities.length) && (
+            <span className="text-xs text-muted-foreground">
+              {requested > cities.length
+                ? `This link asked for ${requested} locations; showing ${cities.length}.`
+                : `Showing the maximum of ${MAX_CITIES} locations. Remove one to add another.`}
             </span>
           )}
         </div>
 
-        {/* Routes */}
-        <div className="mt-4 space-y-3">
-          {resolved.length === 0 ? (
-            <div className="text-sm text-muted-foreground py-8 text-center">
-              {metrosLoading ? (
-                <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+        {axis.length < 2 ? (
+          <div className="text-sm text-muted-foreground py-8 text-center">
+            {metrosLoading ? (
+              <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+            ) : (
+              'Add two or more locations to compare every route between them.'
+            )}
+          </div>
+        ) : (
+          <>
+            <SummaryCards summary={summary} locations={axis.length} />
+
+            <LatencyMatrix
+              axis={axis}
+              grid={grid}
+              selected={selectedIndex}
+              onSelect={(i, j) => setUrl(cities, { from: axis[i].id, to: axis[j].id })}
+            />
+
+            <Legend />
+
+            <OffNetNotes axis={axis} />
+
+            <div className="mt-4">
+              {selected ? (
+                <RouteCard
+                  resolved={selected}
+                  labelFor={labelFor}
+                  metroPkFor={metroPkFor}
+                  latency={selectedLatency}
+                  latencyPending={latencyPending}
+                  latencyError={latencyError}
+                  series={series}
+                  seriesPending={seriesPending}
+                  seriesError={seriesError}
+                  onRemove={() => setUrl(cities, null)}
+                  onAnchorChange={(side, anchor) =>
+                    setAnchor(side === 'from' ? selected.route.from : selected.route.to, anchor)
+                  }
+                />
               ) : (
-                'Pick an origin and a destination to compare a route.'
+                <p className="text-sm text-muted-foreground text-center py-6">
+                  Select a cell to see the full breakdown for that route.
+                </p>
               )}
             </div>
-          ) : (
-            resolved.map((r, i) => (
-              <RouteCard
-                key={`${formatRouteToken(r.route.from, r.route.to, r.route.fromAnchor, r.route.toAnchor)}#${i}`}
-                resolved={r}
-                labelFor={labelFor}
-                metroPkFor={metroPkFor}
-                latency={r.pairKey ? (latencyByPair.get(r.pairKey) ?? null) : null}
-                latencyPending={latencyPending}
-                latencyError={latencyError}
-                series={r.pairKey ? (seriesByPair.get(r.pairKey) ?? null) : null}
-                seriesPending={seriesPending}
-                seriesError={seriesError}
-                onRemove={() => setRoutes(routes.filter((_, idx) => idx !== i))}
-                onAnchorChange={(side, anchor) =>
-                  setRoutes(
-                    routes.map((route, idx) =>
-                      idx === i
-                        ? { ...route, [side === 'from' ? 'fromAnchor' : 'toAnchor']: anchor }
-                        : route,
-                    ),
-                  )
-                }
-              />
-            ))
-          )}
-        </div>
+          </>
+        )}
       </div>
     </div>
   )
 }
 
+/** Axis label: a metro shows its code, an off-net location its own short form. */
+function shortLabel(id: string): string {
+  return (OFF_NET_ENDPOINTS.find((e) => e.id === id)?.short ?? id).toUpperCase()
+}
+
+function SummaryCards({ summary, locations }: { summary: MatrixSummary; locations: number }) {
+  const cards: { label: string; value: string; lines: string[] }[] = [
+    {
+      label: 'Pairs shown',
+      value: String(summary.pairs),
+      lines: [`${locations} locations`],
+    },
+    {
+      label: 'On DoubleZero',
+      value: `${summary.withPath} pairs`,
+      lines: ['where DoubleZero has a path'],
+    },
+    {
+      label: 'Average faster',
+      value: summary.avgSavedMs !== null ? `${summary.avgSavedMs.toFixed(1)} ms` : '—',
+      lines: [
+        summary.avgPct !== null ? `${summary.avgPct.toFixed(1)}% mean reduction` : 'nothing to average',
+      ],
+    },
+    {
+      label: 'Best route',
+      value: summary.best ? `${summary.best.pct.toFixed(1)}%` : '—',
+      lines: summary.best
+        ? [
+            summary.best.label,
+            summary.best.savedMs !== null ? `${summary.best.savedMs.toFixed(1)} ms saved` : '',
+          ].filter(Boolean)
+        : ['no measured comparison'],
+    },
+  ]
+
+  return (
+    <div className="mt-4 grid grid-cols-2 lg:grid-cols-4 gap-2">
+      {cards.map((c) => (
+        <div key={c.label} className="bg-card border border-border rounded-lg p-3">
+          <div className="text-[10px] text-muted-foreground uppercase tracking-wider">{c.label}</div>
+          <div className="mt-1 text-xl font-bold tabular-nums">{c.value}</div>
+          {c.lines.map((l) => (
+            <div key={l} className="text-xs text-muted-foreground">
+              {l}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const CELL_NOTE: Record<Exclude<MatrixCell['kind'], 'improvement' | 'unavailable'>, string> = {
+  diagonal: 'same location',
+  loading: 'loading…',
+  error: 'latency data could not be loaded',
+  'no-path': 'DoubleZero has no path between these metros',
+  'not-measured': 'no public-internet measurements for this pair in the window',
+  withheld: 'improvement withheld: a hop reports its contracted figure, not a measurement',
+}
+
+function CellBody({ cell }: { cell: MatrixCell }) {
+  switch (cell.kind) {
+    case 'improvement':
+      return (
+        <>
+          <span className="text-sm font-semibold tabular-nums">{cell.pct.toFixed(1)}%</span>
+          <span className="text-[10px] text-muted-foreground tabular-nums">
+            {cell.savedMs !== null ? `${cell.savedMs.toFixed(1)} ms` : '—'}
+          </span>
+        </>
+      )
+    case 'unavailable':
+      return <span className="text-xs text-muted-foreground">N/A</span>
+    case 'loading':
+      return <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+    case 'diagonal':
+      return <span className="text-muted-foreground/40">·</span>
+    default:
+      return (
+        <span className="text-[10px] leading-tight text-muted-foreground px-1 text-center">
+          {CELL_TEXT[cell.kind]}
+        </span>
+      )
+  }
+}
+
+/** Spelled out rather than derived from the kind: this is text a customer reads. */
+const CELL_TEXT: Record<'no-path' | 'not-measured' | 'withheld' | 'error', string> = {
+  'no-path': 'no path',
+  'not-measured': 'not measured',
+  withheld: 'withheld',
+  error: 'load failed',
+}
+
+const CELL_BOX = 'w-24 h-14 flex flex-col items-center justify-center gap-0.5 border border-border/40'
+
+function LatencyMatrix({
+  axis,
+  grid,
+  selected,
+  onSelect,
+}: {
+  axis: SelectedCity[]
+  grid: { resolved: ResolvedRoute | null; cell: MatrixCell }[][]
+  selected: { i: number; j: number } | null
+  onSelect: (i: number, j: number) => void
+}) {
+  return (
+    // The grid scrolls inside this box; the page body never scrolls sideways.
+    <div className="mt-4 max-w-full overflow-x-auto">
+      <table className="border-separate border-spacing-0">
+        <caption className="caption-top text-left text-[11px] text-muted-foreground pb-2">
+          Latency reduction on DoubleZero against the public internet, row to column: percentage,
+          and milliseconds saved.
+        </caption>
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-10 bg-background" />
+            {axis.map((c) => (
+              <th
+                key={c.id}
+                scope="col"
+                className="px-1 pb-1 text-[11px] font-medium text-muted-foreground"
+              >
+                {shortLabel(c.id)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {axis.map((row, i) => (
+            <tr key={row.id}>
+              <th
+                scope="row"
+                className="sticky left-0 z-10 bg-background pr-2 text-right text-[11px] font-medium text-muted-foreground"
+              >
+                {shortLabel(row.id)}
+              </th>
+              {axis.map((col, j) => {
+                const { cell } = grid[i][j]
+                if (cell.kind === 'diagonal') {
+                  return (
+                    <td key={col.id} className="p-0">
+                      <div className={cn(CELL_BOX, 'bg-muted/30')}>
+                        <CellBody cell={cell} />
+                      </div>
+                    </td>
+                  )
+                }
+                const isSelected = selected?.i === i && selected?.j === j
+                const note =
+                  cell.kind === 'improvement'
+                    ? `${cell.pct.toFixed(1)}% faster on DoubleZero`
+                    : cell.kind === 'unavailable'
+                      ? (cell.note ?? 'no figure to report')
+                      : CELL_NOTE[cell.kind]
+                return (
+                  <td key={col.id} className="p-0">
+                    <button
+                      onClick={() => onSelect(i, j)}
+                      title={`${shortLabel(row.id)} → ${shortLabel(col.id)} — ${note}`}
+                      aria-pressed={isSelected}
+                      className={cn(
+                        CELL_BOX,
+                        'w-full transition-colors hover:brightness-110',
+                        cell.kind === 'improvement' ? shadeFor(cell.pct) : 'bg-muted/10',
+                        isSelected && 'outline-2 -outline-offset-2 outline-foreground',
+                      )}
+                    >
+                      <CellBody cell={cell} />
+                    </button>
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/**
+ * Where an off-net location's figures actually come from, stated beside the grid
+ * rather than only inside the card. An OHIO row of ordinary-looking numbers is
+ * taken at its on-ramp, and a reader scanning the mesh has to be told that
+ * without having to click a cell first.
+ */
+function OffNetNotes({ axis }: { axis: SelectedCity[] }) {
+  const present = axis.flatMap((c) => OFF_NET_ENDPOINTS.filter((e) => e.id === c.id))
+  if (present.length === 0) return null
+  return (
+    <div className="mt-2 space-y-1 max-w-4xl">
+      {present.map((e) => (
+        <p key={e.id} className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{e.short}</span> — {e.note}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+/** Swatches come from shadeFor, so the key cannot drift from the cells. */
+function Legend() {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2 text-[11px] text-muted-foreground">
+      <span className="flex items-center gap-1">
+        slower
+        {[-1, 5, 15, 25, 35, 45].map((pct) => (
+          <span key={pct} className={cn('w-5 h-3 border border-border/40', shadeFor(pct))} />
+        ))}
+        40%+ faster on DoubleZero
+      </span>
+      <span>no path — DoubleZero cannot route between the two metros</span>
+      <span>not measured — no public-internet samples in the window</span>
+      <span>withheld — a hop reports a contracted figure, so no percentage is claimed</span>
+      <span>N/A — no committed DoubleZero coverage at that location</span>
+    </div>
+  )
+}
+
 function EndpointSelect({
-  label,
   value,
   onChange,
   options,
   loading,
+  disabled,
 }: {
-  label: string
   value: string
   onChange: (v: string) => void
   options: { onNet: { value: string; label: string }[]; offNet: { value: string; label: string }[] }
   loading: boolean
+  disabled: boolean
 }) {
   return (
-    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-      {label}
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        disabled={loading}
-        className="min-w-[14rem] px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors disabled:opacity-50"
-      >
-        <option value="">Select a location…</option>
-        <optgroup label="DoubleZero metros">
-          {options.onNet.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </optgroup>
-        <optgroup label="Not yet on DoubleZero">
-          {options.offNet.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </optgroup>
-      </select>
-    </label>
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={loading || disabled}
+      aria-label="Add a location"
+      className="min-w-[14rem] px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors disabled:opacity-50"
+    >
+      <option value="">Add a location…</option>
+      <optgroup label="DoubleZero metros">
+        {options.onNet.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </optgroup>
+      <optgroup label="Not yet on DoubleZero">
+        {options.offNet.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </optgroup>
+    </select>
   )
 }

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -285,6 +285,12 @@ export function parseCells(
   for (const token of tokens) {
     // Malformed, naming a location outside the mesh, or naming a pair with
     // nothing to compare: dropped, never coerced into a neighbouring route.
+    //
+    // A cell token carrying an anchor is refused rather than half-honoured. The
+    // anchor lives on the location, once, in `?cities=`; parsing `ohio@pit-lon`
+    // and then applying the city's `chi` would render CHI figures under a URL
+    // that says PIT, which is the coercion this parser exists to prevent.
+    if (token.includes('@')) continue
     const parsed = parseRouteToken(token)
     if (!parsed) continue
     const cell = { from: parsed.from, to: parsed.to }
@@ -1047,12 +1053,19 @@ export function RoutesPage() {
               onPick={pickCell}
             />
 
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              Click a cell for the full breakdown of that route. Hold Cmd, Ctrl or Shift — or press
-              Enter with one of them held — to compare several routes side by side.
+            {/* Ctrl-click is a right-click on macOS — Chrome and Safari raise a
+                context menu and dispatch no primary click — so the hint offers
+                Shift and Cmd, the two that work everywhere a Mac reader is. The
+                gesture still accepts Ctrl for everyone else. */}
+            <p id={MATRIX_HINT_ID} className="mt-2 text-[11px] text-muted-foreground">
+              Click a cell for the full breakdown of that route. Hold Shift or Cmd — Ctrl also
+              works away from macOS — or press Enter with one of them held, to compare several
+              routes side by side.
               {atCellLimit && ` Comparing the maximum of ${MAX_CELLS} routes; deselect one to add another.`}
+              {/* Neutral about cause: the shortfall is as likely to be an anchor
+                  change collapsing a pair as anything the link did. */}
               {cellsRequested > selectedCells.length &&
-                ` This link asked for ${cellsRequested} routes; showing ${selectedCells.length}.`}
+                ` ${cellsRequested} routes asked for; showing ${selectedCells.length}.`}
             </p>
 
             <Legend />
@@ -1230,6 +1243,13 @@ function CellBody({ cell }: { cell: MatrixCell }) {
 
 const CELL_BOX = 'w-24 h-14 flex flex-col items-center justify-center gap-0.5 border border-border/40'
 
+/**
+ * Every cell points at the hint line, so focusing one announces what plain and
+ * modified Enter each do. The gesture is otherwise written down nowhere a screen
+ * reader would reach it.
+ */
+const MATRIX_HINT_ID = 'route-matrix-hint'
+
 function LatencyMatrix({
   axis,
   grid,
@@ -1292,26 +1312,36 @@ function LatencyMatrix({
                     : cell.kind === 'unavailable'
                       ? (cell.note ?? CELL_FACTS.unavailable.long)
                       : CELL_FACTS[cell.kind].long
+                // aria-disabled rather than disabled: a disabled control leaves
+                // the tab order and, in Firefox and Safari, stops receiving
+                // pointer events, which would put this cell's title — the only
+                // place its particular reason is written, including the off-net
+                // notes — out of reach of exactly the readers who need it.
+                const inert = !isComparable(cell)
                 return (
                   <td key={col.id} className="p-0">
                     <button
-                      onClick={(e) => onPick(picked, isToggleGesture(e))}
+                      onClick={(e) => {
+                        if (inert) return
+                        onPick(picked, isToggleGesture(e))
+                      }}
                       // Enter and Space already reach onClick; this adds the
                       // modified form of the same gesture, so the comparison is
                       // not mouse-only. preventDefault stops the button also
                       // synthesising a click and toggling twice.
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' && isToggleGesture(e)) {
-                          e.preventDefault()
-                          onPick(picked, true)
-                        }
+                        if (inert || e.key !== 'Enter' || !isToggleGesture(e)) return
+                        e.preventDefault()
+                        onPick(picked, true)
                       }}
-                      disabled={!isComparable(cell)}
+                      aria-disabled={inert}
+                      aria-describedby={MATRIX_HINT_ID}
                       title={`${shortLabel(row.id)} → ${shortLabel(col.id)} — ${note}`}
                       aria-pressed={isCompared}
                       className={cn(
                         CELL_BOX,
-                        'transition-colors enabled:hover:brightness-110 disabled:cursor-not-allowed',
+                        'transition-colors',
+                        inert ? 'cursor-not-allowed' : 'hover:brightness-110',
                         cell.kind === 'improvement' ? shadeFor(cell.pct) : 'bg-muted/10',
                         isCompared && 'outline-2 -outline-offset-2 outline-foreground',
                       )}
@@ -1336,13 +1366,25 @@ function LatencyMatrix({
  * without having to click a cell first.
  */
 function OffNetNotes({ axis }: { axis: SelectedCity[] }) {
-  const present = axis.flatMap((c) => OFF_NET_ENDPOINTS.filter((e) => e.id === c.id))
+  const present = axis.flatMap((c) => {
+    const offNet = OFF_NET_ENDPOINTS.find((e) => e.id === c.id)
+    if (!offNet) return []
+    // When the on-ramp metro is itself in the mesh, the two rows are one row:
+    // both cells resolve to the same pair, so both highlight together and either
+    // one removes the comparison. That is honest — it is one measurement — but
+    // it looks like a bug unless it is said.
+    const anchor = resolveEndpoint(c.id, c.anchor).metroCode
+    const twin = anchor && axis.some((a) => a.id.toLowerCase() === anchor.toLowerCase())
+    return [{ ...offNet, twin: twin ? anchor.toUpperCase() : null }]
+  })
   if (present.length === 0) return null
   return (
     <div className="mt-2 space-y-1 max-w-4xl">
       {present.map((e) => (
         <p key={e.id} className="text-xs text-muted-foreground">
           <span className="font-medium text-foreground">{e.short}</span> — {e.note}
+          {e.twin &&
+            ` While it is on-ramped at ${e.twin}, the ${e.short} row is the ${e.twin} row: those cells are one measurement, so they select and clear together.`}
         </p>
       ))}
     </div>

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -1,0 +1,572 @@
+/* eslint-disable react-refresh/only-export-components */
+// Customer-facing route latency page. Deliberately separate from the internal
+// /performance/path-latency matrix: this one answers "how much faster is my
+// route", so it shows a handful of user-chosen routes with their measured
+// figures and a shareable URL, not an all-pairs grid.
+import { useCallback, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useSearchParams } from 'react-router-dom'
+import { ArrowRight, Loader2, Plus, Route as RouteIcon, X } from 'lucide-react'
+import { fetchFacilitiesByMetro, fetchMetroPathLatency, fetchMetros, fetchRouteSeries } from '@/lib/api'
+import type { MetroPathLatency } from '@/lib/api'
+import {
+  OFF_NET_ENDPOINTS,
+  formatRouteToken,
+  parseRouteToken,
+  resolveEndpoint,
+} from '@/lib/route-anchors'
+import { Sparkline } from '@/components/shared/sparkline'
+import { PageHeader } from '@/components/page-header'
+import { ErrorState } from '@/components/ui/error-state'
+import { cn } from '@/lib/utils'
+
+/** Matches maxRouteSeriesPairs on the route-series endpoint. */
+const MAX_ROUTES = 10
+
+// Copied rather than exported from path-latency-page.tsx: that page is a
+// separate, internal artefact and must not grow an export surface for this one.
+type ImprovementTier = 'great' | 'good' | 'neutral' | 'bad' | 'none'
+
+function getImprovementTier(pct: number | null): ImprovementTier {
+  if (pct === null) return 'none'
+  if (pct > 20) return 'great'
+  if (pct > 0) return 'good'
+  if (pct >= -10) return 'neutral'
+  return 'bad'
+}
+
+const TIER_PCT_TEXT = {
+  great: 'text-green-700 dark:text-green-400',
+  good: 'text-emerald-700 dark:text-emerald-400',
+  neutral: 'text-amber-700 dark:text-amber-400',
+  bad: 'text-red-700 dark:text-red-400',
+  none: 'text-muted-foreground',
+} as const
+
+export type SelectedRoute = {
+  from: string // metro code or off-net id
+  to: string
+  fromAnchor?: string
+  toAnchor?: string
+}
+
+export type ResolvedRoute = {
+  route: SelectedRoute
+  fromMetro: string | null
+  toMetro: string | null
+  /** Non-empty when either endpoint is off-net; drives the note and anchor picker. */
+  notes: string[]
+  /** True when a figure cannot be produced at all (e.g. Zurich). */
+  unavailable: boolean
+  /** Pair key for the latency + series lookups, lexicographically ordered. */
+  pairKey: string | null
+}
+
+/**
+ * Lexicographic, case-folded pair key. Every lookup — measured figures, series,
+ * and the `pairs=` query the series endpoint parses — goes through this one
+ * function, so a route's DoubleZero and public-internet figures are read with
+ * the same key and cannot come from different anchors.
+ */
+export function pairKeyOf(a: string, b: string): string {
+  return [a.toLowerCase(), b.toLowerCase()].sort().join('-')
+}
+
+export function resolveRoute(route: SelectedRoute): ResolvedRoute {
+  const from = resolveEndpoint(route.from, route.fromAnchor)
+  const to = resolveEndpoint(route.to, route.toAnchor)
+  const notes = [from.offNet?.note, to.offNet?.note].filter(Boolean) as string[]
+
+  // Either side unresolvable, or both sides land on the same metro (e.g. an
+  // anchor colliding with the other endpoint) — there is no route to report.
+  const unavailable =
+    !from.metroCode ||
+    !to.metroCode ||
+    from.metroCode.toLowerCase() === to.metroCode.toLowerCase()
+
+  const pairKey = unavailable ? null : pairKeyOf(from.metroCode as string, to.metroCode as string)
+
+  return { route, fromMetro: from.metroCode, toMetro: to.metroCode, notes, unavailable, pairKey }
+}
+
+function fmtMs(ms: number): string {
+  return `${ms.toFixed(2)} ms`
+}
+
+/** One measured figure, or an em dash when the figure is absent. */
+function Stat({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="bg-muted/50 rounded-lg p-2.5">
+      <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">{label}</div>
+      <div
+        className={cn(
+          'text-base font-semibold tabular-nums',
+          value === null && 'text-muted-foreground font-normal',
+        )}
+      >
+        {value ?? '—'}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Collapsed list of the facilities in a metro. Shown only when a metro has more
+ * than one, where "London" alone would be ambiguous.
+ */
+function FacilityDisclosure({ metroPk, metroLabel }: { metroPk: string; metroLabel: string }) {
+  const { data } = useQuery({
+    queryKey: ['facilities-by-metro', metroPk],
+    queryFn: () => fetchFacilitiesByMetro(metroPk),
+    staleTime: 300000,
+  })
+
+  const facilities = data?.items ?? []
+  if (facilities.length < 2) return null
+
+  return (
+    <details className="text-xs text-muted-foreground">
+      <summary className="cursor-pointer hover:text-foreground transition-colors">
+        {metroLabel} — {facilities.length} facilities
+      </summary>
+      <div className="mt-1 pl-4">
+        <div className="text-foreground">
+          {metroLabel} {facilities.map((f) => f.code).join(', ')}
+        </div>
+        <div className="mt-0.5">
+          Latency is measured metro to metro. It is not broken out per facility, so the figures
+          above apply to the metro as a whole rather than to any one of these buildings.
+        </div>
+      </div>
+    </details>
+  )
+}
+
+/** Anchor picker for an off-net endpoint that has committed coverage nearby. */
+function AnchorPicker({
+  candidates,
+  value,
+  onChange,
+}: {
+  candidates: string[]
+  value: string | null
+  onChange: (anchor: string) => void
+}) {
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      On-ramp
+      <select
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="px-2 py-1 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors"
+      >
+        {candidates.map((c) => (
+          <option key={c} value={c}>
+            {c.toUpperCase()}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function RouteCard({
+  resolved,
+  labelFor,
+  metroPkFor,
+  latency,
+  series,
+  onRemove,
+  onAnchorChange,
+}: {
+  resolved: ResolvedRoute
+  labelFor: (id: string) => string
+  metroPkFor: (metroCode: string | null) => string | null
+  latency: MetroPathLatency | null
+  series: { dz: number[]; internet: number[] } | null
+  onRemove: () => void
+  onAnchorChange: (side: 'from' | 'to', anchor: string) => void
+}) {
+  const { route, notes, unavailable, fromMetro, toMetro } = resolved
+  const fromOffNet = OFF_NET_ENDPOINTS.find((e) => e.id === route.from)
+  const toOffNet = OFF_NET_ENDPOINTS.find((e) => e.id === route.to)
+
+  // p95 and jitter are absent — not zero — when a hop had no recent samples and
+  // the route fell back to its contracted figure. Rendering "0.00 ms" there
+  // would read as a real measurement.
+  const partial = latency?.partiallyCommitted ?? false
+  const tier = getImprovementTier(latency?.improvementPct ?? null)
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 font-medium">
+          <span>{labelFor(route.from)}</span>
+          <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span>{labelFor(route.to)}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {fromOffNet && fromOffNet.candidateAnchors.length > 0 && (
+            <AnchorPicker
+              candidates={fromOffNet.candidateAnchors}
+              value={fromMetro}
+              onChange={(a) => onAnchorChange('from', a)}
+            />
+          )}
+          {toOffNet && toOffNet.candidateAnchors.length > 0 && (
+            <AnchorPicker
+              candidates={toOffNet.candidateAnchors}
+              value={toMetro}
+              onChange={(a) => onAnchorChange('to', a)}
+            />
+          )}
+          <button
+            onClick={onRemove}
+            aria-label="Remove route"
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {notes.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {notes.map((n) => (
+            <p key={n} className="text-xs text-muted-foreground">
+              {n}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {unavailable ? (
+        <div className="mt-3 text-sm text-muted-foreground">
+          <span className="text-base font-semibold text-foreground">N/A</span>
+          {notes.length === 0 && (
+            <span className="ml-2">
+              Both ends of this route resolve to the same metro, so there is nothing to compare.
+            </span>
+          )}
+        </div>
+      ) : !latency ? (
+        <div className="mt-3 text-sm text-muted-foreground">
+          No DoubleZero path between these metros.
+        </div>
+      ) : (
+        <>
+          <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+            <Stat label="DoubleZero mean" value={fmtMs(latency.measuredLatencyMs)} />
+            <Stat label="DoubleZero p95" value={partial ? null : fmtMs(latency.measuredP95Ms)} />
+            <Stat label="DoubleZero jitter" value={partial ? null : fmtMs(latency.measuredJitterMs)} />
+            <Stat
+              label="Internet mean"
+              value={latency.internetLatencyMs > 0 ? fmtMs(latency.internetLatencyMs) : null}
+            />
+            <Stat label="Internet p95" value={null} />
+            <Stat label="Internet jitter" value={null} />
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+            <div>
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Improvement
+              </div>
+              <div className={cn('text-lg font-bold tabular-nums', TIER_PCT_TEXT[tier])}>
+                {latency.improvementPct !== null
+                  ? `${latency.improvementPct > 0 ? '+' : ''}${latency.improvementPct.toFixed(1)}%`
+                  : '—'}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Hops
+              </div>
+              <div className="text-lg font-bold tabular-nums">{latency.hopCount}</div>
+            </div>
+            <div className="min-w-0">
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                Path
+              </div>
+              <div className="font-mono text-sm truncate">{latency.pathMetros.join(' ─ ')}</div>
+            </div>
+            <div className="ml-auto">
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
+                7 days
+              </div>
+              <Sparkline dz={series?.dz ?? []} internet={series?.internet ?? []} />
+            </div>
+          </div>
+
+          <div className="mt-3 space-y-1">
+            {partial && (
+              <p className="text-xs text-muted-foreground">
+                One or more hops had no recent measurements; this route shows contracted latency.
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Public-internet p95 and jitter are not measured, so only the mean round-trip is
+              reported for that side.
+            </p>
+            {[fromMetro, toMetro].map((code) => {
+              const pk = metroPkFor(code)
+              if (!pk || !code) return null
+              return <FacilityDisclosure key={code} metroPk={pk} metroLabel={code.toUpperCase()} />
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export function RoutesPage() {
+  // --- URL state -----------------------------------------------------------
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const routes: SelectedRoute[] = useMemo(() => {
+    const raw = searchParams.get('routes')
+    if (!raw) return []
+    // parseRouteToken returns null for a malformed token. Drop those rather than
+    // coercing — a corrupted shared link must not render as a plausible-but-wrong
+    // route, which is the same failure the Zurich N/A rule exists to prevent.
+    return raw
+      .split(',')
+      .filter(Boolean)
+      .map(parseRouteToken)
+      .filter((r): r is NonNullable<ReturnType<typeof parseRouteToken>> => r !== null)
+      .slice(0, MAX_ROUTES)
+  }, [searchParams])
+
+  const setRoutes = useCallback(
+    (next: SelectedRoute[]) => {
+      const tokens = next.map((r) => formatRouteToken(r.from, r.to, r.fromAnchor, r.toAnchor))
+      // Replace the whole param so a shared link reproduces the view exactly.
+      setSearchParams(tokens.length ? { routes: tokens.join(',') } : {})
+    },
+    [setSearchParams],
+  )
+
+  // --- Data ----------------------------------------------------------------
+  const {
+    data: metroData,
+    isLoading: metrosLoading,
+    error: metrosError,
+  } = useQuery({
+    queryKey: ['metros', 'all', 500],
+    queryFn: () => fetchMetros(500),
+    staleTime: 300000,
+  })
+
+  const { data: latencyData } = useQuery({
+    queryKey: ['metro-path-latency', 'latency'],
+    queryFn: () => fetchMetroPathLatency('latency'),
+    staleTime: 60000,
+  })
+
+  const resolved = useMemo(() => routes.map(resolveRoute), [routes])
+
+  const pairKeys = useMemo(
+    () => [...new Set(resolved.map((r) => r.pairKey).filter((k): k is string => k !== null))],
+    [resolved],
+  )
+
+  const { data: seriesData } = useQuery({
+    queryKey: ['route-series', pairKeys.join(',')],
+    queryFn: () => fetchRouteSeries(pairKeys),
+    enabled: pairKeys.length > 0,
+    staleTime: 300000,
+  })
+
+  const latencyByPair = useMemo(() => {
+    const map = new Map<string, MetroPathLatency>()
+    for (const p of latencyData?.paths ?? []) {
+      map.set(pairKeyOf(p.fromMetroCode, p.toMetroCode), p)
+    }
+    return map
+  }, [latencyData])
+
+  const seriesByPair = useMemo(() => {
+    const map = new Map<string, { dz: number[]; internet: number[] }>()
+    for (const s of seriesData?.series ?? []) {
+      map.set(pairKeyOf(s.fromMetroCode, s.toMetroCode), {
+        dz: s.points.map((p) => p.dzMs),
+        internet: s.points.map((p) => p.internetMs),
+      })
+    }
+    return map
+  }, [seriesData])
+
+  const metros = useMemo(() => metroData?.items ?? [], [metroData])
+
+  const metroByCode = useMemo(
+    () => new Map(metros.map((m) => [m.code.toLowerCase(), m])),
+    [metros],
+  )
+
+  const labelFor = useCallback(
+    (id: string) => {
+      const offNet = OFF_NET_ENDPOINTS.find((e) => e.id === id)
+      if (offNet) return offNet.label
+      const metro = metroByCode.get(id.toLowerCase())
+      return metro ? `${metro.name} (${metro.code.toUpperCase()})` : id.toUpperCase()
+    },
+    [metroByCode],
+  )
+
+  const metroPkFor = useCallback(
+    (metroCode: string | null) => metroByCode.get((metroCode ?? '').toLowerCase())?.pk ?? null,
+    [metroByCode],
+  )
+
+  // --- Selection -----------------------------------------------------------
+  const [origin, setOrigin] = useState('')
+  const [destination, setDestination] = useState('')
+
+  const atLimit = routes.length >= MAX_ROUTES
+  const canAdd = Boolean(origin) && Boolean(destination) && origin !== destination && !atLimit
+
+  const addRoute = useCallback(() => {
+    if (!canAdd) return
+    setRoutes([...routes, { from: origin, to: destination }])
+  }, [canAdd, routes, origin, destination, setRoutes])
+
+  const options = useMemo(
+    () => ({
+      onNet: metros.map((m) => ({ value: m.code, label: `${m.name} (${m.code.toUpperCase()})` })),
+      offNet: OFF_NET_ENDPOINTS.map((e) => ({ value: e.id, label: e.label })),
+    }),
+    [metros],
+  )
+
+  if (metrosError) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-background">
+        <ErrorState
+          title="Failed to load metros"
+          message={metrosError instanceof Error ? metrosError.message : 'Unknown error'}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col bg-background overflow-y-auto">
+      <div className="px-6 py-4">
+        <PageHeader icon={RouteIcon} title="Route Latency" />
+
+        <p className="mt-2 text-sm text-muted-foreground">
+          Round-trip latency between metros, measured over the DoubleZero network and the public
+          internet.
+        </p>
+
+        {/* Selection */}
+        <div className="flex flex-wrap items-end gap-2 mt-4">
+          <EndpointSelect
+            label="Origin"
+            value={origin}
+            onChange={setOrigin}
+            options={options}
+            loading={metrosLoading}
+          />
+          <EndpointSelect
+            label="Destination"
+            value={destination}
+            onChange={setDestination}
+            options={options}
+            loading={metrosLoading}
+          />
+          <button
+            onClick={addRoute}
+            disabled={!canAdd}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-border bg-background hover:bg-muted/50 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Plus className="h-3 w-3" />
+            Add route
+          </button>
+          {atLimit && (
+            <span className="text-xs text-muted-foreground pb-1.5">
+              Showing the maximum of {MAX_ROUTES} routes. Remove one to add another.
+            </span>
+          )}
+        </div>
+
+        {/* Routes */}
+        <div className="mt-4 space-y-3">
+          {resolved.length === 0 ? (
+            <div className="text-sm text-muted-foreground py-8 text-center">
+              {metrosLoading ? (
+                <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+              ) : (
+                'Pick an origin and a destination to compare a route.'
+              )}
+            </div>
+          ) : (
+            resolved.map((r, i) => (
+              <RouteCard
+                key={`${formatRouteToken(r.route.from, r.route.to, r.route.fromAnchor, r.route.toAnchor)}#${i}`}
+                resolved={r}
+                labelFor={labelFor}
+                metroPkFor={metroPkFor}
+                latency={r.pairKey ? (latencyByPair.get(r.pairKey) ?? null) : null}
+                series={r.pairKey ? (seriesByPair.get(r.pairKey) ?? null) : null}
+                onRemove={() => setRoutes(routes.filter((_, idx) => idx !== i))}
+                onAnchorChange={(side, anchor) =>
+                  setRoutes(
+                    routes.map((route, idx) =>
+                      idx === i
+                        ? { ...route, [side === 'from' ? 'fromAnchor' : 'toAnchor']: anchor }
+                        : route,
+                    ),
+                  )
+                }
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EndpointSelect({
+  label,
+  value,
+  onChange,
+  options,
+  loading,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  options: { onNet: { value: string; label: string }[]; offNet: { value: string; label: string }[] }
+  loading: boolean
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      {label}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={loading}
+        className="min-w-[14rem] px-3 py-1.5 text-xs border border-border rounded-md bg-background hover:bg-muted transition-colors disabled:opacity-50"
+      >
+        <option value="">Select a location…</option>
+        <optgroup label="DoubleZero metros">
+          {options.onNet.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </optgroup>
+        <optgroup label="Not yet on DoubleZero">
+          {options.offNet.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </optgroup>
+      </select>
+    </label>
+  )
+}

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -289,8 +289,12 @@ export function cellFor(
 
 export type MatrixSummary = {
   pairs: number
-  /** Pairs DoubleZero carries, measured or not. */
+  /** Pairs DoubleZero is known to carry, measured or not. */
   withPath: number
+  /** Pairs whose state is not known yet — the latency query is still in flight. */
+  pending: number
+  /** Pairs whose state could not be asked for — the latency query failed. */
+  failed: number
   avgSavedMs: number | null
   avgPct: number | null
   best: { label: string; pct: number; savedMs: number | null } | null
@@ -300,6 +304,13 @@ export type MatrixSummary = {
  * Totals for the KPI cards. Only `improvement` cells carry a percentage, so a
  * withheld or unmeasured pair moves no average and can never be the best route —
  * it is counted as carried by DoubleZero, which is a fact, and nothing more.
+ *
+ * `pending` and `failed` are counted separately and never folded into
+ * `withPath`, because the same collapse that would misreport one cell misreports
+ * the whole grid at this level: a failed request would otherwise total to "0
+ * pairs where DoubleZero has a path", which reads as "DoubleZero carries none of
+ * your routes" and stays on screen for as long as the endpoint is down. The
+ * caller must state an unknown as an unknown whenever either is non-zero.
  */
 export function summariseMatrix(entries: { label: string; cell: MatrixCell }[]): MatrixSummary {
   const improved = entries.flatMap((e) =>
@@ -307,12 +318,14 @@ export function summariseMatrix(entries: { label: string; cell: MatrixCell }[]):
   )
   const saved = improved.map((e) => e.savedMs).filter((ms): ms is number => ms !== null)
   const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null)
+  const count = (...kinds: MatrixCell['kind'][]) =>
+    entries.filter((e) => kinds.includes(e.cell.kind)).length
 
   return {
     pairs: entries.length,
-    withPath: entries.filter((e) =>
-      ['improvement', 'withheld', 'not-measured'].includes(e.cell.kind),
-    ).length,
+    withPath: count('improvement', 'withheld', 'not-measured'),
+    pending: count('loading'),
+    failed: count('error'),
     avgSavedMs: mean(saved),
     avgPct: mean(improved.map((e) => e.pct)),
     best: improved.reduce<MatrixSummary['best']>(
@@ -883,7 +896,10 @@ export function RoutesPage() {
           )}
         </div>
 
-        {axis.length < 2 ? (
+        {/* The grid waits for the metros: the axes sort on the city name, so
+            rendering before the names arrive shows one order and then visibly
+            reshuffles rows and columns a beat later. */}
+        {metrosLoading || axis.length < 2 ? (
           <div className="text-sm text-muted-foreground py-8 text-center">
             {metrosLoading ? (
               <Loader2 className="h-5 w-5 animate-spin mx-auto" />
@@ -941,34 +957,59 @@ function shortLabel(id: string): string {
   return (OFF_NET_ENDPOINTS.find((e) => e.id === id)?.short ?? id).toUpperCase()
 }
 
+/** `-4.0` reads "4.0% slower", never "-4.0% faster". */
+function fasterPhrase(pct: number): string {
+  return `${Math.abs(pct).toFixed(1)}% ${pct < 0 ? 'slower' : 'faster'}`
+}
+
 function SummaryCards({ summary, locations }: { summary: MatrixSummary; locations: number }) {
+  // Three of the four cards are claims about measurements. While any pair's
+  // state is unknown they state the unknown instead, because a request that
+  // failed would otherwise total to a confident "0 pairs on DoubleZero".
+  const unknown =
+    summary.failed > 0
+      ? 'latency data could not be loaded'
+      : summary.pending > 0
+        ? 'waiting for latency data'
+        : null
+  const avgSlower = (summary.avgPct ?? 0) < 0
+  const bestSaved = summary.best?.savedMs ?? null
+
   const cards: { label: string; value: string; lines: string[] }[] = [
     {
+      // The only card that is arithmetic on the selection rather than a claim
+      // about measurements, so it stands whatever the latency query is doing.
       label: 'Pairs shown',
       value: String(summary.pairs),
       lines: [`${locations} locations`],
     },
     {
       label: 'On DoubleZero',
-      value: `${summary.withPath} pairs`,
-      lines: ['where DoubleZero has a path'],
+      value: unknown ? '—' : `${summary.withPath} pairs`,
+      lines: [unknown ?? 'where DoubleZero has a path'],
     },
     {
-      label: 'Average faster',
-      value: summary.avgSavedMs !== null ? `${summary.avgSavedMs.toFixed(1)} ms` : '—',
+      label: avgSlower ? 'Average slower' : 'Average faster',
+      value: unknown || summary.avgSavedMs === null ? '—' : `${Math.abs(summary.avgSavedMs).toFixed(1)} ms`,
       lines: [
-        summary.avgPct !== null ? `${summary.avgPct.toFixed(1)}% mean reduction` : 'nothing to average',
+        unknown ??
+          (summary.avgPct !== null
+            ? `${Math.abs(summary.avgPct).toFixed(1)}% mean ${avgSlower ? 'increase' : 'reduction'}`
+            : 'nothing to average'),
       ],
     },
     {
       label: 'Best route',
-      value: summary.best ? `${summary.best.pct.toFixed(1)}%` : '—',
-      lines: summary.best
-        ? [
-            summary.best.label,
-            summary.best.savedMs !== null ? `${summary.best.savedMs.toFixed(1)} ms saved` : '',
-          ].filter(Boolean)
-        : ['no measured comparison'],
+      value: unknown || !summary.best ? '—' : fasterPhrase(summary.best.pct),
+      lines:
+        unknown || !summary.best
+          ? [unknown ?? 'no measured comparison']
+          : [
+              summary.best.label,
+              bestSaved !== null
+                ? `${Math.abs(bestSaved).toFixed(1)} ms ${bestSaved < 0 ? 'added' : 'saved'}`
+                : '',
+            ].filter(Boolean),
     },
   ]
 
@@ -989,14 +1030,33 @@ function SummaryCards({ summary, locations }: { summary: MatrixSummary; location
   )
 }
 
-const CELL_NOTE: Record<Exclude<MatrixCell['kind'], 'improvement' | 'unavailable'>, string> = {
-  diagonal: 'same location',
-  loading: 'loading…',
-  error: 'latency data could not be loaded',
-  'no-path': 'DoubleZero has no path between these metros',
-  'not-measured': 'no public-internet measurements for this pair in the window',
-  withheld: 'improvement withheld: a hop reports its contracted figure, not a measurement',
-}
+/**
+ * One wording per fact. The cell, its tooltip and the legend all read from here,
+ * so the grid cannot end up calling the same state three different things.
+ * Spelled out rather than derived from the kind — a customer reads this.
+ */
+const CELL_FACTS: Record<Exclude<MatrixCell['kind'], 'improvement'>, { short: string; long: string }> =
+  {
+    diagonal: { short: '·', long: 'same location' },
+    loading: { short: '', long: 'loading…' },
+    error: { short: 'load failed', long: 'the latency data could not be loaded' },
+    'no-path': { short: 'no path', long: 'DoubleZero cannot route between these two metros' },
+    'not-measured': {
+      short: 'not measured',
+      long: 'no public-internet samples for this pair in the window',
+    },
+    withheld: {
+      short: 'withheld',
+      long: 'a hop reports a contracted figure, so no percentage is claimed',
+    },
+    unavailable: {
+      short: 'N/A',
+      long: 'no committed DoubleZero coverage at this location',
+    },
+  }
+
+/** The states the legend explains, in the order a reader meets them. */
+const LEGEND_FACTS = ['no-path', 'not-measured', 'withheld', 'unavailable'] as const
 
 function CellBody({ cell }: { cell: MatrixCell }) {
   switch (cell.kind) {
@@ -1009,27 +1069,19 @@ function CellBody({ cell }: { cell: MatrixCell }) {
           </span>
         </>
       )
-    case 'unavailable':
-      return <span className="text-xs text-muted-foreground">N/A</span>
     case 'loading':
       return <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+    case 'unavailable':
+      return <span className="text-xs text-muted-foreground">{CELL_FACTS.unavailable.short}</span>
     case 'diagonal':
-      return <span className="text-muted-foreground/40">·</span>
+      return <span className="text-muted-foreground/40">{CELL_FACTS.diagonal.short}</span>
     default:
       return (
         <span className="text-[10px] leading-tight text-muted-foreground px-1 text-center">
-          {CELL_TEXT[cell.kind]}
+          {CELL_FACTS[cell.kind].short}
         </span>
       )
   }
-}
-
-/** Spelled out rather than derived from the kind: this is text a customer reads. */
-const CELL_TEXT: Record<'no-path' | 'not-measured' | 'withheld' | 'error', string> = {
-  'no-path': 'no path',
-  'not-measured': 'not measured',
-  withheld: 'withheld',
-  error: 'load failed',
 }
 
 const CELL_BOX = 'w-24 h-14 flex flex-col items-center justify-center gap-0.5 border border-border/40'
@@ -1050,8 +1102,8 @@ function LatencyMatrix({
     <div className="mt-4 max-w-full overflow-x-auto">
       <table className="border-separate border-spacing-0">
         <caption className="caption-top text-left text-[11px] text-muted-foreground pb-2">
-          Latency reduction on DoubleZero against the public internet, row to column: percentage,
-          and milliseconds saved.
+          Latency on DoubleZero against the public internet, row to column: the percentage and the
+          milliseconds it saves. Negative where DoubleZero is the slower of the two.
         </caption>
         <thead>
           <tr>
@@ -1090,10 +1142,10 @@ function LatencyMatrix({
                 const isSelected = selected?.i === i && selected?.j === j
                 const note =
                   cell.kind === 'improvement'
-                    ? `${cell.pct.toFixed(1)}% faster on DoubleZero`
+                    ? `${fasterPhrase(cell.pct)} on DoubleZero`
                     : cell.kind === 'unavailable'
-                      ? (cell.note ?? 'no figure to report')
-                      : CELL_NOTE[cell.kind]
+                      ? (cell.note ?? CELL_FACTS.unavailable.long)
+                      : CELL_FACTS[cell.kind].long
                 return (
                   <td key={col.id} className="p-0">
                     <button
@@ -1102,7 +1154,7 @@ function LatencyMatrix({
                       aria-pressed={isSelected}
                       className={cn(
                         CELL_BOX,
-                        'w-full transition-colors hover:brightness-110',
+                        'transition-colors hover:brightness-110',
                         cell.kind === 'improvement' ? shadeFor(cell.pct) : 'bg-muted/10',
                         isSelected && 'outline-2 -outline-offset-2 outline-foreground',
                       )}
@@ -1151,10 +1203,11 @@ function Legend() {
         ))}
         40%+ faster on DoubleZero
       </span>
-      <span>no path — DoubleZero cannot route between the two metros</span>
-      <span>not measured — no public-internet samples in the window</span>
-      <span>withheld — a hop reports a contracted figure, so no percentage is claimed</span>
-      <span>N/A — no committed DoubleZero coverage at that location</span>
+      {LEGEND_FACTS.map((kind) => (
+        <span key={kind}>
+          {CELL_FACTS[kind].short} — {CELL_FACTS[kind].long}
+        </span>
+      ))}
     </div>
   )
 }

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -368,7 +368,7 @@ function RouteCard({
                 Improvement
               </div>
               <div className={cn('text-lg font-bold tabular-nums', TIER_PCT_TEXT[tier])}>
-                {figures.improvementPct !== null
+                {figures.improvementPct != null
                   ? `${figures.improvementPct > 0 ? '+' : ''}${figures.improvementPct.toFixed(1)}%`
                   : '—'}
               </div>
@@ -587,7 +587,7 @@ export function RoutesPage() {
           internet.
         </p>
         <p className="mt-1 text-xs text-muted-foreground max-w-4xl">
-          Figures are averages over the last 24 hours; the spark lines show the last 7 days by the
+          Figures cover the last 24 hours; the spark lines show the last 7 days by the
           hour. The public-internet figures are measured end to end. The DoubleZero p95 and jitter
           are sums of each hop&apos;s own p95 and mean jitter — percentiles and jitter do not add,
           so those two figures are higher than what a packet actually sees. The bias runs against

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -93,6 +93,11 @@ function fmtMs(ms: number): string {
   return `${ms.toFixed(2)} ms`
 }
 
+/** 0 means the figure was never measured, so render it as absent, not as zero. */
+function orAbsent(ms: number): string | null {
+  return ms > 0 ? fmtMs(ms) : null
+}
+
 /** One measured figure, or an em dash when the figure is absent. */
 function Stat({ label, value }: { label: string; value: string | null }) {
   return (
@@ -259,12 +264,12 @@ function RouteCard({
             <Stat label="DoubleZero mean" value={fmtMs(latency.measuredLatencyMs)} />
             <Stat label="DoubleZero p95" value={partial ? null : fmtMs(latency.measuredP95Ms)} />
             <Stat label="DoubleZero jitter" value={partial ? null : fmtMs(latency.measuredJitterMs)} />
-            <Stat
-              label="Internet mean"
-              value={latency.internetLatencyMs > 0 ? fmtMs(latency.internetLatencyMs) : null}
-            />
-            <Stat label="Internet p95" value={null} />
-            <Stat label="Internet jitter" value={null} />
+            {/* Suppression is asymmetric: on the DoubleZero side partiallyCommitted
+                is the signal and p95/jitter are 0 when it is set; on the internet
+                side there is no such flag, so 0 is the only signal for absent. */}
+            <Stat label="Internet mean" value={orAbsent(latency.internetLatencyMs)} />
+            <Stat label="Internet p95" value={orAbsent(latency.internetP95Ms)} />
+            <Stat label="Internet jitter" value={orAbsent(latency.internetJitterMs)} />
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
@@ -304,10 +309,6 @@ function RouteCard({
                 One or more hops had no recent measurements; this route shows contracted latency.
               </p>
             )}
-            <p className="text-xs text-muted-foreground">
-              Public-internet p95 and jitter are not measured, so only the mean round-trip is
-              reported for that side.
-            </p>
             {[fromMetro, toMetro].map((code) => {
               const pk = metroPkFor(code)
               if (!pk || !code) return null

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -25,7 +25,8 @@ import { cn } from '@/lib/utils'
 /**
  * Presentational cap. The mesh is quadratic — 12 locations is 66 pairs, which is
  * about as much as a reader can still scan. It is not the route-series cap: the
- * series is fetched for the selected cell alone, one pair at a time.
+ * series is fetched only for the cells opened as cards, which `MAX_CELLS` caps
+ * at the 10 pairs that endpoint accepts.
  */
 export const MAX_CITIES = 12
 
@@ -228,6 +229,94 @@ export function formatCities(cities: SelectedCity[]): string {
   return cities.map((c) => formatCityToken(c.id, c.anchor)).join(',')
 }
 
+/**
+ * One cell of the mesh, as the row and column the reader clicked. The direction
+ * is kept because `orientPath` reads the path in it and the card is headed by
+ * it; the pair it identifies is undirected (see `cellPairKey`).
+ */
+export type SelectedCell = { from: string; to: string }
+
+/**
+ * Matches maxRouteSeriesPairs on the route-series endpoint, which is why the
+ * whole comparison set is fetched in one request rather than one per card.
+ */
+export const MAX_CELLS = 10
+
+function cityOf(cities: SelectedCity[], id: string): SelectedCity | undefined {
+  return cities.find((c) => c.id.toLowerCase() === id.toLowerCase())
+}
+
+/** The route a cell names, with each end's anchor applied. Null if either end left the mesh. */
+export function resolveCell(cell: SelectedCell, cities: SelectedCity[]): ResolvedRoute | null {
+  const from = cityOf(cities, cell.from)
+  const to = cityOf(cities, cell.to)
+  if (!from || !to) return null
+  return resolveRoute({
+    from: from.id,
+    to: to.id,
+    fromAnchor: from.anchor,
+    toAnchor: to.anchor,
+  })
+}
+
+/**
+ * Identity of a cell for the comparison set. Undirected, because the matrix is
+ * symmetric: (LON, TYO) and (TYO, LON) are one route, and two cards for one
+ * route would report the same figures twice under two headings. Null where there
+ * is nothing to compare.
+ */
+export function cellPairKey(cell: SelectedCell, cities: SelectedCity[]): string | null {
+  return resolveCell(cell, cities)?.pairKey ?? null
+}
+
+/**
+ * Reads the `?cell=` set. Membership is by pair, so a link naming both a cell
+ * and its mirror yields one route, keeping the orientation named first — the
+ * heading a reader is already looking at must not flip as the set grows.
+ */
+export function parseCells(
+  raw: string | null,
+  cities: SelectedCity[],
+): { cells: SelectedCell[]; requested: number } {
+  if (!raw) return { cells: [], requested: 0 }
+  const tokens = raw.split(',').filter(Boolean)
+  const seen = new Set<string>()
+  const cells: SelectedCell[] = []
+  for (const token of tokens) {
+    // Malformed, naming a location outside the mesh, or naming a pair with
+    // nothing to compare: dropped, never coerced into a neighbouring route.
+    const parsed = parseRouteToken(token)
+    if (!parsed) continue
+    const cell = { from: parsed.from, to: parsed.to }
+    const key = cellPairKey(cell, cities)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    cells.push(cell)
+  }
+  return { cells: cells.slice(0, MAX_CELLS), requested: tokens.length }
+}
+
+export function formatCells(cells: SelectedCell[]): string {
+  return cells.map((c) => formatRouteToken(c.from, c.to)).join(',')
+}
+
+/**
+ * Adds or removes one cell. Removal matches on the pair, so clicking the mirror
+ * of a selected cell takes that route out rather than adding a second card for
+ * it. At the cap the set is returned unchanged — the caller says so on screen.
+ */
+export function toggleCell(
+  cells: SelectedCell[],
+  cell: SelectedCell,
+  cities: SelectedCity[],
+): SelectedCell[] {
+  const key = cellPairKey(cell, cities)
+  if (!key) return cells
+  const without = cells.filter((c) => cellPairKey(c, cities) !== key)
+  if (without.length < cells.length) return without
+  return cells.length >= MAX_CELLS ? cells : [...cells, cell]
+}
+
 /** Every unordered pair of a selection, each once — the mesh the KPI cards sum over. */
 export function meshPairs<T>(items: T[]): [T, T][] {
   const out: [T, T][] = []
@@ -285,6 +374,28 @@ export function cellFor(
   if (!figures.internetMeasured) return { kind: 'not-measured' }
   if (figures.improvementPct === null) return { kind: 'withheld' }
   return { kind: 'improvement', pct: figures.improvementPct, savedMs: figures.savedMs }
+}
+
+/**
+ * Whether a cell can be opened as a card. N/A, no path and not measured have
+ * nothing to compare; loading and error are not yet known to have anything, and
+ * while either is on screen the grid holds no figures to pick between anyway.
+ */
+export function isComparable(cell: MatrixCell): boolean {
+  return cell.kind === 'improvement' || cell.kind === 'withheld'
+}
+
+/**
+ * Meta, Ctrl and Shift are one gesture: the request arrived as "shift + cmd
+ * click", muscle memory differs by platform, and a matrix has no linear range
+ * for Shift to extend, so there is nothing for them to mean separately.
+ */
+export function isToggleGesture(e: {
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+}): boolean {
+  return e.metaKey || e.ctrlKey || e.shiftKey
 }
 
 export type MatrixSummary = {
@@ -484,7 +595,7 @@ function RouteCard({
           )}
           <button
             onClick={onRemove}
-            aria-label="Clear selected route"
+            aria-label="Remove this route from the comparison"
             className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             <X className="h-4 w-4" />
@@ -612,22 +723,19 @@ export function RoutesPage() {
     [searchParams],
   )
 
-  const selectedCell = useMemo(() => {
-    const parsed = parseRouteToken(searchParams.get('cell') ?? '')
-    if (!parsed) return null
-    // A cell naming a location outside the mesh is dropped on the same rule: a
-    // shared link must not open on a pair this grid does not show.
-    const inMesh = (id: string) => cities.some((c) => c.id.toLowerCase() === id.toLowerCase())
-    if (!inMesh(parsed.from) || !inMesh(parsed.to)) return null
-    if (parsed.from.toLowerCase() === parsed.to.toLowerCase()) return null
-    return { from: parsed.from, to: parsed.to }
-  }, [searchParams, cities])
+  // Same rules as the city list: a malformed token is dropped, a mirrored repeat
+  // folds onto the route it names, and the count asked for is kept so a set the
+  // link could not reproduce is stated rather than silently shorter.
+  const { cells: selectedCells, requested: cellsRequested } = useMemo(
+    () => parseCells(searchParams.get('cell'), cities),
+    [searchParams, cities],
+  )
 
   const setUrl = useCallback(
-    (nextCities: SelectedCity[], cell: { from: string; to: string } | null) => {
+    (nextCities: SelectedCity[], cells: SelectedCell[]) => {
       const params: Record<string, string> = {}
       if (nextCities.length) params.cities = formatCities(nextCities)
-      if (cell) params.cell = formatRouteToken(cell.from, cell.to)
+      if (cells.length) params.cell = formatCells(cells)
       // Replace the whole query so a shared link reproduces the view exactly, and
       // replace the history entry so Back leaves the page rather than walking
       // back through every intermediate selection.
@@ -733,65 +841,77 @@ export function RoutesPage() {
     [axis, grid],
   )
 
-  const selectedIndex = useMemo(() => {
-    if (!selectedCell) return null
-    const at = (id: string) => axis.findIndex((c) => c.id.toLowerCase() === id.toLowerCase())
-    const i = at(selectedCell.from)
-    const j = at(selectedCell.to)
-    return i < 0 || j < 0 || i === j ? null : { i, j }
-  }, [selectedCell, axis])
+  // --- Comparison set ------------------------------------------------------
 
-  const selected = selectedIndex ? grid[selectedIndex.i][selectedIndex.j].resolved : null
-  const selectedLatency = selected?.pairKey ? (latencyByPair.get(selected.pairKey) ?? null) : null
+  const compared = useMemo(
+    () =>
+      selectedCells.flatMap((cell) => {
+        const resolved = resolveCell(cell, cities)
+        return resolved?.pairKey ? [{ cell, resolved, pairKey: resolved.pairKey }] : []
+      }),
+    [selectedCells, cities],
+  )
 
-  // Fetched one pair at a time, for the selected cell only: the grid shows no
-  // sparklines, so the route-series cap of 10 pairs is never approached.
-  const selectedPairKey = selected?.pairKey ?? null
+  // Membership is by pair, so both triangles of a selected route light up and
+  // either one toggles it back off.
+  const comparedKeys = useMemo(() => new Set(compared.map((c) => c.pairKey)), [compared])
+
+  // One request for the whole set, which is why the set is capped at the same 10
+  // pairs the endpoint accepts. A card per request would be up to ten requests.
+  const pairKeys = useMemo(() => compared.map((c) => c.pairKey), [compared])
   const {
     data: seriesData,
     isPending: seriesIsPending,
     error: seriesQueryError,
   } = useQuery({
-    queryKey: ['route-series', selectedPairKey],
-    queryFn: () => fetchRouteSeries([selectedPairKey as string]),
-    enabled: selectedPairKey !== null,
+    queryKey: ['route-series', pairKeys.join(',')],
+    queryFn: () => fetchRouteSeries(pairKeys),
+    enabled: pairKeys.length > 0,
     staleTime: 300000,
   })
 
   // A disabled query reports isPending, so gate on there being something to fetch.
+  // Both flags are shared by every card, which is exactly why the per-pair lookup
+  // below stays separate: a pair absent from a response that arrived is "no
+  // history" for that one card, and it must not read like the request failing.
   const seriesError = Boolean(seriesQueryError) || Boolean(seriesData?.error)
-  const seriesPending = selectedPairKey !== null && seriesIsPending && !seriesError
+  const seriesPending = pairKeys.length > 0 && seriesIsPending && !seriesError
 
-  const series = useMemo(() => {
-    const s = (seriesData?.series ?? []).find(
-      (x) => pairKeyOf(x.fromMetroCode, x.toMetroCode) === selectedPairKey,
-    )
-    if (!s) return null
-    return { dz: s.points.map((p) => p.dzMs), internet: s.points.map((p) => p.internetMs) }
-  }, [seriesData, selectedPairKey])
+  const seriesByPair = useMemo(() => {
+    const map = new Map<string, { dz: number[]; internet: number[] }>()
+    for (const s of seriesData?.series ?? []) {
+      map.set(pairKeyOf(s.fromMetroCode, s.toMetroCode), {
+        dz: s.points.map((p) => p.dzMs),
+        internet: s.points.map((p) => p.internetMs),
+      })
+    }
+    return map
+  }, [seriesData])
 
   // --- Selection -----------------------------------------------------------
   const atLimit = cities.length >= MAX_CITIES
+  const atCellLimit = selectedCells.length >= MAX_CELLS
 
   const addCity = useCallback(
     (id: string) => {
       if (!id || atLimit) return
-      setUrl([...cities, { id }], selectedCell)
+      setUrl([...cities, { id }], selectedCells)
     },
-    [atLimit, cities, selectedCell, setUrl],
+    [atLimit, cities, selectedCells, setUrl],
   )
 
   const removeCity = useCallback(
     (id: string) => {
       const gone = (other: string) => other.toLowerCase() === id.toLowerCase()
-      const stillShown =
-        selectedCell && !gone(selectedCell.from) && !gone(selectedCell.to) ? selectedCell : null
+      const nextCities = cities.filter((c) => !gone(c.id))
+      // A comparison whose location just left the mesh has nothing left to
+      // compare, so it goes with it rather than lingering as a dead card.
       setUrl(
-        cities.filter((c) => !gone(c.id)),
-        stillShown,
+        nextCities,
+        selectedCells.filter((c) => !gone(c.from) && !gone(c.to)),
       )
     },
-    [cities, selectedCell, setUrl],
+    [cities, selectedCells, setUrl],
   )
 
   // One anchor per city rather than per route: the same city cannot sensibly have
@@ -801,10 +921,19 @@ export function RoutesPage() {
     (id: string, anchor: string) => {
       setUrl(
         cities.map((c) => (c.id === id ? { ...c, anchor } : c)),
-        selectedCell,
+        selectedCells,
       )
     },
-    [cities, selectedCell, setUrl],
+    [cities, selectedCells, setUrl],
+  )
+
+  // Plain click replaces the selection; any modifier toggles the cell in or out
+  // of the comparison.
+  const pickCell = useCallback(
+    (cell: SelectedCell, toggle: boolean) => {
+      setUrl(cities, toggle ? toggleCell(selectedCells, cell, cities) : [cell])
+    },
+    [cities, selectedCells, setUrl],
   )
 
   const options = useMemo(() => {
@@ -844,8 +973,8 @@ export function RoutesPage() {
           care about and every route between them is compared.
         </p>
         <p className="mt-1 text-xs text-muted-foreground max-w-4xl">
-          Figures cover the last 24 hours; the selected route also shows the last 7 days by the
-          hour. The public-internet figures are measured end to end. The DoubleZero p95 and jitter
+          Figures cover the last 24 hours; a route opened as a card also shows the last 7 days by
+          the hour. The public-internet figures are measured end to end. The DoubleZero p95 and jitter
           are sums of each hop&apos;s own p95 and mean jitter — percentiles and jitter do not add,
           so those two figures are higher than what a packet actually sees. The bias runs against
           DoubleZero.
@@ -914,37 +1043,52 @@ export function RoutesPage() {
             <LatencyMatrix
               axis={axis}
               grid={grid}
-              selected={selectedIndex}
-              onSelect={(i, j) => setUrl(cities, { from: axis[i].id, to: axis[j].id })}
+              comparedKeys={comparedKeys}
+              onPick={pickCell}
             />
+
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Click a cell for the full breakdown of that route. Hold Cmd, Ctrl or Shift — or press
+              Enter with one of them held — to compare several routes side by side.
+              {atCellLimit && ` Comparing the maximum of ${MAX_CELLS} routes; deselect one to add another.`}
+              {cellsRequested > selectedCells.length &&
+                ` This link asked for ${cellsRequested} routes; showing ${selectedCells.length}.`}
+            </p>
 
             <Legend />
 
             <OffNetNotes axis={axis} />
 
-            <div className="mt-4">
-              {selected ? (
+            {/* Side by side where there is room, stacked where there is not. */}
+            <div className="mt-4 grid gap-3 xl:grid-cols-2">
+              {compared.map(({ cell, resolved, pairKey }) => (
                 <RouteCard
-                  resolved={selected}
+                  key={pairKey}
+                  resolved={resolved}
                   labelFor={labelFor}
                   metroPkFor={metroPkFor}
-                  latency={selectedLatency}
+                  latency={latencyByPair.get(pairKey) ?? null}
                   latencyPending={latencyPending}
                   latencyError={latencyError}
-                  series={series}
+                  // Null here means this pair was absent from a response that did
+                  // arrive, which the card renders as "no history". The request
+                  // having failed is the seriesError flag, and reads differently.
+                  series={seriesByPair.get(pairKey) ?? null}
                   seriesPending={seriesPending}
                   seriesError={seriesError}
-                  onRemove={() => setUrl(cities, null)}
+                  onRemove={() => pickCell(cell, true)}
                   onAnchorChange={(side, anchor) =>
-                    setAnchor(side === 'from' ? selected.route.from : selected.route.to, anchor)
+                    setAnchor(side === 'from' ? cell.from : cell.to, anchor)
                   }
                 />
-              ) : (
-                <p className="text-sm text-muted-foreground text-center py-6">
-                  Select a cell to see the full breakdown for that route.
-                </p>
-              )}
+              ))}
             </div>
+
+            {compared.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-6">
+                Select a cell to see the full breakdown for that route.
+              </p>
+            )}
           </>
         )}
       </div>
@@ -1089,13 +1233,14 @@ const CELL_BOX = 'w-24 h-14 flex flex-col items-center justify-center gap-0.5 bo
 function LatencyMatrix({
   axis,
   grid,
-  selected,
-  onSelect,
+  comparedKeys,
+  onPick,
 }: {
   axis: SelectedCity[]
   grid: { resolved: ResolvedRoute | null; cell: MatrixCell }[][]
-  selected: { i: number; j: number } | null
-  onSelect: (i: number, j: number) => void
+  /** Pair keys currently compared — by pair, so both triangles of a route light up. */
+  comparedKeys: Set<string>
+  onPick: (cell: SelectedCell, toggle: boolean) => void
 }) {
   return (
     // The grid scrolls inside this box; the page body never scrolls sideways.
@@ -1129,7 +1274,7 @@ function LatencyMatrix({
                 {shortLabel(row.id)}
               </th>
               {axis.map((col, j) => {
-                const { cell } = grid[i][j]
+                const { cell, resolved } = grid[i][j]
                 if (cell.kind === 'diagonal') {
                   return (
                     <td key={col.id} className="p-0">
@@ -1139,7 +1284,8 @@ function LatencyMatrix({
                     </td>
                   )
                 }
-                const isSelected = selected?.i === i && selected?.j === j
+                const isCompared = Boolean(resolved?.pairKey && comparedKeys.has(resolved.pairKey))
+                const picked = { from: row.id, to: col.id }
                 const note =
                   cell.kind === 'improvement'
                     ? `${fasterPhrase(cell.pct)} on DoubleZero`
@@ -1149,14 +1295,25 @@ function LatencyMatrix({
                 return (
                   <td key={col.id} className="p-0">
                     <button
-                      onClick={() => onSelect(i, j)}
+                      onClick={(e) => onPick(picked, isToggleGesture(e))}
+                      // Enter and Space already reach onClick; this adds the
+                      // modified form of the same gesture, so the comparison is
+                      // not mouse-only. preventDefault stops the button also
+                      // synthesising a click and toggling twice.
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && isToggleGesture(e)) {
+                          e.preventDefault()
+                          onPick(picked, true)
+                        }
+                      }}
+                      disabled={!isComparable(cell)}
                       title={`${shortLabel(row.id)} → ${shortLabel(col.id)} — ${note}`}
-                      aria-pressed={isSelected}
+                      aria-pressed={isCompared}
                       className={cn(
                         CELL_BOX,
-                        'transition-colors hover:brightness-110',
+                        'transition-colors enabled:hover:brightness-110 disabled:cursor-not-allowed',
                         cell.kind === 'improvement' ? shadeFor(cell.pct) : 'bg-muted/10',
-                        isSelected && 'outline-2 -outline-offset-2 outline-foreground',
+                        isCompared && 'outline-2 -outline-offset-2 outline-foreground',
                       )}
                     >
                       <CellBody cell={cell} />

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -75,6 +75,22 @@ export function pairKeyOf(a: string, b: string): string {
 export function resolveRoute(route: SelectedRoute): ResolvedRoute {
   const from = resolveEndpoint(route.from, route.fromAnchor)
   const to = resolveEndpoint(route.to, route.toAnchor)
+
+  // Same off-net location at both ends — the UI blocks this, but a URL can ask
+  // for it (?routes=ohio@pit-ohio@chi). Its note argues the access leg cancels
+  // between the two paths, which is untrue here because the two legs differ, and
+  // the card would report pit↔chi under an Ohio→Ohio heading. Refuse instead.
+  if (from.offNet && from.offNet === to.offNet) {
+    return {
+      route,
+      fromMetro: from.metroCode,
+      toMetro: to.metroCode,
+      notes: [`${from.offNet.label} is at both ends of this route, so there is nothing to compare.`],
+      unavailable: true,
+      pairKey: null,
+    }
+  }
+
   const notes = [from.offNet?.note, to.offNet?.note].filter(Boolean) as string[]
 
   // Either side unresolvable, or both sides land on the same metro (e.g. an
@@ -89,13 +105,61 @@ export function resolveRoute(route: SelectedRoute): ResolvedRoute {
   return { route, fromMetro: from.metroCode, toMetro: to.metroCode, notes, unavailable, pairKey }
 }
 
-function fmtMs(ms: number): string {
-  return `${ms.toFixed(2)} ms`
+function fmtMs(ms: number, dp = 2): string {
+  return `${ms.toFixed(dp)} ms`
 }
 
 /** 0 means the figure was never measured, so render it as absent, not as zero. */
-function orAbsent(ms: number): string | null {
-  return ms > 0 ? fmtMs(ms) : null
+function orAbsent(ms: number, dp = 2): string | null {
+  return ms > 0 ? fmtMs(ms, dp) : null
+}
+
+export const CONTRACTED_NOTE =
+  'One or more hops had no recent measurements, so this route shows its contracted latency ' +
+  'rather than a measured one. The improvement figure is withheld, because it would be ' +
+  'comparing a commitment against a measurement.'
+
+export type RouteFigures = {
+  tiles: { label: string; value: string | null }[]
+  improvementPct: number | null
+  footnote: string | null
+}
+
+/**
+ * Decides what every figure on a route card shows.
+ *
+ * All the suppression rules live here because they are not uniform, and getting
+ * one wrong prints something that is not a measurement:
+ *
+ *  - `partiallyCommitted` means a hop had no recent samples and the API
+ *    substituted the contracted figure. p95 and jitter arrive as 0 and are
+ *    blanked. The mean is real, but it is a commitment rather than an
+ *    observation, so it is shown with a label that says so. The improvement is
+ *    withheld entirely — a percentage comparing a commitment against a measured
+ *    internet figure is not a claim we can stand behind.
+ *  - the public-internet side has no equivalent flag, so 0 is the only signal
+ *    that one of its figures is absent.
+ *
+ * Jitter renders at 3 dp because a typical per-hop figure is around 0.03 ms,
+ * which 2 dp flattens to a single significant figure.
+ */
+export function routeFigures(l: MetroPathLatency): RouteFigures {
+  const partial = l.partiallyCommitted
+  return {
+    tiles: [
+      {
+        label: partial ? 'DoubleZero mean (contracted)' : 'DoubleZero mean',
+        value: orAbsent(l.measuredLatencyMs),
+      },
+      { label: 'DoubleZero p95', value: partial ? null : orAbsent(l.measuredP95Ms) },
+      { label: 'DoubleZero jitter', value: partial ? null : orAbsent(l.measuredJitterMs, 3) },
+      { label: 'Internet mean', value: orAbsent(l.internetLatencyMs) },
+      { label: 'Internet p95', value: orAbsent(l.internetP95Ms) },
+      { label: 'Internet jitter', value: orAbsent(l.internetJitterMs, 3) },
+    ],
+    improvementPct: partial ? null : l.measuredImprovementPct,
+    footnote: partial ? CONTRACTED_NOTE : null,
+  }
 }
 
 /**
@@ -194,8 +258,11 @@ function RouteCard({
   labelFor,
   metroPkFor,
   latency,
+  latencyPending,
+  latencyError,
   series,
   seriesPending,
+  seriesError,
   onRemove,
   onAnchorChange,
 }: {
@@ -203,8 +270,11 @@ function RouteCard({
   labelFor: (id: string) => string
   metroPkFor: (metroCode: string | null) => string | null
   latency: MetroPathLatency | null
+  latencyPending: boolean
+  latencyError: boolean
   series: { dz: number[]; internet: number[] } | null
   seriesPending: boolean
+  seriesError: boolean
   onRemove: () => void
   onAnchorChange: (side: 'from' | 'to', anchor: string) => void
 }) {
@@ -212,11 +282,8 @@ function RouteCard({
   const fromOffNet = OFF_NET_ENDPOINTS.find((e) => e.id === route.from)
   const toOffNet = OFF_NET_ENDPOINTS.find((e) => e.id === route.to)
 
-  // p95 and jitter are absent — not zero — when a hop had no recent samples and
-  // the route fell back to its contracted figure. Rendering "0.00 ms" there
-  // would read as a real measurement.
-  const partial = latency?.partiallyCommitted ?? false
-  const tier = getImprovementTier(latency?.improvementPct ?? null)
+  const figures = latency ? routeFigures(latency) : null
+  const tier = getImprovementTier(figures?.improvementPct ?? null)
 
   return (
     <div className="bg-card border border-border rounded-lg p-4">
@@ -270,22 +337,29 @@ function RouteCard({
             </span>
           )}
         </div>
-      ) : !latency ? (
+      ) : !latency && latencyError ? (
+        // Distinct from "no path": an unreachable endpoint must never be reported
+        // to a customer as DoubleZero having no route between two of its metros.
+        // Guarded on !latency so a failed background refetch does not hide figures
+        // we already hold.
+        <div className="mt-3 text-sm text-muted-foreground">
+          Couldn&apos;t load latency data. Try again in a moment.
+        </div>
+      ) : !latency && latencyPending ? (
+        <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading latency…
+        </div>
+      ) : !latency || !figures ? (
         <div className="mt-3 text-sm text-muted-foreground">
           No DoubleZero path between these metros.
         </div>
       ) : (
         <>
           <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
-            <Stat label="DoubleZero mean" value={fmtMs(latency.measuredLatencyMs)} />
-            <Stat label="DoubleZero p95" value={partial ? null : fmtMs(latency.measuredP95Ms)} />
-            <Stat label="DoubleZero jitter" value={partial ? null : fmtMs(latency.measuredJitterMs)} />
-            {/* Suppression is asymmetric: on the DoubleZero side partiallyCommitted
-                is the signal and p95/jitter are 0 when it is set; on the internet
-                side there is no such flag, so 0 is the only signal for absent. */}
-            <Stat label="Internet mean" value={orAbsent(latency.internetLatencyMs)} />
-            <Stat label="Internet p95" value={orAbsent(latency.internetP95Ms)} />
-            <Stat label="Internet jitter" value={orAbsent(latency.internetJitterMs)} />
+            {figures.tiles.map((t) => (
+              <Stat key={t.label} label={t.label} value={t.value} />
+            ))}
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
@@ -294,8 +368,8 @@ function RouteCard({
                 Improvement
               </div>
               <div className={cn('text-lg font-bold tabular-nums', TIER_PCT_TEXT[tier])}>
-                {latency.improvementPct !== null
-                  ? `${latency.improvementPct > 0 ? '+' : ''}${latency.improvementPct.toFixed(1)}%`
+                {figures.improvementPct !== null
+                  ? `${figures.improvementPct > 0 ? '+' : ''}${figures.improvementPct.toFixed(1)}%`
                   : '—'}
               </div>
             </div>
@@ -317,15 +391,19 @@ function RouteCard({
               <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
                 7 days
               </div>
-              {/* Sparkline renders "no history" for two empty series. Showing that
-                  while the 7-day query is still in flight reads as "DoubleZero has
-                  no data" at exactly the wrong moment, so wait for the query. */}
-              {seriesPending ? (
+              {/* Sparkline renders "no history" for two empty series. Reaching that
+                  while the query is in flight or has failed would tell a customer
+                  DoubleZero has no measurement history, so both states are named. */}
+              {!series && (seriesPending || seriesError) ? (
                 <div
-                  className="flex items-center justify-center text-muted-foreground"
+                  className="flex items-center justify-center text-xs text-muted-foreground"
                   style={{ width: 220, height: 40 }}
                 >
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  {seriesError ? (
+                    'history unavailable'
+                  ) : (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  )}
                 </div>
               ) : (
                 <Sparkline dz={series?.dz ?? []} internet={series?.internet ?? []} />
@@ -334,10 +412,8 @@ function RouteCard({
           </div>
 
           <div className="mt-3 space-y-1">
-            {partial && (
-              <p className="text-xs text-muted-foreground">
-                One or more hops had no recent measurements; this route shows contracted latency.
-              </p>
+            {figures.footnote && (
+              <p className="text-xs text-muted-foreground">{figures.footnote}</p>
             )}
             {[fromMetro, toMetro].map((code) => {
               const pk = metroPkFor(code)
@@ -355,18 +431,20 @@ export function RoutesPage() {
   // --- URL state -----------------------------------------------------------
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const routes: SelectedRoute[] = useMemo(() => {
+  const { routes, truncated } = useMemo(() => {
     const raw = searchParams.get('routes')
-    if (!raw) return []
+    if (!raw) return { routes: [] as SelectedRoute[], truncated: false }
     // parseRouteToken returns null for a malformed token. Drop those rather than
     // coercing — a corrupted shared link must not render as a plausible-but-wrong
     // route, which is the same failure the Zurich N/A rule exists to prevent.
-    return raw
+    const parsed = raw
       .split(',')
       .filter(Boolean)
       .map(parseRouteToken)
       .filter((r): r is NonNullable<ReturnType<typeof parseRouteToken>> => r !== null)
-      .slice(0, MAX_ROUTES)
+    // Truncation is reported, not silent: otherwise the recipient of a shared
+    // link sees a different set of routes than the sender and cannot tell.
+    return { routes: parsed.slice(0, MAX_ROUTES), truncated: parsed.length > MAX_ROUTES }
   }, [searchParams])
 
   const setRoutes = useCallback(
@@ -391,11 +469,19 @@ export function RoutesPage() {
     staleTime: 300000,
   })
 
-  const { data: latencyData } = useQuery({
+  const {
+    data: latencyData,
+    isPending: latencyPending,
+    error: latencyQueryError,
+  } = useQuery({
     queryKey: ['metro-path-latency', 'latency'],
     queryFn: () => fetchMetroPathLatency('latency'),
     staleTime: 60000,
   })
+
+  // The endpoint also returns 200 with an `error` body on a backend failure, so
+  // check both. Either way the card must not fall through to "no path".
+  const latencyError = Boolean(latencyQueryError) || Boolean(latencyData?.error)
 
   const resolved = useMemo(() => routes.map(resolveRoute), [routes])
 
@@ -404,7 +490,11 @@ export function RoutesPage() {
     [resolved],
   )
 
-  const { data: seriesData, isPending: seriesIsPending } = useQuery({
+  const {
+    data: seriesData,
+    isPending: seriesIsPending,
+    error: seriesQueryError,
+  } = useQuery({
     queryKey: ['route-series', pairKeys.join(',')],
     queryFn: () => fetchRouteSeries(pairKeys),
     enabled: pairKeys.length > 0,
@@ -412,7 +502,8 @@ export function RoutesPage() {
   })
 
   // A disabled query reports isPending, so gate on there being something to fetch.
-  const seriesPending = pairKeys.length > 0 && seriesIsPending
+  const seriesError = Boolean(seriesQueryError) || Boolean(seriesData?.error)
+  const seriesPending = pairKeys.length > 0 && seriesIsPending && !seriesError
 
   const latencyByPair = useMemo(() => {
     const map = new Map<string, MetroPathLatency>()
@@ -495,6 +586,13 @@ export function RoutesPage() {
           Round-trip latency between metros, measured over the DoubleZero network and the public
           internet.
         </p>
+        <p className="mt-1 text-xs text-muted-foreground max-w-4xl">
+          Figures are averages over the last 24 hours; the spark lines show the last 7 days by the
+          hour. The public-internet figures are measured end to end. The DoubleZero p95 and jitter
+          are sums of each hop&apos;s own p95 and mean jitter — percentiles and jitter do not add,
+          so those two figures are higher than what a packet actually sees. The bias runs against
+          DoubleZero.
+        </p>
 
         {/* Selection */}
         <div className="flex flex-wrap items-end gap-2 mt-4">
@@ -520,9 +618,10 @@ export function RoutesPage() {
             <Plus className="h-3 w-3" />
             Add route
           </button>
-          {atLimit && (
+          {(atLimit || truncated) && (
             <span className="text-xs text-muted-foreground pb-1.5">
-              Showing the maximum of {MAX_ROUTES} routes. Remove one to add another.
+              Showing the maximum of {MAX_ROUTES} routes
+              {truncated ? '; this link asked for more.' : '. Remove one to add another.'}
             </span>
           )}
         </div>
@@ -545,8 +644,11 @@ export function RoutesPage() {
                 labelFor={labelFor}
                 metroPkFor={metroPkFor}
                 latency={r.pairKey ? (latencyByPair.get(r.pairKey) ?? null) : null}
+                latencyPending={latencyPending}
+                latencyError={latencyError}
                 series={r.pairKey ? (seriesByPair.get(r.pairKey) ?? null) : null}
                 seriesPending={seriesPending}
+                seriesError={seriesError}
                 onRemove={() => setRoutes(routes.filter((_, idx) => idx !== i))}
                 onAnchorChange={(side, anchor) =>
                   setRoutes(

--- a/web/src/components/routes-page.tsx
+++ b/web/src/components/routes-page.tsx
@@ -98,6 +98,20 @@ function orAbsent(ms: number): string | null {
   return ms > 0 ? fmtMs(ms) : null
 }
 
+/**
+ * Orients an API path so it reads from the origin the customer picked.
+ *
+ * The latency lookup is keyed undirected (see `pairKeyOf`) — that is what stops
+ * a route's DoubleZero and internet figures coming from different anchors — but
+ * the API emits both directions of every pair and builds its slice by ranging a
+ * Go map, so which one wins the lookup is chance. Without this, the same shared
+ * link renders "tyo ─ fra ─ lon" on one load and "lon ─ fra ─ tyo" on the next.
+ * Figures are direction-symmetric, so only the display order needs fixing.
+ */
+export function orientPath(pathMetros: string[], apiFrom: string, routeFrom: string): string[] {
+  return apiFrom.toLowerCase() === routeFrom.toLowerCase() ? pathMetros : [...pathMetros].reverse()
+}
+
 /** One measured figure, or an em dash when the figure is absent. */
 function Stat({ label, value }: { label: string; value: string | null }) {
   return (
@@ -181,6 +195,7 @@ function RouteCard({
   metroPkFor,
   latency,
   series,
+  seriesPending,
   onRemove,
   onAnchorChange,
 }: {
@@ -189,6 +204,7 @@ function RouteCard({
   metroPkFor: (metroCode: string | null) => string | null
   latency: MetroPathLatency | null
   series: { dz: number[]; internet: number[] } | null
+  seriesPending: boolean
   onRemove: () => void
   onAnchorChange: (side: 'from' | 'to', anchor: string) => void
 }) {
@@ -293,13 +309,27 @@ function RouteCard({
               <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
                 Path
               </div>
-              <div className="font-mono text-sm truncate">{latency.pathMetros.join(' ─ ')}</div>
+              <div className="font-mono text-sm truncate">
+                {orientPath(latency.pathMetros, latency.fromMetroCode, fromMetro ?? '').join(' ─ ')}
+              </div>
             </div>
             <div className="ml-auto">
               <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">
                 7 days
               </div>
-              <Sparkline dz={series?.dz ?? []} internet={series?.internet ?? []} />
+              {/* Sparkline renders "no history" for two empty series. Showing that
+                  while the 7-day query is still in flight reads as "DoubleZero has
+                  no data" at exactly the wrong moment, so wait for the query. */}
+              {seriesPending ? (
+                <div
+                  className="flex items-center justify-center text-muted-foreground"
+                  style={{ width: 220, height: 40 }}
+                >
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                </div>
+              ) : (
+                <Sparkline dz={series?.dz ?? []} internet={series?.internet ?? []} />
+              )}
             </div>
           </div>
 
@@ -312,7 +342,7 @@ function RouteCard({
             {[fromMetro, toMetro].map((code) => {
               const pk = metroPkFor(code)
               if (!pk || !code) return null
-              return <FacilityDisclosure key={code} metroPk={pk} metroLabel={code.toUpperCase()} />
+              return <FacilityDisclosure key={code} metroPk={pk} metroLabel={labelFor(code)} />
             })}
           </div>
         </>
@@ -342,8 +372,10 @@ export function RoutesPage() {
   const setRoutes = useCallback(
     (next: SelectedRoute[]) => {
       const tokens = next.map((r) => formatRouteToken(r.from, r.to, r.fromAnchor, r.toAnchor))
-      // Replace the whole param so a shared link reproduces the view exactly.
-      setSearchParams(tokens.length ? { routes: tokens.join(',') } : {})
+      // Replace the whole param so a shared link reproduces the view exactly, and
+      // replace the history entry so Back leaves the page rather than walking
+      // back through every intermediate route list.
+      setSearchParams(tokens.length ? { routes: tokens.join(',') } : {}, { replace: true })
     },
     [setSearchParams],
   )
@@ -372,12 +404,15 @@ export function RoutesPage() {
     [resolved],
   )
 
-  const { data: seriesData } = useQuery({
+  const { data: seriesData, isPending: seriesIsPending } = useQuery({
     queryKey: ['route-series', pairKeys.join(',')],
     queryFn: () => fetchRouteSeries(pairKeys),
     enabled: pairKeys.length > 0,
     staleTime: 300000,
   })
+
+  // A disabled query reports isPending, so gate on there being something to fetch.
+  const seriesPending = pairKeys.length > 0 && seriesIsPending
 
   const latencyByPair = useMemo(() => {
     const map = new Map<string, MetroPathLatency>()
@@ -511,6 +546,7 @@ export function RoutesPage() {
                 metroPkFor={metroPkFor}
                 latency={r.pairKey ? (latencyByPair.get(r.pairKey) ?? null) : null}
                 series={r.pairKey ? (seriesByPair.get(r.pairKey) ?? null) : null}
+                seriesPending={seriesPending}
                 onRemove={() => setRoutes(routes.filter((_, idx) => idx !== i))}
                 onAnchorChange={(side, anchor) =>
                   setRoutes(

--- a/web/src/components/shared/sparkline-points.ts
+++ b/web/src/components/shared/sparkline-points.ts
@@ -1,0 +1,56 @@
+// Inline SVG only. The repo has deliberately migrated off charting libraries for
+// small visuals, and a polyline needs no dependency.
+//
+// Kept out of sparkline.tsx so that file exports only its component: mixing
+// component and non-component exports breaks Fast Refresh.
+
+/**
+ * Builds SVG `points` strings, scaling values to fit width x height — one
+ * string per contiguous run of measured (> 0) values. Zero is treated as
+ * "no data" and splits the series into a new run, so a gap breaks the line
+ * rather than being bridged by a straight segment that implies a trend
+ * across hours that were never measured.
+ *
+ * `scaleAgainst` lets two series share one scale so the gap between them is
+ * readable; it defaults to the series itself.
+ */
+export function sparklinePoints(
+  values: number[],
+  width: number,
+  height: number,
+  scaleAgainst?: number[]
+): string[] {
+  const scaleVals = (scaleAgainst ?? values).filter((v) => v > 0)
+  if (scaleVals.length === 0) return []
+  const min = Math.min(...scaleVals)
+  const max = Math.max(...scaleVals)
+  const span = max - min
+  const lastIdx = values.length - 1
+
+  const segments: string[][] = []
+  let current: string[] = []
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i]
+    if (v > 0) {
+      const x = lastIdx === 0 ? 0 : (i / lastIdx) * width
+      const y = span === 0 ? height / 2 : height - ((v - min) / span) * height
+      current.push(`${round(x)},${round(y)}`)
+    } else if (current.length > 0) {
+      segments.push(current)
+      current = []
+    }
+  }
+  if (current.length > 0) segments.push(current)
+
+  return segments.map((points) => points.join(' '))
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/** Parses a single-point "x,y" segment string produced by sparklinePoints. */
+export function parsePoint(segment: string): { x: number; y: number } {
+  const [x, y] = segment.split(',').map(Number)
+  return { x, y }
+}

--- a/web/src/components/shared/sparkline.test.ts
+++ b/web/src/components/shared/sparkline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sparklinePoints } from './sparkline'
+import { sparklinePoints } from './sparkline-points'
 
 describe('sparklinePoints', () => {
   it('maps the lowest value to the bottom and the highest to the top', () => {

--- a/web/src/components/shared/sparkline.test.ts
+++ b/web/src/components/shared/sparkline.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { sparklinePoints } from './sparkline'
+
+describe('sparklinePoints', () => {
+  it('maps the lowest value to the bottom and the highest to the top', () => {
+    // y is inverted in SVG: the largest value sits at y=0.
+    const out = sparklinePoints([10, 20], 100, 40)
+    expect(out).toBe('0,40 100,0')
+  })
+
+  it('omits zero values so gaps break the line instead of dropping to the floor', () => {
+    const out = sparklinePoints([10, 0, 20], 100, 40)
+    expect(out).toBe('0,40 100,0')
+  })
+
+  it('renders a flat series at mid-height rather than dividing by zero', () => {
+    expect(sparklinePoints([5, 5, 5], 100, 40)).toBe('0,20 50,20 100,20')
+  })
+
+  it('returns an empty string when there is nothing to plot', () => {
+    expect(sparklinePoints([], 100, 40)).toBe('')
+    expect(sparklinePoints([0, 0], 100, 40)).toBe('')
+  })
+})

--- a/web/src/components/shared/sparkline.test.ts
+++ b/web/src/components/shared/sparkline.test.ts
@@ -5,20 +5,28 @@ describe('sparklinePoints', () => {
   it('maps the lowest value to the bottom and the highest to the top', () => {
     // y is inverted in SVG: the largest value sits at y=0.
     const out = sparklinePoints([10, 20], 100, 40)
-    expect(out).toBe('0,40 100,0')
+    expect(out).toEqual(['0,40 100,0'])
   })
 
-  it('omits zero values so gaps break the line instead of dropping to the floor', () => {
+  it('splits into separate segments at a zero so gaps break the line instead of bridging it', () => {
     const out = sparklinePoints([10, 0, 20], 100, 40)
-    expect(out).toBe('0,40 100,0')
+    expect(out).toEqual(['0,40', '100,0'])
   })
 
   it('renders a flat series at mid-height rather than dividing by zero', () => {
-    expect(sparklinePoints([5, 5, 5], 100, 40)).toBe('0,20 50,20 100,20')
+    expect(sparklinePoints([5, 5, 5], 100, 40)).toEqual(['0,20 50,20 100,20'])
   })
 
-  it('returns an empty string when there is nothing to plot', () => {
-    expect(sparklinePoints([], 100, 40)).toBe('')
-    expect(sparklinePoints([0, 0], 100, 40)).toBe('')
+  it('returns an empty array when there is nothing to plot', () => {
+    expect(sparklinePoints([], 100, 40)).toEqual([])
+    expect(sparklinePoints([0, 0], 100, 40)).toEqual([])
+  })
+
+  it('preserves original index positions across a gap rather than re-indexing after filtering', () => {
+    // If the gap were closed up before computing x, the run starting at index 3
+    // would land at x=50 (re-indexed) instead of x=75 (its true position of 5).
+    const out = sparklinePoints([10, 20, 0, 30, 40], 100, 40)
+    expect(out).toHaveLength(2)
+    expect(out[1].startsWith('75,')).toBe(true)
   })
 })

--- a/web/src/components/shared/sparkline.tsx
+++ b/web/src/components/shared/sparkline.tsx
@@ -1,56 +1,7 @@
 // Inline SVG only. The repo has deliberately migrated off charting libraries for
 // small visuals, and a polyline needs no dependency.
 
-/**
- * Builds SVG `points` strings, scaling values to fit width x height — one
- * string per contiguous run of measured (> 0) values. Zero is treated as
- * "no data" and splits the series into a new run, so a gap breaks the line
- * rather than being bridged by a straight segment that implies a trend
- * across hours that were never measured.
- *
- * `scaleAgainst` lets two series share one scale so the gap between them is
- * readable; it defaults to the series itself.
- */
-export function sparklinePoints(
-  values: number[],
-  width: number,
-  height: number,
-  scaleAgainst?: number[]
-): string[] {
-  const scaleVals = (scaleAgainst ?? values).filter((v) => v > 0)
-  if (scaleVals.length === 0) return []
-  const min = Math.min(...scaleVals)
-  const max = Math.max(...scaleVals)
-  const span = max - min
-  const lastIdx = values.length - 1
-
-  const segments: string[][] = []
-  let current: string[] = []
-  for (let i = 0; i < values.length; i++) {
-    const v = values[i]
-    if (v > 0) {
-      const x = lastIdx === 0 ? 0 : (i / lastIdx) * width
-      const y = span === 0 ? height / 2 : height - ((v - min) / span) * height
-      current.push(`${round(x)},${round(y)}`)
-    } else if (current.length > 0) {
-      segments.push(current)
-      current = []
-    }
-  }
-  if (current.length > 0) segments.push(current)
-
-  return segments.map((points) => points.join(' '))
-}
-
-function round(n: number): number {
-  return Math.round(n * 100) / 100
-}
-
-/** Parses a single-point "x,y" segment string produced by sparklinePoints. */
-function parsePoint(segment: string): { x: number; y: number } {
-  const [x, y] = segment.split(',').map(Number)
-  return { x, y }
-}
+import { sparklinePoints, parsePoint } from './sparkline-points'
 
 type SparklineProps = {
   dz: number[]

--- a/web/src/components/shared/sparkline.tsx
+++ b/web/src/components/shared/sparkline.tsx
@@ -2,9 +2,11 @@
 // small visuals, and a polyline needs no dependency.
 
 /**
- * Builds an SVG `points` string, scaling values to fit width x height. Zero is
- * treated as "no data" and omitted, so gaps break the line rather than plunging
- * it to the floor and implying a latency collapse that never happened.
+ * Builds SVG `points` strings, scaling values to fit width x height — one
+ * string per contiguous run of measured (> 0) values. Zero is treated as
+ * "no data" and splits the series into a new run, so a gap breaks the line
+ * rather than being bridged by a straight segment that implies a trend
+ * across hours that were never measured.
  *
  * `scaleAgainst` lets two series share one scale so the gap between them is
  * readable; it defaults to the series itself.
@@ -14,28 +16,40 @@ export function sparklinePoints(
   width: number,
   height: number,
   scaleAgainst?: number[]
-): string {
-  const present = values.map((v, i) => ({ v, i })).filter((p) => p.v > 0)
-  if (present.length === 0) return ''
-
+): string[] {
   const scaleVals = (scaleAgainst ?? values).filter((v) => v > 0)
-  if (scaleVals.length === 0) return ''
+  if (scaleVals.length === 0) return []
   const min = Math.min(...scaleVals)
   const max = Math.max(...scaleVals)
   const span = max - min
   const lastIdx = values.length - 1
 
-  return present
-    .map(({ v, i }) => {
+  const segments: string[][] = []
+  let current: string[] = []
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i]
+    if (v > 0) {
       const x = lastIdx === 0 ? 0 : (i / lastIdx) * width
       const y = span === 0 ? height / 2 : height - ((v - min) / span) * height
-      return `${round(x)},${round(y)}`
-    })
-    .join(' ')
+      current.push(`${round(x)},${round(y)}`)
+    } else if (current.length > 0) {
+      segments.push(current)
+      current = []
+    }
+  }
+  if (current.length > 0) segments.push(current)
+
+  return segments.map((points) => points.join(' '))
 }
 
 function round(n: number): number {
   return Math.round(n * 100) / 100
+}
+
+/** Parses a single-point "x,y" segment string produced by sparklinePoints. */
+function parsePoint(segment: string): { x: number; y: number } {
+  const [x, y] = segment.split(',').map(Number)
+  return { x, y }
 }
 
 type SparklineProps = {
@@ -44,6 +58,31 @@ type SparklineProps = {
   width?: number
   height?: number
   className?: string
+}
+
+function SparklineSeries({ segments, className }: { segments: string[]; className: string }) {
+  return (
+    <>
+      {segments.map((segment, i) => {
+        if (!segment.includes(' ')) {
+          // A run of exactly one point draws nothing as a polyline; mark it with a dot
+          // instead so an isolated measurement is still visible rather than silently dropped.
+          const { x, y } = parsePoint(segment)
+          return <circle key={i} cx={x} cy={y} r="1.5" fill="currentColor" className={className} />
+        }
+        return (
+          <polyline
+            key={i}
+            points={segment}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className={className}
+          />
+        )
+      })}
+    </>
+  )
 }
 
 /** Two overlaid series: DoubleZero and the public internet, sharing one scale. */
@@ -56,10 +95,10 @@ export function Sparkline({
 }: SparklineProps) {
   // Both series share a scale so the gap between them is readable.
   const combined = [...dz, ...internet]
-  const dzPoints = sparklinePoints(dz, width, height, combined)
-  const inetPoints = sparklinePoints(internet, width, height, combined)
+  const dzSegments = sparklinePoints(dz, width, height, combined)
+  const inetSegments = sparklinePoints(internet, width, height, combined)
 
-  if (!dzPoints && !inetPoints) {
+  if (dzSegments.length === 0 && inetSegments.length === 0) {
     return (
       <div
         className={`flex items-center justify-center text-xs text-muted-foreground ${className ?? ''}`}
@@ -79,24 +118,8 @@ export function Sparkline({
       role="img"
       aria-label="7-day latency history: DoubleZero versus public internet"
     >
-      {inetPoints && (
-        <polyline
-          points={inetPoints}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          className="text-muted-foreground/50"
-        />
-      )}
-      {dzPoints && (
-        <polyline
-          points={dzPoints}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          className="text-cyan-400"
-        />
-      )}
+      <SparklineSeries segments={inetSegments} className="text-muted-foreground/50" />
+      <SparklineSeries segments={dzSegments} className="text-cyan-600 dark:text-cyan-400" />
     </svg>
   )
 }

--- a/web/src/components/shared/sparkline.tsx
+++ b/web/src/components/shared/sparkline.tsx
@@ -1,0 +1,102 @@
+// Inline SVG only. The repo has deliberately migrated off charting libraries for
+// small visuals, and a polyline needs no dependency.
+
+/**
+ * Builds an SVG `points` string, scaling values to fit width x height. Zero is
+ * treated as "no data" and omitted, so gaps break the line rather than plunging
+ * it to the floor and implying a latency collapse that never happened.
+ *
+ * `scaleAgainst` lets two series share one scale so the gap between them is
+ * readable; it defaults to the series itself.
+ */
+export function sparklinePoints(
+  values: number[],
+  width: number,
+  height: number,
+  scaleAgainst?: number[]
+): string {
+  const present = values.map((v, i) => ({ v, i })).filter((p) => p.v > 0)
+  if (present.length === 0) return ''
+
+  const scaleVals = (scaleAgainst ?? values).filter((v) => v > 0)
+  if (scaleVals.length === 0) return ''
+  const min = Math.min(...scaleVals)
+  const max = Math.max(...scaleVals)
+  const span = max - min
+  const lastIdx = values.length - 1
+
+  return present
+    .map(({ v, i }) => {
+      const x = lastIdx === 0 ? 0 : (i / lastIdx) * width
+      const y = span === 0 ? height / 2 : height - ((v - min) / span) * height
+      return `${round(x)},${round(y)}`
+    })
+    .join(' ')
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+type SparklineProps = {
+  dz: number[]
+  internet: number[]
+  width?: number
+  height?: number
+  className?: string
+}
+
+/** Two overlaid series: DoubleZero and the public internet, sharing one scale. */
+export function Sparkline({
+  dz,
+  internet,
+  width = 220,
+  height = 40,
+  className,
+}: SparklineProps) {
+  // Both series share a scale so the gap between them is readable.
+  const combined = [...dz, ...internet]
+  const dzPoints = sparklinePoints(dz, width, height, combined)
+  const inetPoints = sparklinePoints(internet, width, height, combined)
+
+  if (!dzPoints && !inetPoints) {
+    return (
+      <div
+        className={`flex items-center justify-center text-xs text-muted-foreground ${className ?? ''}`}
+        style={{ width, height }}
+      >
+        no history
+      </div>
+    )
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      role="img"
+      aria-label="7-day latency history: DoubleZero versus public internet"
+    >
+      {inetPoints && (
+        <polyline
+          points={inetPoints}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="text-muted-foreground/50"
+        />
+      )}
+      {dzPoints && (
+        <polyline
+          points={dzPoints}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="text-cyan-400"
+        />
+      )}
+    </svg>
+  )
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4485,6 +4485,14 @@ export interface MetroPathLatency {
   toMetroPK: string
   toMetroCode: string
   pathLatencyMs: number
+  /** Observed sum of per-hop RTT. Falls back to the contracted figure when partiallyCommitted. */
+  measuredLatencyMs: number
+  /** 0 when partiallyCommitted — absent, not zero. */
+  measuredP95Ms: number
+  /** 0 when partiallyCommitted — absent, not zero. */
+  measuredJitterMs: number
+  partiallyCommitted: boolean
+  pathMetros: string[]
   hopCount: number
   bottleneckBwGbps: number
   internetLatencyMs: number
@@ -4507,6 +4515,31 @@ export async function fetchMetroPathLatency(optimize: PathOptimizeMode = 'latenc
   const res = await apiFetch(`/api/topology/metro-path-latency?optimize=${optimize}`)
   if (!res.ok) {
     throw new Error('Failed to fetch metro path latency')
+  }
+  return res.json()
+}
+
+export interface RouteSeriesPoint {
+  ts: string
+  dzMs: number
+  internetMs: number
+}
+
+export interface RouteSeries {
+  fromMetroCode: string
+  toMetroCode: string
+  points: RouteSeriesPoint[]
+}
+
+export interface RouteSeriesResponse {
+  series: RouteSeries[]
+  error?: string
+}
+
+export async function fetchRouteSeries(pairs: string[]): Promise<RouteSeriesResponse> {
+  const res = await apiFetch(`/api/topology/route-series?pairs=${encodeURIComponent(pairs.join(','))}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch route series')
   }
   return res.json()
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4500,7 +4500,10 @@ export interface MetroPathLatency {
   internetP95Ms: number
   /** 0 when unmeasured — the internet side has no partiallyCommitted-style flag. */
   internetJitterMs: number
+  /** vs internet, from the contracted pathLatencyMs. */
   improvementPct: number | null
+  /** vs internet, from measuredLatencyMs. Separate basis, so the two pages stay self-consistent. */
+  measuredImprovementPct: number | null
 }
 
 export interface MetroPathLatencyResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4496,6 +4496,10 @@ export interface MetroPathLatency {
   hopCount: number
   bottleneckBwGbps: number
   internetLatencyMs: number
+  /** 0 when unmeasured — the internet side has no partiallyCommitted-style flag. */
+  internetP95Ms: number
+  /** 0 when unmeasured — the internet side has no partiallyCommitted-style flag. */
+  internetJitterMs: number
   improvementPct: number | null
 }
 

--- a/web/src/lib/route-anchors.test.ts
+++ b/web/src/lib/route-anchors.test.ts
@@ -45,6 +45,30 @@ describe('route-anchors', () => {
     expect(formatRouteToken('ohio', 'lon', 'pit')).toBe('ohio@pit-lon')
   })
 
+  it('round-trips an anchor on the destination side', () => {
+    expect(parseRouteToken('tyo-ohio@pit')).toEqual({ from: 'tyo', to: 'ohio', toAnchor: 'pit' })
+    expect(formatRouteToken('tyo', 'ohio', undefined, 'pit')).toBe('tyo-ohio@pit')
+  })
+
+  it('round-trips anchors on both sides', () => {
+    expect(parseRouteToken('ohio@pit-ohio@chi')).toEqual({
+      from: 'ohio',
+      to: 'ohio',
+      fromAnchor: 'pit',
+      toAnchor: 'chi',
+    })
+    expect(formatRouteToken('ohio', 'ohio', 'pit', 'chi')).toBe('ohio@pit-ohio@chi')
+  })
+
+  it('rejects malformed route tokens instead of guessing', () => {
+    expect(parseRouteToken('')).toBeNull()
+    expect(parseRouteToken('tyo-lon-extra')).toBeNull()
+    expect(parseRouteToken('-lon')).toBeNull()
+    expect(parseRouteToken('tyo-')).toBeNull()
+    expect(parseRouteToken('ohio@-lon')).toBeNull()
+    expect(parseRouteToken('ohio@pit@x-lon')).toBeNull()
+  })
+
   it('every off-net entry lists its default among its candidates', () => {
     for (const e of OFF_NET_ENDPOINTS) {
       if (e.defaultAnchor) {

--- a/web/src/lib/route-anchors.test.ts
+++ b/web/src/lib/route-anchors.test.ts
@@ -78,6 +78,15 @@ describe('route-anchors', () => {
     expect(formatCityToken('ohio', 'pit')).toBe('ohio@pit')
   })
 
+  // Every id lookup downstream is case-sensitive, so a link an inbox uppercased
+  // has to fold back onto the same location rather than become an unknown one.
+  it('case-folds a location token', () => {
+    expect(parseCityToken('ZURICH')).toEqual({ id: 'zurich' })
+    expect(parseCityToken('Ohio@PIT')).toEqual({ id: 'ohio', anchor: 'pit' })
+    expect(resolveEndpoint('OHIO'.toLowerCase()).metroCode).toBe('chi')
+    expect(parseRouteToken('OHIO@PIT-LON')).toEqual({ from: 'ohio', to: 'lon', fromAnchor: 'pit' })
+  })
+
   it('rejects a malformed location token instead of guessing', () => {
     expect(parseCityToken('')).toBeNull()
     expect(parseCityToken('   ')).toBeNull()

--- a/web/src/lib/route-anchors.test.ts
+++ b/web/src/lib/route-anchors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OFF_NET_ENDPOINTS,
+  formatRouteToken,
+  parseRouteToken,
+  resolveEndpoint,
+} from './route-anchors'
+
+describe('route-anchors', () => {
+  it('resolves an on-net metro to itself', () => {
+    expect(resolveEndpoint('lon')).toEqual({ metroCode: 'lon', offNet: null, anchor: null })
+  })
+
+  it('resolves Ohio to its default anchor', () => {
+    const r = resolveEndpoint('ohio')
+    expect(r.metroCode).toBe('chi')
+    expect(r.anchor).toBe('chi')
+    expect(r.offNet?.label).toContain('Ohio')
+  })
+
+  it('honours an explicit anchor override', () => {
+    expect(resolveEndpoint('ohio', 'pit').metroCode).toBe('pit')
+  })
+
+  it('ignores an anchor that is not a candidate', () => {
+    expect(resolveEndpoint('ohio', 'sao').metroCode).toBe('chi')
+  })
+
+  // Zurich has no DoubleZero presence and no committed coverage, so it resolves
+  // to nothing rather than being silently substituted with Frankfurt.
+  it('resolves Zurich to N/A with no anchor', () => {
+    const r = resolveEndpoint('zurich')
+    expect(r.metroCode).toBeNull()
+    expect(r.anchor).toBeNull()
+    expect(r.offNet?.defaultAnchor).toBeNull()
+  })
+
+  it('round-trips a plain route token', () => {
+    expect(parseRouteToken('tyo-lon')).toEqual({ from: 'tyo', to: 'lon' })
+    expect(formatRouteToken('tyo', 'lon')).toBe('tyo-lon')
+  })
+
+  it('round-trips a route token carrying an anchor', () => {
+    expect(parseRouteToken('ohio@pit-lon')).toEqual({ from: 'ohio', to: 'lon', fromAnchor: 'pit' })
+    expect(formatRouteToken('ohio', 'lon', 'pit')).toBe('ohio@pit-lon')
+  })
+
+  it('every off-net entry lists its default among its candidates', () => {
+    for (const e of OFF_NET_ENDPOINTS) {
+      if (e.defaultAnchor) {
+        expect(e.candidateAnchors).toContain(e.defaultAnchor)
+      }
+    }
+  })
+})

--- a/web/src/lib/route-anchors.test.ts
+++ b/web/src/lib/route-anchors.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   OFF_NET_ENDPOINTS,
+  formatCityToken,
   formatRouteToken,
+  parseCityToken,
   parseRouteToken,
   resolveEndpoint,
 } from './route-anchors'
@@ -67,6 +69,27 @@ describe('route-anchors', () => {
     expect(parseRouteToken('tyo-')).toBeNull()
     expect(parseRouteToken('ohio@-lon')).toBeNull()
     expect(parseRouteToken('ohio@pit@x-lon')).toBeNull()
+  })
+
+  it('round-trips a location token, with and without an anchor', () => {
+    expect(parseCityToken('lon')).toEqual({ id: 'lon' })
+    expect(parseCityToken('ohio@pit')).toEqual({ id: 'ohio', anchor: 'pit' })
+    expect(formatCityToken('lon')).toBe('lon')
+    expect(formatCityToken('ohio', 'pit')).toBe('ohio@pit')
+  })
+
+  it('rejects a malformed location token instead of guessing', () => {
+    expect(parseCityToken('')).toBeNull()
+    expect(parseCityToken('   ')).toBeNull()
+    expect(parseCityToken('ohio@')).toBeNull()
+    expect(parseCityToken('@pit')).toBeNull()
+    expect(parseCityToken('ohio@pit@x')).toBeNull()
+  })
+
+  it('every off-net entry carries a short axis label', () => {
+    for (const e of OFF_NET_ENDPOINTS) {
+      expect(e.short).toMatch(/^[A-Z0-9]{2,6}$/)
+    }
   })
 
   it('every off-net entry lists its default among its candidates', () => {

--- a/web/src/lib/route-anchors.ts
+++ b/web/src/lib/route-anchors.ts
@@ -47,22 +47,45 @@ export function resolveEndpoint(
   return { metroCode: chosen, offNet, anchor: chosen }
 }
 
-/** Parses `tyo-lon` or `ohio@pit-lon` into its endpoints and optional anchors. */
+/**
+ * Parses `tyo-lon` or `ohio@pit-lon` into its endpoints and optional anchors.
+ *
+ * This backs a shareable URL, so a corrupted or hand-edited token must fail
+ * visibly rather than parse into a plausible-but-wrong route. Returns `null`
+ * for anything malformed — callers must drop `null` results, not coerce them
+ * (e.g. with `?? ''`).
+ */
 export function parseRouteToken(token: string): {
   from: string
   to: string
   fromAnchor?: string
   toAnchor?: string
-} {
-  const [rawFrom = '', rawTo = ''] = token.split('-')
-  const [from, fromAnchor] = rawFrom.split('@')
-  const [to, toAnchor] = rawTo.split('@')
+} | null {
+  if (!token.trim()) return null
+
+  const segments = token.split('-')
+  if (segments.length !== 2) return null
+
+  const left = parseSide(segments[0])
+  const right = parseSide(segments[1])
+  if (!left || !right) return null
+
   return {
-    from,
-    to,
-    ...(fromAnchor ? { fromAnchor } : {}),
-    ...(toAnchor ? { toAnchor } : {}),
+    from: left.id,
+    to: right.id,
+    ...(left.anchor ? { fromAnchor: left.anchor } : {}),
+    ...(right.anchor ? { toAnchor: right.anchor } : {}),
   }
+}
+
+/** Splits one side of a route token (`id` or `id@anchor`); null if malformed. */
+function parseSide(raw: string): { id: string; anchor?: string } | null {
+  const parts = raw.split('@')
+  if (parts.length > 2) return null
+  const [id, anchor] = parts
+  if (!id) return null
+  if (parts.length === 2 && !anchor) return null
+  return { id, ...(anchor ? { anchor } : {}) }
 }
 
 export function formatRouteToken(

--- a/web/src/lib/route-anchors.ts
+++ b/web/src/lib/route-anchors.ts
@@ -1,0 +1,77 @@
+// ponytail: throwaway scaffolding for metros DoubleZero does not yet serve.
+// Delete an entry the moment its metro appears in dz_metros_current — the real
+// metro then flows through the normal path and the anchor picker disappears
+// with it. Nothing else in the page is coupled to this list.
+//
+// Rule: anchor where coverage is committed, N/A where it is not.
+
+export type OffNetEndpoint = {
+  id: string
+  label: string
+  note: string
+  /** null means N/A — no substitution is offered. */
+  defaultAnchor: string | null
+  candidateAnchors: string[]
+}
+
+export const OFF_NET_ENDPOINTS: OffNetEndpoint[] = [
+  {
+    id: 'ohio',
+    label: 'Ohio (AWS us-east-2)',
+    note:
+      'DoubleZero coverage in Ohio is in progress. Figures are measured at the on-ramp below. ' +
+      'Your access leg from us-east-2 to the on-ramp applies equally to both the DoubleZero and ' +
+      'public-internet path, so the difference between them is unaffected.',
+    defaultAnchor: 'chi',
+    candidateAnchors: ['chi', 'pit', 'nyc', 'was'],
+  },
+  {
+    id: 'zurich',
+    label: 'Zurich (ZH4)',
+    note: 'DoubleZero has no presence in Zurich, so there is no figure to report.',
+    defaultAnchor: null,
+    candidateAnchors: [],
+  },
+]
+
+export function resolveEndpoint(
+  id: string,
+  anchor?: string
+): { metroCode: string | null; offNet: OffNetEndpoint | null; anchor: string | null } {
+  const offNet = OFF_NET_ENDPOINTS.find((e) => e.id === id)
+  if (!offNet) {
+    return { metroCode: id, offNet: null, anchor: null }
+  }
+  const chosen =
+    anchor && offNet.candidateAnchors.includes(anchor) ? anchor : offNet.defaultAnchor
+  return { metroCode: chosen, offNet, anchor: chosen }
+}
+
+/** Parses `tyo-lon` or `ohio@pit-lon` into its endpoints and optional anchors. */
+export function parseRouteToken(token: string): {
+  from: string
+  to: string
+  fromAnchor?: string
+  toAnchor?: string
+} {
+  const [rawFrom = '', rawTo = ''] = token.split('-')
+  const [from, fromAnchor] = rawFrom.split('@')
+  const [to, toAnchor] = rawTo.split('@')
+  return {
+    from,
+    to,
+    ...(fromAnchor ? { fromAnchor } : {}),
+    ...(toAnchor ? { toAnchor } : {}),
+  }
+}
+
+export function formatRouteToken(
+  from: string,
+  to: string,
+  fromAnchor?: string,
+  toAnchor?: string
+): string {
+  const left = fromAnchor ? `${from}@${fromAnchor}` : from
+  const right = toAnchor ? `${to}@${toAnchor}` : to
+  return `${left}-${right}`
+}

--- a/web/src/lib/route-anchors.ts
+++ b/web/src/lib/route-anchors.ts
@@ -88,9 +88,16 @@ export function parseRouteToken(token: string): {
  * Also one side of a route token, so the `?cities=` list and the `?routes=`
  * encoding share a single rule: anything malformed returns `null` and must be
  * dropped by the caller, never coerced into a plausible-but-wrong location.
+ *
+ * Case-folded, because every id lookup downstream is case-sensitive — the
+ * off-net table here, the metro table on the page. A link an inbox uppercased to
+ * `?cities=ZURICH` would otherwise pass for an unknown metro code and print a
+ * whole row of "no path", asserting DoubleZero cannot reach somewhere it has
+ * only ever said it does not serve. That is the same coercion this function's
+ * strictness exists to prevent, arriving through casing instead of syntax.
  */
 export function parseCityToken(raw: string): { id: string; anchor?: string } | null {
-  const parts = raw.trim().split('@')
+  const parts = raw.trim().toLowerCase().split('@')
   if (parts.length > 2) return null
   const [id, anchor] = parts
   if (!id) return null

--- a/web/src/lib/route-anchors.ts
+++ b/web/src/lib/route-anchors.ts
@@ -8,6 +8,8 @@
 export type OffNetEndpoint = {
   id: string
   label: string
+  /** Axis label in the matrix, where a metro contributes its three-letter code. */
+  short: string
   note: string
   /** null means N/A — no substitution is offered. */
   defaultAnchor: string | null
@@ -18,8 +20,9 @@ export const OFF_NET_ENDPOINTS: OffNetEndpoint[] = [
   {
     id: 'ohio',
     label: 'Ohio (AWS us-east-2)',
+    short: 'OHIO',
     note:
-      'DoubleZero coverage in Ohio is in progress. Figures are measured at the on-ramp below. ' +
+      'DoubleZero coverage in Ohio is in progress. Figures are measured at the on-ramp shown. ' +
       'Your access leg from us-east-2 to the on-ramp applies equally to both the DoubleZero and ' +
       'public-internet path, so the difference between them is unaffected.',
     defaultAnchor: 'chi',
@@ -28,6 +31,7 @@ export const OFF_NET_ENDPOINTS: OffNetEndpoint[] = [
   {
     id: 'zurich',
     label: 'Zurich (ZH4)',
+    short: 'ZRH',
     note: 'DoubleZero has no presence in Zurich, so there is no figure to report.',
     defaultAnchor: null,
     candidateAnchors: [],
@@ -66,8 +70,8 @@ export function parseRouteToken(token: string): {
   const segments = token.split('-')
   if (segments.length !== 2) return null
 
-  const left = parseSide(segments[0])
-  const right = parseSide(segments[1])
+  const left = parseCityToken(segments[0])
+  const right = parseCityToken(segments[1])
   if (!left || !right) return null
 
   return {
@@ -78,14 +82,24 @@ export function parseRouteToken(token: string): {
   }
 }
 
-/** Splits one side of a route token (`id` or `id@anchor`); null if malformed. */
-function parseSide(raw: string): { id: string; anchor?: string } | null {
-  const parts = raw.split('@')
+/**
+ * Parses one location token — `lon`, or `ohio@chi` carrying its anchor.
+ *
+ * Also one side of a route token, so the `?cities=` list and the `?routes=`
+ * encoding share a single rule: anything malformed returns `null` and must be
+ * dropped by the caller, never coerced into a plausible-but-wrong location.
+ */
+export function parseCityToken(raw: string): { id: string; anchor?: string } | null {
+  const parts = raw.trim().split('@')
   if (parts.length > 2) return null
   const [id, anchor] = parts
   if (!id) return null
   if (parts.length === 2 && !anchor) return null
   return { id, ...(anchor ? { anchor } : {}) }
+}
+
+export function formatCityToken(id: string, anchor?: string): string {
+  return anchor ? `${id}@${anchor}` : id
 }
 
 export function formatRouteToken(
@@ -94,7 +108,5 @@ export function formatRouteToken(
   fromAnchor?: string,
   toAnchor?: string
 ): string {
-  const left = fromAnchor ? `${from}@${fromAnchor}` : from
-  const right = toAnchor ? `${to}@${toAnchor}` : to
-  return `${left}-${right}`
+  return `${formatCityToken(from, fromAnchor)}-${formatCityToken(to, toAnchor)}`
 }


### PR DESCRIPTION
## Summary of Changes
- Adds `/performance/routes`, a shareable page showing measured DoubleZero vs public-internet latency (mean, p95, jitter). Pick a set of locations and the page builds the **full mesh between them as a matrix**; the whole view lives in the URL so a link reproduces it exactly. Built for a prospect evaluating DoubleZero on nine specific colo-to-colo routes.
- **Matrix cells shade by improvement, not by internet RTT.** 25 metros carry activated links and the graph is connected, so a DoubleZero path exists for roughly 300 of the 435 measured pairs — "DoubleZero carries this route" is the norm, and shading by internet RTT would spend the colour range on something constant. Four exceptions stay separately worded rather than collapsing into one grey cell: no DoubleZero path, no internet samples, figures withheld, and load failed.
- **Click a cell for the full breakdown; modifier-click to compare several at once.** Cmd, Ctrl or Shift toggles a cell into a comparison set (capped at 10, batched into one series request), and the selected routes render side by side. Mirrored cells fold to one route, since the matrix is symmetric.
- `metro-path-latency` now reports **measured** RTT/p95/jitter summed along the chosen path, alongside the existing contracted figure. Routes where any hop lacks recent samples are flagged `partiallyCommitted` and fall back to the contracted figure rather than silently understating.
- Adds `GET /api/topology/route-series` — 7 days of hourly DoubleZero and internet RTT for up to 10 metro pairs, feeding an inline SVG sparkline that breaks at gaps instead of drawing through them.
- Public-internet p95 and jitter are now surfaced (`quantileExact(0.95)` and mean |IPDV|), so both columns carry all three statistics instead of DoubleZero-only.
- Models endpoints with no DoubleZero presence. Ohio (AWS us-east-2) is **anchored**: both the DoubleZero and internet figures are taken at the same on-ramp metro so the customer's access leg is common-mode and cancels, with the on-ramp user-selectable. Zurich has no committed coverage and renders **N/A** — no substitute metro, labelled or otherwise. Nothing outside the DoubleZero network is measured or modelled.
- **Behaviour change:** `/api/topology/route-series` returns 5xx on backend failure where the initial implementation returned 200 with an error body. Only the new page consumes it, but an HTTP error-rate alert would see a new source.
- `improvementPct` keeps its contracted basis so the existing `/performance/path-latency` page stays consistent; the measured-basis figure is a separate `measuredImprovementPct` field. `path-latency-page.tsx` is unchanged.

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net   |
|--------------|-------|---------------|-------|
| Core logic   |     6 | +1357 / -38   | +1319 |
| Scaffolding  |     4 | +44   / -1    |   +43 |
| Tests        |     5 | +396  / -0    |  +396 |
| **Total**    |    15 | +1797 / -39   | +1758 |

Mostly one new page and one new endpoint; the API-side changes are additive, and the only edits to shared code are the measured-latency fields and a deterministic path tie-break.

<details>
<summary>Key files (click to expand)</summary>

- `web/src/components/routes-page.tsx` — the page: metro/off-net pickers, facility drill-down, anchor selection, URL state, and a single `routeFigures` policy that decides what is a real measurement and what renders absent
- `api/handlers/route_series.go` — 7-day hourly series endpoint, UTC-pinned buckets, zeroes a bucket where any hop is missing rather than reporting a partial sum
- `api/handlers/isis.go` — measured per-hop RTT/p95/jitter summed along the path, path metro list, internet p95/jitter, split improvement fields
- `web/src/components/shared/sparkline.tsx` — inline SVG sparkline rendering one segment per contiguous run so a gap breaks the line
- `web/src/lib/route-anchors.ts` — off-net endpoint model and route-token parsing; rejects malformed tokens outright so a corrupted link cannot render as a plausible-but-wrong route
- `web/src/lib/api.ts` — new response types and the series client
- `api/handlers/isis_ksp.go` — deterministic device ordering so tied equal-cost paths resolve the same way on every call

</details>

## Open questions
- ~~The us-east-2 on-ramp defaults to Chicago and needs confirmation.~~ **Confirmed by Nikesh: Chicago, specifically `dz-ch2-sw01`** (activated, metro `chi`). The default anchor was already correct, so the Tokyo→Ohio headline stands at roughly 25% rather than the 12% a Pittsburgh on-ramp would have given. The picker stays user-selectable.
- The page renders inside the full app shell, so the sidebar travels with the shared link. Only geoloc, hyperliquid and permission-audit are gated on `is_internal_user` — Incidents, Ops, the Agent and `/performance/path-latency` are one click away for anyone holding the URL. Worth a deliberate decision before the link goes to a prospect.
- **Columbus lands ~14 Aug, and that retires the Ohio entry.** Once a Columbus metro exists, Ohio should stop being an off-net endpoint anchored at Chicago — otherwise the page keeps serving anchored figures while real measurements exist, which is the stale-substitute failure the Zurich N/A rule exists to prevent. Deliberately **not** automated: the retirement needs the metro code Columbus will get, which is unknown today, and a wrong guess fails silently. It is a one-line deletion of the `OFF_NET_ENDPOINTS` Ohio entry in `web/src/lib/route-anchors.ts`, and it deserves a human comparing the anchored figure against the real one rather than a silent swap under an already-shared link.
- **Nothing has been checked in a browser.** No dev server was available during implementation, so the colour ramp, cell contrast, modifier-click behaviour, the modified-Enter guard, the responsive card grid and inert-cell focus are all reasoned rather than observed. Two specific things to look at under the preview: the millisecond line uses muted text over the strongest green (weakest contrast on the page, and it lands on the best-performing cells), and `hover:brightness-110` filters cell text along with the background, which reduces contrast in light theme on the cell being pointed at.

## Testing Verification
- Verified the figures against production ClickHouse before wiring them: `lon↔tyo` internet is 259.76 ms mean / 272.05 ms p95 / 2.56 ms jitter, against sub-0.1 ms jitter on DoubleZero links — the determinism gap is the point of the page for this audience.
- Switched `quantile` to `quantileExact` after confirming the approximate variant is non-deterministic run to run; at ~300 samples/pair the exact aggregate costs ~13 ms over 1.16M rows.
- Unit tests pin the rules that a browser check would pass by luck: path orientation (the wrong direction was a per-load coin flip), sparkline index preservation across a gap, incomplete-bucket-to-zero, `partiallyCommitted` suppression, and malformed-token rejection.
- Confirmed a stale `page_cache` payload predating the new fields renders as absent rather than throwing — the worker writes that cache from a separate process, so the first deploy serves old JSON to the new page.
- Confirmed loading, request failure, and genuinely-no-path are three distinct states. All three previously rendered as "No DoubleZero path between these metros", which is a false claim about coverage on a page a customer is reading.
- `go test -race ./api/...` and 234 frontend tests pass; `golangci-lint` clean on `./api/...`.


