### PR TITLE
api: take getSupply off the ledger hot path

### DIFF
--- a/api/handlers/ledger.go
+++ b/api/handlers/ledger.go
@@ -93,10 +93,14 @@ func FetchLedgerData(ctx context.Context, rpcURL string) (*LedgerResponse, error
 		return err
 	})
 
+	// getSupply is best-effort and deliberately outside this group's error path.
+	// It costs ~6.4s against an endpoint where every other call here takes ~45ms, so
+	// letting it return an error cancels gctx and discards five already-finished
+	// results to report nothing. Its own failure now costs only the supply fields,
+	// which keep their last known value.
 	g.Go(func() error {
-		var err error
-		supply, err = client.GetSupply(gctx)
-		return err
+		supply = cachedSupply(gctx, client)
+		return nil
 	})
 
 	g.Go(func() error {
@@ -132,6 +136,14 @@ func FetchLedgerData(ctx context.Context, rpcURL string) (*LedgerResponse, error
 		if totalSec > 0 {
 			tps = float64(totalTxn) / float64(totalSec)
 		}
+	}
+
+	// supply is nil when getSupply has never succeeded since startup. Report zero
+	// rather than fail: every other field on this response is present and useful.
+	var totalSupplySOL, circulatingSupplySOL float64
+	if supply != nil {
+		totalSupplySOL = float64(supply.Value.Total) / 1e9
+		circulatingSupplySOL = float64(supply.Value.Circulating) / 1e9
 	}
 
 	// Skip rate
@@ -173,8 +185,8 @@ func FetchLedgerData(ctx context.Context, rpcURL string) (*LedgerResponse, error
 
 		TPS: tps,
 
-		TotalSupply:       float64(supply.Value.Total) / 1e9,
-		CirculatingSupply: float64(supply.Value.Circulating) / 1e9,
+		TotalSupply:       totalSupplySOL,
+		CirculatingSupply: circulatingSupplySOL,
 
 		InflationTotal:      inflation.Total * 100,
 		InflationValidator:  inflation.Validator * 100,

--- a/api/handlers/ledger_supply.go
+++ b/api/handlers/ledger_supply.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/malbeclabs/lake/api/solana"
+)
+
+// supplyTTL is how long a getSupply result is reused.
+//
+// Total and circulating supply move as inflation accrues, which happens per epoch,
+// so roughly every two days. Refetching every page-cache refresh bought nothing and
+// cost a great deal: measured against the production endpoint, getSupply takes ~6.4s
+// while getEpochInfo, getInflationRate, getVersion and getVoteAccounts each take
+// ~45ms. One call was 150x the cost of the other five combined and produced values
+// that could not have changed.
+//
+// Five minutes is far shorter than the epoch it tracks, so the numbers stay current,
+// and long enough that the expensive call runs on a small fraction of refreshes.
+const supplyTTL = 5 * time.Minute
+
+// supplyCache holds the last getSupply result. Per process rather than shared: it
+// caches two slow-moving numbers, so a second API replica fetching its own copy costs
+// one call per TTL and avoids any coordination.
+var supplyCache struct {
+	mu        sync.Mutex
+	val       *solana.Supply
+	fetchedAt time.Time
+}
+
+// cachedSupply returns the cached supply, refreshing it when older than supplyTTL.
+//
+// It never returns an error. A failed refresh keeps the previous value, and returns
+// nil only when no fetch has ever succeeded. The caller treats nil as "supply
+// unknown" and still reports every other field, which is the point: before this, a
+// slow getSupply cancelled its sibling calls through errgroup.WithContext and took
+// the whole ledger response down with it.
+func cachedSupply(ctx context.Context, client *solana.Client) *solana.Supply {
+	supplyCache.mu.Lock()
+	defer supplyCache.mu.Unlock()
+
+	if supplyCache.val != nil && time.Since(supplyCache.fetchedAt) < supplyTTL {
+		return supplyCache.val
+	}
+
+	// Held across the call on purpose. Concurrent refreshes would each pay the ~6.4s
+	// and hit the endpoint N times for the same numbers; the wait here is the same
+	// wait they would have spent on their own request.
+	val, err := client.GetSupply(ctx)
+	if err != nil {
+		// Keep serving the last good value. Staleness beyond the TTL is a far smaller
+		// problem than dropping the field, and the refresh is retried next call.
+		return supplyCache.val
+	}
+
+	supplyCache.val = val
+	supplyCache.fetchedAt = time.Now()
+	return val
+}

--- a/api/handlers/ledger_supply_test.go
+++ b/api/handlers/ledger_supply_test.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/lake/api/solana"
+	"github.com/stretchr/testify/require"
+)
+
+// supplyBackend serves getSupply, counting calls and optionally failing or stalling.
+func supplyBackend(t *testing.T, calls *atomic.Int64, delay time.Duration, fail *atomic.Bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		if fail != nil && fail.Load() {
+			http.Error(w, "upstream is unhappy", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},`+
+			`"value":{"total":600000000000000000,"circulating":500000000000000000,`+
+			`"nonCirculating":100000000000000000,"nonCirculatingAccounts":[]}}}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func resetSupplyCache() {
+	supplyCache.mu.Lock()
+	defer supplyCache.mu.Unlock()
+	supplyCache.val = nil
+	supplyCache.fetchedAt = time.Time{}
+}
+
+// TestCachedSupply_ReusesWithinTTL is the reason this cache exists. getSupply costs
+// ~6.4s against production while every other call in FetchLedgerData costs ~45ms, and
+// it reports numbers that move once per epoch. Refetching it on every page-cache
+// refresh spent 150x the cost of the other five calls combined to learn nothing.
+func TestCachedSupply_ReusesWithinTTL(t *testing.T) {
+	resetSupplyCache()
+
+	var calls atomic.Int64
+	srv := supplyBackend(t, &calls, 0, nil)
+	client := solana.NewClient(srv.URL)
+	ctx := context.Background()
+
+	first := cachedSupply(ctx, client)
+	require.NotNil(t, first)
+	require.EqualValues(t, 1, calls.Load())
+
+	for range 20 {
+		got := cachedSupply(ctx, client)
+		require.NotNil(t, got)
+		require.Equal(t, first.Value.Total, got.Value.Total)
+	}
+	require.EqualValues(t, 1, calls.Load(),
+		"getSupply must be fetched once per TTL, not once per refresh")
+}
+
+// TestCachedSupply_FailureKeepsLastGoodValue: a failed refresh must not drop the
+// field. Staleness past the TTL is a much smaller problem than reporting nothing.
+func TestCachedSupply_FailureKeepsLastGoodValue(t *testing.T) {
+	resetSupplyCache()
+
+	var calls atomic.Int64
+	var fail atomic.Bool
+	srv := supplyBackend(t, &calls, 0, &fail)
+	client := solana.NewClient(srv.URL)
+	ctx := context.Background()
+
+	good := cachedSupply(ctx, client)
+	require.NotNil(t, good)
+
+	// Expire the entry, then make the upstream fail.
+	supplyCache.mu.Lock()
+	supplyCache.fetchedAt = time.Now().Add(-2 * supplyTTL)
+	supplyCache.mu.Unlock()
+	fail.Store(true)
+
+	got := cachedSupply(ctx, client)
+	require.NotNil(t, got, "a failed refresh must keep serving the last good value")
+	require.Equal(t, good.Value.Total, got.Value.Total)
+}
+
+// TestCachedSupply_NeverFails: with no successful fetch ever, it returns nil rather
+// than an error, so the caller can still report every other ledger field.
+func TestCachedSupply_NeverFails(t *testing.T) {
+	resetSupplyCache()
+
+	var calls atomic.Int64
+	fail := &atomic.Bool{}
+	fail.Store(true)
+	srv := supplyBackend(t, &calls, 0, fail)
+
+	require.Nil(t, cachedSupply(context.Background(), solana.NewClient(srv.URL)),
+		"an unfetched supply is nil, not an error")
+}
+
+// TestFetchLedgerData_SlowSupplyDoesNotSinkTheResponse is the regression.
+//
+// The six calls run concurrently under errgroup.WithContext, so the first error
+// cancels the rest. getSupply is the only slow one — five calls finish in ~45ms and
+// then wait on it. When it exceeded the client timeout it cancelled those five
+// finished results and the whole ledger response failed, which took the solana ledger
+// page cache down for a day.
+func TestFetchLedgerData_SlowSupplyDoesNotSinkTheResponse(t *testing.T) {
+	resetSupplyCache()
+
+	var supplyCalls atomic.Int64
+	slowSupply := &atomic.Bool{}
+	slowSupply.Store(true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		if req.Method == "getSupply" {
+			supplyCalls.Add(1)
+			// Outlast the client's own timeout, as production does.
+			time.Sleep(300 * time.Millisecond)
+			http.Error(w, "too slow", http.StatusGatewayTimeout)
+			return
+		}
+		// Everything else answers immediately, as production does.
+		switch req.Method {
+		case "getEpochInfo":
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"epoch":700,"slotIndex":100,`+
+				`"slotsInEpoch":432000,"absoluteSlot":300000000,"blockHeight":280000000,"transactionCount":9}}`)
+		case "getRecentPerformanceSamples":
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":[{"numTransactions":6000,"samplePeriodSecs":60,`+
+				`"numSlots":150,"slot":1}]}`)
+		case "getInflationRate":
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"total":0.05,"validator":0.045,"foundation":0.005,"epoch":700}}`)
+		case "getVersion":
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"solana-core":"2.0.0"}}`)
+		case "getVoteAccounts":
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"current":[],"delinquent":[]}}`)
+		default:
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":null}`)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := FetchLedgerData(context.Background(), srv.URL)
+	require.NoError(t, err,
+		"a failing getSupply must not fail the whole response; before this it cancelled "+
+			"five already-finished sibling calls through errgroup.WithContext")
+	require.NotNil(t, got)
+
+	// The fields that did resolve are present and correct.
+	require.EqualValues(t, 700, got.Epoch, "epoch came from a call that succeeded in ~45ms")
+	require.EqualValues(t, 300000000, got.AbsoluteSlot)
+	require.InDelta(t, 100.0, got.TPS, 0.01)
+	require.Equal(t, "2.0.0", got.NodeVersion)
+	require.InDelta(t, 5.0, got.InflationTotal, 0.0001, "reported as a percentage")
+
+	// Supply is the only casualty.
+	require.Zero(t, got.TotalSupply, "supply is unknown, and that costs only the supply fields")
+	require.Positive(t, supplyCalls.Load(), "getSupply was attempted")
+}


### PR DESCRIPTION
## Summary

The `solana ledger` page cache failed to refresh for a **full day** — roughly 60 ERROR and 60 WARN per hour, near-flat — and served stale data throughout. The panel showed day-old numbers and the alert fired more or less permanently.

`FetchLedgerData` issues six RPC calls concurrently under `errgroup.WithContext`. Measured against the production endpoint from inside the cluster:

| call | time |
|---|---|
| getEpochInfo | 43ms |
| getInflationRate | 44ms |
| getVersion | 41ms |
| getVoteAccounts | 50ms |
| **getSupply** | **6430ms** |

`getSupply` costs **150x the other five combined**. Five calls finished in ~45ms and then waited on it. When it exceeded the client's 10s timeout, `errgroup.WithContext` cancelled those five finished results and failed the whole response — a complete refresh of 99% of the data discarded because of one straggler.

## Two changes, for two different reasons

**`getSupply` is cached for five minutes.** Total and circulating supply move as inflation accrues, once per epoch, so roughly every two days. Refetching them every 30s bought numbers that could not have changed. Refresh drops from ~6.5s to ~50ms.

**It is best-effort, outside the errgroup's error path.** A failed refresh keeps the last good value; a supply that has never been fetched reports zero rather than failing the response. Its cost is now the supply fields alone.

Both are needed and neither is sufficient. The cache means the expensive call runs rarely; best-effort means the rare run cannot take the entry down with it.

## What this is not

Raising the client timeout was the other option. It would have worked and it would have hidden a call that has no business on a 30-second path, leaving a thin margin as the real cause. The failure was never really about the timeout being 10s.

`getInflationRate` and `getVersion` also report epoch-scale values, and I checked whether they belonged in this change. They do not: at ~42ms each, moving them off the hot path saves nothing measurable. One call is the problem.

## Testing Verification

- `SlowSupplyDoesNotSinkTheResponse` reproduces the shape: `getSupply` outlasts its timeout while the other five answer immediately, then asserts epoch, slot, TPS, version and inflation are all still present and only the supply fields are missing. **Verified it fails on the pre-change code**, reporting that a failing `getSupply` cancelled five already-finished sibling calls.
- `ReusesWithinTTL` asserts 20 consecutive calls produce exactly one upstream fetch, which is the cost argument stated as a test.
- `FailureKeepsLastGoodValue` expires the entry, fails the upstream, and asserts the previous value still serves. Staleness past the TTL beats dropping the field.
- `NeverFails` covers the cold-start case: no successful fetch ever yields nil, not an error.
- `go test -race` and `golangci-lint` clean on `api/handlers` and `api/solana`.

## Operational note

The per-process cache means each API replica fetches its own copy, one call per TTL per pod. That is deliberate: it caches two slow-moving numbers and avoids any coordination between replicas.

Found while investigating a page that fired at 03:00 and again the next evening. The first look read it as a transient blip that self-resolved; the 24-hour view showed it had been failing continuously the whole time.